### PR TITLE
allow targetHealthyDeployPercentage to specify number of healthy inst…

### DIFF
--- a/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForUpInstancesTask.groovy
+++ b/orca-kato/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForUpInstancesTask.groovy
@@ -63,7 +63,11 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
         ((Map) stage.context.capacitySnapshot).desiredCapacity as Integer :
         asg.desiredCapacity as Integer
     if (stage.context.targetHealthyDeployPercentage != null) {
-      targetDesiredSize = Math.ceil((stage.context.targetHealthyDeployPercentage as Double) * targetDesiredSize / 100) as Integer
+      Integer percentage = (Integer) stage.context.targetHealthyDeployPercentage
+      if (percentage < 0 || percentage > 100) {
+        throw new NumberFormatException("targetHealthyDeployPercentage must be an integer between 0 and 100")
+      }
+      targetDesiredSize = Math.ceil(percentage * targetDesiredSize / 100D) as Integer
     }
     targetDesiredSize
   }

--- a/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForUpInstancesTaskSpec.groovy
+++ b/orca-kato/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForUpInstancesTaskSpec.groovy
@@ -144,6 +144,23 @@ class WaitForUpInstancesTaskSpec extends Specification {
   }
 
   @Unroll
+  void 'should throw an exception if targetHealthyDeployPercentage is not between 0 and 100'() {
+    when:
+    task.hasSucceeded(
+      new PipelineStage(new Pipeline(), "", "", [
+        targetHealthyDeployPercentage: percent
+      ]
+      ), null, [], null
+    )
+
+    then:
+    thrown(NumberFormatException)
+
+    where:
+    percent << [-1, 101]
+  }
+
+  @Unroll
   void 'should succeed as #hasSucceeded based on instance providers #healthProviderNames for instances #instances'() {
     expect:
     hasSucceeded == task.hasSucceeded(


### PR DESCRIPTION
…ances before declaring deploy successful

not in love with the field name (`targetHealthyDeployPercentage`), any suggestions are appreciated.
