### PR TITLE
allow rebake via trigger

### DIFF
--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -642,13 +642,41 @@ class CreateBakeTaskSpec extends Specification {
     then:
     1 * task.bakery.createBake(bakeConfig.region,
                                {
-                                 println "** it=$it packageName=$it.packageName"
                                  it.user == "bran" &&
                                  it.packageName == "hodor" &&
                                  it.baseLabel == BakeRequest.Label.release &&
                                  it.baseOs == OperatingSystem.ubuntu
                                },
                                "1") >> Observable.from(runningStatus)
+    0 * _
+  }
+
+  @Unroll
+  def "sets rebake query parameter to #queryParameter when trigger is #trigger"() {
+    given:
+    Pipeline pipeline = Pipeline.builder().withTrigger(trigger).build()
+    Stage stage = new PipelineStage(pipeline, "bake", bakeConfig).asImmutable()
+    task.bakery = Mock(BakeryService)
+
+    when:
+    task.execute(stage)
+
+    then:
+    1 * task.bakery.createBake(bakeConfig.region,
+                               {
+                                 it.user == "bran" &&
+                                 it.packageName == "hodor" &&
+                                 it.baseLabel == BakeRequest.Label.release &&
+                                 it.baseOs == OperatingSystem.ubuntu
+                               },
+                               queryParameter) >> Observable.from(runningStatus)
+    0 * _
+
+    where:
+    trigger         | queryParameter
+    [rebake: true]  | "1"
+    [rebake: false] | null
+    null            | null
   }
 
 }


### PR DESCRIPTION
This will go with a corresponding change in Deck to allow users to explicitly request a rebake when starting a pipeline.

We have heard from a few users that they wanted to force a rebake without having to update the package artifacts explicitly. While they don't necessarily _always_ want the option, they do want an easy way to do so when dependent packages have changed.

Deck PR pending - will add a comment referencing it when it's ready...

@ajordens @duftler please review