### PR TITLE
Override getCloudProvider() for TitanServerGroupCreator

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/titan/TitanServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/titan/TitanServerGroupCreator.groovy
@@ -34,4 +34,8 @@ class TitanServerGroupCreator implements ServerGroupCreator {
   AmazonServerGroupCreator delegate
 
   final String cloudProvider = "titan"
+
+  String getCloudProvider() {
+    return cloudProvider
+  }
 }


### PR DESCRIPTION
- Resulted in 'ServerGroupCreator not found for cloudProvider titan' otherwise