### PR TITLE
Pipeline.start() was made to return an Observable in d1bc847dbf523feb18f...

### DIFF
--- a/orca-smoke-test/src/integrationTest/groovy/com/netflix/spinnaker/orca/smoke/OrcaSmokeSpec.groovy
+++ b/orca-smoke-test/src/integrationTest/groovy/com/netflix/spinnaker/orca/smoke/OrcaSmokeSpec.groovy
@@ -47,12 +47,14 @@ class OrcaSmokeSpec extends Specification {
     def configJson = mapper.writeValueAsString(config)
 
     when:
-    def pipeline = jobStarter.start(configJson)
+    def pipelineObservable = jobStarter.start(configJson)
 
     then:
-    with(jobExplorer.getJobExecution(pipeline.id.toLong())) {
-      status == BatchStatus.COMPLETED
-      exitStatus == ExitStatus.COMPLETED
+    with(pipelineObservable.toBlocking().first()) {
+      with(jobExplorer.getJobExecution(id.toLong())) {
+        status == BatchStatus.COMPLETED
+        exitStatus == ExitStatus.COMPLETED
+      }
     }
 
     where:
@@ -87,12 +89,14 @@ class OrcaSmokeSpec extends Specification {
     def configJson = mapper.writeValueAsString(config)
 
     when:
-    def pipeline = jobStarter.start(configJson)
+    def pipelineObservable = jobStarter.start(configJson)
 
     then:
-    with(jobExplorer.getJobExecution(pipeline.id.toLong())) {
-      status == BatchStatus.COMPLETED
-      exitStatus == ExitStatus.COMPLETED
+    with(pipelineObservable.toBlocking().first()) {
+      with(jobExplorer.getJobExecution(id.toLong())) {
+        status == BatchStatus.COMPLETED
+        exitStatus == ExitStatus.COMPLETED
+      }
     }
 
     where:


### PR DESCRIPTION
...352b2bc464f40af215ddb.

Modify the Orca smoke-test to properly handle the returned Observable.

Without this fix './gradlew orca-smoke-test:integrationTest' yields:

com.netflix.spinnaker.orca.smoke.OrcaSmokeSpec > can bake and deploy FAILED
    groovy.lang.MissingPropertyException: No such property: id for class: rx.subjects.ReplaySubject
        at com.netflix.spinnaker.orca.smoke.OrcaSmokeSpec.can bake and deploy(OrcaSmokeSpec.groovy:54)

com.netflix.spinnaker.orca.smoke.OrcaSmokeSpec > can deploy next ASG FAILED
    groovy.lang.MissingPropertyException: No such property: id for class: rx.subjects.ReplaySubject
        at com.netflix.spinnaker.orca.smoke.OrcaSmokeSpec.can deploy next ASG(OrcaSmokeSpec.groovy:94)
