### PR TITLE
only add redblack steps if there is a previous ASG

### DIFF
--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DeployStrategyStage.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DeployStrategyStage.groovy
@@ -110,6 +110,9 @@ abstract class DeployStrategyStage extends LinearStage {
           continue
         }
         def latestAsg = existingAsgs.findAll { it.region == region }.sort { a, b -> b.name <=> a.name }?.getAt(0)
+        if (!latestAsg) {
+          continue
+        }
         def nextStageContext = [asgName: latestAsg.name, regions: [region], credentials: cleanupConfig.account]
 
         if (nextStageContext.asgName) {


### PR DESCRIPTION
Fixes #253

It is not an unreasonable case for the pipeline to be configured to red black but there not be an existing ASG when
it is executing (just cloned a pipeline into a new region, have some script that cleans up after a canary is done, etc)
