### PR TITLE
GCE-specific find image tweaks

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/FindImageFromClusterTask.groovy
@@ -102,7 +102,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
         return [(location): lookupResults]
       } catch (RetrofitError e) {
         if (e.response.status == 404) {
-          def message = "Could not find cluster '$cluster' in account '$account'"
+          def message = "Could not find cluster '$cluster' for '$account' in '$location.value'"
           try {
             Map reason = objectMapper.readValue(e.response.body.in(), new TypeReference<Map<String, Object>>() {})
             if (reason.error.contains("target.fail.strategy")){

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/FindImageFromClusterTask.groovy
@@ -102,7 +102,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
         return [(location): lookupResults]
       } catch (RetrofitError e) {
         if (e.response.status == 404) {
-          def message = "Could not find cluster '$cluster' for '$account' in '$location.value'"
+          def message = "Could not find cluster '$cluster' for '$account' in '$location.value'."
           try {
             Map reason = objectMapper.readValue(e.response.body.in(), new TypeReference<Map<String, Object>>() {})
             if (reason.error.contains("target.fail.strategy")){

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/gce/GoogleServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/gce/GoogleServerGroupCreator.groovy
@@ -69,7 +69,7 @@ class GoogleServerGroupCreator implements ServerGroupCreator {
     }
 
     if (!operation.image) {
-      throw new IllegalStateException("No image could be found in ${stage.context.zone}")
+      throw new IllegalStateException("No image could be found in ${stage.context.zone}.")
     }
 
     return [[(ServerGroupCreator.OPERATION): operation]]

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/gce/GoogleServerGroupCreatorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/gce/GoogleServerGroupCreatorSpec.groovy
@@ -46,5 +46,42 @@ class GoogleServerGroupCreatorSpec extends Specification {
               ],
           ]
       ]
+
+    when: "fallback to non-zone matching image"
+      ctx.zone = "south-pole-1"
+      stage = new PipelineStage(new Pipeline(), "whatever", ctx)
+      ops = new GoogleServerGroupCreator().getOperations(stage)
+
+    then:
+      ops == [
+          [
+              "createServerGroup": [
+                  account          : "abc",
+                  credentials      : "abc",
+                  image            : "testImageId",
+                  zone             : "south-pole-1",
+                  deploymentDetails: [[imageId: "testImageId", zone: "north-pole-1"]],
+              ],
+          ]
+      ]
+
+    when: "throw error if >1 image"
+      ctx.deploymentDetails = [[imageId: "testImageId-1", zone: "east-pole-1"],
+                               [imageId: "testImageId-2", zone: "west-pole-1"]]
+      stage = new PipelineStage(new Pipeline(), "whatever", ctx)
+      ops = new GoogleServerGroupCreator().getOperations(stage)
+
+    then:
+      IllegalStateException ise = thrown()
+      ise.message.startsWith("Ambiguous choice of deployment images")
+
+    when: "throw error if no image found"
+      ctx.deploymentDetails = []
+      stage = new PipelineStage(new Pipeline(), "whatever", ctx)
+      ops = new GoogleServerGroupCreator().getOperations(stage)
+
+    then:
+      ise = thrown()
+      ise.message == "No image could be found in south-pole-1"
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/gce/GoogleServerGroupCreatorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/gce/GoogleServerGroupCreatorSpec.groovy
@@ -82,6 +82,6 @@ class GoogleServerGroupCreatorSpec extends Specification {
 
     then:
       ise = thrown()
-      ise.message == "No image could be found in south-pole-1"
+      ise.message == "No image could be found in south-pole-1."
   }
 }


### PR DESCRIPTION
1.) Add more helpful error message when image is not found

![emdmukgrfjt](https://cloud.githubusercontent.com/assets/13141550/11348490/e62aae5a-91f4-11e5-94ea-0ce296d48ff5.png)

2.) GCE is not limited to regional images, so we now fallback to non-matching zone iff 1 deploymentDetail entry is found (this allows cross-zonal "Clone" operations).
  a.) Fail with helpful message if this is the case:

![mclozzpaytj](https://cloud.githubusercontent.com/assets/13141550/11348560/39b6a2fe-91f5-11e5-9e0e-bb68863dc743.png)

3.) Fail with graceful error message if no image is found. Previously, this bubbled up a cryptic Clouddriver error. 
![cvn6rwig5k5](https://cloud.githubusercontent.com/assets/13141550/11348648/b484eb4e-91f5-11e5-8e6d-fba6e4716843.png)
  

@duftler, @spinnaker/google-reviewers PTAL 