### PR TITLE
JobExecutionListeners are now sorted

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.groovy
@@ -153,8 +153,15 @@ class OrcaConfiguration {
   }
 
   @Bean
-  ExecutionPropagationListener pipelineStatusPropagationListener(ExecutionRepository executionRepository) {
-    new ExecutionPropagationListener(executionRepository)
+  ExecutionPropagationListener executionPropagationListenerBefore(ExecutionRepository executionRepository) {
+    // need a dedicated beforeJob listener due to how spring boot ordered listeners
+    new ExecutionPropagationListener(executionRepository, true, false)
+  }
+
+  @Bean
+  ExecutionPropagationListener executionPropagationListenerAfter(ExecutionRepository executionRepository) {
+    // need a dedicated afterJob listener due to how spring boot ordered listeners
+    new ExecutionPropagationListener(executionRepository, false, true)
   }
 
   @Bean

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/OrchestrationJobBuilder.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/OrchestrationJobBuilder.groovy
@@ -34,13 +34,16 @@ import org.springframework.stereotype.Component
 class OrchestrationJobBuilder extends ExecutionJobBuilder<Orchestration> {
 
   @Autowired
-  ExecutionPropagationListener executionStatusPropagationListener
+  Collection<ExecutionPropagationListener> executionPropagationListeners
 
   @Override
   Job build(Orchestration orchestration) {
     String name = jobNameFor(orchestration)
     JobBuilder jobBuilder = jobs.get(name)
-    jobBuilder = jobBuilder.listener(executionStatusPropagationListener)
+
+    executionPropagationListeners.each {
+      jobBuilder = jobBuilder.listener(it)
+    }
 
     Tasklet t = new OrchestrationInitializerTasklet(orchestration)
     Step tasklet = t.createTasklet(steps)

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarterListener.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarterListener.groovy
@@ -24,11 +24,13 @@ import groovy.util.logging.Slf4j
 import org.springframework.batch.core.JobExecution
 import org.springframework.batch.core.JobExecutionListener
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.annotation.Order
 
 /**
  * Reacts to pipelines finishing and schedules the next job waiting
  */
 @Slf4j
+@Order(0)
 @CompileStatic
 class PipelineStarterListener implements JobExecutionListener {
 

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/restart/ExecutionTracker.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/restart/ExecutionTracker.groovy
@@ -11,10 +11,12 @@ import org.springframework.batch.core.JobExecution
 import org.springframework.batch.core.JobExecutionListener
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 
-@Component
 @Slf4j
+@Order(0)
+@Component
 @CompileStatic
 class ExecutionTracker implements JobExecutionListener {
 

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/ExecutionPropagationListenerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/ExecutionPropagationListenerSpec.groovy
@@ -27,7 +27,7 @@ import spock.lang.Unroll
 
 class ExecutionPropagationListenerSpec extends Specification {
   def executionRepository = Mock(ExecutionRepository)
-  def listener = new ExecutionPropagationListener(executionRepository)
+  def listener = new ExecutionPropagationListener(executionRepository, true, true)
 
   def "should mark pipeline/orchestration as RUNNING and set initial global execution context in beforeJob"() {
     given:

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/ExecutionCancellationSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/ExecutionCancellationSpec.groovy
@@ -71,7 +71,7 @@ class ExecutionCancellationSpec extends AbstractBatchLifecycleSpec {
   protected Job configureJob(JobBuilder jobBuilder) {
     def stage = pipeline.namedStage("cancel")
     def builder = jobBuilder
-      .listener(new ExecutionPropagationListener(executionRepository))
+      .listener(new ExecutionPropagationListener(executionRepository, true, true))
       .flow(initializationStep(steps, pipeline))
     def stageBuilder = new CancellationStageBuilder(
       steps: steps,

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingPipelineExecutionListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingPipelineExecutionListener.groovy
@@ -9,9 +9,11 @@ import groovy.util.logging.Slf4j
 import org.springframework.batch.core.ExitStatus
 import org.springframework.batch.core.JobExecution
 import org.springframework.batch.core.JobExecutionListener
+import org.springframework.core.annotation.Order
 
-@CompileStatic
 @Slf4j
+@Order(0)
+@CompileStatic
 class EchoNotifyingPipelineExecutionListener implements JobExecutionListener {
 
   protected final ExecutionRepository executionRepository

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.orca.front50.config
 
+import org.springframework.core.annotation.Order
+
 import static retrofit.Endpoints.newFixedEndpoint
 
 import com.google.gson.Gson

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
@@ -25,9 +25,11 @@ import groovy.transform.CompileDynamic
 import groovy.util.logging.Slf4j
 import org.springframework.batch.core.JobExecution
 import org.springframework.batch.core.JobExecutionListener
+import org.springframework.core.annotation.Order
 
-@CompileDynamic
 @Slf4j
+@Order(0)
+@CompileDynamic
 class DependentPipelineExecutionListener implements JobExecutionListener {
 
   protected final ExecutionRepository executionRepository


### PR DESCRIPTION
- ExecutionPropagationListener must run first in both `beforeJob` and `afterJob`
