### PR TITLE
Adds scale_to_cluster as an option for ResizeServerGroup.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/AbstractCloudProviderAwareStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/AbstractCloudProviderAwareStage.groovy
@@ -16,33 +16,13 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline
 
+import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 import com.netflix.spinnaker.orca.pipeline.LinearStage
-import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
 
-/**
- * @author sthadeshwar
- */
 @Slf4j
-abstract class AbstractCloudProviderAwareStage extends LinearStage {
-
-  private static final String DEFAULT_CLOUD_PROVIDER = "aws"  // TODO: Should we fetch this from configuration instead?
-
+abstract class AbstractCloudProviderAwareStage extends LinearStage implements CloudProviderAware {
   AbstractCloudProviderAwareStage(String name) {
     super(name)
-  }
-
-  protected String getCloudProvider(Stage stage) {
-    stage.context.cloudProvider ?: DEFAULT_CLOUD_PROVIDER
-  }
-
-  protected String getCredentials(Stage stage) {
-    String credentials = stage.context."account.name"
-    if (!credentials && stage.context.account) {
-      credentials = stage.context.account
-    } else if (!credentials && stage.context.credentials) {
-      credentials = stage.context.credentials
-    }
-    credentials
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/ResizeServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/ResizeServerGroupStage.groovy
@@ -17,13 +17,11 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline
 
 import com.netflix.spinnaker.orca.clouddriver.pipeline.aws.ModifyAwsScalingProcessStage
-import com.netflix.spinnaker.orca.clouddriver.pipeline.support.TargetServerGroup
 import com.netflix.spinnaker.orca.clouddriver.pipeline.support.TargetServerGroupLinearStageSupport
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.ResizeServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.WaitForCapacityMatchTask
-import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeSupport
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
 import org.springframework.batch.core.Step
@@ -59,12 +57,6 @@ class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
       buildStep(stage, "waitForCapacityMatch", WaitForCapacityMatchTask),
     ]
   }
-
-  @Override
-  protected List<Map<String, Object>> buildStaticTargetDescriptions(Stage stage, List<TargetServerGroup> targets) {
-    ResizeSupport.createResizeDescriptors(stage, targets)
-  }
-
 
   @Override
   protected List<Injectable> preStatic(Map descriptor) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/Location.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/Location.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.support
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import groovy.transform.Immutable
 import groovy.transform.ToString
 
@@ -32,6 +33,7 @@ class Location {
   /**
    * @return The all lowercase, plural form of this location type ("regions" or "zones")
    */
+  @JsonIgnore
   String pluralType() {
     return this.type.toString().toLowerCase() + "s"
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroup.groovy
@@ -73,6 +73,13 @@ class TargetServerGroup {
       return new Location(type: Location.Type.REGION, value: serverGroup.region)
     }
 
+    static Location locationFromOperation(Map<String, Object> operation) {
+      if (!operation.targetLocation) {
+        return null
+      }
+      new Location(type: Location.Type.valueOf(operation.targetLocation.type), value: operation.targetLocation.value)
+    }
+
     static Location locationFromStageData(StageData stageData) {
       if (stageData.cloudProvider == "gce") {
         def zones = stageData.availabilityZones.values().flatten().toArray()

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroupLinearStageSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroupLinearStageSupport.groovy
@@ -94,6 +94,7 @@ abstract class TargetServerGroupLinearStageSupport extends LinearStage implement
         // Clouddriver operations work with multiple values here, but we're choosing to only use 1 per operation.
         description.regions = [location.value]
       }
+      description.targetLocation = [type: location.type.name(), value: location.value]
 
       descriptions << description
     }
@@ -117,15 +118,17 @@ abstract class TargetServerGroupLinearStageSupport extends LinearStage implement
       remove("regions")
     }
 
-    def locationValues = params.locations.collect { it.value }
     def locationType = params.locations[0].pluralType()
 
     Map dtsgContext = new HashMap(stage.context)
-    dtsgContext[locationType] = new ArrayList(locationValues)
+    dtsgContext[locationType] = params.locations.collect { it.value }
 
     // The original stage.context object is reused here because concrete subclasses must actually perform the requested
     // operation. All future copies of the subclass (operating on different regions/zones) use a copy of the context.
-    stage.context[locationType] = [locationValues.remove(0)]
+    def initialLocation = params.locations.head()
+    def remainingLocations = params.locations.tail()
+    stage.context[locationType] = [initialLocation.value]
+    stage.context.targetLocation = [type: initialLocation.type.name(), value: initialLocation.value]
 
     preDynamic(stage.context).each {
       injectBefore(stage, it.name, it.stage, it.context)
@@ -134,9 +137,10 @@ abstract class TargetServerGroupLinearStageSupport extends LinearStage implement
       injectAfter(stage, it.name, it.stage, it.context)
     }
 
-    for (location in locationValues) {
+    for (location in remainingLocations) {
       def ctx = new HashMap(stage.context)
-      ctx[locationType] = [location]
+      ctx[locationType] = [location.value]
+      ctx.targetLocation = [type: location.type.name(), value: location.value]
       preDynamic(ctx).each {
         // Operations done after the first pre-postDynamic injection must all be added with injectAfter.
         injectAfter(stage, it.name, it.stage, it.context)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractCloudProviderAwareTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractCloudProviderAwareTask.groovy
@@ -16,33 +16,14 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks
 
-import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 import groovy.util.logging.Slf4j
 
 /**
  * @author sthadeshwar
  */
 @Slf4j
-abstract class AbstractCloudProviderAwareTask {
-
-  private static final String DEFAULT_CLOUD_PROVIDER = "aws"  // TODO: Should we fetch this from configuration instead?
-
-  protected String getCloudProvider(Stage stage) {
-    if (!stage.context.cloudProvider) {
-      log.info("The stage context for this cloud provider aware task does not contain 'cloudProvider': ${stage.context}")
-      return DEFAULT_CLOUD_PROVIDER
-    }
-    return stage.context.cloudProvider
-  }
-
-  protected String getCredentials(Stage stage) {
-    String credentials = stage.context."account.name"
-    if (!credentials && stage.context.account) {
-      credentials = stage.context.account
-    } else if (!credentials && stage.context.credentials) {
-      credentials = stage.context.credentials
-    }
-    credentials
-  }
+abstract class AbstractCloudProviderAwareTask implements CloudProviderAware, Task {
 
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractServerGroupTask.groovy
@@ -24,14 +24,30 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.support.TargetServerGroup
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 
-abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask implements Task {
+abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+
+  @Override
+  long getBackoffPeriod() {
+    return 2000
+  }
+
+  @Override
+  long getTimeout() {
+    return 60000
+  }
 
   @Autowired
   KatoService kato
 
-  protected boolean addTargetOpOutputs = false
+  protected boolean isAddTargetOpOutputs() {
+    false
+  }
 
   abstract String getServerGroupAction()
+
+  Map getAdditionalStageOutputs(Stage stage, Map operation) {
+    [:]
+  }
 
   TaskResult execute(Stage stage) {
     String cloudProvider = getCloudProvider(stage)
@@ -57,7 +73,7 @@ abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask im
       ]
     }
 
-    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, stageOutputs)
+    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, stageOutputs + getAdditionalStageOutputs(stage, operation))
   }
 
   Map convert(Stage stage) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DisableServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DisableServerGroupTask.groovy
@@ -21,6 +21,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class DisableServerGroupTask extends AbstractServerGroupTask {
-  boolean addTargetOpOutputs = true
+  @Override
+  protected boolean isAddTargetOpOutputs() {
+    true
+  }
   String serverGroupAction = DisableServerGroupStage.PIPELINE_CONFIG_TYPE
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/EnableServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/EnableServerGroupTask.groovy
@@ -21,6 +21,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class EnableServerGroupTask extends AbstractServerGroupTask {
-  protected boolean addTargetOpOutputs = true
+  @Override
+  protected boolean isAddTargetOpOutputs() {
+    true
+  }
   String serverGroupAction = EnableServerGroupStage.PIPELINE_CONFIG_TYPE
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/RebootInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/RebootInstancesTask.groovy
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-@CompileStatic
 class RebootInstancesTask extends AbstractCloudProviderAwareTask implements Task {
   static final String CLOUD_OPERATION_TYPE = "rebootInstances"
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/CloudProviderAware.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/CloudProviderAware.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.utils;
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+
+import java.util.Map;
+
+public interface CloudProviderAware {
+  String DEFAULT_CLOUD_PROVIDER = "aws";  // TODO: Should we fetch this from configuration instead?
+
+  default String getDefaultCloudProvider() {
+    return DEFAULT_CLOUD_PROVIDER;
+  }
+
+  default String getCloudProvider(Stage stage) {
+    return getCloudProvider(stage.getContext());
+  }
+
+  default String getCloudProvider(Map<String, Object> context) {
+    return (String) context.getOrDefault("cloudProvider", getDefaultCloudProvider());
+  }
+
+  default String getCredentials(Stage stage) {
+    return getCredentials(stage.getContext());
+  }
+
+  default String getCredentials(Map<String, Object> context) {
+    return (String) context.getOrDefault("account.name",
+      context.getOrDefault("account",
+        context.get("credentials")));
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeStrategy.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.pipeline.support
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.support.Location
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.transform.Canonical
+
+interface ResizeStrategy {
+  static enum ResizeAction {
+    scale_exact, scale_up, scale_down, scale_to_cluster
+  }
+
+  static class OptionalConfiguration {
+    ResizeAction action
+    Integer scalePct
+    Integer scaleNum
+    String resizeType
+
+    //Temporary shim to support old style configuration where scale_exact was not an action
+    //TODO(cfieber) - remove this after we've rolled this in and don't need to roll back
+    ResizeAction getActualAction() {
+      if (resizeType == 'exact') {
+        return ResizeAction.scale_exact
+      }
+      // resize Orchestration doesn't provide action currently
+      if (action == null) {
+        return ResizeAction.scale_exact
+      }
+      return action
+    }
+  }
+
+  @Canonical
+  static class Capacity {
+    Integer max
+    Integer desired
+    Integer min
+  }
+
+  boolean handles(ResizeAction resizeAction)
+  Capacity capacityForOperation(Stage stage, String account, String serverGroupName, String cloudProvider, Location location, OptionalConfiguration resizeConfig)
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleExactResizeStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleExactResizeStrategy.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.pipeline.support
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.support.Location
+import com.netflix.spinnaker.orca.clouddriver.pipeline.support.TargetServerGroup
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.Capacity
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.OptionalConfiguration
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.ResizeAction
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class ScaleExactResizeStrategy implements ResizeStrategy {
+
+  @Autowired
+  OortHelper oortHelper
+
+  @Override
+  boolean handles(ResizeAction resizeAction) {
+    resizeAction == ResizeAction.scale_exact
+  }
+
+  @Override
+  Capacity capacityForOperation(Stage stage, String account, String serverGroupName, String cloudProvider, Location location, OptionalConfiguration resizeConfig) {
+    TargetServerGroup tsg = oortHelper.getTargetServerGroup(account, serverGroupName, location.value, cloudProvider)
+      .orElseThrow({
+      new IllegalStateException("no server group found $cloudProvider/$account/$serverGroupName in $location")
+    })
+
+    def currentMin = Integer.parseInt(tsg.capacity.min.toString())
+    def currentDesired = Integer.parseInt(tsg.capacity.desired.toString())
+    def currentMax = Integer.parseInt(tsg.capacity.max.toString())
+
+    Capacity configured = stage.mapTo("/capacity", Capacity)
+    return mergeConfiguredCapacityWithCurrent(configured, currentMin, currentDesired, currentMax)
+  }
+
+  static Capacity mergeConfiguredCapacityWithCurrent(Capacity configured, int currentMin, int currentDesired, int currentMax) {
+    boolean minConfigured = configured.min != null;
+    boolean desiredConfigured = configured.desired != null;
+    boolean maxConfigured = configured.max != null;
+    Capacity result = new Capacity(
+      min: minConfigured ? configured.min : currentMin,
+    )
+    if (maxConfigured) {
+      result.max = configured.max
+      result.min = Math.min(result.min, configured.max)
+    } else {
+      result.max = Math.max(result.min, currentMax)
+    }
+    if (desiredConfigured) {
+      result.desired = configured.desired
+    } else {
+      result.desired = currentDesired
+      if (currentDesired < result.min) {
+        result.desired = result.min
+      }
+      if (currentDesired > result.max) {
+        result.desired = result.max
+      }
+    }
+
+    result
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleRelativeResizeStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleRelativeResizeStrategy.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.pipeline.support
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.support.Location
+import com.netflix.spinnaker.orca.clouddriver.pipeline.support.TargetServerGroup
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.Capacity
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.OptionalConfiguration
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.ResizeAction
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class ScaleRelativeResizeStrategy implements ResizeStrategy {
+
+  @Autowired
+  OortHelper oortHelper
+
+  @Override
+  boolean handles(ResizeAction resizeAction) {
+    resizeAction == ResizeAction.scale_down || resizeAction == ResizeAction.scale_up
+  }
+
+  @Override
+  Capacity capacityForOperation(Stage stage, String account, String serverGroupName, String cloudProvider, Location location, OptionalConfiguration resizeConfig) {
+    TargetServerGroup tsg = oortHelper.getTargetServerGroup(account, serverGroupName, location.value, cloudProvider)
+      .orElseThrow({
+      new IllegalStateException("no server group found $cloudProvider/$account/$serverGroupName in $location")
+    })
+
+    def currentMin = Integer.parseInt(tsg.capacity.min.toString())
+    def currentDesired = Integer.parseInt(tsg.capacity.desired.toString())
+    def currentMax = Integer.parseInt(tsg.capacity.max.toString())
+
+    int sign = resizeConfig.action == ResizeAction.scale_up ? 1 : -1
+
+    if (resizeConfig.scalePct) {
+      double factor = resizeConfig.scalePct / 100.0d
+      def minDiff = sign * Math.ceil(currentMin * factor)
+      def desiredDiff = sign * Math.ceil(currentDesired * factor)
+      def maxDiff = sign * Math.ceil(currentMax * factor)
+      return new Capacity(
+        min: Math.max(currentMin + minDiff, 0),
+        desired: Math.max(currentDesired + desiredDiff, 0),
+        max: Math.max(currentMax + maxDiff, 0)
+      )
+    } else if (resizeConfig.scaleNum) {
+      int delta = sign * resizeConfig.scaleNum
+      return new Capacity(
+        min: Math.max(currentMin + delta, 0),
+        desired: Math.max(currentDesired + delta, 0),
+        max: Math.max(currentMax + delta, 0)
+      )
+    } else {
+      return new Capacity(
+        min: currentMin,
+        desired: currentDesired,
+        max: currentMax
+      )
+    }
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToClusterResizeStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToClusterResizeStrategy.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.pipeline.support
+
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.orca.clouddriver.pipeline.support.Location
+import com.netflix.spinnaker.orca.clouddriver.pipeline.support.TargetServerGroup
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.Capacity
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.OptionalConfiguration
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.ResizeAction
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class ScaleToClusterResizeStrategy implements ResizeStrategy{
+
+  @Autowired
+  OortHelper oortHelper
+
+  @Override
+  boolean handles(ResizeAction resizeAction) {
+    return resizeAction == ResizeAction.scale_to_cluster
+  }
+
+  @Override
+  Capacity capacityForOperation(Stage stage, String account, String serverGroupName, String cloudProvider, Location location, OptionalConfiguration resizeConfig) {
+    def names = Names.parseName(serverGroupName)
+    def appName = names.app
+    def clusterName = names.cluster
+
+    def cluster = oortHelper.getCluster(appName, account, clusterName, cloudProvider)
+    List<TargetServerGroup> targetServerGroups = cluster
+      .orElse([serverGroups: []])
+      .serverGroups.collect { new TargetServerGroup(serverGroup: it) }
+      .findAll { it.getLocation() == location }
+
+    if (!targetServerGroups) {
+      throw new IllegalStateException("no server groups found for cluster $cloudProvider/$account/$clusterName in $location")
+    }
+    Capacity capacity = targetServerGroups.inject(new Capacity(0, 0, 0)) { Capacity capacity, TargetServerGroup tsg ->
+      capacity.min = Math.max(capacity.min, tsg.capacity?.min ?: 0)
+      capacity.max = Math.max(capacity.max, tsg.capacity?.max ?: 0)
+      capacity.desired = Math.max(capacity.desired, tsg.capacity?.desired ?: 0)
+      return capacity
+    }
+
+    int increment = 0
+    if (resizeConfig.scalePct) {
+      double factor = Math.abs(resizeConfig.scalePct) / 100.0d
+      increment = (int) Math.ceil(capacity.desired * factor)
+    } else if (resizeConfig.scaleNum) {
+      increment = Math.abs(resizeConfig.scaleNum)
+    }
+    //ensure our bounds are legitimate:
+    capacity.max = Math.max(capacity.max, capacity.min)
+    capacity.min = Math.min(capacity.max, capacity.min)
+    capacity.desired = Math.max(capacity.min, capacity.desired)
+    capacity.desired = Math.min(capacity.desired + increment, capacity.max)
+
+    return capacity
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateDeployTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateDeployTask.groovy
@@ -36,7 +36,6 @@ import org.springframework.stereotype.Component
 
 @Slf4j
 @Component
-@CompileStatic
 class CreateDeployTask extends AbstractCloudProviderAwareTask implements Task {
 
   static final List<String> DEFAULT_VPC_SECURITY_GROUPS = ["nf-infrastructure-vpc", "nf-datacenter-vpc"]

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DestroyAwsServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DestroyAwsServerGroupTask.groovy
@@ -36,7 +36,6 @@ import static com.netflix.spinnaker.orca.kato.pipeline.DestroyAsgStage.DESTROY_A
  * TODO: This task can be moved to clouddriver.tasks package once the convert() method has been cleaned up using the new oort APIs
  */
 @Component
-@CompileStatic
 @Deprecated
 class DestroyAwsServerGroupTask extends AbstractCloudProviderAwareTask implements Task {
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/TerminateInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/TerminateInstancesTask.groovy
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-@CompileStatic
 class TerminateInstancesTask extends AbstractCloudProviderAwareTask implements Task {
   @Autowired
   KatoService kato

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/TerminateGoogleInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/gce/TerminateGoogleInstancesTask.groovy
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-@CompileStatic
 class TerminateGoogleInstancesTask extends AbstractCloudProviderAwareTask implements Task {
   @Autowired
   KatoService kato

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/ResizeServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/ResizeServerGroupTaskSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks
+
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.Capacity
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class ResizeServerGroupTaskSpec extends Specification {
+
+  KatoService katoService = Mock(KatoService)
+
+  @Subject
+  ResizeServerGroupTask task = new ResizeServerGroupTask(kato: katoService, resizeStrategies: [])
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeSupportSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeSupportSpec.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.kato.pipeline.support
 
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
-import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -60,28 +59,28 @@ class ResizeSupportSpec extends Specification {
   @Unroll
   def "should scale target capacity up or down by percentage or number"() {
     setup:
-      context[method] = value
-      context.action = direction
-      def stage = new PipelineStage(new Pipeline(), "resizeAsg", context)
+    context[method] = value
+    context.action = direction
+    def stage = new PipelineStage(new Pipeline(), "resizeAsg", context)
 
     when:
-      def descriptors = resizeSupport.createResizeStageDescriptors(stage, targetRefs)
+    def descriptors = resizeSupport.createResizeStageDescriptors(stage, targetRefs)
 
     then:
-      !descriptors.empty
-      descriptors[0].capacity == [min: want, max: want, desired: want] as Map
+    !descriptors.empty
+    descriptors[0].capacity == [min: want, max: want, desired: want] as Map
 
     where:
-      method     | direction    | value || want
-      "scalePct" | null         | 50    || 15
-      "scalePct" | "scale_up"   | 50    || 15
-      "scalePct" | "scale_down" | 50    || 5
-      "scalePct" | "scale_down" | 100   || 0
-      "scalePct" | "scale_down" | 1000  || 0
-      "scaleNum" | null         | 6     || 16
-      "scaleNum" | "scale_up"   | 6     || 16
-      "scaleNum" | "scale_down" | 6     || 4
-      "scaleNum" | "scale_down" | 100   || 0
+    method     | direction    | value || want
+    "scalePct" | null         | 50    || 15
+    "scalePct" | "scale_up"   | 50    || 15
+    "scalePct" | "scale_down" | 50    || 5
+    "scalePct" | "scale_down" | 100   || 0
+    "scalePct" | "scale_down" | 1000  || 0
+    "scaleNum" | null         | 6     || 16
+    "scaleNum" | "scale_up"   | 6     || 16
+    "scaleNum" | "scale_down" | 6     || 4
+    "scaleNum" | "scale_down" | 100   || 0
   }
 
   @Unroll
@@ -111,39 +110,5 @@ class ResizeSupportSpec extends Specification {
       [min: "0", max: "2"]               | [minSize: 1, maxSize: 3, desiredCapacity: 3] || [min: 0, max: 2, desired: 2]
       [min: "0", max: "2", desired: "3"] | [minSize: 1, maxSize: 3, desiredCapacity: 3] || [min: 0, max: 2, desired: 3]
       [:]                                | [minSize: 1, maxSize: 3, desiredCapacity: 3] || [min: 1, max: 3, desired: 3]
-  }
-
-  @Ignore
-  def "should use GCE-specific modifications"() {
-    setup:
-      context.provider = "gce"
-      context.scaleNum = 2
-      context.action = "scale_up"
-      context.target = "current_asg_dynamic"
-
-      def stage = new PipelineStage(new Pipeline(), "resizeAsg", context)
-      targetRefs[0].asg.zones = ["north-pole"]
-
-    when:
-      def descriptors = resizeSupport.createResizeStageDescriptors(stage, targetRefs)
-
-    then:
-      !descriptors.empty
-      descriptors[0] == [
-        action         : "scale_up",
-        asgName        : "testapp-asg-v001",
-        capacity       : [min:12, desired:12, max:12],
-        cluster        : "testapp-asg",
-        credentials    : "test",
-        targetSize     : 12,
-        provider       : "gce",
-        regions        : ["us-west-1"],
-        serverGroupName: "testapp-asg-v001",
-        scaleNum       : 2,
-        target         : "current_asg_dynamic",
-        zones          : ["north-pole"],
-        asgName        : "testapp-asg-v001",
-        capacity       : [min: 12, desired: 12, max: 12]
-      ]
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleRelativeResizeStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleRelativeResizeStrategySpec.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.pipeline.support
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.support.Location
+import com.netflix.spinnaker.orca.clouddriver.pipeline.support.TargetServerGroup
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class ScaleRelativeResizeStrategySpec extends Specification {
+  OortHelper oortHelper = Mock(OortHelper)
+  Stage stage = Mock(Stage)
+  ScaleRelativeResizeStrategy strategy = new ScaleRelativeResizeStrategy(oortHelper: oortHelper)
+  @Unroll
+  def "should scale target capacity up or down by percentage or number"() {
+
+    when:
+    def cap = strategy.capacityForOperation(stage, account, serverGroupName, cloudProvider, location, resizeConfig)
+
+    then:
+    cap == expected
+    1 * oortHelper.getTargetServerGroup(account, serverGroupName, region, cloudProvider) >> targetServerGroup
+    0 * _
+
+    where:
+    method     | direction    | value || want
+    "scalePct" | null         | 50    || 15
+    "scalePct" | "scale_up"   | 50    || 15
+    "scalePct" | "scale_down" | 50    || 5
+    "scalePct" | "scale_down" | 100   || 0
+    "scalePct" | "scale_down" | 1000  || 0
+    "scaleNum" | null         | 6     || 16
+    "scaleNum" | "scale_up"   | 6     || 16
+    "scaleNum" | "scale_down" | 6     || 4
+    "scaleNum" | "scale_down" | 100   || 0
+    serverGroupName = asgName()
+    targetServerGroup = Optional.of(new TargetServerGroup(serverGroup: [name: serverGroupName, region: region, type: cloudProvider, capacity: [min: 10, max: 10, desired: 10]]))
+    expected = new ResizeStrategy.Capacity(want, want, want)
+    scalePct = method == 'scalePct' ? value : null
+    scaleNum = method == 'scaleNum' ? value : null
+    resizeConfig = cfg(direction, scalePct, scaleNum)
+  }
+
+  static final AtomicInteger asgSeq = new AtomicInteger(100)
+  static final String cloudProvider = 'aws'
+  static final String application = 'foo'
+  static final String region = 'us-east-1'
+  static final String account = 'test'
+  static final String clusterName = application + '-main'
+  static final Location location = TargetServerGroup.Support.locationFromCloudProviderValue(cloudProvider, region)
+
+  ResizeStrategy.OptionalConfiguration cfg(String direction, Integer scalePct = null, Integer scaleNum = null) {
+    def cfg = new ResizeStrategy.OptionalConfiguration()
+    if (direction == "scale_down") {
+      cfg.action = ResizeStrategy.ResizeAction.scale_down
+    } else {
+      cfg.action = ResizeStrategy.ResizeAction.scale_up
+    }
+    cfg.scalePct = scalePct
+    cfg.scaleNum = scaleNum
+    return cfg
+  }
+
+
+
+  static String asgName() {
+    clusterName + '-v' + asgSeq.incrementAndGet()
+  }
+
+
+
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToClusterResizeStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToClusterResizeStrategySpec.groovy
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.pipeline.support
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.support.Location
+import com.netflix.spinnaker.orca.clouddriver.pipeline.support.TargetServerGroup
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.Capacity
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class ScaleToClusterResizeStrategySpec extends Specification {
+
+  Stage stage = Mock(Stage)
+  OortHelper oortHelper = Mock(OortHelper)
+  @Subject ScaleToClusterResizeStrategy strategy = new ScaleToClusterResizeStrategy(oortHelper: oortHelper)
+
+  def 'empty or missing cluster fails on scale_to_cluster'() {
+    when:
+    strategy.capacityForOperation(stage, account, serverGroupName, cloudProvider, location, resizeConfig)
+
+    then:
+    thrown(IllegalStateException)
+    1 * oortHelper.getCluster(application, account, clusterName, cloudProvider) >> cluster
+    0 * _
+
+    where:
+    serverGroupName = asgName()
+    cluster << [Optional.empty(), Optional.of([serverGroups: []]), Optional.of([serverGroups: [mkSG(0, 0, 0, 'boom')]])]
+    resizeConfig = cfg()
+  }
+
+  def 'capacity is the maximum value of min/max/desired across the cluster for scale_to_cluster'() {
+    when:
+    def cap = strategy.capacityForOperation(stage, account, serverGroupName, cloudProvider, location, resizeConfig)
+
+    then:
+    cap == expectedCapacity
+    1 * oortHelper.getCluster(application, account, clusterName, cloudProvider) >> cluster
+    0 * _
+
+    where:
+    serverGroups                                          | expectedCapacity
+    [mkSG()]                                              | new Capacity(0, 0, 0)
+    [mkSG(1)]                                             | new Capacity(1, 1, 1)
+    [mkSG(1), mkSG(1000, 1000, 1000, 'different-region')] | new Capacity(1, 1, 1)
+    [mkSG(0, 0, 10), mkSG(0, 1, 5), mkSG(5, 0, 9)]        | new Capacity(10, 5, 1)
+
+    serverGroupName = asgName()
+    resizeConfig = cfg()
+    cluster = Optional.of([serverGroups: serverGroups])
+  }
+
+  def 'desired capacity is increased by scalePct or scaleNum for scale_to_cluster within the min/max bounds'() {
+    when:
+    def cap = strategy.capacityForOperation(stage, account, serverGroupName, cloudProvider, location, resizeConfig)
+
+    then:
+    cap == expectedCapacity
+    1 * oortHelper.getCluster(application, account, clusterName, cloudProvider) >> cluster
+    0 * _
+
+    where:
+    serverGroups                                   | scaleNum | scalePct | expectedCapacity
+    [mkSG()]                                       | 1        | null     | new Capacity(0, 0, 0)
+    [mkSG(1)]                                      | 1        | null     | new Capacity(1, 1, 1)
+    [mkSG(0, 0, 10), mkSG(0, 1, 5), mkSG(5, 0, 9)] | 1        | null     | new Capacity(10, 6, 1)
+    [mkSG(100, 0, 1000)]                           | null     | 1        | new Capacity(1000, 101, 0)
+
+    resizeConfig = cfg(scalePct, scaleNum)
+    cluster = Optional.of([serverGroups: serverGroups])
+    serverGroupName = asgName()
+  }
+
+  static final AtomicInteger asgSeq = new AtomicInteger(100)
+  static final String cloudProvider = 'aws'
+  static final String application = 'foo'
+  static final String region = 'us-east-1'
+  static final String account = 'test'
+  static final String clusterName = application + '-main'
+  static final Location location = TargetServerGroup.Support.locationFromCloudProviderValue(cloudProvider, region)
+
+  static String asgName() {
+    clusterName + '-v' + asgSeq.incrementAndGet()
+  }
+
+  ResizeStrategy.OptionalConfiguration cfg(Integer scalePct = null, Integer scaleNum = null) {
+    def cfg = new ResizeStrategy.OptionalConfiguration()
+    cfg.action = ResizeStrategy.ResizeAction.scale_to_cluster
+    cfg.scalePct = scalePct
+    cfg.scaleNum = scaleNum
+    return cfg
+  }
+
+  Map mkSG(int desired = 0, Integer min = null, Integer max = null, String regionName = region) {
+    Capacity capacity = new Capacity(max == null ? desired : max, desired, min == null ? desired : min)
+    [
+      type    : cloudProvider,
+      region  : regionName,
+      name    : asgName(),
+      capacity: capacity
+    ]
+  }
+}


### PR DESCRIPTION
The targeted ServerGroup is sized to the largest value for min, max, and desired capacity among
all ServerGroups in the cluster in the targeted ServerGroup's location.
The computed size can be increasted by either scaleNum or scalePct options up to but not exceeding
the computed new capacity 'max'.
Adds scale_exact as an explicit option for scaling to a configured capacity.

@ttomsu took a hefty refactor over ResizeSupport (only the non-deprecated component of it) if you wouldn't mind taking a look
