### PR TITLE
Output baked package name in context

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -44,7 +44,7 @@ class CreateBakeTask implements Task {
 
     def bakeStatus = bakery.createBake(region, bake).toBlocking().single()
 
-    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [status: bakeStatus])
+    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [status: bakeStatus, bakePackageName: bake.packageName])
   }
 
   @CompileDynamic

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -127,10 +127,11 @@ class CreateBakeTaskSpec extends Specification {
     }
 
     when:
-    task.execute(stage)
+    def result = task.execute(stage)
 
     then:
     bake.packageName == 'hodor_1.1_all'
+    result.outputs.bakePackageName == 'hodor_1.1_all'
 
     where:
     triggerInfo      | contextInfo
@@ -198,6 +199,20 @@ class CreateBakeTaskSpec extends Specification {
       id == runningStatus.id
       state == runningStatus.state
     }
+  }
+
+
+  def "outputs the packageName of the bake"() {
+    given:
+    task.bakery = Stub(BakeryService) {
+      createBake(*_) >> Observable.from(runningStatus)
+    }
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.outputs.bakePackageName == bakeConfig.package
   }
 
 }


### PR DESCRIPTION
since the baked package name can be different based on artifacts in the pipeline path, output this to the pipeline context for easier debugging
