### PR TITLE
return the amiName as part of the bake result 

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
@@ -41,7 +41,11 @@ class CompletedBakeTask implements Task {
     try {
       def bake = bakery.lookupBake(region, bakeStatus.resourceId).toBlocking().first()
       // This treatment of ami allows both the aws and gce bake results to be propagated.
-      new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [ami: bake.ami ?: bake.imageName])
+      def results = [ami: bake.ami ?: bake.imageName]
+      if(bake.imageName){
+        results.imageName = bake.imageName
+      }
+      new DefaultTaskResult(ExecutionStatus.SUCCEEDED, results )
     } catch (RetrofitError e) {
       // TODO: attach some reporting info here
       new DefaultTaskResult(ExecutionStatus.FAILED)


### PR DESCRIPTION
this is so the amiName can be used by downstream events
