### PR TITLE
accept OutOfService as Down when waiting for down instances

### DIFF
--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDownInstancesTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDownInstancesTask.groovy
@@ -30,7 +30,7 @@ class WaitForDownInstancesTask extends AbstractWaitingForInstancesTask {
       def healths = interestingHealthProviderNames ? it.health.findAll { health ->
         health.type in interestingHealthProviderNames
       } : it.health
-      boolean someAreDown = healths.any { it.state == 'Down' }
+      boolean someAreDown = healths.any { it.state == 'Down' || it.state == 'OutOfService' }
       boolean noneAreUp = !healths.any { it.state == 'Up' }
       someAreDown && noneAreUp
     }

--- a/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDownInstancesTaskSpec.groovy
+++ b/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDownInstancesTaskSpec.groovy
@@ -87,6 +87,7 @@ class WaitForDownInstancesTaskSpec extends Specification {
     false        || ['a']               | [ [ health: [ [ type: 'a', state : "Up"] ] ] ]
     false        || ['b']               | [ [ health: [ [ type: 'a', state : "Down"] ] ] ]
     false        || ['b']               | [ [ health: [ [ type: 'a', state : "Up"] ] ] ]
+    true         || ['a']               | [ [ health: [ [ type: 'a', state: "OutOfService"] ] ] ]
 
     // multiple health providers
     false        || []                  | [ [ health: [ [ type: 'a', state : "Up"], [ type: 'b', state : "Up"] ] ] ]
@@ -101,6 +102,7 @@ class WaitForDownInstancesTaskSpec extends Specification {
     false        || ['a']               | [ [ health: [ [ type: 'a', state : "Unknown"], [ type: 'b', state : "Down"] ] ] ]
     true         || ['b']               | [ [ health: [ [ type: 'a', state : "Unknown"], [ type: 'b', state : "Down"] ] ] ]
     true         || ['a', 'b']          | [ [ health: [ [ type: 'a', state : "Unknown"], [ type: 'b', state : "Down"] ] ] ]
+    true         || ['a', 'b']          | [ [ health: [ [ type: 'a', state : "Unknown"], [ type: 'b', state : "OutOfService"] ] ] ]
 
     // multiple instances
     false        || []                  | [ [ health: [ [ type: 'a', state : "Up"] ] ], [ health: [ [ type: 'a', state : "Up"] ] ] ]


### PR DESCRIPTION
Since we now return "OutOfService" for discovery status, our instances will never appear "Down" when waiting.
