### PR TITLE
throw exception if target is not found

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceLinearStageSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceLinearStageSupport.groovy
@@ -47,6 +47,9 @@ abstract class TargetReferenceLinearStageSupport extends LinearStage {
 
   private void composeStaticTargets(Stage stage) {
     def descriptionList = buildStaticTargetDescriptions(stage)
+    if (descriptionList.empty) {
+      throw new TargetReferenceNotFoundException("Could not find any server groups for specified target")
+    }
     def first = descriptionList.remove(0)
     stage.context.putAll(first)
     if (descriptionList.size()) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceLinearStageSupportSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceLinearStageSupportSpec.groovy
@@ -91,6 +91,22 @@ class TargetReferenceLinearStageSupportSpec extends Specification {
     ]
   }
 
+  void "should throw a TargetReferenceNotFoundException when no static targets are found"() {
+    given:
+    def targetReferenceSupport = Mock(TargetReferenceSupport)
+    def supportStage = new TargetReferenceLinearStageSupportStage()
+    def stage = new PipelineStage(new Pipeline(), "test", [:])
+    supportStage.targetReferenceSupport = targetReferenceSupport
+
+    when:
+    supportStage.composeTargets(stage)
+
+    then:
+    thrown TargetReferenceNotFoundException
+    1 * targetReferenceSupport.isDynamicallyBound(stage) >> false
+    1 * targetReferenceSupport.getTargetAsgReferences(stage) >> []
+  }
+
   class TargetReferenceLinearStageSupportStage extends TargetReferenceLinearStageSupport {
 
     TargetReferenceLinearStageSupportStage() {


### PR DESCRIPTION
It's a deprecated method, but it's still around and in use, so let's not throw ArrayIndexOutOfBoundsExceptions
