### PR TITLE
include resourceUri in bake result

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeStatus.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeStatus.groovy
@@ -39,6 +39,11 @@ class BakeStatus implements Serializable {
   Result result
 
   /**
+   * A URI reference to the bake details
+   */
+  String resourceUri
+
+  /**
    * The bake id that can be used to find the details of the bake.
    *
    * @see BakeryService#lookupBake


### PR DESCRIPTION
The bakery includes the full path the bake details - if we capture it here, we can remove the [hardcoded value in Deck](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/pipelines/config/stages/bake/aws/bakeExecutionDetails.html#L37) and make integration with other bakeries a lot easier.
