### PR TITLE
adds CheckPreconditionsStage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/ClusterSizePreconditionTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/ClusterSizePreconditionTask.groovy
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.tasks.PreconditionTask
+import groovy.transform.Canonical
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import retrofit.RetrofitError
+import retrofit.converter.ConversionException
+import retrofit.converter.JacksonConverter
+
+@Component
+class ClusterSizePreconditionTask extends AbstractCloudProviderAwareTask implements RetryableTask, PreconditionTask {
+  public static final String PRECONDITION_TYPE = 'clusterSize'
+
+  final String preconditionType = PRECONDITION_TYPE
+  final long backoffPeriod = 5000
+  final long timeout = 30000
+
+  @Autowired
+  OortService oortService
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  @Canonical
+  static class ComparisonConfig {
+    String cluster
+    String comparison = '=='
+    int expected = 1
+    Set<String> regions
+
+    public String getApplication() {
+      Names.parseName(cluster)?.app
+    }
+
+    public Operator getOp() {
+      Operator.fromString(comparison)
+    }
+
+    public void validate() {
+      def errors = []
+      if (!cluster) {
+        errors << 'Missing cluster'
+      }
+      if (!application) {
+        errors << 'Unable to determine application for cluster ' + cluster
+      }
+      if (!op) {
+        errors << 'Unsupported comparison ' + comparison
+      }
+      if (expected < 0) {
+        errors << 'Invalid value for expected ' + expected
+      }
+      if (!regions) {
+        errors << 'Missing regions'
+      }
+      if (errors) {
+        throw new IllegalStateException("Invalid configuration " + errors.join(','))
+      }
+    }
+  }
+
+  Map readCluster(ComparisonConfig config, String credentials, String cloudProvider) {
+    def response
+    try {
+      response = oortService.getCluster(config.application, credentials, config.cluster, cloudProvider)
+    } catch (RetrofitError re) {
+      if (re.kind == RetrofitError.Kind.HTTP && re.response.status == 404) {
+        return [:]
+      }
+      throw re
+    }
+
+    JacksonConverter converter = new JacksonConverter(objectMapper)
+    try {
+      return converter.fromBody(response.body, Map) as Map
+    } catch (ConversionException ce) {
+      throw RetrofitError.conversionError(response.url, response, converter, Map, ce)
+    }
+  }
+
+  @Override
+  TaskResult execute(Stage stage) {
+    String credentials = getCredentials(stage)
+    String cloudProvider = getCloudProvider(stage)
+    ComparisonConfig config = stage.mapTo(ComparisonConfig)
+    config.validate()
+
+    Map cluster = readCluster(config, credentials, cloudProvider)
+    Map<String, List<Map>> serverGroupsByRegion = ((cluster.serverGroups as List<Map>) ?: []).groupBy { it.region }
+
+    def failures = []
+    for (String region : config.regions) {
+      def serverGroups = serverGroupsByRegion[region] ?: []
+      int actual = serverGroups.size()
+      boolean acceptable = config.getOp().evaluate(actual, config.expected)
+      if (!acceptable) {
+        failures << "Failed for $region, expected $config.expected ServerGroups but found $actual : ${serverGroups*.name}"
+      }
+    }
+
+    if (failures) {
+      throw new IllegalStateException("precondition check failed: ${failures.join(',')}")
+    }
+
+    return DefaultTaskResult.SUCCEEDED
+  }
+
+  static enum Operator {
+    LT('<', { a, e -> a < e}),
+    LE('<=', { a, e -> a <= e}),
+    EQ('==', { a, e -> a == e}),
+    GE('>=', { a, e -> a >= e}),
+    GT('>', { a, e -> a > e})
+
+    private final String value
+    private final Closure<Boolean> closure
+
+    public Operator(String value, Closure<Boolean> closure) {
+      this.value = value
+      this.closure = closure
+    }
+
+    public static Operator fromString(String opString) {
+      values().find { it.value == opString }
+    }
+
+    public boolean evaluate(int actualValue, int expectedValue) {
+      closure.call(actualValue, expectedValue)
+    }
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/ClusterSizePreconditionTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/ClusterSizePreconditionTaskSpec.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import retrofit.client.Response
+import retrofit.mime.TypedByteArray
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class ClusterSizePreconditionTaskSpec extends Specification {
+
+  static AtomicInteger cnt = new AtomicInteger(100)
+  ObjectMapper objectMapper = new ObjectMapper()
+  OortService oortService = Mock(OortService)
+
+  @Subject
+  ClusterSizePreconditionTask task = new ClusterSizePreconditionTask(objectMapper: objectMapper, oortService: oortService)
+
+  @Unroll
+  def 'ops test #actual #op #expected #result'() {
+    expect:
+    ClusterSizePreconditionTask.Operator.fromString(op).evaluate(actual, expected) == result
+
+    where:
+    actual | op   | expected | result
+    1      | '<'  | 2        | true
+    2      | '<'  | 1        | false
+    2      | '<=' | 2        | true
+    2      | '<=' | 1        | false
+    1      | '==' | 1        | true
+    1      | '==' | 2        | false
+    2      | '>'  | 1        | true
+    1      | '>'  | 2        | false
+    2      | '>=' | 2        | true
+    1      | '>=' | 2        | false
+  }
+
+  def 'checks cluster size'() {
+    setup:
+    def body = new TypedByteArray('application/json', objectMapper.writeValueAsBytes([
+      serverGroups: serverGroups
+    ]))
+    def response = new Response('http://foo', 200, 'OK', [], body)
+    def stage = new PipelineStage(new Pipeline(), 'checkCluster', [
+      credentials: credentials,
+      cluster    : cluster,
+      regions    : regions
+    ])
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * oortService.getCluster('foo', 'test', 'foo', 'aws') >> response
+
+    result.status == ExecutionStatus.SUCCEEDED
+
+    where:
+    credentials = 'test'
+    cluster = 'foo'
+    serverGroups = [mkSg('us-west-1'), mkSg('us-east-1')]
+
+    regions | success
+    ['us-west-1'] | true
+    ['us-east-1'] | true
+    ['us-west-1', 'us-east-1'] | true
+  }
+
+  def 'fails if cluster size wrong'() {
+    setup:
+    def body = new TypedByteArray('application/json', objectMapper.writeValueAsBytes([
+      serverGroups: serverGroups
+    ]))
+    def response = new Response('http://foo', 200, 'OK', [], body)
+    def stage = new PipelineStage(new Pipeline(), 'checkCluster', [
+      credentials: credentials,
+      cluster    : cluster,
+      regions    : regions
+    ])
+
+    when:
+    task.execute(stage)
+
+    then:
+    1 * oortService.getCluster('foo', 'test', 'foo', 'aws') >> response
+
+    thrown(IllegalStateException)
+
+    where:
+    credentials = 'test'
+    cluster = 'foo'
+    serverGroups = [mkSg('us-west-1'), mkSg('us-east-1'), mkSg('us-west-2'), mkSg('us-west-2')]
+
+    regions << [['eu-west-1'], ['eu-west-1', 'us-west-1'], ['us-east-1', 'us-west-2']]
+  }
+
+
+  Map mkSg(String region) {
+    [name: "foo-v${cnt.incrementAndGet()}".toString(), region: region]
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/CheckPreconditionsStage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/CheckPreconditionsStage.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline
+
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.tasks.PreconditionTask
+import org.springframework.batch.core.Step
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class CheckPreconditionsStage extends ParallelStage implements StepProvider {
+  static final String PIPELINE_CONFIG_TYPE = "checkPreconditions"
+
+  @Autowired
+  List<PreconditionTask> preconditionTasks
+
+  CheckPreconditionsStage() {
+    super(PIPELINE_CONFIG_TYPE)
+  }
+
+  @Override
+  List<Step> buildSteps(Stage stage) {
+    String preconditionType = stage.context.preconditionType
+    if (!preconditionType) {
+      throw new IllegalStateException("no preconditionType specified for stage $stage.id")
+    }
+    Task preconditionTask = preconditionTasks.find { it.preconditionType == preconditionType }
+    if (!preconditionTask) {
+      throw new IllegalStateException("no Precondition implementation for type $preconditionType")
+    }
+    [buildStep(stage, "checkPrecondition", preconditionTask)]
+  }
+
+  @Override
+  List<Step> buildParallelContextSteps(Stage stage) {
+    buildSteps(stage)
+  }
+
+  @Override
+  String parallelStageName(Stage stage, boolean hasParallelFlows) {
+    "Check Preconditions"
+  }
+
+  @Override
+  Task completeParallel() {
+    new Task() {
+      @Override
+      TaskResult execute(Stage stage) {
+        DefaultTaskResult.SUCCEEDED
+      }
+    }
+  }
+
+  @Override
+  List<Map<String, Object>> parallelContexts(Stage stage) {
+    def baseContext = new HashMap(stage.context)
+    List<Map> preconditions = baseContext.remove('preconditions') as List<Map>
+    return preconditions.collect { preconditionConfig ->
+      def context = baseContext + preconditionConfig + [type: PIPELINE_CONFIG_TYPE]
+      context.name = context.name ?: "Check precondition $context.preconditionType".toString()
+      return context
+    }
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/tasks/NoopPreconditionTask.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/tasks/NoopPreconditionTask.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.tasks
+
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.stereotype.Component
+
+@Component
+class NoopPreconditionTask implements PreconditionTask {
+
+  final String preconditionType = 'noop'
+
+  @Override
+  TaskResult execute(Stage stage) {
+    DefaultTaskResult.SUCCEEDED
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/tasks/PreconditionTask.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/tasks/PreconditionTask.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.tasks
+
+import com.netflix.spinnaker.orca.Task
+
+/**
+ * Marker interface for tasks used to evaluate a precondition.
+ *
+ * A precondition task is intended to evaluates current state without any side-effects.
+ * It will be executed by {@link com.netflix.spinnaker.orca.pipeline.CheckPreconditionsStage}.
+ */
+interface PreconditionTask extends Task {
+  String getPreconditionType()
+}


### PR DESCRIPTION
`CheckPreconditionsStage` accepts multiple preconditions, and looks up
the implementation as a `PreconditionTask`. `PreconditionTask`s are
evaluated in parallel, and the overall stage succeeds if all
preconditions are successful.

example stage context:

``` json
{
  "application": "foo",
  "name": "check preconditions example",
  "stages": [{
    "type": "checkPreconditions",
    "preconditions": [{
      "preconditionType": "clusterSize",
      "cloudProvider": "aws",
      "credentials": "test",
      "cluster": "foo-test",
      "comparison": "<=",
      "expected": 2,
      "regions": ["us-east-1", "us-west-2", "eu-west-1"]
    },{
      "preconditionType": "clusterSize",
      "cloudProvider": "aws",
      "credentials": "test",
      "cluster": "foo-canary",
      "regions": ["us-east-1", "us-west-2", "eu-west-1"],
      "expected": 0
    }]
  }]
}
```
