### PR TITLE
working jenkins stage with parameters

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.groovy
@@ -19,11 +19,12 @@ package com.netflix.spinnaker.orca.igor
 import retrofit.http.GET
 import retrofit.http.PUT
 import retrofit.http.Path
+import retrofit.http.QueryMap
 
 interface IgorService {
 
   @PUT("/masters/{name}/jobs/{jobName}")
-  Map<String, Object> build(@Path("name") String master, @Path("jobName") String jobName)
+  Map<String, Object> build(@Path("name") String master, @Path("jobName") String jobName, @QueryMap Map<String,String> queryParams)
 
   @GET("/jobs/{master}/{job}/{buildNumber}")
   Map<String, Object> getBuild(@Path("master") String master,

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTask.groovy
@@ -36,9 +36,10 @@ class StartJenkinsJobTask implements Task {
   TaskResult execute(Stage stage) {
     String master = stage.context.master
     String job = stage.context.job
+    Map<String,String> parameters = stage.context.parameters
 
     try {
-      Map<String, Object> build = igorService.build(master, job)
+      Map<String, Object> build = igorService.build(master, job, parameters)
       new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [buildNumber: build.number])
     } catch (RetrofitError e) {
       new DefaultTaskResult(ExecutionStatus.TERMINAL)

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTaskSpec.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.tasks
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.igor.IgorService
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import retrofit.RetrofitError
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+class StartJenkinsJobTaskSpec extends Specification {
+
+  @Subject
+  StartJenkinsJobTask task = new StartJenkinsJobTask()
+
+  @Shared
+  Pipeline pipeline = new Pipeline()
+
+    def "should trigger build without parameters"() {
+        given:
+        def stage = new PipelineStage(pipeline, "jenkins", [master: "builds", job: "orca"]).asImmutable()
+
+        and:
+        task.igorService = Stub(IgorService) {
+            build(stage.context.master, stage.context.job, stage.context.parameters) >> [ result : 'SUCCESS', running: true, number: 4 ]
+        }
+
+        when:
+        def result = task.execute(stage)
+
+        then:
+        result.status == ExecutionStatus.SUCCEEDED
+    }
+
+  def "should trigger build with parameters"() {
+      given:
+      def stage = new PipelineStage(pipeline, "jenkins", [master: "builds", job: "orca", parameters : [foo : "bar", version : "12345"]]).asImmutable()
+
+      and:
+      task.igorService = Stub(IgorService) {
+          build(stage.context.master, stage.context.job, stage.context.parameters) >> [ result : 'SUCCESS', running: true, number: 4 ]
+      }
+
+      when:
+      def result = task.execute(stage)
+
+      then:
+      result.status == ExecutionStatus.SUCCEEDED
+    }
+
+    def "throw exception when you can't trigger a build"() {
+        given:
+        def stage = new PipelineStage(pipeline, "jenkins", [master: "builds", job: "orca", parameters : [foo : "bar", version : "12345"]]).asImmutable()
+
+        and:
+        task.igorService = Stub(IgorService) {
+            build(stage.context.master, stage.context.job, stage.context.parameters) >> {throw RetrofitError.unexpectedError("http://test", new RuntimeException())}
+        }
+
+        when:
+        def result = task.execute(stage)
+
+        then:
+        result.status == ExecutionStatus.TERMINAL
+    }
+}


### PR DESCRIPTION
Tested with Jenkins jobs which use and don't use parameters
If you want to trigger a Jenkins job add  'parameter' map : 
           "parameters": {"foo2":"dz"}
