### PR TITLE
Adds the upsertAmazonDNS task type to orchestration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ allprojects {
   }
 
   configurations.all {
+    exclude group: 'javax.servlet', module: 'servlet-api'
+    exclude group: "org.slf4j", module: "slf4j-log4j12"
+    exclude group: "org.slf4j", module: "slf4j-simple"
     resolutionStrategy {
       force "com.netflix.rxjava:rxjava-core:$versions.rx"
     }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/UpsertAmazonDNSStage.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/UpsertAmazonDNSStage.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.pipeline
+
+import com.netflix.spinnaker.orca.kato.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.kato.tasks.NotifyEchoTask
+import com.netflix.spinnaker.orca.kato.tasks.UpsertAmazonDNSTask
+import com.netflix.spinnaker.orca.pipeline.ConfigurableStage
+import com.netflix.spinnaker.orca.pipeline.LinearStage
+import groovy.transform.CompileStatic
+import org.springframework.batch.core.Step
+import org.springframework.stereotype.Component
+
+@CompileStatic
+@Component
+class UpsertAmazonDNSStage extends LinearStage {
+
+  public static final String MAYO_CONFIG_TYPE = "upsertAmazonDNS"
+
+  UpsertAmazonDNSStage() {
+    super(MAYO_CONFIG_TYPE)
+  }
+
+  @Override
+  protected List<Step> buildSteps(ConfigurableStage stage) {
+    def step1 = buildStep("upsertAmazonDNS", UpsertAmazonDNSTask)
+    def step2 = buildStep("monitorUpsertDNS", MonitorKatoTask)
+    def step3 = buildStep("sendNotification", NotifyEchoTask)
+    [step1, step2, step3]
+  }
+}

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/UpsertAmazonLoadBalancerStage.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/UpsertAmazonLoadBalancerStage.groovy
@@ -3,6 +3,7 @@
 
 package com.netflix.spinnaker.orca.kato.pipeline
 
+import com.netflix.spinnaker.orca.kato.tasks.UpsertAmazonLoadBalancerResultObjectExtrapolationTask
 import groovy.transform.CompileStatic
 import com.netflix.spinnaker.orca.kato.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.kato.tasks.NotifyEchoTask
@@ -27,8 +28,9 @@ class UpsertAmazonLoadBalancerStage extends LinearStage {
   protected List<Step> buildSteps(ConfigurableStage stage) {
     def step1 = buildStep("upsertAmazonLoadBalancer", UpsertAmazonLoadBalancerTask)
     def step2 = buildStep("monitorUpsert", MonitorKatoTask)
-    def step3 = buildStep("forceCacheRefresh", UpsertAmazonLoadBalancerForceRefreshTask)
-    def step4 = buildStep("sendNotification", NotifyEchoTask)
-    [step1, step2, step3, step4]
+    def step3 = buildStep("extrapolateUpsertResult", UpsertAmazonLoadBalancerResultObjectExtrapolationTask)
+    def step4 = buildStep("forceCacheRefresh", UpsertAmazonLoadBalancerForceRefreshTask)
+    def step5 = buildStep("sendNotification", NotifyEchoTask)
+    [step1, step2, step3, step4, step5]
   }
 }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/MonitorKatoTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/MonitorKatoTask.groovy
@@ -56,7 +56,8 @@ class MonitorKatoTask implements RetryableTask {
       if (stage.context.containsKey("kato.tasks")) {
         katoTasks = stage.context."kato.tasks" as List<Map<String, Object>>
       }
-      Map<String, Object> m = [id: katoTask.id, status: katoTask.status, history: katoTask.history]
+      Map<String, Object> m = [id: katoTask.id, status: katoTask.status, history: katoTask.history,
+                               resultObjects: katoTask.resultObjects]
       if (katoTask.resultObjects.find { it.type == "EXCEPTION" }) {
         def exception = katoTask.resultObjects.find { it.type == "EXCEPTION" }
         m.exception = exception

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertAmazonDNSTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertAmazonDNSTask.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.tasks
+
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.PipelineStatus
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.kato.api.KatoService
+import com.netflix.spinnaker.orca.kato.pipeline.UpsertAmazonLoadBalancerStage
+import com.netflix.spinnaker.orca.pipeline.Stage
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.annotation.Autowired
+
+@CompileStatic
+class UpsertAmazonDNSTask implements Task {
+
+  @Autowired
+  KatoService kato
+
+  @Override
+  TaskResult execute(Stage stage) {
+    def operation = [type: stage.context.recordType, name: stage.context.name, hostedZoneName: stage.context.hostedZone,
+                     credentials: stage.context.credentials]
+
+    def upsertElbStage = stage.preceding(UpsertAmazonLoadBalancerStage.MAYO_CONFIG_TYPE)
+    if (upsertElbStage) {
+      operation.target = upsertElbStage.context.dnsName
+    } else {
+      operation.target = stage.context.target
+    }
+
+    def taskId = kato.requestOperations([[upsertAmazonDNSDescription: operation]]).toBlocking().first()
+
+    Map outputs = [
+      "notification.type": "upsertamazondns",
+      "kato.last.task.id": taskId
+    ]
+
+    return new DefaultTaskResult(PipelineStatus.SUCCEEDED, outputs)
+  }
+}

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertAmazonLoadBalancerResultObjectExtrapolationTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertAmazonLoadBalancerResultObjectExtrapolationTask.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.tasks
+
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.PipelineStatus
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.kato.api.TaskId
+import com.netflix.spinnaker.orca.pipeline.Stage
+
+class UpsertAmazonLoadBalancerResultObjectExtrapolationTask implements Task {
+
+  @Override
+  TaskResult execute(Stage stage) {
+    TaskId lastTaskId = stage.context."kato.last.task.id" as TaskId
+    def katoTasks = stage.context."kato.tasks" as List<Map>
+    def lastKatoTask = katoTasks.find { it.id.toString() == lastTaskId.id }
+
+    if (!lastKatoTask) {
+      return new DefaultTaskResult(PipelineStatus.FAILED)
+    }
+
+    def resultObjects = lastKatoTask.resultObjects as List<Map>
+    def resultObjectMap = resultObjects?.getAt(0) as Map
+    def dnsName = resultObjectMap.loadBalancers.entrySet().getAt(0).value.dnsName
+
+    return new DefaultTaskResult(PipelineStatus.SUCCEEDED, [dnsName: dnsName])
+  }
+
+}

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertAmazonLoadBalancerTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertAmazonLoadBalancerTask.groovy
@@ -51,10 +51,10 @@ class UpsertAmazonLoadBalancerTask implements Task {
     ]
 
     if (upsertAmazonLoadBalancerOperation.clusterName) {
-      outputs."upsert.clusterName" = upsertAmazonLoadBalancerOperation.clusterName
+      outputs.clusterName = upsertAmazonLoadBalancerOperation.clusterName
     }
     if (upsertAmazonLoadBalancerOperation.name) {
-      outputs."upsert.name" = upsertAmazonLoadBalancerOperation.name
+      outputs.name = upsertAmazonLoadBalancerOperation.name
     }
 
     new DefaultTaskResult(PipelineStatus.SUCCEEDED, outputs)

--- a/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertAmazonLoadBalancerResultObjectExtrapolationTaskSpec.groovy
+++ b/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertAmazonLoadBalancerResultObjectExtrapolationTaskSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.tasks
+
+import com.google.common.collect.ImmutableMap
+import com.netflix.spinnaker.orca.kato.api.TaskId
+import com.netflix.spinnaker.orca.pipeline.Stage
+import spock.lang.Specification
+import spock.lang.Subject
+
+class UpsertAmazonLoadBalancerResultObjectExtrapolationTaskSpec extends Specification {
+
+  @Subject
+    task = new UpsertAmazonLoadBalancerResultObjectExtrapolationTask()
+
+  def dnsName = "my-awesome-elb.amazonaws.com"
+
+  def katoTasks = [
+    [
+      id           : 1,
+      resultObjects: [
+        [
+          loadBalancers: [
+            "us-east-1": [
+              dnsName: dnsName
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+
+  void "should put extrapolate resulting DNS name from resultObjects"() {
+    setup:
+    def stage = Mock(Stage)
+    stage.getContext() >> {
+      ImmutableMap.copyOf(["kato.tasks": katoTasks, "kato.last.task.id": new TaskId("1")])
+    }
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.outputs.dnsName == dnsName
+  }
+
+}

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -26,12 +26,6 @@ apply from: "$rootDir/gradle/groovy-module.gradle"
 
 apply plugin: 'spring-boot'
 
-configurations.all {
-    exclude group: 'javax.servlet', module: 'servlet-api'
-    exclude group: "org.slf4j", module: "slf4j-log4j12"
-    exclude group: "org.slf4j", module: "slf4j-simple"
-}
-
 springBoot {
     mainClass = 'com.netflix.spinnaker.orca.Main'
 }


### PR DESCRIPTION
This operation can follow an `upsertAmazonLoadBalancer` stage in a pipeline configuration to add a DNS name to the created ELB. On the Kato side, this operation is idempotent, so no problem in running it several times with the same inputs.

If the stage is executed as a non-pipeline orchestration, then a `target` field needs to be added to the stage context configuration with the value of the target record (ip for 'A' recordType, hostname for 'CNAME' record type). The only discrepancy between the inputs for `upsertAmazonDNS` and [Kato's upsertAmazonDNSDescription](https://github.com/spinnaker/kato/blob/master/kato-manual/src/asciidoc/ops/upsertAmazonDNSDescription.adoc) is that the `type` parameter is reserved in Orca, so it has been ingested to the stage as `recordType` instead.

Example pipeline config:

``` json
{
    "application": "foo",
    "description": "bar",
    "stages": [{
        "type": "upsertAmazonLoadBalancer",
        "name": "kato-main-frontend",
        "subnetType": "internal",
        "securityGroups": ["nf-infrastructure-vpc", "nf-datacenter-vpc"],
        "availabilityZones": {
            "us-east-1": []
        },
        "listeners": [{
            "externalProtocol": "TCP",
            "internalProtocol": "TCP",
            "externalPort": "7001",
            "internalPort": "7001"
        }],
        "healthCheck": "HTTP:7001/health",
        "credentials": "test"
    }, {
        "type": "upsertAmazonDNS",
        "recordType": "CNAME",
        "name": "dankato.test.netflix.net.",
        "hostedZone": "test.netflix.net.",
        "credentials": "test"
    }]
}
```
