### PR TITLE
get app config from mayo and use health check names to filter providers

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -21,5 +21,6 @@ dependencies {
   compile commonDependencies.jacksonDatabind
   compile commonDependencies.jacksonGuava
   compile commonDependencies.rxJava
+  compile project(":orca-mayo")
   testCompile project(":orca-test")
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/Pipeline.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/Pipeline.groovy
@@ -32,6 +32,8 @@ class Pipeline implements Serializable {
   final Map<String, Serializable> trigger = [:]
   private final List<PipelineStage> stages = []
 
+  final Map<String, Serializable> config = [:]
+
   ImmutableMap<String, Serializable> getTrigger() {
     ImmutableMap.copyOf(trigger)
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/Stage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/Stage.groovy
@@ -31,6 +31,11 @@ interface Stage extends Serializable {
   ImmutableMap<String, Serializable> getContext()
 
   /**
+   * @return pipeline that contains this stage
+   */
+  Pipeline getPipeline()
+
+  /**
    * Gets the last stage preceding this stage that has the specified type.
    */
   Stage preceding(String type)

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/AbstractInstancesCheckTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/AbstractInstancesCheckTask.groovy
@@ -39,7 +39,7 @@ abstract class AbstractInstancesCheckTask implements RetryableTask {
 
   abstract protected Map<String, List<String>> getServerGroups(Stage stage)
 
-  abstract protected boolean hasSucceeded(List instances)
+  abstract protected boolean hasSucceeded(List instances, Collection<String> interestingHealthProviderNames)
 
   @Override
   TaskResult execute(Stage stage) {
@@ -79,7 +79,8 @@ abstract class AbstractInstancesCheckTask implements RetryableTask {
         }
 
         seenServerGroup[name] = true
-        def isComplete = hasSucceeded(instances)
+        Collection<String> interestingHealthProviderNames = stage.pipeline.config.interestingHealthProviderNames as Collection ?: ["Amazon", "LoadBalancer", "Discovery"] // TODO pull from app config
+        def isComplete = hasSucceeded(instances, interestingHealthProviderNames)
         if (!isComplete) {
           return new DefaultTaskResult(PipelineStatus.RUNNING)
         }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForCapacityMatchTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForCapacityMatchTask.groovy
@@ -25,7 +25,7 @@ class WaitForCapacityMatchTask extends AbstractInstancesCheckTask {
   }
 
   @Override
-  protected boolean hasSucceeded(List instances) {
+  protected boolean hasSucceeded(List instances, Collection<String> interestingHealthProviderNames) {
     // By here, we will have already passed the minSize > # instances check in the super class
     true
   }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDownInstancesTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDownInstancesTask.groovy
@@ -19,7 +19,10 @@ package com.netflix.spinnaker.orca.kato.tasks
 class WaitForDownInstancesTask extends AbstractWaitingForInstancesTask {
 
   @Override
-  protected boolean hasSucceeded(List instances) {
-    !instances.find { it.isHealthy }
+  protected boolean hasSucceeded(List instances, Collection<String> interestingHealthProviderNames) {
+    def healths = instances.health.findAll {
+      it.type in interestingHealthProviderNames
+    }
+    healths.any { it.state == 'Down' } && !healths.any { it.state == 'Up' }
   }
 }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForUpInstancesTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForUpInstancesTask.groovy
@@ -20,8 +20,11 @@ package com.netflix.spinnaker.orca.kato.tasks
 class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
 
   @Override
-  protected boolean hasSucceeded(List instances) {
-    !instances.find { !it.isHealthy }
+  protected boolean hasSucceeded(List instances, Collection<String> interestingHealthProviderNames) {
+    def healths = instances.health.findAll {
+      it.type in interestingHealthProviderNames
+    }
+    healths.any { it.state == 'Up' } && !healths.any { it.state == 'Down' }
   }
 
 }

--- a/orca-mayo/src/main/groovy/com/netflix/spinnaker/orca/mayo/MayoService.groovy
+++ b/orca-mayo/src/main/groovy/com/netflix/spinnaker/orca/mayo/MayoService.groovy
@@ -19,10 +19,15 @@ package com.netflix.spinnaker.orca.mayo
 import retrofit.client.Response
 import retrofit.http.GET
 import retrofit.http.Headers
+import retrofit.http.Path
 
 interface MayoService {
 
   @GET("/pipelines")
   @Headers("Accept: application/json")
   Response getPipelines()
+
+  @GET("/application/{id}")
+  @Headers("Accept: application/json")
+  Response getApplication(@Path("id") String id)
 }

--- a/orca-retrofit/orca-retrofit.gradle
+++ b/orca-retrofit/orca-retrofit.gradle
@@ -17,7 +17,7 @@
 apply from: "$rootDir/gradle/groovy-module.gradle"
 
 dependencies {
-  compile project(":orca-core")
+  compile commonDependencies.springBatch
   compile commonDependencies.retrofit
   compile commonDependencies.rxJava
   compile commonDependencies.okHttp


### PR DESCRIPTION
The configurable timeout is complicated enough to be a separate issue, and should not hold up this health check improvement.

This needs more testing before being merged, but going ahead and putting it out there for feedback (especially the dependency changes needed to avoid circular deps).

I stopped here because I couldn't run unit tests from home, possibly due to the VPN. I was getting the following error:
FAILURE: Build failed with an exception.
- What went wrong:
  Execution failed for task ':orca-retrofit:jarManifest'.
  > java.net.UnknownHostException: lgml-cmccoy4: lgml-cmccoy4: nodename nor servname provided, or not known
