### PR TITLE
try less hard for commits, wait longer

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
@@ -36,10 +36,10 @@ import java.util.concurrent.TimeUnit
 @Slf4j
 @Component
 class GetCommitsTask implements DiffTask {
-  private static final int MAX_RETRIES = 10
+  private static final int MAX_RETRIES = 3
 
-  long backoffPeriod = 1000
-  long timeout = TimeUnit.SECONDS.toMillis(30) // always set this higher than retries * backoffPeriod would take
+  long backoffPeriod = 3000
+  long timeout = TimeUnit.SECONDS.toMillis(60) // always set this higher than retries * backoffPeriod would take
 
   @Autowired
   OortService oortService


### PR DESCRIPTION
cc: @dzapata 

Seeing this fail hitting the 30s task timeout currently - backing it off to only try 3 times and giving it more time to complete (seems like API calls can take on the order of 10+ seconds at times)
