### PR TITLE
supply vpcId to force cache refresh for elbs

### DIFF
--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeleteAmazonLoadBalancerForceRefreshTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeleteAmazonLoadBalancerForceRefreshTask.groovy
@@ -36,10 +36,11 @@ class DeleteAmazonLoadBalancerForceRefreshTask implements Task {
   TaskResult execute(Stage stage) {
     String account = stage.context.credentials
     String name = stage.context.loadBalancerName
+    String vpcId = stage.context.vpcId ?: ''
     List<String> regions = stage.context.regions
 
     regions.each { region ->
-      def model = [loadBalancerName: name, region: region, account: account, evict: true]
+      def model = [loadBalancerName: name, region: region, account: account, vpcId: vpcId, evict: true]
       oort.forceCacheUpdate(REFRESH_TYPE, model)
     }
     new DefaultTaskResult(ExecutionStatus.SUCCEEDED)


### PR DESCRIPTION
Orca companion to https://github.com/spinnaker/deck/pull/793

I have not tested this locally because I am afraid to run Orca, but this seems to be what's missing and causing ELBs to stick around forever when they're deleted via Deck.
