### PR TITLE
All the state wasn't getting through from deck to pond

### DIFF
--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateCopyLastAsgTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateCopyLastAsgTask.groovy
@@ -39,7 +39,7 @@ class CreateCopyLastAsgTask implements Task {
 
   @Override
   TaskResult execute(TaskContext context) {
-    CopyLastAsgOperation operation = deployOperationFromContext(context)
+    Map operation = deployOperationFromContext(context)
     def taskId = kato.requestOperations([[copyLastAsgDescription: operation]])
                      .toBlocking()
                      .first()
@@ -53,11 +53,11 @@ class CreateCopyLastAsgTask implements Task {
     )
   }
 
-  private CopyLastAsgOperation deployOperationFromContext(TaskContext context) {
+  private Map deployOperationFromContext(TaskContext context) {
     def operation = mapper.copy()
                           .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-                          .convertValue(context.getInputs("copyLastAsg"), CopyLastAsgOperation)
-    operation.amiName = operation.amiName.or(Optional.fromNullable(context.inputs.'bake.ami' as String))
+                          .convertValue(context.getInputs("copyLastAsg"), Map)
+    operation.amiName = operation.amiName ?: Optional.fromNullable(context.inputs.'bake.ami' as String)
     return operation
   }
 }

--- a/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateCopyLastAsgTaskSpec.groovy
+++ b/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateCopyLastAsgTaskSpec.groovy
@@ -15,16 +15,15 @@
  */
 
 package com.netflix.spinnaker.orca.kato.tasks
-
+import spock.lang.Specification
+import spock.lang.Subject
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.guava.GuavaModule
+import com.google.common.base.Optional
 import com.netflix.spinnaker.orca.SimpleTaskContext
-import com.netflix.spinnaker.orca.kato.api.ops.CopyLastAsgOperation
 import com.netflix.spinnaker.orca.kato.api.KatoService
 import com.netflix.spinnaker.orca.kato.api.TaskId
 import rx.Observable
-import spock.lang.Specification
-import spock.lang.Subject
 
 class CreateCopyLastAsgTaskSpec extends Specification {
     @Subject task = new CreateCopyLastAsgTask()
@@ -64,19 +63,12 @@ class CreateCopyLastAsgTaskSpec extends Specification {
 
         then:
         operations.size() == 1
-        with(operations[0].copyLastAsgDescription) {
-            it instanceof CopyLastAsgOperation
-            application == copyLastAsgConfig.application
-            availabilityZones == copyLastAsgConfig.availabilityZones
-            credentials == copyLastAsgConfig.credentials
-
-            !amiName.present
-            !stack.present
-            !instanceType.present
-            !securityGroups.present
-            !subnetType.present
-            !capacity.present
-        }
+        operations[0].copyLastAsgDescription == [
+            amiName: Optional.absent(),
+            application: "hodor",
+            availabilityZones: ["us-east-1": ["a", "d"], "us-west-1": ["a", "b"]],
+            credentials: "fzlem"
+        ]
     }
 
     def "can include optional parameters"() {
@@ -97,10 +89,14 @@ class CreateCopyLastAsgTaskSpec extends Specification {
 
         then:
         operations.size() == 1
-        with(operations[0].copyLastAsgDescription) {
-            instanceType.get() == context."copyLastAsg.instanceType"
-            stack.get() == context."copyLastAsg.stack"
-        }
+        operations[0].copyLastAsgDescription == [
+            amiName: Optional.absent(),
+            application: "hodor",
+            availabilityZones: ["us-east-1": ["a", "d"], "us-west-1": ["a", "b"]],
+            credentials: "fzlem",
+            instanceType: "t1.megaBig",
+            stack: "hodork"
+        ]
     }
 
     def "amiName prefers value from context over bake input"() {
@@ -122,9 +118,12 @@ class CreateCopyLastAsgTaskSpec extends Specification {
 
         then:
         operations.size() == 1
-        with(operations[0].copyLastAsgDescription) {
-            amiName.get() == context."copyLastAsg.amiName"
-        }
+        operations[0].copyLastAsgDescription == [
+            amiName: "ami-696969",
+            application: "hodor",
+            availabilityZones: ["us-east-1": ["a", "d"], "us-west-1": ["a", "b"]],
+            credentials: "fzlem"
+        ]
     }
 
     def "amiName uses value from bake"() {
@@ -145,8 +144,11 @@ class CreateCopyLastAsgTaskSpec extends Specification {
 
         then:
         operations.size() == 1
-        with(operations[0].copyLastAsgDescription) {
-            amiName.get() == context."bake.ami"
-        }
+        operations[0].copyLastAsgDescription == [
+            amiName: Optional.of("ami-soixante-neuf"),
+            application: "hodor",
+            availabilityZones: ["us-east-1": ["a", "d"], "us-west-1": ["a", "b"]],
+            credentials: "fzlem"
+        ]
     }
 }


### PR DESCRIPTION
... because I had not added the fields to CopyLastAsgOperation.
I could add the same fields that are in Kato to the bean, but I don't think that we should have to make redundant changes like that in Orca.
Orca doesn't even need to know about those fields to do anything with them.
If I make it a Map then everything gets passed through for free. This seems preferable to me in most of our existing cases.
