### PR TITLE
Adds "ResizeServerGroup" as a the first generic implementation Orca t…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ModifyScalingProcessStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ModifyScalingProcessStage.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.kato.pipeline
 
+import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.kato.pipeline.support.TargetReferenceLinearStageSupport
 import com.netflix.spinnaker.orca.kato.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.kato.tasks.ServerGroupCacheForceRefreshTask

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ResizeServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ResizeServerGroupStage.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.pipeline
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.kato.pipeline.support.TargetReferenceSupport
+import com.netflix.spinnaker.orca.kato.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.kato.tasks.ResizeServerGroupTask
+import com.netflix.spinnaker.orca.kato.tasks.ServerGroupCacheForceRefreshTask
+import com.netflix.spinnaker.orca.kato.tasks.WaitForCapacityMatchTask
+import com.netflix.spinnaker.orca.pipeline.LinearStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
+import org.springframework.batch.core.Step
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+@Slf4j
+class ResizeServerGroupStage extends LinearStage {
+
+  public static final String TYPE = "resizeServerGroup"
+
+  ResizeServerGroupStage() {
+    super(TYPE)
+  }
+
+  @Override
+  List<Step> buildSteps(Stage stage) {
+    [
+      buildStep(stage, "resizeServerGroup", ResizeServerGroupTask),
+      buildStep(stage, "monitorServerGroup", MonitorKatoTask),
+      buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
+      buildStep(stage, "waitForCapacityMatch", WaitForCapacityMatchTask),
+    ]
+  }
+
+  /**
+   * This version in only used for Pipeline executions, due to the dynamic nature of the target server group. It injects
+   * a synthetic stage to resolve the target server group, then adds the Orchestration execution version of Resize
+   * afterwards.
+   */
+  @Component
+  @Slf4j
+  class Pipeline extends LinearStage {
+
+    public static final String TYPE = "resizeServerGroup_pipeline"
+
+    @Autowired
+    DetermineTargetReferenceStage determineTargetReferenceStage
+
+    @Autowired
+    TargetReferenceSupport targetReferenceSupport
+
+    @Autowired
+    ModifyScalingProcessStage modifyScalingProcessStage
+
+
+    ResizeServerGroupStage resizeServerGroupStage
+
+    /**
+     * Because this is a nested, non-static class, the JVM passes the parent class instance as part of the default
+     * constructor (usually implicitly, but by making it explicit, we can now use the @Autowired annotation to enable
+     * Spring to manage it like any other @Component).
+     */
+    @Autowired
+    Pipeline(ResizeServerGroupStage parent) {
+      super(TYPE)
+      newCloudProviderStyle = true
+      resizeServerGroupStage = parent
+    }
+
+    @Override
+    List<Step> buildSteps(Stage stage) {
+      injectBefore(stage, "determineTargetReferences", determineTargetReferenceStage, stage.context)
+
+      for (targetReference in targetReferenceSupport.getTargetAsgReferences(stage)) {
+        def context = [
+          credentials : stage.context.credentials,
+          regions     : [targetReference.region]
+        ]
+
+        if (targetReferenceSupport.isDynamicallyBound(stage)) {
+          def resizeContext = new HashMap(stage.context)
+          resizeContext.regions = [targetReference.region]
+          context.remove("asgName")
+          context.target = stage.context.target
+          injectAfter(stage, ResizeServerGroupStage.TYPE, resizeServerGroupStage, resizeContext)
+        } else {
+          context.asgName = targetReference.asg.name
+        }
+
+        if (stage.context.cloudProvider == 'aws') {
+          injectBefore(stage, "resumeScalingProcesses", modifyScalingProcessStage, context + [
+            action   : "resume",
+            processes: ["Launch", "Terminate"]
+          ])
+          injectAfter(stage, "suspendScalingProcesses", modifyScalingProcessStage, context + [
+            action: "suspend"
+          ])
+        }
+      }
+
+      // mark as SUCCEEDED otherwise a stage w/o child tasks will remain in NOT_STARTED
+      stage.status = ExecutionStatus.SUCCEEDED
+      return []
+    }
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeSupport.groovy
@@ -88,7 +88,7 @@ class ResizeSupport {
         description.capacity = mergeConfiguredCapacityWithCurrent(capacity, currentMin, currentDesired, currentMax)
       }
 
-      if (description.provider == "gce") {
+      if (description.provider == "gce" || description.cloudProvider == "gce") {
         augmentDescriptionForGCE(description, target)
       }
       descriptions[asg.name as String] = description
@@ -125,7 +125,7 @@ class ResizeSupport {
   }
 
   private augmentDescriptionForGCE(Map description, TargetReference target) {
-    description.zones = target.asg.zones
+    description.zone = target.asg.zones[0]
     description.numReplicas = description.capacity.desired
     description.replicaPoolName = description.asgName
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceConfiguration.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceConfiguration.groovy
@@ -30,7 +30,8 @@ class TargetReferenceConfiguration {
   String credentials
   List<String> regions
   List<String> zones
-  String providerType = "aws"
+  @Deprecated String providerType = "aws"
+  String cloudProvider
 
   List<String> getLocations() {
     if (regions && !regions.isEmpty()) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/AbstractInstancesCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/AbstractInstancesCheckTask.groovy
@@ -61,7 +61,9 @@ abstract class AbstractInstancesCheckTask implements RetryableTask {
     }
     Names names = Names.parseName(serverGroups.values().flatten()[0])
     try {
-      def response = oortService.getCluster(names.app, account, names.cluster, stage.context.providerType ?: "aws")
+      // TODO(ttomsu): Remove this when providerType is dead.
+      def cloudProvider = stage.context.cloudProvider ?: stage.context.providerType ?: "aws"
+      def response = oortService.getCluster(names.app, account, names.cluster, cloudProvider)
 
       if (response.status != 200) {
         return new DefaultTaskResult(ExecutionStatus.RUNNING)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/ResizeServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/ResizeServerGroupTask.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.tasks
+
+import com.netflix.spinnaker.orca.DebugSupport
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.kato.api.KatoService
+import com.netflix.spinnaker.orca.kato.pipeline.ResizeAsgStage
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeSupport
+import com.netflix.spinnaker.orca.kato.pipeline.support.TargetReferenceSupport
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+@Slf4j
+class ResizeServerGroupTask implements Task{
+
+  @Autowired
+  KatoService kato
+
+  @Autowired
+  TargetReferenceSupport targetReferenceSupport
+
+  @Autowired
+  ResizeSupport resizeSupport
+
+  @Override
+  TaskResult execute(Stage stage) {
+    def operation = convert(stage)
+    def taskId = kato.requestOperations([[resizeServerGroup: operation]])
+                     .toBlocking()
+                     .first()
+    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [
+      "notification.type"   : "resizeasg", // TODO(someone on NFLX side): Rename to 'resizeservergroup'?
+      "deploy.account.name" : operation.credentials,
+      "kato.last.task.id"   : taskId,
+      "asgName"             : operation.asgName,
+      "capacity"            : operation.capacity,
+      "deploy.server.groups": operation.regions.collectEntries {
+        [(it): [operation.asgName]]
+      }
+    ])
+  }
+
+  Map convert(Stage stage) {
+    Map operation = new HashMap(stage.context)
+    if (targetReferenceSupport.isDynamicallyBound(stage)) {
+      def targetReference = targetReferenceSupport.getDynamicallyBoundTargetAsgReference(stage)
+      def descriptors = resizeSupport.createResizeStageDescriptors(stage, [targetReference])
+      if (descriptors) {
+        operation = descriptors[0]
+      }
+    }
+    if (operation.containsKey(ResizeAsgStage.PIPELINE_CONFIG_TYPE)) {
+      operation = (Map) operation[ResizeAsgStage.PIPELINE_CONFIG_TYPE]
+    }
+    operation
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeSupportSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeSupportSpec.groovy
@@ -114,7 +114,7 @@ class ResizeSupportSpec extends Specification {
 
   def "should use GCE-specific modifications"() {
     setup:
-      context.provider = "gce"
+      context.cloudProvider = "gce"
       context.scaleNum = 2
       context.action = "scale_up"
       context.target = "current_asg_dynamic"
@@ -131,15 +131,15 @@ class ResizeSupportSpec extends Specification {
         action         : "scale_up",
         asgName        : "testapp-asg-v001",
         capacity       : [min:12, desired:12, max:12],
+        cloudProvider  : "gce",
         cluster        : "testapp-asg",
         credentials    : "test",
         numReplicas    : 12,
-        provider       : "gce",
         regions        : ["us-west-1"],
         replicaPoolName: "testapp-asg-v001",
         scaleNum       : 2,
         target         : "current_asg_dynamic",
-        zones          : ["north-pole"],
+        zone           : "north-pole", // TODO(ttomsu): should this be zones?
         asgName        : "testapp-asg-v001",
         capacity       : [min: 12, desired: 12, max: 12]
       ]

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/LinearStage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/LinearStage.groovy
@@ -35,6 +35,8 @@ import static com.netflix.spinnaker.orca.pipeline.model.Stage.SyntheticStageOwne
 @CompileStatic
 abstract class LinearStage extends StageBuilder implements StepProvider {
 
+  protected boolean newCloudProviderStyle = false
+
   LinearStage(String name) {
     super(name)
   }


### PR DESCRIPTION
…o use the new @GoogleOperation/@AmazonOperation annotations in clouddriver.

Note that there is still (a lot) of provider-specific implementation details in the Orca stages. Before I go mucking around with the tests, I wanted to get some opinions/discussion on this as a first pass.

@duftler @cfieber @sthadeshwar @anotherchrisberry 
