### PR TITLE
JobBuilder should only be tracked as built if > 0 steps present

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/LinearStage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/LinearStage.groovy
@@ -122,7 +122,9 @@ abstract class LinearStage extends StageBuilder implements StepProvider {
       }
     }
 
-    stage.execution.builtPipelineObjects << jobBuilder
+    if (steps) {
+      stage.execution.builtPipelineObjects << jobBuilder
+    }
     return jobBuilder
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/LinearStageSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/LinearStageSpec.groovy
@@ -123,6 +123,12 @@ class LinearStageSpec extends AbstractBatchLifecycleSpec {
     pipeline.stages << new PipelineStage(pipeline, "", [:])
 
     when:
+    linearStage.wireSteps(jobBuilder, [], pipeline.stages[0])
+
+    then:
+    !pipeline.builtPipelineObjects.contains(jobBuilder)
+
+    when:
     linearStage.wireSteps(jobBuilder, [buildStep("Step1"), buildStep("Step2")], pipeline.stages[0])
 
     then:


### PR DESCRIPTION
@dzapata - This should fix quip when run in parallel. Rather surprising this is the first stage to run into it.
