### PR TITLE
Updates dynamic TargetServerGroup resolve to Task time

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetServerGroupLinearStageSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetServerGroupLinearStageSupport.groovy
@@ -40,21 +40,22 @@ abstract class TargetServerGroupLinearStageSupport extends LinearStage implement
   }
 
   void composeTargets(Stage stage) {
-    def tsgs = resolver.resolve(stage)
+    def params = TargetServerGroup.Params.fromStage(stage)
     if (TargetServerGroup.isDynamicallyBound(stage)) {
-      composeDynamicTargets(stage, tsgs)
+      composeDynamicTargets(stage, params)
     } else {
-      composeStaticTargets(stage, tsgs)
+      composeStaticTargets(stage, params)
     }
   }
 
-  private void composeStaticTargets(Stage stage, List<TargetServerGroup> targets) {
+  private void composeStaticTargets(Stage stage, TargetServerGroup.Params params) {
     if (stage.parentStageId) {
       // Only process this stage as-is when the user specifies. Otherwise, the targets should already be defined in the
       // context.
       return
     }
 
+    def targets = resolver.resolveByParams(params)
     def descriptionList = buildStaticTargetDescriptions(stage, targets)
     def first = descriptionList.remove(0)
     stage.context.putAll(first)
@@ -97,7 +98,7 @@ abstract class TargetServerGroupLinearStageSupport extends LinearStage implement
     descriptions.values().toList()
   }
 
-  private void composeDynamicTargets(Stage stage, List<TargetServerGroup> tsgs) {
+  private void composeDynamicTargets(Stage stage, TargetServerGroup.Params params) {
     if (stage.parentStageId) {
       // We only want to determine the target ASGs once per stage, so only inject if this is the root stage, i.e.
       // the one the user configured
@@ -106,7 +107,7 @@ abstract class TargetServerGroupLinearStageSupport extends LinearStage implement
       return
     }
 
-    def configuredLocations = tsgs.collect { it.location }
+    def configuredLocations = params.locations
     Map dtsgContext = new HashMap(stage.context)
     dtsgContext.regions = new ArrayList(configuredLocations)
     stage.context.regions = [configuredLocations.remove(0)]

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetServerGroupLinearStageSupportSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetServerGroupLinearStageSupportSpec.groovy
@@ -32,99 +32,92 @@ class TargetServerGroupLinearStageSupportSpec extends Specification {
   @Unroll
   void "#description determineTargetReferences stage when target is dynamic and parentStageId is #parentStageId"() {
     given:
-      def stage = new PipelineStage(new Pipeline(), "test", [regions: ["us-east-1"], target: "current_asg_dynamic"])
-      stage.parentStageId = parentStageId
+    def stage = new PipelineStage(new Pipeline(), "test", [regions: ["us-east-1"], target: "current_asg_dynamic"])
+    stage.parentStageId = parentStageId
 
     when:
-      supportStage.composeTargets(stage)
+    supportStage.composeTargets(stage)
 
     then:
-      resolver.resolve(_) >> [new TargetServerGroup(location: "us-east-1")]
-      stage.beforeStages.size() == stageNamesBefore.size()
-      stage.afterStages.size() == 0
-      stage.beforeStages*.name == stageNamesBefore
+    stage.beforeStages.size() == stageNamesBefore.size()
+    stage.afterStages.size() == 0
+    stage.beforeStages*.name == stageNamesBefore
 
     where:
-      parentStageId | stageNamesBefore               | description
-      null          | ["determineTargetServerGroup"] | "should inject"
-      "a"           | []                             | "should inject"
+    parentStageId | stageNamesBefore               | description
+    null          | ["determineTargetServerGroup"] | "should inject"
+    "a"           | []                             | "should inject"
   }
 
   void "should inject a stage for each extra region when the target is dynamically bound"() {
     given:
-      def stage = new PipelineStage(new Pipeline(), "test", [
-        regions: ["us-east-1", "us-west-1", "us-west-2", "eu-west-2"],
-        target : "current_asg_dynamic"
-      ])
+    def stage = new PipelineStage(new Pipeline(), "test", [
+      regions: ["us-east-1", "us-west-1", "us-west-2", "eu-west-2"],
+      target : "current_asg_dynamic"
+    ])
 
     when:
-      supportStage.composeTargets(stage)
+    supportStage.composeTargets(stage)
 
     then:
-      resolver.resolve(_) >> [
-        new TargetServerGroup(location: "us-east-1"),
-        new TargetServerGroup(location: "us-west-1"),
-        new TargetServerGroup(location: "us-west-2"),
-        new TargetServerGroup(location: "eu-west-2"),
-      ]
-      stage.beforeStages.size() == 1
-      stage.afterStages.size() == 3
-      stage.afterStages*.name == ["testSupportStage", "testSupportStage", "testSupportStage"]
-      stage.context.regions == ["us-east-1"]
-      stage.afterStages*.context.regions.flatten() == ["us-west-1", "us-west-2", "eu-west-2"]
+    stage.beforeStages.size() == 1
+    stage.afterStages.size() == 3
+    stage.afterStages*.name == ["testSupportStage", "testSupportStage", "testSupportStage"]
+    stage.context.regions == ["us-east-1"]
+    stage.afterStages*.context.regions.flatten() == ["us-west-1", "us-west-2", "eu-west-2"]
 
   }
 
   void "should inject a stage after for each extra target when target is not dynamically bound"() {
     given:
-      def stage = new PipelineStage(new Pipeline(), "test", [:])
+    def stage = new PipelineStage(new Pipeline(), "test", [:])
 
     when:
-      supportStage.composeTargets(stage)
+    supportStage.composeTargets(stage)
 
     then:
-      resolver.resolve(_) >> [
-        new TargetServerGroup(location: "us-east-1", serverGroup: [name: "asg-v001"]),
-        new TargetServerGroup(location: "us-west-1", serverGroup: [name: "asg-v001"]),
-        new TargetServerGroup(location: "us-west-2", serverGroup: [name: "asg-v002"]),
-        new TargetServerGroup(location: "eu-west-2", serverGroup: [name: "asg-v003"]),
-      ]
-      stage.beforeStages.size() == 0
-      stage.afterStages.size() == 2
-      stage.afterStages*.name == ["testSupportStage", "testSupportStage"]
+    1 * resolver.resolveByParams(_) >> [
+      new TargetServerGroup(location: "us-east-1", serverGroup: [name: "asg-v001"]),
+      new TargetServerGroup(location: "us-west-1", serverGroup: [name: "asg-v001"]),
+      new TargetServerGroup(location: "us-west-2", serverGroup: [name: "asg-v002"]),
+      new TargetServerGroup(location: "eu-west-2", serverGroup: [name: "asg-v003"]),
+    ]
+    stage.beforeStages.size() == 0
+    stage.afterStages.size() == 2
+    stage.afterStages*.name == ["testSupportStage", "testSupportStage"]
   }
 
   @Unroll
   def "#target should inject stages correctly before and after each location stage"() {
     given:
-      def stage = new PipelineStage(new Pipeline(), "test", [target: target, regions: ["us-east-1", "us-west-1"]])
-      def arbitraryStageBuilder = new ResizeServerGroupStage()
-      supportStage.preInjectables = [new TargetServerGroupLinearStageSupport.Injectable(
-        name: "testPreInjectable",
-        stage: arbitraryStageBuilder,
-        context: ["abc": 123]
-      )]
-      supportStage.postInjectables = [new TargetServerGroupLinearStageSupport.Injectable(
-        name: "testPostInjectable",
-        stage: arbitraryStageBuilder,
-        context: ["abc": 123]
-      )]
+    def stage = new PipelineStage(new Pipeline(), "test", [target: target, regions: ["us-east-1", "us-west-1"]])
+    def arbitraryStageBuilder = new ResizeServerGroupStage()
+    supportStage.preInjectables = [new TargetServerGroupLinearStageSupport.Injectable(
+      name: "testPreInjectable",
+      stage: arbitraryStageBuilder,
+      context: ["abc": 123]
+    )]
+    supportStage.postInjectables = [new TargetServerGroupLinearStageSupport.Injectable(
+      name: "testPostInjectable",
+      stage: arbitraryStageBuilder,
+      context: ["abc": 123]
+    )]
 
     when:
-      supportStage.composeTargets(stage)
+    supportStage.composeTargets(stage)
 
     then:
-      resolver.resolve(_) >> [
-        new TargetServerGroup(location: "us-east-1", serverGroup: [name: "asg-v001"]),
-        new TargetServerGroup(location: "us-west-1", serverGroup: [name: "asg-v002"]),
-      ]
-      stage.beforeStages*.name == beforeNames
-      stage.afterStages*.name == ["testPostInjectable", "testPreInjectable", "testSupportStage", "testPostInjectable"]
+    (shouldResolve ? 1 : 0) * resolver.resolveByParams(_) >> [
+      new TargetServerGroup(location: "us-east-1", serverGroup: [name: "asg-v001"]),
+      new TargetServerGroup(location: "us-west-1", serverGroup: [name: "asg-v002"]),
+    ]
+    stage.beforeStages*.name == beforeNames
+    stage.afterStages*.name == ["testPostInjectable", "testPreInjectable", "testSupportStage", "testPostInjectable"]
 
     where:
-      target                | beforeNames
-      "current_asg"         | ["testPreInjectable"]
-      "current_asg_dynamic" | ["testPreInjectable", "determineTargetServerGroup"]
+    target                | beforeNames                                         | shouldResolve
+    "current_asg"         | ["testPreInjectable"]                               | true
+    "current_asg_dynamic" | ["testPreInjectable", "determineTargetServerGroup"] | false
   }
 
   class TestSupportStage extends TargetServerGroupLinearStageSupport {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetServerGroupResolverSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetServerGroupResolverSpec.groovy
@@ -45,7 +45,7 @@ class TargetServerGroupResolverSpec extends Specification {
       ))
 
     then:
-      oort.getTargetServerGroup("test", "testCreds", "test-app", "abc", "north-pole", "current_asg") >>
+      1 * oort.getTargetServerGroup("test", "testCreds", "test-app", "abc", "north-pole", "current_asg") >>
         new Response("clouddriver", 200, 'ok', [], new TypedString(mapper.writeValueAsString([
           name: "test-app-v010",
           data: 123,
@@ -64,7 +64,7 @@ class TargetServerGroupResolverSpec extends Specification {
       ))
 
     then:
-      oort.getServerGroup("test", "testCreds", "test-app", "test-app-v010", null, "abc") >>
+      1 * oort.getServerGroup("test", "testCreds", "test-app", "test-app-v010", null, "abc") >>
         new Response("clouddriver", 200, 'ok', [], new TypedString(mapper.writeValueAsString([[
                                                                                                 name : "test-app-v010",
                                                                                                 zones: ["north-pole"],


### PR DESCRIPTION
At stage evaluation time, it isn't possible to reliably resolve dynamic targets. (for example a
pipeline that creates a new server group followed by a stage that destroys the ancestor_asg_dynamic
would fail at stage evaluation time if the cluster only had a single ServerGroup at the start of
the pipeline).

@ttomsu can you review this?
