### PR TITLE
Fix execution windows

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/RetryableTaskTasklet.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/RetryableTaskTasklet.groovy
@@ -57,7 +57,7 @@ class RetryableTaskTasklet extends TaskTasklet {
     def now = clock.millis()
     def startTime = chunkContext.stepContext.getStepExecution().startTime.time
     if (now - startTime > timeoutMs) {
-      throw new TimeoutException("Operation timed out after ${timeoutMs}ms (startTime: ${startTime}, endTime: ${now})")
+      throw new TimeoutException("Operation timed out after ${timeoutMs}ms")
     }
     return super.doExecuteTask(stage, chunkContext)
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/notifications/scheduling/SuspendedPipelinesNotificationHandler.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/notifications/scheduling/SuspendedPipelinesNotificationHandler.groovy
@@ -17,10 +17,12 @@
 package com.netflix.spinnaker.orca.notifications.scheduling
 
 import com.netflix.spinnaker.orca.notifications.AbstractNotificationHandler
+import groovy.util.logging.Slf4j
 
 /**
  *
  */
+@Slf4j
 class SuspendedPipelinesNotificationHandler extends AbstractNotificationHandler {
 
   String handlerType = SuspendedPipelinesPollingNotificationAgent.NOTIFICATION_TYPE
@@ -32,9 +34,9 @@ class SuspendedPipelinesNotificationHandler extends AbstractNotificationHandler 
   @Override
   void handle(Map pipeline) {
     try {
-      pipelineStarter.restart(pipeline.id)
+      pipelineStarter.resume(pipelineStarter.executionRepository.retrievePipeline(pipeline.id as String))
     } catch (e) {
-      e.printStackTrace()
+      log.error("Unable to resume pipeline", e)
       throw e
     }
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/notifications/scheduling/SuspendedPipelinesPollingNotificationAgent.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/notifications/scheduling/SuspendedPipelinesPollingNotificationAgent.groovy
@@ -48,10 +48,12 @@ class SuspendedPipelinesPollingNotificationAgent extends AbstractPollingNotifica
   @Override
   protected List<Map> filterEvents(List<Map> pipelines) {
     long now = new Date().time
-    return pipelines.findAll {
+    def filteredEvents = pipelines.findAll {
       it.status == ExecutionStatus.SUSPENDED.name() &&
-      it.stages.find { Map stage -> now >= extractScheduledTime(stage) != null }
+      it.stages.find { Map stage -> now >= extractScheduledTime(stage) } != null
     } as List<Map>
+
+    return filteredEvents
   }
 
   @Override

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/LinearStage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/LinearStage.groovy
@@ -44,10 +44,12 @@ abstract class LinearStage extends StageBuilder implements StepProvider {
      * is supposed to run only during certain time windows in a day
      */
     boolean executionRestricted = stage.context.containsKey("restrictExecutionDuringTimeWindow") ?
-        stage.context.restrictExecutionDuringTimeWindow as Boolean : false
+      stage.context.restrictExecutionDuringTimeWindow as Boolean : false
+
+    def parentStage = stage.execution.stages.find { it.id == stage.parentStageId }
     if (executionRestricted &&
-        stage.syntheticStageOwner == null && stage.parentStageId == null &&
-        stage.execution.stages.find { Stage stg -> stg.parentStageId == stage.id } == null) {
+      ((stage.syntheticStageOwner == null && stage.parentStageId == null) || parentStage?.initializationStage)
+    ) {
       injectBefore(stage, "restrictExecutionDuringTimeWindow", applicationContext.getBean(RestrictExecutionDuringTimeWindow), stage.context)
     }
 

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ParallelStage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ParallelStage.groovy
@@ -41,9 +41,10 @@ abstract class ParallelStage extends StageBuilder {
 
   @Override
   FlowBuilder buildInternal(FlowBuilder jobBuilder, Stage stage) {
+    stage.initializationStage = true
+
     List<Flow> flows = buildFlows(stage)
     stage.name = parallelStageName(stage, flows.size() > 1)
-    stage.type = "initialization"
 
     if (stage.execution.stages.indexOf(stage) == 0) {
       jobBuilder = jobBuilder.start(buildStep(stage, "beginParallel", beginParallel()))

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineJobBuilder.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineJobBuilder.groovy
@@ -56,7 +56,10 @@ class PipelineJobBuilder extends ExecutionJobBuilder<Pipeline> {
 
   private JobFlowBuilder buildFlow(JobFlowBuilder jobBuilder, Pipeline pipeline) {
     def stages = []
-    stages.addAll(pipeline.stages)
+    stages.addAll(pipeline.stages.findAll {
+      // only consider non-synthetic stages when building the flow
+      return it.parentStageId == null
+    })
     stages.inject(jobBuilder, this.&createStage) as JobFlowBuilder
   }
 

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AbstractStage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AbstractStage.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import groovy.transform.CompileStatic
 
+import java.util.concurrent.atomic.AtomicInteger
 
 import static ExecutionStatus.NOT_STARTED
 import static java.util.Collections.EMPTY_MAP
@@ -42,12 +43,19 @@ abstract class AbstractStage<T extends Execution> implements Stage<T>, Serializa
   T execution
   Map<String, Object> context = [:]
   boolean immutable = false
+  boolean initializationStage = false
   List<Task> tasks = []
   String parentStageId
   Stage.SyntheticStageOwner syntheticStageOwner
   List<InjectedStageConfiguration> beforeStages = []
   List<InjectedStageConfiguration> afterStages = []
   long scheduledTime
+
+  @JsonIgnore
+  AtomicInteger stageCounter = new AtomicInteger(0)
+
+  @JsonIgnore
+  AtomicInteger taskCounter = new AtomicInteger(0)
 
   transient ObjectMapper objectMapper = new OrcaObjectMapper()
 

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/ImmutableStageSupport.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/ImmutableStageSupport.groovy
@@ -23,6 +23,8 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import java.lang.reflect.Method
 import net.sf.cglib.proxy.*
 
+import java.util.concurrent.atomic.AtomicInteger
+
 class ImmutableStageSupport {
 
   static def <T extends Stage> T toImmutable(T stage) {
@@ -122,6 +124,21 @@ class ImmutableStageSupport {
         this.context = ImmutableMap.copyOf(validContext)
       }
       this.context
+    }
+
+    @Override
+    boolean isInitializationStage() {
+      self.initializationStage
+    }
+
+    @Override
+    void setInitializationStage(boolean initializationStage) {
+      self.initializationStage = initializationStage
+    }
+
+    @Override
+    AtomicInteger getTaskCounter() {
+      self.taskCounter
     }
 
     void setContext(ImmutableMap<String, Object> context) {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.groovy
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.orca.ExecutionStatus
 import groovy.transform.CompileStatic
 
+import java.util.concurrent.atomic.AtomicInteger
+
 @CompileStatic
 interface Stage<T extends Execution> {
 
@@ -88,6 +90,22 @@ interface Stage<T extends Execution> {
    * @return
    */
   boolean isImmutable()
+
+  /**
+   * Returns a flag indicating if the stage is a parallel initialization stage
+   * @return
+   */
+  boolean isInitializationStage()
+
+  /**
+   * @param initializationStage
+   */
+  void setInitializationStage(boolean initializationStage)
+
+  /**
+   * @return
+   */
+  AtomicInteger getTaskCounter()
 
   /**
    * Returns the stage as an immutable object. Stage state can be discovered through {@link #isImmutable()}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/StageBuilderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/StageBuilderSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.batch
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class StageBuilderSpec extends Specification {
+  @Shared
+  def execution = new Pipeline()
+
+  @Shared
+  def uuidRegex = '.' * 36 /* super hack */
+
+  @Unroll
+  def "should use parent stage id and counter to build child stage id"() {
+    when:
+    def stage1 = StageBuilder.newStage(execution, null, "NewStage!@#", [:], parent as Stage, null)
+
+    then:
+    stage1.id =~ expectedStage1Id
+
+    when:
+    def stage2 = StageBuilder.newStage(execution, null, "NewStage!@#", [:], parent as Stage, null)
+
+    then:
+    stage2.id =~ expectedStage2Id
+
+    where:
+    parent                                              || expectedStage1Id           || expectedStage2Id
+    buildParent(execution, "ParentId")                  || "ParentId-1-NewStage"      || "ParentId-2-NewStage"
+    buildParent(execution, "GrandParentId", "ParentId") || "GrandParentId-1-NewStage" || "GrandParentId-2-NewStage"
+    null                                                || uuidRegex                  || uuidRegex
+  }
+
+  Stage buildParent(Execution execution, String... parentStageIds) {
+    def stages = [] as List<Stage>
+
+    parentStageIds.each {
+      def parent = new PipelineStage()
+      parent.id = it
+
+      if (stages) {
+        parent.parentStageId = stages[-1].id
+      }
+
+      stages << parent
+    }
+
+    execution.stages.addAll(stages)
+    return stages[-1]
+  }
+}

--- a/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStageSpec.groovy
+++ b/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStageSpec.groovy
@@ -36,9 +36,9 @@ class ParallelDeployStageSpec extends Specification {
 
     where:
     stageContext                                            || expectedParallelContexts
-    deployStageContext("prod", "us-west-1")                 || [[account: "prod", cluster: [availabilityZones: ["us-west-1": []]], type: "linearDeploy", name: "Deploy in us-west-1"]]
-    deployStageContext("prod", "us-west-1", "us-east-1")    || [[account: "prod", cluster: [availabilityZones: ["us-west-1": []]], type: "linearDeploy", name: "Deploy in us-west-1"],
-                                                                [account: "prod", cluster: [availabilityZones: ["us-east-1": []]], type: "linearDeploy", name: "Deploy in us-east-1"]]
+    deployStageContext("prod", "us-west-1")                 || [[account: "prod", restrictedExecutionWindow: [:], cluster: [availabilityZones: ["us-west-1": []]], type: "linearDeploy", name: "Deploy in us-west-1"]]
+    deployStageContext("prod", "us-west-1", "us-east-1")    || [[account: "prod", restrictedExecutionWindow: [:], cluster: [availabilityZones: ["us-west-1": []]], type: "linearDeploy", name: "Deploy in us-west-1"],
+                                                                [account: "prod", restrictedExecutionWindow: [:], cluster: [availabilityZones: ["us-east-1": []]], type: "linearDeploy", name: "Deploy in us-east-1"]]
     [availabilityZones: ["us-west-1": []], account: "prod"] || [[account: "prod", cluster: [availabilityZones: ["us-west-1": []], account: "prod"], type: "linearDeploy", name: "Deploy in us-west-1"]]
   }
 
@@ -57,7 +57,7 @@ class ParallelDeployStageSpec extends Specification {
   }
 
   Map deployStageContext(String account, String... availabilityZones) {
-    def context = ["account": account]
+    def context = ["account": account, restrictedExecutionWindow: [:]]
     if (availabilityZones.size() == 1) {
       context.cluster = ["availabilityZones": [(availabilityZones[0]): []]]
     } else {

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
@@ -47,8 +47,8 @@ class RetrofitConfiguration {
     return new OkClient(okHttpClient)
   }
 
-  @Bean LogLevel retrofitLogLevel() {
-    LogLevel.NONE
+  @Bean LogLevel retrofitLogLevel(@Value('${retrofit.logLevel:BASIC}') String retrofitLogLevel) {
+    return LogLevel.valueOf(retrofitLogLevel)
   }
 
   @Bean Gson gson() {


### PR DESCRIPTION
- child stage ids are now based on their highest parent's id and offset
- suspended pipeline polling agent will now correctly find runnable stages
