### PR TITLE
Referenced instance.ids property name seems to be wrong.

### DIFF
--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForTerminatedInstancesTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForTerminatedInstancesTask.groovy
@@ -37,7 +37,7 @@ class WaitForTerminatedInstancesTask implements RetryableTask {
 
   @Override
   TaskResult execute(Stage stage) {
-    List<String> instanceIds = stage.context."instance.ids"
+    List<String> instanceIds = stage.context."terminate.instance.ids"
 
     if (!instanceIds || !instanceIds.size()) {
       return new DefaultTaskResult(ExecutionStatus.FAILED)

--- a/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForTerminatedInstancesTaskSpec.groovy
+++ b/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForTerminatedInstancesTaskSpec.groovy
@@ -46,7 +46,7 @@ class WaitForTerminatedInstancesTaskSpec extends Specification {
 
     and:
     def stage = new PipelineStage(pipeline, "whatever", [
-      "instance.ids": [instanceId]
+      "terminate.instance.ids": [instanceId]
     ]).asImmutable()
 
     expect:
@@ -72,7 +72,7 @@ class WaitForTerminatedInstancesTaskSpec extends Specification {
 
     and:
     def stage = new PipelineStage(pipeline, "whatever", [
-      "instance.ids": [instanceId]
+      "terminate.instance.ids": [instanceId]
     ]).asImmutable()
 
     expect:
@@ -100,7 +100,7 @@ class WaitForTerminatedInstancesTaskSpec extends Specification {
 
     and:
     def stage = new PipelineStage(pipeline, "whatever", [
-      "instance.ids": [instanceId]
+      "terminate.instance.ids": [instanceId]
     ]).asImmutable()
 
     expect:
@@ -120,7 +120,7 @@ class WaitForTerminatedInstancesTaskSpec extends Specification {
 
     and:
     def stage = new PipelineStage(pipeline, "whatever", [
-      "instance.ids": instanceIds
+      "terminate.instance.ids": instanceIds
     ]).asImmutable()
 
     expect:
@@ -150,7 +150,7 @@ class WaitForTerminatedInstancesTaskSpec extends Specification {
 
     and:
     def stage = new PipelineStage(pipeline, "whatever", [
-      "instance.ids": instanceIds
+      "terminate.instance.ids": instanceIds
     ]).asImmutable()
 
     expect:


### PR DESCRIPTION
Started noticing (not sure when) that TerminateGoogleInstances operations were succeeding, but being reported by orca as having failed. Traced through each task in the stage and noticed that WaitForTerminatedInstancesTask is always returning FAILED because it is not finding any instance ids.

It is looking for the instance ids at stage.context."instance.ids", but they aren't there. They are at both stage.context.instanceIds and stage.context."terminate.instance.ids": https://github.com/spinnaker/orca/blob/master/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/TerminateInstancesTask.groovy#L44

Some captured values are down below (from a GCE instance termination, but it should be the same).

I was next intending to use providerType (if it exists, 'AWS' as default otherwise) as a parameter to this call:

def response = oortService.getSearchResults(instanceId, "serverGroupInstances", "aws")

But, as it turns out, this mechanism for verifying an instance termination doesn't make sense on GCE. Within a GCE replica pool, a terminated instance will be re-created with the same id. So I'll have to create a different WaitForGoogleRecreatedInstancesTask or something similar (maybe considering creation timestamp).

In any case, I believe this fix is needed to properly verify AWS instance terminations. At least I can't find a codepath that leads to that property having a non-null value. If I'm off here, feel free to close this PR.

*\* WaitForTerminatedInstancesTask.execute(): stage.context=[credentials:my-account-name, instanceIds:[roscoapp-dev-v000-q8dm], kato.last.task.id:[id:7zc16b], kato.task.id:[id:7zc16b], kato.tasks:[[history:[[phase:ORCHESTRATION, status:Initializing Orchestration Task...], [phase:ORCHESTRATION, status:Processing op: TerminateGoogleInstancesAtomicOperation], [phase:TERMINATE_INSTANCES, status:Initializing termination of instances (roscoapp-dev-v000-q8dm).], [phase:TERMINATE_INSTANCES, status:Attempting termination of instance roscoapp-dev-v000-q8dm...], [phase:TERMINATE_INSTANCES, status:Done executing termination of instances (roscoapp-dev-v000-q8dm).], [phase:ORCHESTRATION, status:Orchestration completed.], [phase:ORCHESTRATION, status:Orchestration completed.]], id:7zc16b, resultObjects:[], status:[completed:true, failed:false]]], notification.type:terminategoogleinstances, providerType:gce, region:us-central1, terminate.account.name:my-account-name, terminate.instance.ids:[roscoapp-dev-v000-q8dm], terminate.region:us-central1-a, user:[anonymous], zone:us-central1-a]
*\* WaitForTerminatedInstancesTask.execute(): stage.context."instance.ids"=null
*\* WaitForTerminatedInstancesTask.execute(): stage.context."terminate.instance.ids"=[roscoapp-dev-v000-q8dm]
*\* WaitForTerminatedInstancesTask.execute(): stage.context.instanceIds=[roscoapp-dev-v000-q8dm]
