### PR TITLE
Makes stage & task log output more readable.

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/DebugSupport.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/DebugSupport.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2015 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.orca
 
-import org.apache.commons.collections.MapUtils
+import com.fasterxml.jackson.databind.ObjectMapper
 
 /**
  * Utility class that aids in debugging Maps in the logs.
@@ -29,9 +29,9 @@ class DebugSupport {
    * @return a prettier, loggable string version of a Map.
    */
   static String prettyPrint(Map m) {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    PrintStream ps = new PrintStream(baos);
-    MapUtils.debugPrint(ps, null, m);
-    return baos.toString();
+    try {
+      return new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(m)
+    } catch (Exception ignored) {}
+    return "Could not pretty print map: ${m}"
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/TaskTasklet.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/TaskTasklet.groovy
@@ -229,7 +229,9 @@ class TaskTasklet implements Tasklet {
     def taskLogger = LoggerFactory.getLogger(task.class)
     if (result.status.complete || taskLogger.isDebugEnabled()) {
       def executionId = stage.execution.id + (stage.refId ? ":${stage.refId}" : "")
-      def message = "${stage.execution.class.simpleName}:${executionId} ${taskName(chunkContext)} ${result.status} -- Batch step id: ${chunkContext.stepContext.stepExecution.id},  Task Outputs: ${result.outputs},  Stage Context: ${stage.context}"
+      def outputs = DebugSupport.prettyPrint(result.outputs)
+      def ctx = DebugSupport.prettyPrint(stage.context)
+      def message = "${stage.execution.class.simpleName}:${executionId} ${taskName(chunkContext)} ${result.status} -- Batch step id: ${chunkContext.stepContext.stepExecution.id},  Task Outputs: ${outputs},  Stage Context: ${ctx}"
       if (result.status.complete) {
         taskLogger.info message
       } else {


### PR DESCRIPTION
@duftler @tomaslin PTAL

Example:
![prettyprint](https://cloud.githubusercontent.com/assets/13141550/10672399/e89e4ee4-78bd-11e5-8085-7917bad0811b.png)
