### PR TITLE
Remove extraneous reference to 'createApplication' in context.

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/CreateApplicationTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/CreateApplicationTask.groovy
@@ -47,7 +47,7 @@ class CreateApplicationTask implements Task {
       new DefaultTaskResult(PipelineStatus.TERMINAL)
     } else {
       new DefaultTaskResult(PipelineStatus.SUCCEEDED, ["application.name": application.name,
-                                                       "account": stage.context."createApplication.account"])
+                                                       "account": stage.context.account])
     }
   }
 }


### PR DESCRIPTION
Without this fix, creating an application with Orca yields:
java.lang.NullPointerException: null value in entry: account=null
    at com.google.common.collect.CollectPreconditions.checkEntryNotNull(CollectPreconditions.java:33)
    at com.google.common.collect.RegularImmutableMap.<init>(RegularImmutableMap.java:88)
    at com.google.common.collect.ImmutableMap.copyOf(ImmutableMap.java:294)
    at com.netflix.spinnaker.orca.DefaultTaskResult.<init>(DefaultTaskResult.groovy:40)
