### PR TITLE
Allow stage context to be mapped to model objects

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.groovy
@@ -70,7 +70,7 @@ class OrcaConfiguration {
   }
 
   @Bean ObjectMapper mapper() {
-    new OrcaObjectMapper()
+    OrcaObjectMapper.DEFAULT
   }
 
   @Bean @ConditionalOnMissingBean(name = "orchestrationStore")

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/jackson/OrcaObjectMapper.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/jackson/OrcaObjectMapper.groovy
@@ -27,6 +27,7 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKN
 class OrcaObjectMapper extends ObjectMapper {
   private static final SimpleModule simpleModule = new SimpleModule().addSerializer(Stage, new StageSerializer())
     .addDeserializer(Stage, new StageDeserializer())
+  public static final OrcaObjectMapper DEFAULT = new OrcaObjectMapper()
 
   OrcaObjectMapper() {
     super()

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/ImmutableStageSupport.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/ImmutableStageSupport.groovy
@@ -132,6 +132,26 @@ class ImmutableStageSupport {
       ImmutableList.copyOf(self.tasks)
     }
 
+    @Override
+    def <O> O mapTo(Class<O> type) {
+      self.mapTo(type)
+    }
+
+    @Override
+    def <O> O mapTo(String pointer, Class<O> type) {
+      self.mapTo(pointer, type)
+    }
+
+    @Override
+    void commit(Object obj) {
+      throw new IllegalStateException("Stage is currently immutable")
+    }
+
+    @Override
+    void commit(String pointer, Object obj) {
+      throw new IllegalStateException("Stage is currently immutable")
+    }
+
     Stage<T> unwrap() {
       self
     }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.groovy
@@ -96,6 +96,35 @@ interface Stage<T extends Execution> {
   @JsonIgnore
   Stage<T> getSelf()
 
+  /**
+   * Returns the tasks that are associated with this stage. Tasks are the most granular unit of work in a stage.
+   * Because tasks can be dynamically composed, this list is open updated during a stage's execution.
+   *
+   * @see com.netflix.spinnaker.orca.batch.StageTaskPropagationListener
+   */
   List<Task> getTasks()
+
+  /**
+   * Maps the stage's context to a typed object
+   */
+  public <O> O mapTo(Class<O> type)
+
+  /**
+   * Maps the stage's context to a typed object at a provided pointer. Uses
+   * <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer</a> notation for determining the pointer's position
+   */
+  public <O> O mapTo(String pointer, Class<O> type)
+
+  /**
+   * Commits a typed object back to the stage's context. The context is recreated during this operation, so callers
+   * will need to re-reference the context object to have the new values reflected
+   */
+  public void commit(Object obj)
+
+  /**
+   * Commits a typed object back to the stage's context at a provided pointer. Uses <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer</a>
+   * notation for detremining the pointer's position
+   */
+  void commit(String pointer, Object obj)
 
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/ContextTypeMappingSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/ContextTypeMappingSpec.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.batch.pipeline
+
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import spock.lang.Specification
+
+class ContextTypeMappingSpec extends Specification {
+
+  def pipeline = new Pipeline()
+  def context = [name: "foo", type: "bar", nested: [isNested: true, numbers: 1234]]
+  def stage = new PipelineStage(pipeline, "foo", context)
+
+  static class StageData {
+    String name
+    String type
+  }
+
+  void "should be able to map stage context to POJO"() {
+    given:
+    def data = stage.mapTo(StageData)
+
+    expect:
+    data.name == context.name
+    data.type == context.type
+  }
+
+  static class NestedData {
+    boolean isNested
+    int numbers
+  }
+
+  void "should be able to map nested data to POJO"() {
+    given:
+    def data = stage.mapTo("/nested", NestedData)
+
+    expect:
+    data.isNested
+    data.numbers == context.nested.numbers
+  }
+
+  static class StageAndNestedData {
+    String name
+    String type
+    Map<String, Object> nested
+  }
+
+  void "should be able to map top-level data perserving nested structure"() {
+    given:
+    def data = stage.mapTo(StageAndNestedData)
+
+    expect:
+    data.name == context.name
+    data.type == context.type
+    data.nested == context.nested
+  }
+
+  void "should be able to commit data structures back to the context"() {
+    setup:
+    def data = stage.mapTo(StageAndNestedData)
+
+    when:
+    data.type = newtype
+
+    and:
+    stage.commit(data)
+
+    then:
+    stage.context.type == newtype
+
+    where:
+    newtype = "newtype"
+  }
+
+  void "should be able to commit data structures back to the context at a nested depth"() {
+    setup:
+    def data = stage.mapTo("/nested", NestedData)
+
+    when:
+    data.numbers = newnum
+
+    and:
+    stage.commit("/nested", data)
+
+    then:
+    stage.context.nested.numbers == newnum
+
+    where:
+    newnum = 456
+  }
+}


### PR DESCRIPTION
This commit allows a stage's context to be mapped to model objects and worked with in a type safe way. It provides the ability to map all or a subset of the parameters in a context to an arbitrary POGO. Depth is preserved in the mapping, meaning that nested structures of a context can be mapped using [JSON pointer](https://tools.ietf.org/html/rfc6901) notation. Models can then be committed back to the context at either the root level or at a specified depth in the graph.

This commit in conjunction with https://github.com/spinnaker/orca/commit/0fbb24866939a916e3279440f1139a1f5f8e2553 address many of the stability concerns outlined in https://github.com/spinnaker/spinnaker/issues/285 by @claymccoy. This should be good progress toward a type-safe-but-still-dynamic execution.

<h3>Example usages:</h3>


**_mapping to an arbitrary object from the context**_

``` groovy
def stageData = stage.mapTo(StageData)
```

**_mapping to an arbitrary object from the context at a particular depth**_

``` groovy
def stageData = stage.mapTo("/resizeAsg", ResizeAsgData)
```

**_committing model back to the context**_

``` groovy
def stageData = stage.mapTo(ResizeAsgData)
stageData.capacity.min = 5
stage.commit(stageData)
```
