### PR TITLE
Defaulting to 'aws' as cloudProvider value if not present in the stage context

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetServerGroup.groovy
@@ -73,7 +73,7 @@ class TargetServerGroup {
 
     String credentials
     List<String> locations // regions or zones.
-    String cloudProvider
+    String cloudProvider = "aws"
 
     String getApp() {
       Names.parseName(asgName ?: cluster)?.app


### PR DESCRIPTION
@cfieber Please review this

@ttomsu The destroy server group is broken for existing pipelines as those pipeline stage context does not have the key "cloudProvider" (has "providerType" or "provider" instead). Adding a default value of 'aws' to the `TargetServerGroup` class. Are there other places in TRF (new implementation) which assumes "cloudProvider" key to be always present in stage context? If yes, then we should probably add a default of 'aws' for backwards compatibility.
