### PR TITLE
add pipeline config id to pipeline

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarter.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarter.groovy
@@ -53,7 +53,7 @@ class PipelineStarter extends ExecutionStarter<Pipeline> {
     Pipeline.builder()
             .withApplication(config.application.toString())
             .withName(config.name.toString())
-            .withPipelineId(config.id ? config.id.toString() : null)
+            .withPipelineConfigId(config.id ? config.id.toString() : null)
             .withTrigger((Map<String, Object>) config.trigger)
             .withStages((List<Map<String, Object>>) config.stages)
             .withAppConfig((Map<String, Serializable>) config.appConfig)

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Pipeline.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Pipeline.groovy
@@ -23,7 +23,7 @@ class Pipeline extends Execution<Pipeline> {
 
   String application
   String name
-  String pipelineId
+  String pipelineConfigId
   final Map<String, Object> trigger = [:]
   final Map<String, Serializable> initialConfig = [:]
 
@@ -43,8 +43,8 @@ class Pipeline extends Execution<Pipeline> {
       return this
     }
 
-    Builder withPipelineId(String id) {
-      pipeline.pipelineId = id
+    Builder withPipelineConfigId(String id) {
+      pipeline.pipelineConfigId = id
       return this
     }
 


### PR DESCRIPTION
If an `id` is present in the config, add it as `pipelineId` so we can group pipelines by `id` in the UI.

Dependent on https://github.com/spinnaker/tick/pull/6, or a similar PR written by a grown-up.
