### PR TITLE
Changes GCE task outputs that have 'deploy.server.groups' to be keyed…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroupLinearStageSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroupLinearStageSupport.groovy
@@ -101,6 +101,7 @@ abstract class TargetServerGroupLinearStageSupport extends LinearStage implement
         // Clouddriver operations work with multiple values here, but we're choosing to only use 1 per operation.
         description.regions = [location.value]
       }
+      description.deployServerGroupsRegion = target.region
       description.targetLocation = [type: location.type.name(), value: location.value]
 
       descriptions << description

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractClusterWideClouddriverTask.groovy
@@ -118,10 +118,11 @@ abstract class AbstractClusterWideClouddriverTask extends AbstractCloudProviderA
       return DefaultTaskResult.SUCCEEDED
     }
 
+    // "deploy.server.groups" is keyed by region, and all TSGs will have this value.
     def locationGroups = filteredServerGroups.groupBy {
-      it.getLocation()
-    }.collectEntries { Location location, List<TargetServerGroup> serverGroup ->
-      [(location.value): serverGroup.collect { it.name }]
+      it.region
+    }.collectEntries { String region, List<TargetServerGroup> serverGroup ->
+      [(region): serverGroup.collect { it.name }]
     }
 
     def taskId = katoService.requestOperations(clusterSelection.cloudProvider, katoOps).toBlocking().first()
@@ -148,7 +149,10 @@ abstract class AbstractClusterWideClouddriverTask extends AbstractCloudProviderA
     return serverGroups.findAll { !isActive(it) }
   }
 
-  protected List<TargetServerGroup> filterParentDeploys(Stage stage, String account, Location location, List<TargetServerGroup> serverGroups) {
+  protected List<TargetServerGroup> filterParentDeploys(Stage stage,
+                                                        String account,
+                                                        Location location,
+                                                        List<TargetServerGroup> serverGroups) {
     //if we are a synthetic stage child of a deploy, don't operate on what we just deployed
     final Set<String> deployStageTypes = [
       DeployStage.PIPELINE_CONFIG_TYPE,
@@ -166,15 +170,25 @@ abstract class AbstractClusterWideClouddriverTask extends AbstractCloudProviderA
           it.context.'deploy.account.name' == account
       }
       if (parentDeployStage) {
-        Set<String> names = (parentDeployStage.context.'deploy.server.groups'[location.value] ?: []) as Set
-        deployedServerGroups = serverGroups.findAll { it.getLocation() == location && names.contains(it.name) }
+        Map<String, String> dsgs = (parentDeployStage.context.'deploy.server.groups' ?: [:]) as Map
+        switch(location.type) {
+          case Location.Type.ZONE:
+            deployedServerGroups = serverGroups.findAll { it.zones.contains(location.value) && dsgs[it.region].contains(it.name)}
+            break;
+          case Location.Type.REGION:
+            deployedServerGroups = serverGroups.findAll { it.region == location.value && dsgs[location.value].contains(it.name) }
+            break;
+        }
       }
     }
 
     return serverGroups - deployedServerGroups
   }
 
-  List<TargetServerGroup> filterServerGroups(Stage stage, String account, Location location, List<TargetServerGroup> serverGroups) {
+  List<TargetServerGroup> filterServerGroups(Stage stage,
+                                             String account,
+                                             Location location,
+                                             List<TargetServerGroup> serverGroups) {
     if (!serverGroups) {
       return []
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractServerGroupTask.groovy
@@ -86,6 +86,7 @@ abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask im
       operation.serverGroupName = tsg.name
 
       def location = tsg.getLocation()
+      operation.deployServerGroupsRegion = tsg.region
       if (location.type == Location.Type.ZONE) {
         operation.zone = location.value
         operation.remove("zones")
@@ -100,7 +101,9 @@ abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask im
    */
   static Map deployServerGroups(Map operation) {
     def collection
-    if (operation.region) {
+    if (operation.deployServerGroupsRegion) {
+      collection = [operation.deployServerGroupsRegion]
+    } else if (operation.region) {
       collection = [operation.region]
     } else if (operation.regions) {
       collection = operation.regions

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractServerGroupTaskSpec.groovy
@@ -106,7 +106,7 @@ class AbstractServerGroupTaskSpec extends Specification {
       )
       result.stageOutputs.asgName == "foo-v001"
       result.stageOutputs.serverGroupName == "foo-v001"
-      result.stageOutputs."deploy.server.groups" == ["us-west-1": ["foo-v001"], "us-east-1": ["foo-v001"]]
+      result.stageOutputs."deploy.server.groups" == ["us-east-1": ["foo-v001"]]
   }
 
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractWaitForClusterWideClouddriverTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractWaitForClusterWideClouddriverTaskSpec.groovy
@@ -58,7 +58,7 @@ class AbstractWaitForClusterWideClouddriverTaskSpec extends Specification {
     where:
     serverGroups = [sg('s1', 'r1'), sg('s2', 'r1'), sg('s3', 'r2'), sg('s4', 'r2')]
     deployServerGroups = serverGroups.groupBy { it.region }.collectEntries { k, v -> [(k): v.collect { it.name }]}
-    expected = serverGroups.collect { new DeployServerGroup(new Location(Location.Type.REGION, it.region), it.name) }
+    expected = serverGroups.collect { new DeployServerGroup(it.region, it.name) }
     regions = ['r1', 'r2']
   }
 
@@ -115,7 +115,7 @@ class AbstractWaitForClusterWideClouddriverTaskSpec extends Specification {
   }
 
   DeployServerGroup dsg(String name, String r = region) {
-    new DeployServerGroup(new Location(Location.Type.REGION, r), name)
+    new DeployServerGroup(r, name)
   }
 
   Stage stage(Map context) {


### PR DESCRIPTION
… by region instead of location (which for GCE is zone).

This bug manifests in the UI when the Angular model updates itself with the values of "deploy.server.groups" before a full refresh cycle happens, causing server groups to jump into different regions, like so:

![opm3xymdmh8 1](https://cloud.githubusercontent.com/assets/13141550/11156551/9d08bf50-8a1a-11e5-8dd5-f55406c06ca3.png)

To ensure the generic ops don't get confused with this new requirement, I introduced a `deployServerGroupRegion` property in `stage.context` that takes precedence over regions and zones.

I also had to (unfortunately) change back some of @cfieber 's location generic code in the cluster wide tasks.

@duftler @anotherchrisberry @cfieber - PTAL
