### PR TITLE
Set stageOutputs.bakePackageName to empty string if no packageName wa…

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -60,7 +60,7 @@ class CreateBakeTask implements RetryableTask {
 
       def stageOutputs = [
         status: bakeStatus,
-        bakePackageName: bake.packageName
+        bakePackageName: bake.packageName ?: ""
       ] as Map<String, ? extends Object>
 
       if (bake.buildHost) {


### PR DESCRIPTION
…s specified.

Otherwise, the null property causes DefaultTaskResult to fail its PreConditions check and surfaces this error in the UI: "null value in entry: bakePackageName=null".
