### PR TITLE
Removes 'path' field from non-browser HTTP 4XX responses

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/web/config/WebConfiguration.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/web/config/WebConfiguration.groovy
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.orca.web.config
 
-import javax.servlet.*
-import javax.servlet.http.HttpServletResponse
 import com.netflix.spectator.api.ExtendedRegistry
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
@@ -25,11 +23,17 @@ import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowire
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.web.DefaultErrorAttributes
+import org.springframework.boot.autoconfigure.web.ErrorAttributes
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.context.request.RequestAttributes
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
+
+import javax.servlet.*
+import javax.servlet.http.HttpServletResponse
 
 @Configuration
 @ComponentScan(basePackages = 'com.netflix.spinnaker.orca.controllers')
@@ -71,6 +75,28 @@ class WebConfiguration extends WebMvcConfigurerAdapter {
       public void init(FilterConfig filterConfig) {}
 
       public void destroy() {}
+    }
+  }
+
+  @Bean
+  ErrorAttributes errorAttributes() {
+    return new ErrorAttributes() {
+
+      DefaultErrorAttributes defaultErrorAttributes = new DefaultErrorAttributes()
+
+      @Override
+      Map<String, Object> getErrorAttributes(RequestAttributes attrs, boolean includeStackTrace) {
+        Map<String, Object> errorAttributes = defaultErrorAttributes.getErrorAttributes(attrs, includeStackTrace)
+        // By default, Spring echoes back the user's requested path. This opens up a potential XSS vulnerability where a
+        // user, for example, requests "GET /<script>alert('Hi')</script> HTTP/1.1".
+        errorAttributes.remove("path")
+        return errorAttributes
+      }
+
+      @Override
+      Throwable getError(RequestAttributes requestAttributes) {
+        return defaultErrorAttributes.getError(requestAttributes)
+      }
     }
   }
 }


### PR DESCRIPTION
This PR composes the default error attributes object provided by Spring, and simply removes the offending `path` entry. It affects only incoming connections, as opposed to the existing RetrofitExceptionHandler, which handles exceptions from outgoing connections.

Reference: http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-error-handling

@ajordens @duftler @gregturn PTAL
