### PR TITLE
Add back .toString() so decorated stage name matches key in stages map.

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarter.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarter.groovy
@@ -85,7 +85,7 @@ class PipelineStarter {
   private List<StageBuilder> stageBuildersFor(List<Map<String, ?>> config) {
     config.collect {
       if (it.providerType == "gce") {
-        it.type = "${it.type}_gce"
+        it.type = "${it.type}_gce".toString()
       }
 
       if (stages.containsKey(it.type)) {


### PR DESCRIPTION
It was a string before: https://github.com/spinnaker/orca/blob/f156826185e9630b5edba42971bc525f07242523/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarter.groovy#L106-L108), but was changed (or at least the change was merged) here https://github.com/spinnaker/orca/commit/fd7cb819020762ee22919e8fbf9fa6c4e342ea83#diff-fa88b5a3b62b2d4dcc807fc1d0fe060b.

If it's a gstring, and not a string. the stage name will never match any of the stages in the stages map since their keys are of type string.

Without this fix, none of the *_gce stages can be resolved in the PipelineStarter.
