### PR TITLE
removed defaults for endpoints.

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfiguration.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfiguration.groovy
@@ -49,7 +49,7 @@ class BakeryConfiguration {
   @Autowired LogLevel retrofitLogLevel
 
   @Bean
-  Endpoint bakeryEndpoint(@Value('${bakery.baseUrl:http://localhost:7001}') String bakeryBaseUrl) {
+  Endpoint bakeryEndpoint(@Value('${bakery.baseUrl}') String bakeryBaseUrl) {
     newFixedEndpoint(bakeryBaseUrl)
   }
 

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
@@ -49,7 +49,7 @@ class EchoConfiguration {
   @Autowired RestAdapter.LogLevel retrofitLogLevel
 
   @Bean Endpoint echoEndpoint(
-    @Value('${echo.baseUrl:http://localhost:7002}') String echoBaseUrl) {
+    @Value('${echo.baseUrl}') String echoBaseUrl) {
     newFixedEndpoint(echoBaseUrl)
   }
 

--- a/orca-flex/src/main/groovy/com/netflix/spinnaker/orca/flex/config/FlexConfiguration.groovy
+++ b/orca-flex/src/main/groovy/com/netflix/spinnaker/orca/flex/config/FlexConfiguration.groovy
@@ -47,7 +47,7 @@ class FlexConfiguration {
   @Autowired RestAdapter.LogLevel retrofitLogLevel
 
   @Bean Endpoint flexEndpoint(
-    @Value('${flex.baseUrl:http://localhost:7003}') String flexBaseUrl) {
+    @Value('${flex.baseUrl}') String flexBaseUrl) {
     newFixedEndpoint(flexBaseUrl)
   }
 

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
@@ -46,7 +46,7 @@ class Front50Configuration {
   @Autowired RestAdapter.LogLevel retrofitLogLevel
 
   @Bean Endpoint front50Endpoint(
-      @Value('${front50.baseUrl:http://localhost:7004}') String front50BaseUrl) {
+      @Value('${front50.baseUrl}') String front50BaseUrl) {
     newFixedEndpoint(front50BaseUrl)
   }
 

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/IgorConfiguration.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/IgorConfiguration.groovy
@@ -47,7 +47,7 @@ class IgorConfiguration {
   @Autowired RestAdapter.LogLevel retrofitLogLevel
 
   @Bean Endpoint igorEndpoint(
-    @Value('${igor.baseUrl:http://localhost:7005}') String igorBaseUrl) {
+    @Value('${igor.baseUrl}') String igorBaseUrl) {
     newFixedEndpoint(igorBaseUrl)
   }
 

--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/config/KatoConfiguration.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/config/KatoConfiguration.groovy
@@ -54,7 +54,7 @@ class KatoConfiguration {
   }
 
   @Bean Endpoint katoEndpoint(
-      @Value('${kato.baseUrl:http://localhost:7006}') String katoBaseUrl) {
+      @Value('${kato.baseUrl}') String katoBaseUrl) {
     newFixedEndpoint(katoBaseUrl)
   }
 

--- a/orca-mort/src/main/groovy/com/netflix/spinnaker/orca/mort/config/MortConfiguration.groovy
+++ b/orca-mort/src/main/groovy/com/netflix/spinnaker/orca/mort/config/MortConfiguration.groovy
@@ -44,7 +44,7 @@ class MortConfiguration {
   @Autowired Client retrofitClient
   @Autowired RestAdapter.LogLevel retrofitLogLevel
 
-  @Bean Endpoint mortEndpoint(@Value('${mort.baseUrl:http://localhost:7007}') String mortBaseUrl) {
+  @Bean Endpoint mortEndpoint(@Value('${mort.baseUrl}') String mortBaseUrl) {
     newFixedEndpoint(mortBaseUrl)
   }
 

--- a/orca-oort/src/main/groovy/com/netflix/spinnaker/orca/oort/config/OortConfiguration.groovy
+++ b/orca-oort/src/main/groovy/com/netflix/spinnaker/orca/oort/config/OortConfiguration.groovy
@@ -47,7 +47,7 @@ class OortConfiguration {
   @Autowired Client retrofitClient
   @Autowired RestAdapter.LogLevel retrofitLogLevel
 
-  @Bean Endpoint oortEndpoint(@Value('${oort.baseUrl:http://localhost:7008}') String oortBaseUrl) {
+  @Bean Endpoint oortEndpoint(@Value('${oort.baseUrl}') String oortBaseUrl) {
     newFixedEndpoint(oortBaseUrl)
   }
 

--- a/orca-rush/src/main/groovy/com/netflix/spinnaker/orca/rush/config/RushConfiguration.groovy
+++ b/orca-rush/src/main/groovy/com/netflix/spinnaker/orca/rush/config/RushConfiguration.groovy
@@ -54,7 +54,7 @@ class RushConfiguration {
 
   @Bean
   Endpoint rushEndpoint(
-      @Value('${rush.baseUrl:http://localhost:7009}') String rushBaseUrl) {
+      @Value('${rush.baseUrl}') String rushBaseUrl) {
     newFixedEndpoint(rushBaseUrl)
   }
 


### PR DESCRIPTION
this leads orca to fail if a required baseURL is not set correctly. 
