### PR TITLE
expose errors from SourceResolver

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTask.groovy
@@ -18,37 +18,84 @@ package com.netflix.spinnaker.orca.kato.pipeline.strategy
 
 import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.kato.pipeline.support.SourceResolver
 import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import retrofit.RetrofitError
+
+import java.util.concurrent.TimeUnit
 
 @Component
-class DetermineSourceServerGroupTask implements Task {
+@Slf4j
+class DetermineSourceServerGroupTask implements RetryableTask {
+
+  static final int MAX_ATTEMPTS = 10
+  static final int MIN_CONSECUTIVE_404 = 5
+
+  final long backoffPeriod = TimeUnit.SECONDS.toMillis(5)
+
+  // not expecting to timeout, we will fail after MAX_ATTEMPTS:
+  final long timeout = TimeUnit.SECONDS.toMillis(300)
 
   @Autowired
   SourceResolver sourceResolver
 
   @Override
   TaskResult execute(Stage stage) {
-    def source = sourceResolver.getSource(stage)
-    def stageOutputs = [:]
-    if (source) {
-      stageOutputs.source = [
-        asgName          : source.asgName,
-        account          : source.account,
-        region           : source.region,
-        useSourceCapacity: useSourceCapacity(stage, source)
-      ]
+    def stageData = stage.mapTo(StageData)
+    if (!stageData.availabilityZones) {
+      throw new IllegalStateException("missing 'availabilityZones' in stage context")
     }
-    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, stageOutputs)
+    Exception lastException = null
+    try {
+      def source = sourceResolver.getSource(stage)
+      Boolean useSourceCapacity = useSourceCapacity(stage, source)
+      if (useSourceCapacity && !source) {
+        throw new IllegalStateException( "useSourceCapacity requested, but unable to determine source for ${stageData.account}/${stageData.availabilityZones?.keySet()?.getAt(0)}/${stageData.cluster}")
+      }
+      def stageOutputs = [:]
+      if (source) {
+        stageOutputs.source = [
+          asgName          : source.asgName,
+          account          : source.account,
+          region           : source.region,
+          useSourceCapacity: useSourceCapacity
+        ]
+      }
+      return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, stageOutputs)
+    } catch (ex) {
+      log.warn("${getClass().simpleName} failed with $ex.message on attempt ${stage.context.attempt ?: 1}")
+      lastException = ex
+    }
+
+    Boolean useSourceCapacity = useSourceCapacity(stage, null)
+    boolean isNotFound = (lastException instanceof RetrofitError && lastException.kind == RetrofitError.Kind.HTTP && lastException.response.status == 404)
+
+    def ctx = [
+      lastException: lastException,
+      attempt: (stage.context.attempt ?: 1) + 1,
+      consecutiveNotFound: isNotFound ? (stage.context.consecutiveNotFound ?: 0) + 1 : 0
+    ]
+
+    if (ctx.consecutiveNotFound >= MIN_CONSECUTIVE_404 && !useSourceCapacity) {
+      //we aren't asking to use the source capacity for sizing and have got some repeated 404s on the cluster - assume that is a legit
+      return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, ctx)
+    }
+
+    if (ctx.attempt <= MAX_ATTEMPTS) {
+      return new DefaultTaskResult(ExecutionStatus.RUNNING, ctx)
+    }
+
+    throw new IllegalStateException("maxAttempts exceeded", lastException)
   }
 
   Boolean useSourceCapacity(Stage stage, StageData.Source source) {
-    if (source.useSourceCapacity != null) return source.useSourceCapacity
+    if (source?.useSourceCapacity != null) return source.useSourceCapacity
     if (stage.context.useSourceCapacity != null) return (stage.context.useSourceCapacity as Boolean)
     return null
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTaskSpec.groovy
@@ -16,11 +16,16 @@
 
 package com.netflix.spinnaker.orca.kato.pipeline.strategy
 
+import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.kato.pipeline.support.SourceResolver
 import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import retrofit.RetrofitError
+import retrofit.client.Response
+import retrofit.converter.Converter
+import retrofit.mime.TypedString
 import spock.lang.Specification
 
 class DetermineSourceServerGroupTaskSpec extends Specification {
@@ -54,7 +59,7 @@ class DetermineSourceServerGroupTaskSpec extends Specification {
 
   void 'should useSourceCapacity from context if not provided in Source'() {
     given:
-    Stage stage = new PipelineStage(new Pipeline(), 'deploy', 'deploy', [useSourceCapacity: contextUseSourceCapacity])
+    Stage stage = new PipelineStage(new Pipeline(), 'deploy', 'deploy', [useSourceCapacity: contextUseSourceCapacity, account: account, application: application, availabilityZones: [(region): []]])
 
     def resolver = Mock(SourceResolver)
 
@@ -62,17 +67,151 @@ class DetermineSourceServerGroupTaskSpec extends Specification {
     def result = new DetermineSourceServerGroupTask(sourceResolver: resolver).execute(stage)
 
     then:
-    1 * resolver.getSource(_) >> new StageData.Source(account: 'test', region: 'us-east-1', asgName: 'foo-v001', useSourceCapacity: sourceUseSourceCapacity)
+    1 * resolver.getSource(stage) >> new StageData.Source(account: account, region: region, asgName: "$application-v001", useSourceCapacity: sourceUseSourceCapacity)
 
     and:
     result.stageOutputs.source.useSourceCapacity == expectedUseSourceCapacity
 
     where:
+    account = 'test'
+    region = 'us-east-1'
+    application = 'foo'
+
+
     contextUseSourceCapacity | sourceUseSourceCapacity | expectedUseSourceCapacity
-    null                     | null                    | null
-    null                     | true                    | true
-    false                    | true                    | true
-    false                    | null                    | false
-    true                     | null                    | true
+    null | null | null
+    null | true | true
+    false | true | true
+    false | null | false
+    true | null | true
+  }
+
+  void 'should fail if there is no availabilityZones in context'() {
+    given:
+    Stage stage = new PipelineStage(new Pipeline(), 'deploy', 'deploy', [
+      account    : 'test',
+      application: 'foo'])
+
+    def resolver = Mock(SourceResolver)
+
+    when:
+    new DetermineSourceServerGroupTask(sourceResolver: resolver).execute(stage)
+
+    then:
+    def ex = thrown(IllegalStateException)
+    ex.message == "missing 'availabilityZones' in stage context"
+  }
+
+  void 'should retry on exception from source resolver'() {
+    given:
+    Exception expected = new Exception('kablamo')
+    Stage stage = new PipelineStage(new Pipeline(), 'deploy', 'deploy', [
+      account          : 'test',
+      application      : 'foo',
+      availabilityZones: ['us-east-1': []]])
+
+    def resolver = Mock(SourceResolver)
+
+    when:
+    def result = new DetermineSourceServerGroupTask(sourceResolver: resolver).execute(stage)
+
+    then:
+    1 * resolver.getSource(_) >> { throw expected }
+
+    result.status == ExecutionStatus.RUNNING
+    result.stageOutputs.lastException.is expected
+    result.stageOutputs.attempt == 2
+    result.stageOutputs.consecutiveNotFound == 0
+  }
+
+  void 'should reset consecutiveNotFound on non 404 exception'() {
+    given:
+    Exception expected = new Exception('kablamo')
+    Stage stage = new PipelineStage(new Pipeline(), 'deploy', 'deploy', [
+      account            : 'test',
+      application        : 'foo',
+      consecutiveNotFound: 3,
+      availabilityZones  : ['us-east-1': []]])
+
+    def resolver = Mock(SourceResolver)
+
+    when:
+    def result = new DetermineSourceServerGroupTask(sourceResolver: resolver).execute(stage)
+
+    then:
+    1 * resolver.getSource(_) >> { throw expected }
+
+    result.status == ExecutionStatus.RUNNING
+    result.stageOutputs.lastException.is expected
+    result.stageOutputs.attempt == 2
+    result.stageOutputs.consecutiveNotFound == 0
+  }
+
+  void 'should fail after MAX_ATTEMPTS'() {
+    Exception expected = new Exception('kablamo')
+    Stage stage = new PipelineStage(new Pipeline(), 'deploy', 'deploy', [
+      account          : 'test',
+      application      : 'foo',
+      attempt          : DetermineSourceServerGroupTask.MAX_ATTEMPTS,
+      availabilityZones: ['us-east-1': []]])
+
+    def resolver = Mock(SourceResolver)
+
+    when:
+    new DetermineSourceServerGroupTask(sourceResolver: resolver).execute(stage)
+
+    then:
+    1 * resolver.getSource(_) >> { throw expected }
+
+    def ex = thrown(IllegalStateException)
+    ex.cause.is expected
+  }
+
+  void "should #status after #attempt consecutive 404s with useSourceCapacity #useSourceCapacity"() {
+    Response response = new Response("http://oort.com", 404, "NOT_FOUND", [], new TypedString(""))
+    Exception expected = RetrofitError.httpError("http://oort.com", response, Stub(Converter), Response)
+    Stage stage = new PipelineStage(new Pipeline(), 'deploy', 'deploy', [
+      account            : 'test',
+      application        : 'foo',
+      useSourceCapacity  : useSourceCapacity,
+      attempt            : attempt,
+      consecutiveNotFound: attempt,
+      availabilityZones  : ['us-east-1': []]])
+
+    def resolver = Mock(SourceResolver)
+
+    when:
+    def taskResult = new DetermineSourceServerGroupTask(sourceResolver: resolver).execute(stage)
+
+    then:
+    1 * resolver.getSource(_) >> { throw expected }
+
+    taskResult.status == status
+
+    where:
+    status                    | useSourceCapacity | attempt
+    ExecutionStatus.SUCCEEDED | false             | DetermineSourceServerGroupTask.MIN_CONSECUTIVE_404
+    ExecutionStatus.RUNNING   | true              | DetermineSourceServerGroupTask.MIN_CONSECUTIVE_404
+    ExecutionStatus.RUNNING   | false             | 1
+    ExecutionStatus.RUNNING   | true              | 1
+  }
+
+  def 'should fail if no source resolved and useSourceCapacity requested'() {
+    Stage stage = new PipelineStage(new Pipeline(), 'deploy', 'deploy', [
+      account            : 'test',
+      application        : 'foo',
+      useSourceCapacity  : true,
+      availabilityZones  : ['us-east-1': []]])
+
+    def resolver = Mock(SourceResolver)
+
+    when:
+    def result = new DetermineSourceServerGroupTask(sourceResolver: resolver).execute(stage)
+
+    then:
+    1 * resolver.getSource(_) >> null
+
+    result.status == ExecutionStatus.RUNNING
+    result.stageOutputs.lastException.message  == "useSourceCapacity requested, but unable to determine source for test/us-east-1/foo"
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolverSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolverSpec.groovy
@@ -86,7 +86,7 @@ class SourceResolverSpec extends Specification {
     "empty"                | "singleRegion"   || "test-v003"     || "test"          || "us-west-1"
     "empty"                | "mixedRegions"   || "test-v001"     || "test"          || "us-west-1"
     "useSourceCapacity"    | "singleRegion"   || "test-v000"     || "test"          || "us-west-1"
-    "useSourceCapacity"    | "allDisabled"    || null            || null            || null
+    "useSourceCapacity"    | "allDisabled"    || "test-v001"     || "test"          || "us-west-1"
   }
 
   void 'should sort oort server groups by createdTime'() {


### PR DESCRIPTION
Made SourceResolver not mask errors when trying to determine source (exceptions bubble out)
SourceResolver will consider disabled server groups when no active server groups are present
If useSourceCapacity is requested, it will fail with an error in the DetermineSourceServerGroupTask
Added retry behaviour to DetermineSourceServerGroup to ensure we don't fail on transient exceptions
Retrying on 404 to make sure we aren't seeing a caching blip where a cluster is missing server groups
