### PR TITLE
ad-hoc pipelines should not trigger empty pipeline triggers

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
@@ -47,11 +47,12 @@ class DependentPipelineExecutionListener implements JobExecutionListener {
   @Override
   void afterJob(JobExecution jobExecution) {
     def execution = currentExecution(jobExecution)
-    if (execution) {
+    if (execution && execution.pipelineConfigId) {
       front50Service.getAllPipelines().each {
         it.triggers.each { trigger ->
           if (trigger.enabled &&
             trigger.type == 'pipeline' &&
+            trigger.pipeline &&
             trigger.pipeline == execution.pipelineConfigId &&
             trigger.status.contains(convertStatus(execution))
           ) {

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListenerSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListenerSpec.groovy
@@ -152,4 +152,24 @@ class DependentPipelineExecutionListenerSpec extends Specification {
     0 * dependentPipelineStarter._
   }
 
+  def "ignores executions with null pipelineConfigIds"(){
+    pipeline.stages.each {
+      it.status = ExecutionStatus.SUCCEEDED
+      it.tasks = [Mock(Task)]
+    }
+
+    pipelineConfig.triggers.first().pipeline = null
+    pipeline.pipelineConfigId = null
+
+    executionRepository.retrievePipeline(_) >> pipeline
+    front50Service.getAllPipelines() >> [
+      pipelineConfig
+    ]
+
+    when:
+    listener.afterJob(jobExecution)
+
+    then:
+    0 * dependentPipelineStarter._
+  }
 }


### PR DESCRIPTION
when a pipeline is ad-hoc, it will have a null pipelineConfigId.

We were seeing issues where if an user accidentally enters a pipeline trigger without a pipeline selected, it will catch treat all the ad-hoc pipelines as a trigger
