### PR TITLE
CreateBake should retry on a 404 response from the bakery

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
@@ -32,23 +32,19 @@ import retrofit.RetrofitError
 @CompileStatic
 class CompletedBakeTask implements Task {
 
-  @Autowired BakeryService bakery
+  @Autowired
+  BakeryService bakery
 
   @Override
   TaskResult execute(Stage stage) {
     def region = stage.context.region as String
     def bakeStatus = stage.context.status as BakeStatus
-    try {
-      def bake = bakery.lookupBake(region, bakeStatus.resourceId).toBlocking().first()
-      // This treatment of ami allows both the aws and gce bake results to be propagated.
-      def results = [ami: bake.ami ?: bake.imageName]
-      if(bake.imageName){
-        results.imageName = bake.imageName
-      }
-      new DefaultTaskResult(ExecutionStatus.SUCCEEDED, results )
-    } catch (RetrofitError e) {
-      // TODO: attach some reporting info here
-      new DefaultTaskResult(ExecutionStatus.FAILED)
+    def bake = bakery.lookupBake(region, bakeStatus.resourceId).toBlocking().first()
+    // This treatment of ami allows both the aws and gce bake results to be propagated.
+    def results = [ami: bake.ami ?: bake.imageName]
+    if (bake.imageName) {
+      results.imageName = bake.imageName
     }
+    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, results)
   }
 }

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -48,7 +48,7 @@ class MonitorBakeTask implements RetryableTask {
       def newStatus = bakery.lookupStatus(region, previousStatus.id).toBlocking().single()
       new DefaultTaskResult(mapStatus(newStatus), [status: newStatus])
     } catch (RetrofitError e) {
-      if (e.response.status == 404) {
+      if (e.response?.status == 404) {
         return new DefaultTaskResult(ExecutionStatus.RUNNING)
       }
       throw e

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
@@ -77,10 +77,10 @@ class CompletedBakeTaskSpec extends Specification {
       .asImmutable()
 
     when:
-    def result = task.execute(stage)
+    task.execute(stage)
 
     then:
-    result.status == ExecutionStatus.FAILED
+    thrown(RetrofitError)
 
     where:
     region = "us-west-1"

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
@@ -34,10 +34,12 @@ class RetrofitExceptionHandler implements ExceptionHandler<RetrofitError> {
 
       try {
         def body = e.getBodyAs(Map) as Map
-        response.details = new ExceptionHandler.ResponseDetails(
-          body.error ?: reason,
-          (body.errors ?: (body.message ? [body.message] : [])) as List<String>
-        )
+
+        def error = body.error ?: reason
+        def errors = body.errors ?: (body.messages ?: []) as List<String>
+        errors = errors ?: (body.message ? [body.message] : [])
+
+        response.details = new ExceptionHandler.ResponseDetails(error, errors as List<String>)
 
         if (body.exception) {
           response.details.rootException = body.exception


### PR DESCRIPTION
- RetrofitExceptionHandler now supports an error response containing a 'messages' key
