### PR TITLE
Enables custom strategies for GCE pipelines and deploys

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/strategies/AbstractDeployStrategyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/strategies/AbstractDeployStrategyStage.groovy
@@ -58,6 +58,7 @@ abstract class AbstractDeployStrategyStage extends AbstractCloudProviderAwareSta
     })
     strategy.composeFlow(stage)
 
+    // TODO(ttomsu): This is currently an AWS-only stage. I need to add and support the "useSourceCapacity" option.
     List<Step> steps = [buildStep(stage, "determineSourceServerGroup", DetermineSourceServerGroupTask)]
     if (!strategy.replacesBasicSteps()) {
       steps.addAll((basicSteps(stage) ?: []) as List<Step>)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/strategies/CustomStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/strategies/CustomStrategy.groovy
@@ -46,13 +46,6 @@ class CustomStrategy implements Strategy {
       parentStageId                          : stage.id
     ]
 
-    if (stage.context.image) {
-      parameters += [
-          imageId: stage.context.image,
-          capacity: stage.context.capacity,
-      ]
-    }
-
     if(stage.context.pipelineParameters){
       parameters.putAll(stage.context.pipelineParameters as Map)
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/strategies/CustomStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/strategies/CustomStrategy.groovy
@@ -46,6 +46,13 @@ class CustomStrategy implements Strategy {
       parentStageId                          : stage.id
     ]
 
+    if (stage.context.image) {
+      parameters += [
+          imageId: stage.context.image,
+          capacity: stage.context.capacity,
+      ]
+    }
+
     if(stage.context.pipelineParameters){
       parameters.putAll(stage.context.pipelineParameters as Map)
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/Location.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/Location.groovy
@@ -45,4 +45,12 @@ class Location {
   String singularType() {
     return this.type.toString().toLowerCase()
   }
+
+  static Location zone(String value) {
+    return new Location(type: Location.Type.ZONE, value: value)
+  }
+
+  static Location region(String value) {
+    return new Location(type: Location.Type.REGION, value: value)
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroup.groovy
@@ -145,23 +145,16 @@ class TargetServerGroup {
     static Params fromStage(Stage stage) {
       Params p = stage.mapTo(Params)
 
-      def toZones = { String z ->
-        return new Location(type: Location.Type.ZONE, value: z)
-      }
-      def toRegions = { String r ->
-        return new Location(type: Location.Type.REGION, value: r)
-      }
-
       if (stage.context.zones) {
         if (stage.context.regions && stage.context.cloudProvider != "gce") {
           // Prefer regions if both are specified, except for GCE.
-          p.locations = stage.context.regions.collect(toRegions)
+          p.locations = stage.context.regions.collect { String r -> Location.region(r) }
         } else {
-          p.locations = stage.context.zones.collect(toZones)
+          p.locations = stage.context.zones.collect { String z -> Location.zone(z) }
         }
       } else {
         // Default to regions.
-        p.locations = stage.context.regions.collect(toRegions)
+        p.locations = stage.context.regions.collect { String r -> Location.region(r) }
       }
       p
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroupLinearStageSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroupLinearStageSupport.groovy
@@ -43,9 +43,14 @@ abstract class TargetServerGroupLinearStageSupport extends LinearStage implement
   void composeTargets(Stage stage) {
     if(stage.execution instanceof Pipeline && stage.execution.trigger.parameters?.strategy == true){
       Map trigger = ((Pipeline) stage.execution).trigger
-      stage.context.regions = [trigger.parameters.region]
+      stage.context.cloudProvider = trigger.parameters.cloudProvider
       stage.context.cluster = trigger.parameters.cluster
       stage.context.credentials = trigger.parameters.credentials
+      if (trigger.parameters.region) {
+        stage.context.regions = [trigger.parameters.region]
+      } else if (trigger.parameters.zone) {
+        stage.context.zones = [trigger.parameters.zone]
+      }
     }
     def params = TargetServerGroup.Params.fromStage(stage)
     if (TargetServerGroup.isDynamicallyBound(stage)) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroupResolver.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/support/TargetServerGroupResolver.groovy
@@ -68,7 +68,7 @@ class TargetServerGroupResolver {
         params.target.name())
     }
     if (!tsgMap) {
-      throw new TargetServerGroup.NotFoundException("Unable to locate ${params.target.name()} in $params.credentials/$location/$params.cluster")
+      throw new TargetServerGroup.NotFoundException("Unable to locate ${params.target.name()} in $params.credentials/$location.value/$params.cluster")
     }
     return new TargetServerGroup(serverGroup: tsgMap)
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStage.groovy
@@ -112,8 +112,12 @@ class ParallelDeployStage extends ParallelStage {
         }
         Map cluster = parentStage.context as Map
         cluster.strategy = 'none'
-        if (!cluster.amiName) {
+        if (!cluster.amiName && trigger.parameters.amiName) {
           cluster.amiName = trigger.parameters.amiName
+        }
+        if (!cluster.image && trigger.parameters.imageId) {
+          // GCE uses 'image' as the ID key to clouddriver.
+          cluster.image = trigger.parameters.imageId
         }
         stage.context.clusters = [cluster as Map<String, Object>]
       }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
@@ -60,7 +60,7 @@ class StartPipelineTask implements Task {
         return base
       } ?: [:]
 
-      if (!deploymentDetails?.isEmpty()) {
+      if (deploymentDetails) {
         parameters.deploymentDetails = deploymentDetails
         if (!parameters.amiName && (parameters.region || parameters.zone)) {
           def details = deploymentDetails.find { (it.region && it.region == parameters.region) ||

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
@@ -51,10 +51,7 @@ class StartPipelineTask implements Task {
 
     if (isStrategy) {
       def deploymentDetails = stage.context.deploymentDetails?.collect { Map it ->
-        def base = [ami: it.ami, imageName: it.imageName]
-        if (it.imageId) {
-          base.imageId = it.imageId
-        }
+        def base = [ami: it.ami, imageName: it.imageName, imageId: it.imageId]
         if (it.region) {
           base.region = it.region
         } else if (it.zone) {
@@ -63,7 +60,7 @@ class StartPipelineTask implements Task {
         return base
       } ?: [:]
 
-      if (!deploymentDetails.empty) {
+      if (!deploymentDetails?.isEmpty()) {
         parameters.deploymentDetails = deploymentDetails
         if (!parameters.amiName && (parameters.region || parameters.zone)) {
           def details = deploymentDetails.find { (it.region && it.region == parameters.region) ||

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTaskSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.front50.tasks
+
+import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import spock.lang.Specification
+import spock.lang.Subject
+
+class StartPipelineTaskSpec extends Specification {
+
+  Front50Service front50Service = Mock(Front50Service)
+  DependentPipelineStarter dependentPipelineStarter = Stub(DependentPipelineStarter)
+  @Subject
+  StartPipelineTask task = new StartPipelineTask(front50Service: front50Service,
+                                                 dependentPipelineStarter: dependentPipelineStarter)
+
+  def "should trigger the dependent pipeline with the correct context"() {
+    given:
+      def pipelineConfig = [id: "testStrategyId", name: "testStrategy"]
+      1 * front50Service.getStrategies(_) >> [pipelineConfig]
+      def stage = new PipelineStage(new Pipeline(), "whatever", [
+          pipelineId        : "testStrategyId",
+          pipelineParameters: [
+              strategy: true,
+              zone    : "north-pole-1",
+          ],
+          deploymentDetails : [
+              [
+                  ami      : "testAMI",
+                  imageName: "testImageName",
+                  imageId  : "testImageId",
+                  zone     : "north-pole-1",
+              ]
+          ],
+          user              : "testUser"
+      ])
+      def gotContext
+
+    when:
+      def result = task.execute(stage)
+
+    then:
+      dependentPipelineStarter.trigger(*_) >> {
+        gotContext = it[3] // 3rd arg is context.
+        return [id: "testPipelineId"]
+      }
+      gotContext == [
+          strategy         : true,
+          zone             : "north-pole-1",
+          amiName          : "testAMI",
+          imageId          : "testImageId",
+          deploymentDetails: [
+              [
+                  ami      : "testAMI",
+                  imageName: "testImageName",
+                  imageId  : "testImageId",
+                  zone     : "north-pole-1",
+              ]
+          ]
+      ]
+  }
+}


### PR DESCRIPTION
Propagates a few deployment properties through the pipeline starter and differentiates regions and zones in a few places.

Tested with a custom strategy in both AWS and GCE through both the UI clone button and findImage/deploy pipelines.

@duftler @tomaslin @cfieber PTAL

https://github.com/spinnaker/spinnaker/issues/585