### PR TITLE
surface ami details locally from findAmi 

### DIFF
--- a/orca-oort/src/main/groovy/com/netflix/spinnaker/orca/oort/tasks/FindAmiFromClusterTask.groovy
+++ b/orca-oort/src/main/groovy/com/netflix/spinnaker/orca/oort/tasks/FindAmiFromClusterTask.groovy
@@ -129,7 +129,9 @@ class FindAmiFromClusterTask implements Task {
     }
 
 
-    return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [:], [
+    return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [
+      amiDetails: deploymentDetails
+    ], [
       deploymentDetails: deploymentDetails
     ])
   }


### PR DESCRIPTION
So it becomes available if the next stage is not a deploy
