### PR TITLE
WIP around supporting cancellation of Deploy and Monitor canary stages

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/CancellableStage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/CancellableStage.groovy
@@ -18,11 +18,16 @@ package com.netflix.spinnaker.orca
 
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 
-/**
- * Upon cancellation of pipeline execution, cancel() method would be called for a task that is implementing
- * this interface
- * @author sthadeshwar
- */
-interface CancellableTask {
-  TaskResult cancel(Stage stage)
+interface CancellableStage {
+  Result cancel(Stage stage)
+
+  static class Result {
+    final String stageId
+    final Map details
+
+    Result(Stage stage, Map details) {
+      this.stageId = stage.id
+      this.details = details
+    }
+  }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.groovy
@@ -20,7 +20,9 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.batch.ExecutionPropagationListener
 import com.netflix.spinnaker.orca.libdiffs.ComparableLooseVersion
 import com.netflix.spinnaker.orca.libdiffs.DefaultComparableLooseVersion
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.ApplicationContext
 
 import java.time.Clock
 import java.time.Duration
@@ -173,6 +175,11 @@ class OrcaConfiguration {
   @ConditionalOnProperty(value = 'jarDiffs.enabled', matchIfMissing = false)
   ComparableLooseVersion comparableLooseVersion() {
     new DefaultComparableLooseVersion()
+  }
+
+  @Bean
+  StageNavigator stageNavigator(ApplicationContext applicationContext) {
+    return new StageNavigator(applicationContext)
   }
 
   @CompileDynamic

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AbstractStage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AbstractStage.groovy
@@ -18,13 +18,14 @@ package com.netflix.spinnaker.orca.pipeline.model
 
 import com.fasterxml.jackson.annotation.JsonBackReference
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TreeTraversingParser
 import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.batch.StageBuilder
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import groovy.transform.CompileStatic
 import groovy.transform.ToString
 
@@ -63,6 +64,9 @@ abstract class AbstractStage<T extends Execution> implements Stage<T>, Serializa
 
   @JsonIgnore
   AtomicInteger taskCounter = new AtomicInteger(0)
+
+  @JsonIgnore
+  StageNavigator stageNavigator = null
 
   transient ObjectMapper objectMapper = new OrcaObjectMapper()
 
@@ -140,6 +144,11 @@ abstract class AbstractStage<T extends Execution> implements Stage<T>, Serializa
     }
     mergeCommit ptr, obj
     context = objectMapper.convertValue(rootNode, LinkedHashMap)
+  }
+
+  @Override
+  List<StageNavigator.Result> ancestors(Closure<Boolean> matcher = { Stage stage, StageBuilder stageBuilder -> true }) {
+    return stageNavigator ? stageNavigator.findAll(this, matcher) :[]
   }
 
   private JsonNode getPointer(String pointer, ObjectNode rootNode = contextToNode()) {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/ImmutableStageSupport.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/ImmutableStageSupport.groovy
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.orca.pipeline.model
 
 import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.batch.StageBuilder
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -105,6 +107,11 @@ class ImmutableStageSupport {
     @Override
     Stage preceding(String type) {
       self.preceding(type)?.asImmutable()
+    }
+
+    @Override
+    List<StageNavigator.Result> ancestors(Closure<Boolean> matcher = { Stage stage, StageBuilder stageBuilder -> true }) {
+      return self.ancestors(matcher)
     }
 
     @Override

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.pipeline.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import groovy.transform.CompileStatic
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -83,6 +84,18 @@ interface Stage<T extends Execution> {
    * Gets the last stage preceding this stage that has the specified type.
    */
   Stage preceding(String type)
+
+  /**
+   * Gets all ancestor stages that satisfy {@code matcher}, including the current stage.
+   * @return
+   */
+  List<StageNavigator.Result> ancestors(Closure<Boolean> matcher)
+
+  /**
+   * Gets all ancestor stages, including the current stage.
+   * @return
+   */
+  List<StageNavigator.Result> ancestors()
 
   /**
    * The context driving this stage. Provides inputs necessary to component steps

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -1,6 +1,9 @@
 package com.netflix.spinnaker.orca.pipeline.persistence.jedis
 
+import com.netflix.spinnaker.orca.batch.StageBuilder
+import com.netflix.spinnaker.orca.pipeline.LinearStage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionCriteria
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import redis.clients.jedis.Response
 
 import java.util.function.Function
@@ -44,6 +47,9 @@ class JedisExecutionRepository implements ExecutionRepository {
   private final int chunkSize
   private final Scheduler queryAllScheduler
   private final Scheduler queryByAppScheduler
+
+  @Autowired
+  StageNavigator stageNavigator
 
   @Autowired
   JedisExecutionRepository(
@@ -423,6 +429,7 @@ class JedisExecutionRepository implements ExecutionRepository {
       def stageIds = map.stageIndex.tokenize(",")
       stageIds.each { stageId ->
         def stage = execution instanceof Pipeline ? new PipelineStage() : new OrchestrationStage()
+        stage.stageNavigator = stageNavigator
         stage.id = stageId
         stage.refId = map["stage.${stageId}.refId".toString()]
         stage.type = map["stage.${stageId}.type".toString()]

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/StageNavigator.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/StageNavigator.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.pipeline.util
+
+import com.netflix.spinnaker.orca.batch.StageBuilder
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.transform.CompileStatic
+import org.springframework.context.ApplicationContext
+
+@CompileStatic
+class StageNavigator {
+  private final ApplicationContext applicationContext
+
+  StageNavigator(ApplicationContext applicationContext) {
+    this.applicationContext = applicationContext
+  }
+
+  List<Result> findAll(Stage startingStage, Closure<Boolean> matcher) {
+    def stageBuilders = stageBuilders()
+
+    def ancestors = [startingStage] + ancestors(startingStage)
+    def results = ancestors.findAll { Stage stage ->
+      def stageBuilder = stageBuilders.find { it.type == stage.type }
+      return matcher.call(stage, stageBuilder)
+    }.collect { Stage stage ->
+      new Result(stage: stage, stageBuilder: stageBuilders.find { it.type == stage.type })
+    }
+
+    return results
+  }
+
+  protected Collection<StageBuilder> stageBuilders() {
+    return applicationContext.getBeansOfType(StageBuilder).values()
+  }
+
+  private List<Stage> ancestors(Stage startingStage) {
+    if (startingStage.requisiteStageRefIds) {
+      def previousStages = startingStage.execution.stages.findAll {
+        it.refId in startingStage.requisiteStageRefIds
+      }
+      def syntheticStages = startingStage.execution.stages.findAll {
+        it.parentStageId in previousStages*.id
+      }
+      return ((previousStages + syntheticStages) + previousStages.collect { ancestors(it) }.flatten()) as List<Stage>
+    } else if (startingStage.parentStageId) {
+      def parent = startingStage.execution.stages.find { it.id == startingStage.parentStageId }
+      return (([parent] + ancestors(parent)).flatten()) as List<Stage>
+    } else {
+      return []
+    }
+  }
+
+  static class Result {
+    Stage stage
+    StageBuilder stageBuilder
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/StageNavigatorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/StageNavigatorSpec.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.pipeline.util
+
+import com.netflix.spinnaker.orca.batch.StageBuilder
+import com.netflix.spinnaker.orca.pipeline.LinearStage
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.batch.core.Step
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+
+class StageNavigatorSpec extends Specification {
+  @Shared
+  def stageBuilders = [
+    new ExampleStageBuilder("One"), new ExampleStageBuilder("Two"), new ExampleStageBuilder("Three")
+  ]
+
+  @Subject
+  def stageNavigator = new StageNavigator(null) {
+    @Override
+    protected Collection<StageBuilder> stageBuilders() {
+      return stageBuilders
+    }
+  }
+
+  def execution = new Pipeline()
+
+  def "traverses up the synthetic stage hierarchy"() {
+    given:
+    def stage1 = buildStage("One")
+    def stage2 = buildStage("Two")
+    def stage3 = buildStage("Three")
+
+    stage1.parentStageId = stage2.id
+    stage2.parentStageId = stage3.id
+
+    expect:
+    stage1.ancestors()*.stage*.type == ["One", "Two", "Three"]
+    stage1.ancestors({ Stage stage, StageBuilder stageBuilder -> false })*.stage*.type == []
+    stage1.ancestors({ Stage stage, StageBuilder stageBuilder -> true })*.stage*.type == ["One", "Two", "Three"]
+    stage1.ancestors({ Stage stage, StageBuilder stageBuilder -> stage.type == "One" })*.stage*.type == ["One"]
+    stage1.ancestors({ Stage stage, StageBuilder stageBuilder -> stage.type == "Four" })*.stage*.type == []
+  }
+
+  def "traverses up the refId stage hierarchy"() {
+    given:
+    def stage1 = buildStage("One")
+    def stage2 = buildStage("Two")
+    def stage4 = buildStage("Four")
+    def stage3 = buildStage("Three")
+
+    stage1.refId = "1"
+    stage2.refId = "2"
+    stage3.refId = "3"
+    stage4.refId = "4"
+
+    stage1.requisiteStageRefIds = ["2"]
+    stage2.requisiteStageRefIds = ["3", "4"]
+
+    expect:
+    // order is dependent on the order of a stage within `execution.stages`
+    stage1.ancestors({ Stage stage, StageBuilder stageBuilder -> true })*.stage*.type == ["One", "Two", "Four", "Three"]
+  }
+
+  def "traverses up both synthetic and refId stage hierarchies"() {
+    given:
+    def stage1 = buildStage("One")
+    def stage2 = buildStage("Two")
+    def stage4 = buildStage("Four")
+    def stage3 = buildStage("Three")
+
+    stage1.refId = "1"
+    stage2.refId = "2"
+    stage3.refId = "3"
+    stage4.refId = "4"
+
+    stage1.requisiteStageRefIds = ["2"]
+    stage2.parentStageId = stage3.id
+    stage3.requisiteStageRefIds = ["4"]
+
+    expect:
+    // order is dependent on the order of a stage within `execution.stages`
+    stage1.ancestors({ Stage stage, StageBuilder stageBuilder -> true })*.stage*.type == ["One", "Two", "Three", "Four"]
+  }
+
+  private Stage buildStage(String type) {
+    def pipelineStage = new PipelineStage(execution, type)
+    pipelineStage.stageNavigator = stageNavigator
+
+    execution.stages << pipelineStage
+
+    return pipelineStage
+  }
+
+  static class ExampleStageBuilder extends LinearStage {
+    ExampleStageBuilder(String name) {
+      super(name)
+    }
+
+    @Override
+    List<Step> buildSteps(Stage stage) {
+      []
+    }
+  }
+
+}

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryStage.groovy
@@ -16,18 +16,27 @@
 
 package com.netflix.spinnaker.orca.mine.pipeline
 
+import com.netflix.frigga.autoscaling.AutoScalingGroupNameBuilder
+import com.netflix.spinnaker.orca.CancellableStage
+import com.netflix.spinnaker.orca.clouddriver.tasks.ShrinkClusterTask
 import com.netflix.spinnaker.orca.pipeline.LinearStage
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
 import org.springframework.batch.core.Step
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.util.concurrent.TimeUnit
+
+@Slf4j
 @Component
-class CanaryStage extends LinearStage {
+class CanaryStage extends LinearStage implements CancellableStage {
   public static final String PIPELINE_CONFIG_TYPE = "canary"
 
   @Autowired DeployCanaryStage deployCanaryStage
   @Autowired MonitorCanaryStage monitorCanaryStage
+  @Autowired ShrinkClusterTask shrinkClusterTask
 
   CanaryStage() {
     super(PIPELINE_CONFIG_TYPE)
@@ -43,5 +52,43 @@ class CanaryStage extends LinearStage {
     injectAfter(stage, "Deploy Canary", deployCanaryStage, deployContext)
     injectAfter(stage, "Monitor Canary", monitorCanaryStage, monitorContext)
     []
+  }
+
+  @Override
+  CancellableStage.Result cancel(Stage stage) {
+    log.info("Cancelling stage (stageId: ${stage.id}, executionId: ${stage.execution.id}, context: ${stage.context as Map})")
+
+    // it's possible the server groups haven't been created yet, allow a grace period before cleanup
+    Thread.sleep(TimeUnit.MINUTES.toMillis(2))
+
+    Collection<Map<String, Object>> shrinkContexts = []
+    stage.context.clusterPairs.each { Map<String, Map> clusterPair ->
+      [clusterPair.baseline, clusterPair.canary].each { Map<String, String> cluster ->
+
+        def builder = new AutoScalingGroupNameBuilder()
+        builder.appName = cluster.application
+        builder.stack = cluster.stack
+        builder.detail = cluster.freeFormDetails
+
+        shrinkContexts << [
+          cluster          : builder.buildGroupName(),
+          regions          : (cluster.availabilityZones as Map).keySet(),
+          shrinkToSize     : 0,
+          allowDeleteActive: true,
+          credentials      : cluster.account
+        ]
+      }
+    }
+
+    def shrinkResults = shrinkContexts.collect {
+      def shrinkStage = new PipelineStage()
+      shrinkStage.context.putAll(it)
+      shrinkClusterTask.execute(shrinkStage)
+    }
+
+    return new CancellableStage.Result(stage, [
+      shrinkContexts: shrinkContexts,
+      shrinkResults : shrinkResults
+    ])
   }
 }


### PR DESCRIPTION
Aiming to align with what @robfletcher has in-flight.
- Provides a means to navigate up the execution graph (ie. ancestors)
- `CancellableStage` should be applied to StageBuilders rather than individual Tasks
- DeployCanaryStage currently uses a ShrinkClusterTask to actually do the cleanup

Outstanding:
- MonitorCanaryStage isn't cleaning anything up (will likely delegate up the ancestor graph to the CanaryStage for both `MonitorCanaryStage` and `DeployCanaryStage` cleanup)
- The canary itself must be cancelled (via mine)
- The terminations need to emit events to echo (existing issue)
- Probably a few test cases (will align with what Rob has around the StageNavigator)
