### PR TITLE
Only mark a stage as SUCCEEDED when the last task succeeds

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/StageStatusPropagationListener.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/StageStatusPropagationListener.groovy
@@ -46,15 +46,15 @@ class StageStatusPropagationListener extends AbstractStagePropagationListener {
   void afterTask(Stage stage, StepExecution stepExecution) {
     def orcaTaskStatus = stepExecution.executionContext.get("orcaTaskStatus") as ExecutionStatus
     if (orcaTaskStatus) {
-      if (orcaTaskStatus.complete) {
-        stage.endTime = System.currentTimeMillis()
-      }
-
       if (orcaTaskStatus == ExecutionStatus.SUCCEEDED && (stage.tasks && stage.tasks[-1].status != ExecutionStatus.SUCCEEDED)) {
         // mark stage as RUNNING as not all tasks have completed
         stage.status = ExecutionStatus.RUNNING
       } else {
         stage.status = orcaTaskStatus
+
+        if (orcaTaskStatus.complete) {
+          stage.endTime = System.currentTimeMillis()
+        }
       }
     } else {
       stage.endTime = System.currentTimeMillis()

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/StageStatusPropagationListenerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/StageStatusPropagationListenerSpec.groovy
@@ -71,9 +71,11 @@ class StageStatusPropagationListenerSpec extends Specification {
 
     when: "the listener is triggered"
     def exitStatus = listener.afterStep stepExecution
+    def currentStage = executionRepository.retrievePipeline(pipeline.id).stages.first()
 
     then: "it updates the status of the stage to RUNNING because it is not the final task"
-    executionRepository.retrievePipeline(pipeline.id).stages.first().status == ExecutionStatus.RUNNING
+    currentStage.status == ExecutionStatus.RUNNING
+    currentStage.endTime == null
 
     and: "the exit status of the batch step is unchanged"
     exitStatus == null
@@ -86,9 +88,11 @@ class StageStatusPropagationListenerSpec extends Specification {
 
     and: "the listener is triggered"
     exitStatus = listener.afterStep stepExecution
+    currentStage = executionRepository.retrievePipeline(pipeline.id).stages.first()
 
     then: "it updates the status of the stage to SUCCEEDED because it is the final task"
-    executionRepository.retrievePipeline(pipeline.id).stages.first().status == ExecutionStatus.SUCCEEDED
+    currentStage.status == ExecutionStatus.SUCCEEDED
+    currentStage.endTime != null
 
     and: "the exit status of the batch step is unchanged"
     exitStatus == null


### PR DESCRIPTION
@robfletcher - Bit of a hack but targeted at eliminating the window where a stage could report SUCCEEDED but not actually be done.

Horrible idea?
