### PR TITLE
select application on FindAmi task from cluster name, not stage context

### DIFF
--- a/orca-oort/orca-oort.gradle
+++ b/orca-oort/orca-oort.gradle
@@ -15,6 +15,7 @@
  */
 
 dependencies {
+  compile spinnaker.dependency('frigga')
   compile project(":orca-retrofit")
   testCompile project(":orca-test")
 }

--- a/orca-oort/src/main/groovy/com/netflix/spinnaker/orca/oort/tasks/FindAmiFromClusterTask.groovy
+++ b/orca-oort/src/main/groovy/com/netflix/spinnaker/orca/oort/tasks/FindAmiFromClusterTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.oort.tasks
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.frigga.Names
 import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
@@ -86,7 +87,7 @@ class FindAmiFromClusterTask implements Task {
 
   @Override
   TaskResult execute(Stage stage) {
-    String app = stage.context.cluster.split('-')[0]
+    String app = Names.parseName(stage.context.cluster).app
     String account = stage.context.account
     String cluster = stage.context.cluster
     Set<String> requiredRegions = new HashSet<>(stage.context.regions?.asType(List) ?: [])

--- a/orca-oort/src/test/groovy/com/netflix/spinnaker/orca/oort/tasks/FindAmiFromClusterTaskSpec.groovy
+++ b/orca-oort/src/test/groovy/com/netflix/spinnaker/orca/oort/tasks/FindAmiFromClusterTaskSpec.groovy
@@ -112,10 +112,7 @@ class FindAmiFromClusterTaskSpec extends Specification {
     1 * oortService.getCluster('otherapp', account, cluster, 'aws') >> response
 
     where:
-    cluster                | _
-    'otherapp-test'        | _
-    'otherapp-test-detail' | _
-    'otherapp'             | _
+    cluster << [ 'otherapp-test', 'otherapp-test-detail', 'otherapp' ]
 
     app = 'contextapp'
     account = 'test'


### PR DESCRIPTION
Fixes an issue reported 5/20 by @tomaslin 

@cfieber can you take a look? I have not run this locally to try to test but it seems like this is all we need to do.
