### PR TITLE
Fix for SPIN-316:  Adding the entire orchestration model to the OrchestrationViewModel.

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -140,7 +140,8 @@ class TaskController {
       steps: orchestration.stages.tasks.flatten(),
       buildTime: orchestration.buildTime,
       startTime: orchestration.startTime,
-      endTime: orchestration.endTime
+      endTime: orchestration.endTime,
+      execution: orchestration
     )
   }
 }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/model/OrchestrationViewModel.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/model/OrchestrationViewModel.groovy
@@ -17,10 +17,11 @@
 package com.netflix.spinnaker.orca.model
 
 import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.pipeline.model.Orchestration
 import com.netflix.spinnaker.orca.pipeline.model.Task
 import groovy.transform.Immutable
 
-@Immutable(knownImmutables = ['status', 'variables', 'steps'])
+@Immutable(knownImmutables = ['status', 'variables', 'steps', 'execution'])
 class OrchestrationViewModel {
   String id
   String name
@@ -30,4 +31,5 @@ class OrchestrationViewModel {
   Long buildTime
   Long startTime
   Long endTime
+  def execution
 }


### PR DESCRIPTION
Doing a red/black or highlander strategy when cloning an ASG results in the 'deploy.server.groups' variable being overwritten (showing the name of the disabled asg) when creating the OrchestrationViewModal. We need/want the name of the new asg name from the clone command.
The solution will be to attach the complete Orchestration model to the OrchestrationViewModel. This will give us access to the entire task model where we can pull off the correct 'deploy.server.groups' value. In talking with Tomas this will increase the size of the data going over the wire but will allow access to the entire Orchestration model.
