### PR TITLE
add a #fromUrl helper method that will allow fetching content 

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.groovy
@@ -115,8 +115,12 @@ class ContextParameterProcessor {
       evaluationContext.addPropertyAccessor(MapPropertyAccessor)
       evaluationContext.registerFunction('alphanumerical', ContextStringUtilities.getDeclaredMethod("alphanumerical", String))
       evaluationContext.registerFunction('toJson', ContextStringUtilities.getDeclaredMethod("toJson", Object))
+      evaluationContext.registerFunction('readJson', ContextStringUtilities.getDeclaredMethod("readJson", String))
       evaluationContext.registerFunction('toInt', ContextStringUtilities.getDeclaredMethod("toInt", String))
       evaluationContext.registerFunction('toFloat', ContextStringUtilities.getDeclaredMethod("toFloat", String))
+      evaluationContext.registerFunction('fromUrl', ContextStringUtilities.getDeclaredMethod("fromUrl", String))
+      evaluationContext.registerFunction('jsonFromUrl', ContextStringUtilities.getDeclaredMethod("jsonFromUrl", String))
+
       try {
         Expression exp = parser.parseExpression(parameters, parserContext)
         convertedValue = exp.getValue(evaluationContext)
@@ -124,7 +128,7 @@ class ContextParameterProcessor {
         convertedValue = parameters
       }
 
-      if(convertedValue == null){
+      if (convertedValue == null) {
         convertedValue = parameters
       }
 
@@ -140,15 +144,31 @@ abstract class ContextStringUtilities {
   static String alphanumerical(String str) {
     str.replaceAll('[^A-Za-z0-9]', '')
   }
+
   static String toJson(Object o) {
     new ObjectMapper().writeValueAsString(o)
   }
+
   static Integer toInt(String str) {
     Integer.valueOf(str)
   }
+
   static Float toFloat(String str) {
     Float.valueOf(str)
   }
+
+  static String fromUrl(String url) {
+    new URL(url).text
+  }
+
+  static Object readJson(String text){
+    new ObjectMapper().readValue(text, text.startsWith('[') ? List : Map)
+  }
+
+  static Object jsonFromUrl(String url) {
+    readJson(fromUrl(url))
+  }
+
 }
 
 class MapPropertyAccessor extends ReflectivePropertyAccessor {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
@@ -332,4 +332,16 @@ class ContextParameterProcessorSpec extends Specification {
     '7.5' | 7.5f
   }
 
+  @Unroll
+  def 'json reader returns a list if the item passed starts with a ['() {
+    expect:
+    expectedClass.isInstance(ContextStringUtilities.readJson(json))
+
+    where:
+    json               | expectedClass
+    '[ "one", "two" ]' | List
+    '{ "one":"two" }'  | Map
+
+  }
+
 }


### PR DESCRIPTION
Adds a #fromUrl helper method that will either return a list or map from the url that is sent in. 

This is intended to help in situations where you might want to check against a healthcheck or get more details from another pipeline. 

This is just a building block, we will add more helper functions that will make it easier to get things like a #hostname from a cluster, for example. 

Usage:

```#fromUrl( 'http://myserver/endpoint' )[0].instances```