### PR TITLE
Support for retrieving executions by `executionStatus`

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgent.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgent.groovy
@@ -116,7 +116,9 @@ class TopApplicationExecutionCleanupPollingNotificationAgent implements Applicat
               break
             case "orchestration":
               log.info("Cleaning up orchestration executions (application: ${application}, threshold: ${threshold})")
-              cleanup(executionRepository.retrieveOrchestrationsForApplication(application), application, "orchestration")
+
+              def executionCriteria = new ExecutionRepository.ExecutionCriteria(limit: 500)
+              cleanup(executionRepository.retrieveOrchestrationsForApplication(application, executionCriteria), application, "orchestration")
               break
             default:
               log.error("Unable to cleanup executions, unsupported type: ${type}")

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.groovy
@@ -37,9 +37,14 @@ interface ExecutionRepository {
   void deletePipeline(String id)
   rx.Observable<Pipeline> retrievePipelines()
   rx.Observable<Pipeline> retrievePipelinesForApplication(String application)
-  rx.Observable<Pipeline> retrievePipelinesForPipelineConfigId(String pipelineConfigId, int limit)
+  rx.Observable<Pipeline> retrievePipelinesForPipelineConfigId(String pipelineConfigId, ExecutionCriteria criteria)
   Orchestration retrieveOrchestration(String id)
   void deleteOrchestration(String id)
   rx.Observable<Orchestration> retrieveOrchestrations()
-  rx.Observable<Orchestration> retrieveOrchestrationsForApplication(String application)
+  rx.Observable<Orchestration> retrieveOrchestrationsForApplication(String application, ExecutionCriteria criteria)
+
+  static class ExecutionCriteria {
+    int limit
+    Collection<String> statuses = []
+  }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
@@ -80,7 +80,7 @@ class TopApplicationExecutionCleanupPollingNotificationAgentSpec extends Specifi
       }
     }
     agent.executionRepository = Mock(ExecutionRepository) {
-      1 * retrieveOrchestrationsForApplication("app1") >> { return rx.Observable.from(orchestrations) }
+      1 * retrieveOrchestrationsForApplication("app1", _) >> { return rx.Observable.from(orchestrations) }
       1 * retrievePipelinesForApplication("app2") >> { return rx.Observable.from(pipelines) }
       0 * _
     }


### PR DESCRIPTION
- Both pipeline and task endpoints support a `statuses` query parameter (comma-separated)
