### PR TITLE
If 'AddToLoadBalancer' is suspended, only 'Amazon' health should be c…

### DIFF
--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/AbstractInstancesCheckTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/AbstractInstancesCheckTask.groovy
@@ -84,7 +84,10 @@ abstract class AbstractInstancesCheckTask implements RetryableTask {
         }
 
         seenServerGroup[name] = true
-        Collection<String> interestingHealthProviderNames = stage.context?.appConfig?.interestingHealthProviderNames as Collection
+        Collection<String> interestingHealthProviderNames = stage.context.interestingHealthProviderNames as Collection
+        if (interestingHealthProviderNames == null) {
+          interestingHealthProviderNames = stage.context?.appConfig?.interestingHealthProviderNames as Collection
+        }
         def isComplete = hasSucceeded(stage, asg, instances, interestingHealthProviderNames)
         if (!isComplete) {
           return new DefaultTaskResult(ExecutionStatus.RUNNING)

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateCopyLastAsgTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateCopyLastAsgTask.groovy
@@ -47,12 +47,19 @@ class CreateCopyLastAsgTask implements Task {
     def taskId = kato.requestOperations(getDescriptions(operation))
                      .toBlocking()
                      .first()
-    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [
-        "notification.type"  : "createcopylastasg",
-        "kato.last.task.id"  : taskId,
-        "kato.task.id"       : taskId, // TODO retire this.
-        "deploy.account.name": operation.credentials,
-    ])
+
+    def outputs = [
+      "notification.type"  : "createcopylastasg",
+      "kato.last.task.id"  : taskId,
+      "deploy.account.name": operation.credentials,
+    ]
+
+    def suspendedProcesses = stage.context.suspendedProcesses as Set<String>
+    if (suspendedProcesses?.contains("AddToLoadBalancer")) {
+      outputs.interestingHealthProviderNames = ["Amazon"]
+    }
+
+    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, outputs)
   }
 
   private List<Map<String, Object>> getDescriptions(Map operation) {

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForUpInstancesTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForUpInstancesTask.groovy
@@ -43,6 +43,10 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
         health.type in interestingHealthProviderNames
       } : instance.health
       boolean someAreUp = healths.any { Map health -> health.state == 'Up' }
+      if (interestingHealthProviderNames?.contains("Amazon")) {
+        // given that Amazon health never reports as 'Up' (only 'Unknown') we can only verify it isn't 'Down'.
+        someAreUp = someAreUp || healths.any { Map health -> health.type == 'Amazon' && health.state != 'Down' }
+      }
       boolean noneAreDown = !healths.any { Map health -> health.state == 'Down' }
       someAreUp && noneAreDown
     }

--- a/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateDeployTaskSpec.groovy
+++ b/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateDeployTaskSpec.groovy
@@ -215,7 +215,7 @@ class CreateDeployTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.outputs."kato.task.id" == taskId
+    result.stageOutputs."kato.last.task.id" == taskId
   }
 
 }

--- a/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForUpInstancesTaskSpec.groovy
+++ b/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForUpInstancesTaskSpec.groovy
@@ -125,8 +125,11 @@ class WaitForUpInstancesTaskSpec extends Specification {
     true         || 1       | ['a']               | [ [ health: [ [ type: 'a', state : "Up"] ] ] ]
     false        || 1       | ['b']               | [ [ health: [ [ type: 'a', state : "Down"] ] ] ]
     false        || 1       | ['b']               | [ [ health: [ [ type: 'a', state : "Up"] ] ] ]
+    true         || 1       | ['Amazon']          | [ [ health: [ [ type: 'Amazon', statue: "Unknown"] ] ] ]
+    false        || 1       | ['Amazon']          | [ [ health: [ [ type: 'Amazon', state: "Down"] ] ] ]
 
     // multiple health providers
+    true         || 1       | ['Amazon']          | [ [ health: [ [ type: 'Amazon', statue: "Unknown"], [ type: 'b', state : "Down"] ] ] ]
     true         || 1       | null                | [ [ health: [ [ type: 'a', state : "Up"], [ type: 'b', state : "Up"] ] ] ]
     false        || 1       | null                | [ [ health: [ [ type: 'a', state : "Down"], [ type: 'b', state : "Down"] ] ] ]
     false        || 1       | null                | [ [ health: [ [ type: 'a', state : "Up"], [ type: 'b', state : "Down"] ] ] ]


### PR DESCRIPTION
…hecked
- Health check needs to be smart enough to known that Amazon != 'Down' is health (as it never reports 'Up')

Fixes SPIN-396

---

@cfieber - This seems kinda lame... particularly having to special case the Amazon health provider because it never reports 'Up' https://github.com/spinnaker/oort/blob/master/oort-aws/src/main/groovy/com/netflix/spinnaker/oort/aws/provider/agent/InstanceCachingAgent.groovy#L176. Was toying with the idea of just checking no health providers if AddToLoadBalancer is suspended?
