### PR TITLE
Propagating authentication details across task execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     maven { url "http://dl.bintray.com/spinnaker/gradle" }
   }
   dependencies {
-    classpath "com.netflix.spinnaker:spinnaker-gradle-project:1.12.82"
+    classpath "com.netflix.spinnaker:spinnaker-gradle-project:1.12.90"
   }
 }
 

--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -24,6 +24,7 @@ dependencies {
   compile spinnaker.dependency('jacksonGuava')
   compile spinnaker.dependency('rxJava')
   compile spinnaker.dependency('korkJedis')
+  compile spinnaker.dependency('korkSecurity')
   compile spinnaker.dependency('korkJedisTest')
   compile spinnaker.dependency('rxJava')
   compile spinnaker.dependency('spectatorApi')

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/OrchestrationStarter.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/OrchestrationStarter.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.pipeline
 
+import com.netflix.spinnaker.orca.pipeline.model.Execution
 import groovy.transform.CompileStatic
 import com.netflix.spinnaker.orca.pipeline.model.Orchestration
 import com.netflix.spinnaker.orca.pipeline.model.OrchestrationStage
@@ -68,6 +69,8 @@ class OrchestrationStarter extends ExecutionStarter<Orchestration> {
     }
 
     orchestration.buildTime = System.currentTimeMillis()
+    orchestration.authentication = Execution.AuthenticationDetails.build().orElse(new Execution.AuthenticationDetails())
+
     return orchestration
   }
 

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Pipeline.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Pipeline.groovy
@@ -83,6 +83,8 @@ class Pipeline extends Execution<Pipeline> {
 
     Pipeline build() {
       pipeline.buildTime = System.currentTimeMillis()
+      pipeline.authentication = Execution.AuthenticationDetails.build().orElse(new Execution.AuthenticationDetails())
+
       pipeline
     }
 

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/ExecutionSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/ExecutionSpec.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.model
+
+import com.netflix.spinnaker.security.AuthenticatedRequest
+import org.apache.log4j.MDC
+import spock.lang.Specification
+
+class ExecutionSpec extends Specification {
+  void "should return Optional.empty if no authenticated details available"() {
+    given:
+    MDC.clear()
+
+    expect:
+    !Execution.AuthenticationDetails.build().present
+  }
+
+  void "should build AuthenticationDetails containing authenticated details"() {
+    given:
+    MDC.clear()
+    MDC.put(AuthenticatedRequest.SPINNAKER_USER, "SpinnakerUser")
+    MDC.put(AuthenticatedRequest.SPINNAKER_ACCOUNTS, "Account1,Account2")
+
+    when:
+    def authenticationDetails = Execution.AuthenticationDetails.build().get()
+
+    then:
+    authenticationDetails.user == "SpinnakerUser"
+    authenticationDetails.allowedAccounts == ["Account1", "Account2"]
+  }
+}

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/web/config/WebConfiguration.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/web/config/WebConfiguration.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.web.config
 
 import com.netflix.spectator.api.ExtendedRegistry
+import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.persistence.jedis.JedisOrchestrationStore
@@ -80,6 +81,11 @@ class WebConfiguration extends WebMvcConfigurerAdapter {
   @Bean
   BatchConfigurer multiThreadedJedisBatchConfigurer(JedisCommands jedisCommands, TaskExecutor taskExecutor) {
     new MultiThreadedJedisBatchConfigurer(jedisCommands, taskExecutor)
+  }
+
+  @Bean
+  Filter authenticatedRequestFilter() {
+    new AuthenticatedRequestFilter(true)
   }
 
   @Bean

--- a/orca-web/src/main/resources/logback-defaults.xml
+++ b/orca-web/src/main/resources/logback-defaults.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright 2015 Netflix, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License")
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p ${PID:- } --- [%15.15t] %-40.40logger{39} : [%X{X-SPINNAKER-USER}] %m%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Look for two http headers (X-SPINNAKER-USER and X-SPINNAKER-ACCOUNTS) and propagate them across task execution (via MDC).

Authentication details are stored in the Execution itself.

@robfletcher - Can you take a quick peak at this.
