### PR TITLE
dep update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,21 +20,20 @@ buildscript {
     maven { url "http://dl.bintray.com/spinnaker/gradle" }
   }
   dependencies {
-    classpath "com.netflix.spinnaker:spinnaker-gradle-project:1.12.1"
+    classpath "com.netflix.spinnaker:spinnaker-gradle-project:1.12.3"
   }
 }
 
 ext {
   versions = [
       groovy  : "2.3.4",
-      spring  : "4.0.5.RELEASE",
+      spring  : "4.0.6.RELEASE",
       batch   : "3.0.1.RELEASE",
-      guava   : "17.0",
+      guava   : "14.0.1",
       jackson : "2.3.3",
       rx      : "0.18.3",
       retrofit: "1.5.1",
       spock   : "1.0-groovy-2.0-SNAPSHOT",
-      logback : "1.0.13",
       slf4j   : "1.7.5"
   ]
 
@@ -48,11 +47,12 @@ ext {
       jacksonDatabind  : dependencies.create("com.fasterxml.jackson.core:jackson-databind:$versions.jackson"),
       jacksonGuava     : dependencies.create("com.fasterxml.jackson.datatype:jackson-datatype-guava:$versions.jackson"),
       kork             : dependencies.create("com.netflix.spinnaker.kork:kork-core:1.12"),
-      logback          : dependencies.create("ch.qos.logback:logback-classic:$versions.logback"),
       okHttp           : dependencies.create("com.squareup.okhttp:okhttp:1.5.4"),
       retrofit         : dependencies.create("com.squareup.retrofit:retrofit:$versions.retrofit"),
       rxJava           : dependencies.create("com.netflix.rxjava:rxjava-core:$versions.rx"),
-      slf4j            : dependencies.create("org.slf4j:jcl-over-slf4j:$versions.slf4j"),
+      slf4j            : dependencies.create("org.slf4j:slf4j-api:$versions.slf4j"),
+      slf4jJcl         : dependencies.create("org.slf4j:jcl-over-slf4j:$versions.slf4j"),
+      slf4jSimple      : dependencies.create("org.slf4j:slf4j-simple:$versions.slf4j"),
       spock            : dependencies.create("org.spockframework:spock-core:$versions.spock") {
         exclude module: "groovy-all"
       },

--- a/gradle/groovy-module.gradle
+++ b/gradle/groovy-module.gradle
@@ -31,6 +31,7 @@ dependencies {
   compile commonDependencies.groovy
   compile commonDependencies.guava
   compile commonDependencies.slf4j
-  compile commonDependencies.logback
   testCompile commonDependencies.spock
+  testRuntime commonDependencies.slf4jSimple
+  testRuntime commonDependencies.slf4jJcl
 }

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.1.1.RELEASE"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.1.4.RELEASE"
     }
 }
 apply from: "$rootDir/gradle/groovy-module.gradle"


### PR DESCRIPTION
some notes in this diff:

downgraded guava to 14.0.1 - this is aligned with the platform and is less likely to grief us at runtime (if there are features we are dieing to adopt in the latest release we can push back on this one)

changed logging a bit - groovy module now just has slf4j-api as a compile time dep, and has slf4j-simple at testRuntime. we will figure out logging config in the runtime version (boot logging actuator also does this)
