### PR TITLE
If 'bakery.extractBuildDetails' is set, also try to extract commit hash ...

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
@@ -34,13 +34,14 @@ import com.netflix.spinnaker.orca.pipeline.util.OperatingSystem
 @Immutable(copyWith = true)
 @CompileStatic
 class BakeRequest {
-  static final Default = new BakeRequest(System.getProperty("user.name"), null, null, null, null, CloudProviderType.aws, Label.release, OperatingSystem.ubuntu, null, null, null, null, null, null, null)
+  static final Default = new BakeRequest(System.getProperty("user.name"), null, null, null, null, null, CloudProviderType.aws, Label.release, OperatingSystem.ubuntu, null, null, null, null, null, null, null)
 
   String user
   @JsonProperty("package") @SerializedName("package") String packageName
   String buildHost
   String job
   String buildNumber
+  String commitHash
   CloudProviderType cloudProviderType
   Label baseLabel
   OperatingSystem baseOs

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -50,20 +50,24 @@ class CreateBakeTask implements Task {
 
     def bakeStatus = bakery.createBake(region, bake).toBlocking().single()
 
+    def stageOutputs = [
+      status: bakeStatus,
+      bakePackageName: bake.packageName
+    ] as Map<String, ? extends Object>
+
     if (bake.buildHost) {
-      new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [
-        status: bakeStatus,
-        bakePackageName: bake.packageName,
+      stageOutputs << [
         buildHost: bake.buildHost,
         job: bake.job,
         buildNumber: bake.buildNumber
-      ])
-    } else {
-      new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [
-        status: bakeStatus,
-        bakePackageName: bake.packageName
-      ])
+      ]
+
+      if (bake.commitHash) {
+        stageOutputs.commitHash = bake.commitHash
+      }
     }
+
+    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, stageOutputs)
   }
 
   @CompileDynamic

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
@@ -115,12 +115,24 @@ class PackageInfo {
           request.put('job', buildInfoUrlParts[1].toString())
           request.put('buildNumber', buildInfoUrlParts[2].toString())
         }
+
+        def commitHash = buildArtifact ? extractCommitHash(buildInfo) : extractCommitHash(trigger?.buildInfo)
+
+        if (commitHash) {
+          request.put('commitHash', commitHash)
+        }
       }
 
       return request
     }
 
     throw new IllegalStateException("Unable to find deployable artifact starting with ${prefix} and ending with ${fileExtension} in ${buildArtifacts} and ${triggerArtifacts}")
+  }
+
+  @CompileDynamic
+  private String extractCommitHash(Map buildInfo) {
+    // buildInfo.scm contains a list of maps. Each map contains these keys: name, sha1, branch.
+    buildInfo?.scm?.first()?.sha1
   }
 
   @CompileDynamic


### PR DESCRIPTION
...from jenkins buildInfo and pass it on bake requests.

Motivation for this change is that 'buildDeb' produces deb packages without buildNumber and commit hash (in the filename). With this new parameter, we can make rosco capable of building complete appversion tags from buildDeb-produced deb packages.

@dzapata and/or @tomaslin please review.

cc: @cfieber This is the change I mentioned during yesterday's mtg. Turned out to be trivial.
