### PR TITLE
Remove GCE-specific logic from generic resize task

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/ResizeServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/ResizeServerGroupTask.groovy
@@ -55,16 +55,6 @@ class ResizeServerGroupTask extends AbstractServerGroupTask {
 
     operation.capacity = [min: newCapacity.min, desired: newCapacity.desired, max: newCapacity.max]
 
-    // TODO(ttomsu): Remove cloud provider-specific operation.
-    if (cloudProvider == "gce") {
-      augmentDescriptionForGCE(operation, location)
-    }
-
     return operation
-  }
-
-  static void augmentDescriptionForGCE(Map description, Location location) {
-    description.zone = location.value
-    description.targetSize = description.capacity.desired
   }
 }


### PR DESCRIPTION
@duftler 

Requires https://github.com/spinnaker/clouddriver/pull/165 to be submitted first.

Tested in UI, and pipeline against dynamic and static targets.
