### PR TITLE
Add support for passing the ?rebake=1 query param to the bakery if th…

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryService.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2015 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,22 @@
  * limitations under the License.
  */
 
-
-
-
-
 package com.netflix.spinnaker.orca.bakery.api
 
 import retrofit.http.Body
 import retrofit.http.GET
 import retrofit.http.POST
 import retrofit.http.Path
+import retrofit.http.Query
 import rx.Observable
 
 /**
- * An interface to the Bakery's REST API. See {@link https://confluence.netflix.com/display/ENGTOOLS/Bakery+API}.
+ * An interface to the Bakery's REST API.
  */
 interface BakeryService {
 
   @POST("/api/v1/{region}/bake")
-  Observable<BakeStatus> createBake(@Path("region") String region, @Body BakeRequest bake)
+  Observable<BakeStatus> createBake(@Path("region") String region, @Body BakeRequest bake, @Query("rebake") String rebake)
 
   @GET("/api/v1/{region}/status/{statusId}")
   Observable<BakeStatus> lookupStatus(@Path("region") String region, @Path("statusId") String statusId)

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -56,7 +56,8 @@ class CreateBakeTask implements RetryableTask {
     def bake = bakeFromContext(stage)
 
     try {
-      def bakeStatus = bakery.createBake(region, bake).toBlocking().single()
+      String rebake = stage.context.rebake ? "1" : null
+      def bakeStatus = bakery.createBake(region, bake, rebake).toBlocking().single()
 
       def stageOutputs = [
         status: bakeStatus,

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryServiceSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryServiceSpec.groovy
@@ -105,7 +105,7 @@ class BakeryServiceSpec extends Specification {
     }
 
     expect: "createBake should return the status of the bake"
-    with(bakery.createBake(region, bake).toBlocking().first()) {
+    with(bakery.createBake(region, bake, null).toBlocking().first()) {
       id == statusId
       state == BakeStatus.State.PENDING
       resourceId == bakeId
@@ -129,7 +129,7 @@ class BakeryServiceSpec extends Specification {
     }
 
     expect: "createBake should return the status of the bake"
-    with(bakery.createBake(region, bake).toBlocking().first()) {
+    with(bakery.createBake(region, bake, null).toBlocking().first()) {
       id == statusId
       state == BakeStatus.State.RUNNING
       resourceId == bakeId // TODO: would we actually get a bake id if it was incomplete?


### PR DESCRIPTION
…e stage context has rebake set to true.

The rebake query param is not set on bakery calls at all if the stage context does not have rebake set to true.

Tested on both AWS and Google.
