### PR TITLE
Consider STOPPED stages and SUCCEEDED pipelines as `complete` rather than…

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionStatus.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionStatus.groovy
@@ -21,7 +21,6 @@ import org.springframework.batch.core.ExitStatus
 
 @CompileStatic
 enum ExecutionStatus {
-
   /**
    * The task has yet to start.
    */
@@ -84,9 +83,15 @@ enum ExecutionStatus {
 
   final ExitStatus exitStatus
 
+  private static final Collection<ExecutionStatus> SUCCESSFUL = [SUCCEEDED, STOPPED]
+
   ExecutionStatus(boolean complete, boolean halt, ExitStatus exitStatus) {
     this.complete = complete
     this.halt = halt
     this.exitStatus = exitStatus
+  }
+
+  boolean isSuccessful() {
+    return SUCCESSFUL.contains(this)
   }
 }

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingPipelineExecutionListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingPipelineExecutionListener.groovy
@@ -54,7 +54,7 @@ class EchoNotifyingPipelineExecutionListener implements JobExecutionListener {
         echoService.recordEvent(
           details: [
             source     : "orca",
-            type       : "orca:pipeline:${(wasSuccessful(jobExecution) ? "complete" : "failed")}".toString(),
+            type       : "orca:pipeline:${(wasSuccessful(jobExecution, execution) ? "complete" : "failed")}".toString(),
             application: execution.application,
           ],
           content: [
@@ -84,7 +84,7 @@ class EchoNotifyingPipelineExecutionListener implements JobExecutionListener {
    * even if the Orca task failed we'll get a `jobExecution.status` of
    * `COMPLETED` as the error was handled.
    */
-  private static boolean wasSuccessful(JobExecution jobExecution) {
-    jobExecution.exitStatus.exitCode == ExitStatus.COMPLETED.exitCode
+  private static boolean wasSuccessful(JobExecution jobExecution, Execution currentExecution) {
+    jobExecution.exitStatus.exitCode == ExitStatus.COMPLETED.exitCode || currentExecution.status.isSuccessful()
   }
 }

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageExecutionListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageExecutionListener.groovy
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.orca.echo.spring
 
+import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.batch.StageExecutionListener
 import com.netflix.spinnaker.orca.echo.EchoService
 import com.netflix.spinnaker.orca.pipeline.model.Orchestration
@@ -82,6 +83,7 @@ class EchoNotifyingStageExecutionListener extends StageExecutionListener {
    * `COMPLETED` as the error was handled.
    */
   private static boolean wasSuccessful(StepExecution stepExecution) {
-    stepExecution.exitStatus.exitCode == ExitStatus.COMPLETED.exitCode
+    ExecutionStatus orcaTaskStatus = (ExecutionStatus) stepExecution.executionContext.get("orcaTaskStatus")
+    stepExecution.exitStatus.exitCode == ExitStatus.COMPLETED.exitCode || orcaTaskStatus?.isSuccessful()
   }
 }


### PR DESCRIPTION
… `failed` when it comes to recording events (and sending notifications)