### PR TITLE
Fixes a few small issues

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractClusterWideClouddriverTask.groovy
@@ -23,12 +23,12 @@ import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.CloneServerGroupStage
+import com.netflix.spinnaker.orca.clouddriver.pipeline.CreateServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.support.TargetServerGroup
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.kato.pipeline.CopyLastAsgStage
 import com.netflix.spinnaker.orca.kato.pipeline.DeployStage
-import com.netflix.spinnaker.orca.kato.pipeline.gce.DeployGoogleServerGroupStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.transform.Canonical
 import org.springframework.beans.factory.annotation.Autowired
@@ -154,7 +154,7 @@ abstract class AbstractClusterWideClouddriverTask extends AbstractCloudProviderA
       DeployStage.PIPELINE_CONFIG_TYPE,
       CopyLastAsgStage.PIPELINE_CONFIG_TYPE,
       CloneServerGroupStage.PIPELINE_CONFIG_TYPE,
-      DeployGoogleServerGroupStage.PIPELINE_CONFIG_TYPE
+      CreateServerGroupStage.PIPELINE_CONFIG_TYPE,
     ]
     List<TargetServerGroup> deployedServerGroups = []
     if (stage.parentStageId) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/FindImageFromClusterTask.groovy
@@ -21,11 +21,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.support.Location
-import com.netflix.spinnaker.orca.clouddriver.pipeline.support.TargetServerGroup
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
@@ -34,9 +33,13 @@ import retrofit.RetrofitError
 
 @Component
 @Slf4j
-class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements Task {
+class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements RetryableTask {
 
   static String SUMMARY_TYPE = "Image"
+
+  final long backoffPeriod = 2000
+
+  final long timeout = 60000
 
   static enum SelectionStrategy {
     /**


### PR DESCRIPTION
Adds the new Deploy stage to the cluster wide op filter list.
Makes FindImage retryable.

@cfieber, @duftler PTAL
