### PR TITLE
Make DeployGoogleServerGroupStage extends DeployStrategyStage.

### DIFF
--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/gce/DeployGoogleServerGroupStage.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/gce/DeployGoogleServerGroupStage.groovy
@@ -17,18 +17,18 @@
 package com.netflix.spinnaker.orca.kato.pipeline.gce
 
 import groovy.transform.CompileStatic
+import com.netflix.spinnaker.orca.kato.pipeline.strategy.DeployStrategyStage
 import com.netflix.spinnaker.orca.kato.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.kato.tasks.WaitForUpInstancesTask
 import com.netflix.spinnaker.orca.kato.tasks.gce.CreateGoogleServerGroupTask
 import com.netflix.spinnaker.orca.kato.tasks.gce.GoogleServerGroupCacheForceRefreshTask
-import com.netflix.spinnaker.orca.pipeline.LinearStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.batch.core.Step
 import org.springframework.stereotype.Component
 
 @Component
 @CompileStatic
-class DeployGoogleServerGroupStage extends LinearStage {
+class DeployGoogleServerGroupStage extends DeployStrategyStage {
 
   public static final String MAYO_CONFIG_TYPE = "linearDeploy_gce"
 
@@ -37,7 +37,7 @@ class DeployGoogleServerGroupStage extends LinearStage {
   }
 
   @Override
-  public List<Step> buildSteps(Stage stage) {
+  protected List<Step> basicSteps(Stage stage) {
     def step1 = buildStep(stage, "createDeploy", CreateGoogleServerGroupTask)
     def step2 = buildStep(stage, "monitorDeploy", MonitorKatoTask)
     def step3 = buildStep(stage, "forceCacheRefresh", GoogleServerGroupCacheForceRefreshTask)

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/CreateGoogleServerGroupTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/CreateGoogleServerGroupTask.groovy
@@ -54,7 +54,12 @@ class CreateGoogleServerGroupTask implements Task {
     // If this stage was synthesized by a parallel deploy stage, the operation properties will be under 'cluster'.
     if (stage.context.containsKey("cluster")) {
       operation.putAll(stage.context.cluster as Map)
+    } else {
+      operation.putAll(stage.context)
+    }
 
+    // instanceMetadata from a pipeline is sent as a list of maps, each containing key and value entries.
+    if (operation.instanceMetadata instanceof List) {
       def transformedInstanceMetadata = [:]
 
       // The instanceMetadata is stored using 'key' and 'value' attributes to enable the Add/Remove behavior in the
@@ -69,8 +74,6 @@ class CreateGoogleServerGroupTask implements Task {
       }
 
       operation.instanceMetadata = transformedInstanceMetadata
-    } else {
-      operation.putAll(stage.context)
     }
 
     operation.initialNumReplicas = operation.capacity.desired


### PR DESCRIPTION
We are not supporting deployment strategies yet, but we need to extend this class to get the DeployStrategyStage.correctContext() behavior.
Fix up logic in CreateGoogleServerGroupTask to check actual type of instanceMetadata in deciding whether it still needs list -> map conversion (as opposed to relying on presence of context.cluster).
@ajordens one more small PR here in same area. Thanks.
@anotherchrisberry you were right in terms of where to look for the transformation. After this change, pipeline GCE deployment execution details are populated in deck.
