### PR TITLE
StartJenkinsJob is now retryable and will auto-recover from any network ...

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.groovy
@@ -84,6 +84,10 @@ abstract class Execution<T> implements Serializable {
       return TERMINAL
     }
 
+    if (stages.status.any { it == FAILED }) {
+      return FAILED
+    }
+
     if (stages.status.every { it == SUCCEEDED }) {
       return SUCCEEDED
     }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineSpec.groovy
@@ -52,6 +52,7 @@ class PipelineSpec extends Specification {
         SUCCEEDED    | SUCCEEDED    | SUCCEEDED    | SUCCEEDED
         SUCCEEDED    | FAILED       | NOT_STARTED  | FAILED
         SUCCEEDED    | SUCCEEDED    | FAILED       | FAILED
+        FAILED       | SUCCEEDED    | RUNNING      | FAILED
         SUCCEEDED    | SUSPENDED    | NOT_STARTED  | SUSPENDED
         SUCCEEDED    | SUCCEEDED    | SUSPENDED    | SUSPENDED
         TERMINAL     | SUCCEEDED    | NOT_STARTED  | TERMINAL //BUG: WAS RETURNING RUNNING

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
@@ -39,9 +39,9 @@ class MonitorJenkinsJobTask implements RetryableTask {
 
   private static Map<String, ExecutionStatus> statusMap = [
     'ABORTED' : ExecutionStatus.CANCELED,
-    'FAILURE' : ExecutionStatus.FAILED,
+    'FAILURE' : ExecutionStatus.TERMINAL,
     'SUCCESS' : ExecutionStatus.SUCCEEDED,
-    'UNSTABLE': ExecutionStatus.FAILED
+    'UNSTABLE': ExecutionStatus.TERMINAL
   ]
 
   @Override

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTask.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.orca.igor.tasks
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.igor.IgorService
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
@@ -27,10 +27,11 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import retrofit.RetrofitError
 
 @Component
-class StartJenkinsJobTask implements Task {
+class StartJenkinsJobTask implements RetryableTask {
+  long backoffPeriod = 10000
+  long timeout = 1800000
 
   @Autowired
   IgorService igorService

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
@@ -52,9 +52,9 @@ class MonitorJenkinsJobTaskSpec extends Specification {
     where:
     jobState   | taskStatus
     'ABORTED'  | ExecutionStatus.CANCELED
-    'FAILURE'  | ExecutionStatus.FAILED
+    'FAILURE'  | ExecutionStatus.TERMINAL
     'SUCCESS'  | ExecutionStatus.SUCCEEDED
-    'UNSTABLE' | ExecutionStatus.FAILED
+    'UNSTABLE' | ExecutionStatus.TERMINAL
     null       | ExecutionStatus.RUNNING
     'UNKNOWN'  | ExecutionStatus.RUNNING
   }


### PR DESCRIPTION
...error
- Any FAILED stage will mark the pipeline as FAILED
- Jenkins tasks should return TERMINAL (vs. FAILED) to properly stop the pipeline

Please review @tomaslin 
