### PR TITLE
sort pipelines and tasks by start time

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -30,7 +30,7 @@ class TaskController {
 
   @RequestMapping(value = "/applications/{application}/tasks", method = RequestMethod.GET)
   List<Orchestration> list(@PathVariable String application) {
-    executionRepository.retrieveOrchestrationsForApplication(application).collect { convert it }
+    executionRepository.retrieveOrchestrationsForApplication(application).collect { convert it }.sort { it.startTime ?: it.id }.reverse()
   }
 
   @RequestMapping(value = "/tasks", method = RequestMethod.GET)
@@ -67,7 +67,7 @@ class TaskController {
 
   @RequestMapping(value = "/pipelines", method = RequestMethod.GET)
   List<Pipeline> getPipelines() {
-    executionRepository.retrievePipelines()
+    executionRepository.retrievePipelines().sort { it.startTime ?: it.id }.reverse()
   }
 
   @RequestMapping(value = "/applications/{application}/pipelines", method = RequestMethod.GET)

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -54,6 +54,24 @@ class TaskControllerSpec extends Specification {
     1 * executionRepository.retrieveOrchestrations()
   }
 
+  void '/tasks are sorted by startTime, with non-started tasks first'() {
+    given:
+    def tasks = [
+      [ startTime: 1, id: 'c' ],
+      [ startTime: 2, id: 'd' ],
+      [ id: 'b' ],
+      [ id: 'a' ]
+    ]
+
+    when:
+    def response = mockMvc.perform(get("/pipelines")).andReturn().response
+    List results = new ObjectMapper().readValue(response.contentAsString, List)
+
+    then:
+    1 * executionRepository.retrievePipelines() >> tasks
+    results.id == [ 'b', 'a', 'd', 'c']
+  }
+
   void 'step names are properly translated'() {
     when:
     def response = mockMvc.perform(get('/tasks')).andReturn().response
@@ -113,5 +131,24 @@ class TaskControllerSpec extends Specification {
     1 * executionRepository.retrievePipelines() >> [new Pipeline(), new Pipeline()]
     List tasks = new ObjectMapper().readValue(response.contentAsString, List)
     tasks.size() == 2
+  }
+
+  void '/pipelines sorted by startTime, with non-started pipelines first'() {
+    given:
+    def pipelines = [
+      [ startTime: 1, id: 'c' ],
+      [ startTime: 2, id: 'd' ],
+      [ id: 'b' ],
+      [ id: 'a' ]
+    ]
+
+    when:
+    def response = mockMvc.perform(get("/pipelines")).andReturn().response
+    List results = new ObjectMapper().readValue(response.contentAsString, List)
+
+    then:
+    1 * executionRepository.retrievePipelines() >> pipelines
+    results.id == [ 'b', 'a', 'd', 'c']
+
   }
 }


### PR DESCRIPTION
Trying to make debugging a little easier by sorting pipelines/tasks most recent first, with enqueued pipelines/tasks first.
