### PR TITLE
Removes use of OperatingSystem enum in favor of String when baking im…

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.orca.bakery.api
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.netflix.spinnaker.orca.pipeline.util.OperatingSystem
 import groovy.transform.CompileStatic
 import groovy.transform.Immutable
 
@@ -29,7 +28,7 @@ import groovy.transform.Immutable
 @Immutable(copyWith = true)
 @CompileStatic
 class BakeRequest {
-  static final Default = new BakeRequest(System.getProperty("user.name"), null, null, null, null, null, CloudProviderType.aws, Label.release, OperatingSystem.ubuntu, null, null, null, null, null, null, null)
+  static final Default = new BakeRequest(System.getProperty("user.name"), null, null, null, null, null, CloudProviderType.aws, Label.release, "ubuntu", null, null, null, null, null, null, null)
 
   String user
   @JsonProperty("package") String packageName
@@ -39,7 +38,7 @@ class BakeRequest {
   String commitHash
   CloudProviderType cloudProviderType
   Label baseLabel
-  OperatingSystem baseOs
+  String baseOs
   String baseName
   String baseAmi
   VmType vmType

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryService.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryService.groovy
@@ -37,4 +37,12 @@ interface BakeryService {
   @GET("/api/v1/{region}/bake/{bakeId}")
   Observable<Bake> lookupBake(@Path("region") String region, @Path("bakeId") String bakeId)
 
+  //
+  // Methods below this line are not supported by the Netflix Bakery, and are only available
+  // iff bakery.roscoApisEnabled is true.
+  //
+
+  @GET("/bakeOptions/{cloudProvider}/baseImages/{imageId}")
+  Observable<BaseImage> getBaseImage(@Path("cloudProvider") String cloudProvider,
+                                     @Path("imageId") String imageId)
 }

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BaseImage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BaseImage.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2015 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,19 +14,14 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.orca.pipeline.util
+package com.netflix.spinnaker.orca.bakery.api
 
-@Deprecated
-public enum OperatingSystem {
-  centos(PackageType.RPM), ubuntu(PackageType.DEB), trusty(PackageType.DEB)
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.netflix.spinnaker.orca.pipeline.util.PackageType
 
-  private final PackageType packageType
-  private OperatingSystem(PackageType packageType) {
-    this.packageType = packageType
-  }
+class BaseImage {
+  String id
 
-  PackageType getPackageType() {
-    return packageType
-  }
+  // Needs JsonProperty because of LowerCaseWithUnderscoresStrategy property naming strategy.
+  @JsonProperty("packageType")  PackageType packageType
 }
-

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -18,8 +18,6 @@ package com.netflix.spinnaker.orca.bakery.tasks
 
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.bakery.api.BakeStatus
-import com.netflix.spinnaker.orca.bakery.api.BaseImage
-
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.util.OperatingSystem
 import com.netflix.spinnaker.orca.pipeline.util.PackageInfo
@@ -62,6 +60,8 @@ class CreateBakeTask implements RetryableTask {
     String region = stage.context.region
 
     try {
+      // If the user has specified a base OS that is unrecognized by Rosco, this method will
+      // throw a Retrofit exception (HTTP 404 Not Found)
       def bake = bakeFromContext(stage)
       String rebake = shouldRebake(stage) ? "1" : null
       def bakeStatus = bakery.createBake(region, bake, rebake).toBlocking().single()

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -18,9 +18,12 @@ package com.netflix.spinnaker.orca.bakery.tasks
 
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.bakery.api.BakeStatus
+import com.netflix.spinnaker.orca.bakery.api.BaseImage
+
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.util.OperatingSystem
 import com.netflix.spinnaker.orca.pipeline.util.PackageInfo
+import com.netflix.spinnaker.orca.pipeline.util.PackageType
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -48,6 +51,8 @@ class CreateBakeTask implements RetryableTask {
   @Value('${bakery.extractBuildDetails:false}')
   boolean extractBuildDetails
 
+  @Value('${bakery.roscoApisEnabled:false}')
+  boolean roscoApisEnabled
 
   @Value('${bakery.propagateCloudProviderType:false}')
   boolean propagateCloudProviderType
@@ -55,9 +60,9 @@ class CreateBakeTask implements RetryableTask {
   @Override
   TaskResult execute(Stage stage) {
     String region = stage.context.region
-    def bake = bakeFromContext(stage)
 
     try {
+      def bake = bakeFromContext(stage)
       String rebake = shouldRebake(stage) ? "1" : null
       def bakeStatus = bakery.createBake(region, bake, rebake).toBlocking().single()
 
@@ -111,10 +116,22 @@ class CreateBakeTask implements RetryableTask {
 
   @CompileDynamic
   private BakeRequest bakeFromContext(Stage stage) {
-    OperatingSystem operatingSystem = OperatingSystem.valueOf(stage.context.baseOs as String)
+    PackageType packageType
+    if (roscoApisEnabled) {
+      def baseImage = bakery.getBaseImage(stage.context.cloudProviderType as String,
+                                          stage.context.baseOs as String).toBlocking().single()
+      packageType = baseImage.packageType as PackageType
+    } else {
+      OperatingSystem operatingSystem = OperatingSystem.valueOf(stage.context.baseOs as String)
+      packageType = operatingSystem.packageType
+    }
 
-    PackageInfo packageInfo = new PackageInfo(stage, operatingSystem.packageType.packageType,
-      operatingSystem.packageType.versionDelimiter, extractBuildDetails, false, mapper)
+    PackageInfo packageInfo = new PackageInfo(stage,
+                                              packageType.packageType,
+                                              packageType.versionDelimiter,
+                                              extractBuildDetails,
+                                              false /* extractVersion */,
+                                              mapper)
     Map requestMap = packageInfo.findTargetPackage()
     BakeRequest bakeRequest = mapper.convertValue(requestMap, BakeRequest)
 

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.pipeline.util.OperatingSystem
 import retrofit.RetrofitError
 import retrofit.client.Response
 import retrofit.mime.TypedString
@@ -61,7 +60,7 @@ class CreateBakeTaskSpec extends Specification {
     region   : "us-west-1",
     package  : "hodor",
     user     : "bran",
-    baseOs   : OperatingSystem.ubuntu.name(),
+    baseOs   : "ubuntu",
     baseLabel: BakeRequest.Label.release.name()
   ]
 
@@ -71,7 +70,7 @@ class CreateBakeTaskSpec extends Specification {
     package           : "hodor",
     user              : "bran",
     cloudProviderType : "aws",
-    baseOs            : OperatingSystem.ubuntu.name(),
+    baseOs            : "ubuntu",
     baseLabel         : BakeRequest.Label.release.name()
   ]
 
@@ -81,7 +80,7 @@ class CreateBakeTaskSpec extends Specification {
     package           : "hodor",
     user              : "bran",
     cloudProviderType : "aws",
-    baseOs            : OperatingSystem.ubuntu.name(),
+    baseOs            : "ubuntu",
     baseLabel         : BakeRequest.Label.release.name(),
     rebake            : true
   ]
@@ -240,7 +239,7 @@ class CreateBakeTaskSpec extends Specification {
     then:
     bake.user == bakeConfig.user
     bake.packageName == bakeConfig.package
-    bake.baseOs.name() == bakeConfig.baseOs
+    bake.baseOs == bakeConfig.baseOs
     bake.baseLabel.name() == bakeConfig.baseLabel
   }
 
@@ -510,7 +509,7 @@ class CreateBakeTaskSpec extends Specification {
                                  it.user == "bran" &&
                                  it.packageName == "hodor_1.1_all" &&
                                  it.baseLabel == BakeRequest.Label.release &&
-                                 it.baseOs == OperatingSystem.ubuntu &&
+                                 it.baseOs == "ubuntu" &&
                                  it.buildHost == "http://spinnaker.builds.test.netflix.net/" &&
                                  it.job == "SPINNAKER-package-echo" &&
                                  it.buildNumber == "69"
@@ -542,7 +541,7 @@ class CreateBakeTaskSpec extends Specification {
                                  it.user == "bran" &&
                                  it.packageName == "hodor_1.1_all" &&
                                  it.baseLabel == BakeRequest.Label.release &&
-                                 it.baseOs == OperatingSystem.ubuntu &&
+                                 it.baseOs == "ubuntu" &&
                                  it.buildHost == null &&
                                  it.job == null &&
                                  it.buildNumber == null &&
@@ -574,7 +573,7 @@ class CreateBakeTaskSpec extends Specification {
                                  it.user == "bran" &&
                                  it.packageName == "hodor_1.1_all" &&
                                  it.baseLabel == BakeRequest.Label.release &&
-                                 it.baseOs == OperatingSystem.ubuntu &&
+                                 it.baseOs == "ubuntu" &&
                                  it.buildHost == null &&
                                  it.job == null &&
                                  it.buildNumber == null &&
@@ -608,7 +607,7 @@ class CreateBakeTaskSpec extends Specification {
     bake.cloudProviderType == expectedCloudProviderType
     bake.user              == bakeConfigWithCloudProviderType.user
     bake.packageName       == bakeConfigWithCloudProviderType.package
-    bake.baseOs.name()     == bakeConfigWithCloudProviderType.baseOs
+    bake.baseOs            == bakeConfigWithCloudProviderType.baseOs
     bake.baseLabel.name()  == bakeConfigWithCloudProviderType.baseLabel
 
     where:
@@ -651,7 +650,7 @@ class CreateBakeTaskSpec extends Specification {
                                  it.user == "bran" &&
                                  it.packageName == "hodor" &&
                                  it.baseLabel == BakeRequest.Label.release &&
-                                 it.baseOs == OperatingSystem.ubuntu
+                                 it.baseOs == "ubuntu"
                                } as BakeRequest,
                                "1") >> Observable.from(runningStatus)
     0 * _
@@ -673,7 +672,7 @@ class CreateBakeTaskSpec extends Specification {
                                  it.user == "bran" &&
                                  it.packageName == "hodor" &&
                                  it.baseLabel == BakeRequest.Label.release &&
-                                 it.baseOs == OperatingSystem.ubuntu
+                                 it.baseOs == "ubuntu"
                                } as BakeRequest,
                                queryParameter) >> Observable.from(runningStatus)
     0 * _
@@ -687,7 +686,7 @@ class CreateBakeTaskSpec extends Specification {
         it.user == "bran" &&
           it.packageName == "hodor" &&
           it.baseLabel == BakeRequest.Label.release &&
-          it.baseOs == OperatingSystem.ubuntu
+          it.baseOs == "ubuntu"
       } as BakeRequest,
       null) >> Observable.from(runningStatus)
     0 * _

--- a/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca-clouddriver/orca-clouddriver.gradle
@@ -18,5 +18,6 @@ dependencies {
   compile spinnaker.dependency('frigga')
   compile project(":orca-retrofit")
   compile project(":orca-front50")
+  compile project(":orca-bakery")
   testCompile project(":orca-test")
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
@@ -19,8 +19,6 @@ package com.netflix.spinnaker.orca.kato.pipeline
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.bakery.api.BakeryService
-import com.netflix.spinnaker.orca.bakery.api.BaseImage
-
 import com.netflix.spinnaker.orca.clouddriver.InstanceService
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTask.groovy
@@ -6,8 +6,6 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.pipeline.util.OperatingSystem
-import com.netflix.spinnaker.orca.pipeline.util.PackageInfo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTaskSpec.groovy
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.InstanceService
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
-import com.netflix.spinnaker.orca.pipeline.util.OperatingSystem
 import retrofit.RetrofitError
 import retrofit.client.Response
 import retrofit.mime.TypedString
@@ -64,7 +63,7 @@ class TriggerQuipTaskSpec extends Specification {
       "account" : account,
       "region" : region,
       "application" : app,
-      "baseOs" : OperatingSystem.ubuntu.toString(),
+      "baseOs" : "ubuntu",
       "package" : app,
       "version" : "1.2"
     ])
@@ -103,7 +102,7 @@ class TriggerQuipTaskSpec extends Specification {
       "account" : account,
       "region" : region,
       "application" : app,
-      "baseOs" : OperatingSystem.ubuntu.toString(),
+      "baseOs" : "ubuntu",
       "package" : app,
       "version" : "1.2"
     ])
@@ -148,7 +147,7 @@ class TriggerQuipTaskSpec extends Specification {
       "account" : account,
       "region" : region,
       "application" : app,
-      "baseOs" : OperatingSystem.ubuntu.toString(),
+      "baseOs" : "ubuntu",
       "package" : packageName
     ])
 

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -19,8 +19,8 @@ echo:
   enabled: false
 bakery:
   baseUrl: http://localhost:8089
-  # Rosco exposes more endpoints than Netflix's internal bakery. This turn
-  # off the use of those endpoints.
+  # Rosco exposes more endpoints than Netflix's internal bakery. This disables
+  # the use of those endpoints.
   roscoApisEnabled: true
 
 redis:

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -19,6 +19,9 @@ echo:
   enabled: false
 bakery:
   baseUrl: http://localhost:8089
+  # Rosco exposes more endpoints than Netflix's internal bakery. This turn
+  # off the use of those endpoints.
+  roscoApisEnabled: true
 
 redis:
   connection: ${REDIS_URL:redis://localhost:6379}


### PR DESCRIPTION
…ages. It now uses Rosco (when enabled) to lookup the package type.

@spinnaker/reviewers - **NETFLIX** - You'll need to change `bakery.roscoApisEnabled` to `false` in your config. Otherwise, your internal bakery will get API requests, return (I assume) a 404, and then bakes will fail :-(

Tested with upcoming deck and gate changes by baking GCE and AWS images. Since we do not yet support quick patch, that change was not tested.

Tag: https://github.com/spinnaker/spinnaker/issues/597