### PR TITLE
Enable redis passwords

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@
 
 Netflix, Inc  <*@netflix.com>
 Google, Inc <*@google.com>
+Pivotal, Inc <*@pivotal.io>

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/JesqueConfiguration.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/JesqueConfiguration.groovy
@@ -41,12 +41,20 @@ class JesqueConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(Config)
-  Config jesqueConfig(@Value('${redis.connection}') String connection) {
-    def jedisConnection = URI.create(connection)
-    new ConfigBuilder()
-      .withHost(jedisConnection.host)
-      .withPort(jedisConnection.port)
-      .build()
+  Config jesqueConfig(@Value('${redis.connection:redis://localhost:6379}') String connection) {
+
+    RedisConnectionInfo connectionInfo = RedisConnectionInfo.parseConnectionUri(connection)
+
+    ConfigBuilder builder = new ConfigBuilder()
+      .withHost(connectionInfo.host)
+      .withPort(connectionInfo.port)
+      .withDatabase(connectionInfo.database)
+
+    if (connectionInfo.hasPassword()) {
+      builder.withPassword(connectionInfo.password)
+    }
+
+    builder.build()
   }
 
   @Bean

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/RedisConnectionInfo.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/RedisConnectionInfo.groovy
@@ -1,0 +1,39 @@
+package com.netflix.spinnaker.orca.config
+
+import redis.clients.jedis.Protocol
+import redis.clients.util.JedisURIHelper
+
+/**
+ * @author Greg Turnquist
+ */
+class RedisConnectionInfo {
+
+  String host
+  int port
+  int database
+  String password
+
+  boolean hasPassword() {
+    password?.length() > 0
+  }
+
+  static RedisConnectionInfo parseConnectionUri(String connection) {
+
+    URI redisConnection = URI.create(connection)
+
+    String host = redisConnection.host
+    int port = redisConnection.port == -1 ? Protocol.DEFAULT_PORT : redisConnection.port
+
+    int database = JedisURIHelper.getDBIndex(redisConnection)
+
+    String password = JedisURIHelper.getPassword(redisConnection)
+
+    new RedisConnectionInfo([
+        host: host,
+        port: port,
+        database: database,
+        password: password
+    ])
+  }
+
+}


### PR DESCRIPTION
Redis URL can be configuration via redis.connection (or REDIS_CONNECTION). This adds the ability to configure redis.password (or REDIS_PASSWORD) as well for more secure configurations.
