### PR TITLE
Less verbose library diffs

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTask.groovy
@@ -103,7 +103,7 @@ class JarDiffsTask implements DiffTask {
       List sourceJarList = getJarList(sourceInstances)
 
       // diff
-      LibraryDiffTool libraryDiffTool = new LibraryDiffTool(comparableLooseVersion)
+      LibraryDiffTool libraryDiffTool = new LibraryDiffTool(comparableLooseVersion, false)
       LibraryDiffs jarDiffs = libraryDiffTool.calculateLibraryDiffs(sourceJarList, targetJarList)
 
       // add the diffs to the context


### PR DESCRIPTION
- By default, do not include library details (no consumers)
- Do not even bother recording unchanged diffs
