### PR TITLE
Removes 'Last' from 'CloneLastServerGroup(Stage|Task)

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/CloneServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/CloneServerGroupStage.groovy
@@ -16,35 +16,30 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline
 
+import com.netflix.spinnaker.orca.clouddriver.pipeline.strategies.AbstractDeployStrategyStage
+import com.netflix.spinnaker.orca.clouddriver.tasks.CloneServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.WaitForUpInstancesTask
-import com.netflix.spinnaker.orca.kato.pipeline.strategy.DeployStrategyStage
-import com.netflix.spinnaker.orca.kato.tasks.CloneLastServerGroupTask
 import com.netflix.spinnaker.orca.kato.tasks.DiffTask
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import groovy.transform.CompileStatic
 import org.springframework.batch.core.Step
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
-/**
- * @author sthadeshwar
- */
 @Component
-@CompileStatic
-class CloneLastServerGroupStage extends DeployStrategyStage {
+class CloneServerGroupStage extends AbstractDeployStrategyStage {
 
-  public static final String PIPELINE_CONFIG_TYPE = "cloneLastServerGroup"
+  public static final String PIPELINE_CONFIG_TYPE = "cloneServerGroup"
 
   @Autowired(required = false)
   List<DiffTask> diffTasks
 
-  CloneLastServerGroupStage() {
+  CloneServerGroupStage() {
     super(PIPELINE_CONFIG_TYPE)
   }
 
-  CloneLastServerGroupStage(String type) {
+  CloneServerGroupStage(String type) {
     super(type)
   }
 
@@ -52,7 +47,7 @@ class CloneLastServerGroupStage extends DeployStrategyStage {
   List<Step> basicSteps(Stage stage) {
     def steps = []
 
-    steps << buildStep(stage, "cloneLastServerGroup", CloneLastServerGroupTask)
+    steps << buildStep(stage, "cloneServerGroup", CloneServerGroupTask)
     steps << buildStep(stage, "monitorDeploy", MonitorKatoTask)
     steps << buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask)
     steps << buildStep(stage, "waitForUpInstances", WaitForUpInstancesTask)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractClusterWideClouddriverTask.groovy
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.KatoService
-import com.netflix.spinnaker.orca.clouddriver.pipeline.CloneLastServerGroupStage
+import com.netflix.spinnaker.orca.clouddriver.pipeline.CloneServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.support.TargetServerGroup
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
@@ -153,7 +153,7 @@ abstract class AbstractClusterWideClouddriverTask extends AbstractCloudProviderA
     final Set<String> deployStageTypes = [
       DeployStage.PIPELINE_CONFIG_TYPE,
       CopyLastAsgStage.PIPELINE_CONFIG_TYPE,
-      CloneLastServerGroupStage.PIPELINE_CONFIG_TYPE,
+      CloneServerGroupStage.PIPELINE_CONFIG_TYPE,
       DeployGoogleServerGroupStage.PIPELINE_CONFIG_TYPE
     ]
     List<TargetServerGroup> deployedServerGroups = []

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/CloneServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/CloneServerGroupTask.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.orca.kato.tasks
+package com.netflix.spinnaker.orca.clouddriver.tasks
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.DefaultTaskResult
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.KatoService
-import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
 import com.netflix.spinnaker.orca.clouddriver.utils.HealthHelper
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
@@ -30,7 +29,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 @Component
-class CloneLastServerGroupTask extends AbstractCloudProviderAwareTask implements Task {
+class CloneServerGroupTask extends AbstractCloudProviderAwareTask implements Task {
 
   @Autowired
   KatoService kato

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/CopyLastAsgStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/CopyLastAsgStage.groovy
@@ -15,14 +15,15 @@
  */
 
 package com.netflix.spinnaker.orca.kato.pipeline
-import com.netflix.spinnaker.orca.clouddriver.pipeline.CloneLastServerGroupStage
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.CloneServerGroupStage
 import groovy.transform.CompileStatic
 import org.springframework.stereotype.Component
 
 @Component
 @CompileStatic
 @Deprecated
-class CopyLastAsgStage extends CloneLastServerGroupStage {
+class CopyLastAsgStage extends CloneServerGroupStage {
 
   public static final String PIPELINE_CONFIG_TYPE = "copyLastAsg"
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/CloneServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/CloneServerGroupTaskSpec.groovy
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.orca.kato.tasks
+package com.netflix.spinnaker.orca.clouddriver.tasks
 
 import com.fasterxml.jackson.datatype.guava.GuavaModule
-import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import rx.Observable
 import spock.lang.Specification
 import spock.lang.Subject
 
-class CloneLastServerGroupTaskSpec extends Specification {
-  @Subject task = new CloneLastServerGroupTask()
+class CloneServerGroupTaskSpec extends Specification {
+  @Subject task = new CloneServerGroupTask()
   def stage = new PipelineStage(new Pipeline(), "copyLastAsg")
   def mapper = new OrcaObjectMapper()
   def taskId = new TaskId(UUID.randomUUID().toString())


### PR DESCRIPTION
And moved the task to the new package.

It doesn't look like @sthadeshwar changed Deck to use the new (now changed) "cloneLastServerGroup" pipeline type, so there should be no operational effect of this change until I update Deck.

Tested by cloning a SG in the UI in both AWS and GCE
