### PR TITLE
get full build details when there is a pipeline trigger match

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/notifications/jenkins/BuildJobNotificationHandler.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/notifications/jenkins/BuildJobNotificationHandler.groovy
@@ -42,8 +42,11 @@ class BuildJobNotificationHandler extends AbstractNotificationHandler {
           def pipelineConfigClone = new HashMap(pipelineConfig)
           pipelineConfigClone.trigger = new HashMap(trigger)
           pipelineConfigClone.trigger.buildInfo = input
-          if(igorService && pipelineConfigClone.trigger.propertyFile ){
-            pipelineConfigClone.trigger.properties = igorService.getPropertyFile(input.master, input.name, input.lastBuild?.number, pipelineConfigClone.trigger.propertyFile)
+          if(igorService && input.lastBuild?.number){
+            pipelineConfigClone.trigger.buildInfo = igorService.getBuild(input.master, input.name, input.lastBuild?.number)
+            if( pipelineConfigClone.trigger.propertyFile ) {
+              pipelineConfigClone.trigger.properties = igorService.getPropertyFile(input.master, input.name, input.lastBuild?.number, pipelineConfigClone.trigger.propertyFile)
+            }
           }
           def json = objectMapper.writeValueAsString(pipelineConfigClone)
           log.info "Starting pipeline '$pipelineConfig.name' for application '$pipelineConfig.application' due to Jenkins job '$key.job'"


### PR DESCRIPTION
This makes the behaviour consistent with the orchestration controller
