### PR TITLE
Globally configure configure(FAIL_ON_UNKNOWN_PROPERTIES, false) in OrcaO...

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.bakery.api.BakeRequest
 import com.netflix.spinnaker.orca.bakery.api.BakeryService
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 @CompileStatic
 class CreateBakeTask implements Task {
@@ -45,8 +44,6 @@ class CreateBakeTask implements Task {
   }
 
   private BakeRequest bakeFromContext(Stage stage) {
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(stage.context, BakeRequest)
+    mapper.convertValue(stage.context, BakeRequest)
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/jackson/OrcaObjectMapper.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/jackson/OrcaObjectMapper.groovy
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.datatype.guava.GuavaModule
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
+
 class OrcaObjectMapper extends ObjectMapper {
   private static final SimpleModule simpleModule = new SimpleModule().addSerializer(Stage, new StageSerializer())
     .addDeserializer(Stage, new StageDeserializer())
@@ -29,9 +31,6 @@ class OrcaObjectMapper extends ObjectMapper {
     super()
     registerModule(simpleModule)
     registerModule(new GuavaModule())
-  }
-
-  OrcaObjectMapper copy() {
-    new OrcaObjectMapper()
+    configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
   }
 }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/AbstractFront50Task.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/AbstractFront50Task.groovy
@@ -28,8 +28,6 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 import retrofit.RetrofitError
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
-
 abstract class AbstractFront50Task implements Task {
   @Autowired
   Front50Service front50Service
@@ -41,9 +39,7 @@ abstract class AbstractFront50Task implements Task {
 
   @Override
   TaskResult execute(Stage stage) {
-    def application = mapper.copy()
-      .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-      .convertValue(stage.context.application, Application)
+    def application = mapper.convertValue(stage.context.application, Application)
 
     try {
       def account = (stage.context.account as String).toLowerCase()

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/AbstractAsgTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/AbstractAsgTask.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.kato.api.KatoService
 import com.netflix.spinnaker.orca.kato.api.ops.EnableOrDisableAsgOperation
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 @CompileStatic
 abstract class AbstractAsgTask implements Task {
@@ -56,8 +55,6 @@ abstract class AbstractAsgTask implements Task {
   }
 
   private EnableOrDisableAsgOperation operationFromContext(Stage stage) {
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(stage.context.containsKey(asgAction) ? stage.context[asgAction] : stage.context, EnableOrDisableAsgOperation)
+    mapper.convertValue(stage.context.containsKey(asgAction) ? stage.context[asgAction] : stage.context, EnableOrDisableAsgOperation)
   }
 }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeleteAmazonLoadBalancerTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeleteAmazonLoadBalancerTask.groovy
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.orca.kato.api.KatoService
 import com.netflix.spinnaker.orca.kato.api.ops.DeleteAmazonLoadBalancerOperation
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 /**
  * Created by aglover on 9/26/14.
@@ -56,8 +55,6 @@ class DeleteAmazonLoadBalancerTask implements Task {
   }
 
   DeleteAmazonLoadBalancerOperation convert(Stage stage) {
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(stage.context, DeleteAmazonLoadBalancerOperation)
+    mapper.convertValue(stage.context, DeleteAmazonLoadBalancerOperation)
   }
 }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeleteAsgTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeleteAsgTask.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.kato.api.KatoService
 import com.netflix.spinnaker.orca.kato.api.ops.DeleteAsgOperation
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 @CompileStatic
 class DeleteAsgTask implements Task {
@@ -52,8 +51,6 @@ class DeleteAsgTask implements Task {
   }
 
   DeleteAsgOperation convert(Stage stage) {
-    mapper.copy()
-      .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-      .convertValue(stage.context, DeleteAsgOperation)
+    mapper.convertValue(stage.context, DeleteAsgOperation)
   }
 }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DestroyAsgTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DestroyAsgTask.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.kato.api.KatoService
 import com.netflix.spinnaker.orca.kato.api.ops.DestroyAsgOperation
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 @CompileStatic
 class DestroyAsgTask implements Task {
@@ -60,8 +59,6 @@ class DestroyAsgTask implements Task {
       input = ((List)stage.context.destroyAsgDescriptions).pop()
     }
 
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(input, DestroyAsgOperation)
+    mapper.convertValue(input, DestroyAsgOperation)
   }
 }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/PreconfigureDestroyAsgTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/PreconfigureDestroyAsgTask.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.kato.api.ops.ResizeAsgOperation
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 @CompileStatic
 class PreconfigureDestroyAsgTask implements Task {
@@ -47,8 +46,6 @@ class PreconfigureDestroyAsgTask implements Task {
   }
 
   ResizeAsgOperation convert(Stage stage) {
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(stage.context, ResizeAsgOperation)
+    mapper.convertValue(stage.context, ResizeAsgOperation)
   }
 }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/ResizeAsgTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/ResizeAsgTask.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.orca.kato.api.KatoService
 import com.netflix.spinnaker.orca.kato.api.ops.ResizeAsgOperation
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 class ResizeAsgTask implements Task {
 
@@ -55,8 +54,6 @@ class ResizeAsgTask implements Task {
     if (stage.context.containsKey("resizeAsg")) {
       input = stage.context.resizeAsg
     }
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(input, ResizeAsgOperation)
+    mapper.convertValue(input, ResizeAsgOperation)
   }
 }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/TerminateInstancesTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/TerminateInstancesTask.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.kato.api.KatoService
 import com.netflix.spinnaker.orca.kato.api.ops.TerminateInstancesOperation
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 @CompileStatic
 class TerminateInstancesTask implements Task {
@@ -53,8 +52,6 @@ class TerminateInstancesTask implements Task {
   }
 
   TerminateInstancesOperation convert(Stage stage) {
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(stage.context, TerminateInstancesOperation)
+    mapper.convertValue(stage.context, TerminateInstancesOperation)
   }
 }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertSecurityGroupTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertSecurityGroupTask.groovy
@@ -27,7 +27,6 @@ import com.netflix.spinnaker.orca.mort.MortService
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 import retrofit.client.Response
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 class UpsertSecurityGroupTask implements Task {
 
@@ -66,9 +65,7 @@ class UpsertSecurityGroupTask implements Task {
   }
 
   UpsertSecurityGroupOperation convert(Stage stage) {
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(stage.context, UpsertSecurityGroupOperation)
+    mapper.convertValue(stage.context, UpsertSecurityGroupOperation)
   }
 
   static String parseCurrentValue(Response response) {

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/CreateCopyLastGoogleServerGroupTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/CreateCopyLastGoogleServerGroupTask.groovy
@@ -27,8 +27,6 @@ import com.netflix.spinnaker.orca.kato.api.ops.gce.DeployGoogleServerGroupOperat
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
-
 class CreateCopyLastGoogleServerGroupTask implements Task {
 
   @Autowired
@@ -57,9 +55,7 @@ class CreateCopyLastGoogleServerGroupTask implements Task {
     operation.initialNumReplicas = operation.capacity.desired
     operation.networkLoadBalancers = operation.loadBalancers
 
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(operation, DeployGoogleServerGroupOperation)
+    mapper.convertValue(operation, DeployGoogleServerGroupOperation)
   }
 
   private TaskId deploy(DeployGoogleServerGroupOperation deployOperation) {

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/CreateGoogleServerGroupTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/CreateGoogleServerGroupTask.groovy
@@ -24,10 +24,8 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.kato.api.KatoService
 import com.netflix.spinnaker.orca.kato.api.TaskId
 import com.netflix.spinnaker.orca.kato.api.ops.gce.DeployGoogleServerGroupOperation
-import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 class CreateGoogleServerGroupTask implements Task {
 
@@ -57,9 +55,7 @@ class CreateGoogleServerGroupTask implements Task {
     operation.initialNumReplicas = operation.capacity.desired
     operation.networkLoadBalancers = operation.loadBalancers
 
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(operation, DeployGoogleServerGroupOperation)
+    mapper.convertValue(operation, DeployGoogleServerGroupOperation)
   }
 
   private TaskId deploy(DeployGoogleServerGroupOperation deployOperation) {

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/DestroyGoogleReplicaPoolTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/DestroyGoogleReplicaPoolTask.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.orca.kato.api.KatoService
 import com.netflix.spinnaker.orca.kato.api.ops.gce.DestroyGoogleReplicaPoolOperation
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 class DestroyGoogleReplicaPoolTask implements Task {
   @Autowired
@@ -56,8 +55,6 @@ class DestroyGoogleReplicaPoolTask implements Task {
     operation.replicaPoolName = operation.asgName
     operation.zone = operation.zones ? operation.zones[0] : null
 
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(operation, DestroyGoogleReplicaPoolOperation)
+    mapper.convertValue(operation, DestroyGoogleReplicaPoolOperation)
   }
 }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/ResizeGoogleReplicaPoolTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/ResizeGoogleReplicaPoolTask.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.orca.kato.api.KatoService
 import com.netflix.spinnaker.orca.kato.api.ops.gce.ResizeGoogleReplicaPoolOperation
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 class ResizeGoogleReplicaPoolTask implements Task {
   @Autowired
@@ -56,8 +55,6 @@ class ResizeGoogleReplicaPoolTask implements Task {
     operation.numReplicas = operation.capacity.desired
     operation.zone = operation.zones ? operation.zones[0] : null
 
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(operation, ResizeGoogleReplicaPoolOperation)
+    mapper.convertValue(operation, ResizeGoogleReplicaPoolOperation)
   }
 }

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/TerminateGoogleInstancesTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/TerminateGoogleInstancesTask.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.kato.api.KatoService
 import com.netflix.spinnaker.orca.kato.api.ops.gce.TerminateGoogleInstancesOperation
 import org.springframework.beans.factory.annotation.Autowired
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 
 @CompileStatic
 class TerminateGoogleInstancesTask implements Task {
@@ -55,8 +54,6 @@ class TerminateGoogleInstancesTask implements Task {
   }
 
   TerminateGoogleInstancesOperation convert(Stage stage) {
-    mapper.copy()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .convertValue(stage.context, TerminateGoogleInstancesOperation)
+    mapper.convertValue(stage.context, TerminateGoogleInstancesOperation)
   }
 }

--- a/orca-rush/src/main/groovy/com/netflix/spinnaker/orca/rush/tasks/RunScriptTask.groovy
+++ b/orca-rush/src/main/groovy/com/netflix/spinnaker/orca/rush/tasks/RunScriptTask.groovy
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.orca.rush.tasks
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
@@ -39,9 +37,7 @@ class RunScriptTask implements Task {
 
   @Override
   TaskResult execute(Stage stage) {
-    def script = mapper.copy()
-      .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-      .convertValue(stage.context, ScriptRequest)
+    def script = mapper.convertValue(stage.context, ScriptRequest)
 
     def scriptId = rushService.runScript(script).toBlocking().single()
 


### PR DESCRIPTION
...bjectMapper.

Remove OrcaObjectMapper.copy().
Closes #143.
Will need to update the 2 tasks in #142 after this is merged.
