### PR TITLE
add bakeExists flag if createBake returns COMPLETED

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.bakery.tasks
 
 import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.bakery.api.BakeStatus
 import com.netflix.spinnaker.orca.pipeline.util.OperatingSystem
 import com.netflix.spinnaker.orca.pipeline.util.PackageInfo
 import groovy.transform.CompileDynamic
@@ -60,8 +61,9 @@ class CreateBakeTask implements RetryableTask {
       def bakeStatus = bakery.createBake(region, bake, rebake).toBlocking().single()
 
       def stageOutputs = [
-        status         : bakeStatus,
-        bakePackageName: bake.packageName ?: ""
+        status          : bakeStatus,
+        bakePackageName : bake.packageName ?: "",
+        previouslyBaked : bakeStatus.state == BakeStatus.State.COMPLETED
       ] as Map<String, ? extends Object>
 
       if (bake.buildHost) {


### PR DESCRIPTION
The goal is to surface this in the UI, letting users know that an actual bake did not occur and we are instead using a previously baked artifact.

When performing a bake (at least via the internal Netflix bakery), there are two signals that the requested bake already exists:
1. The response status code from the API call is 200 instead of 202
2. The status of the returned bake is `COMPLETED` instead of `RUNNING`

I do not see a clean way of getting at the status code on a successful bake call via Retrofit+OkClient, so am going with (2), which is probably more straightforward, anyway.

Not in love with the flag name (`bakeExists`) and am open to suggestions there.

@robfletcher @duftler please review