### PR TITLE
mark quickPatchAsg stage as initializationStage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
@@ -116,6 +116,8 @@ class QuickPatchStage extends LinearStage {
       nextStageContext.put("instanceIds", instances.collect {key, value -> key}) // for WaitForDown/UpInstancesTask
       injectAfter(stage, "bulkQuickPatchStage", bulkQuickPatchStage, nextStageContext)
     }
+
+    stage.initializationStage = true
     // mark as SUCCEEDED otherwise a stage w/o child tasks will remain in NOT_STARTED
     stage.status = ExecutionStatus.SUCCEEDED
     return steps


### PR DESCRIPTION
Like the `ResizeAsgStage`, the `QuickPatchStage` itself just spawns a child stage, which does all the work.

Right now, it marks itself as `SUCCEEDED`, so it gets an `endTime` but no `startTime` when Orca persists it, which causes grief in the UI. Also, since the stage doesn't really show us anything useful (all its data is presented in the child stages it spawns), it just takes up space in the execution details.

@cfieber does this seem legit or are there bigger problems setting this flag on this stage?