### PR TITLE
ServerGroupCacheForceRefreshTask should succeed rather than fail if a…

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
@@ -24,10 +24,17 @@ import retrofit.client.Response
 import retrofit.mime.TypedString
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
+
+import java.time.Clock
+import java.util.concurrent.TimeUnit
+
+import static com.netflix.spinnaker.orca.ExecutionStatus.*
 
 class ServerGroupCacheForceRefreshTaskSpec extends Specification {
 
-  @Subject task = new ServerGroupCacheForceRefreshTask(objectMapper: new ObjectMapper())
+  @Subject
+  def task = new ServerGroupCacheForceRefreshTask(objectMapper: new ObjectMapper())
   def stage = new PipelineStage(type: "whatever")
 
   def deployConfig = [
@@ -38,11 +45,15 @@ class ServerGroupCacheForceRefreshTaskSpec extends Specification {
 
   def setup() {
     stage.context.putAll(deployConfig)
+    stage.startTime = 0
+    task.oort = Mock(OortService)
   }
 
   void "should force cache refresh server groups via oort"() {
     setup:
-    task.oort = Mock(OortService)
+    task.clock = Mock(Clock) {
+      1 * millis() >> 0
+    }
     Map expectations = [:]
 
     when:
@@ -57,6 +68,86 @@ class ServerGroupCacheForceRefreshTaskSpec extends Specification {
     expectations.serverGroupName == (deployConfig."deploy.server.groups"."us-east-1").get(0)
     expectations.account == deployConfig."account.name"
     expectations.region == "us-east-1"
-    result.status == ExecutionStatus.RUNNING
+    result.status == RUNNING
+  }
+
+  void "should auto-succeed if force cache refresh takes longer than 12 minutes"() {
+    setup:
+    task.clock = Mock(Clock) {
+      1 * millis() >> TimeUnit.MINUTES.toMillis(12) + 1
+    }
+
+    expect:
+    task.execute(stage.asImmutable()).status == SUCCEEDED
+  }
+
+  @Unroll
+  void "should only force cache refresh server groups that haven't been refreshed yet"() {
+    given:
+    def stageData = new ServerGroupCacheForceRefreshTask.StageData(
+      deployServerGroups: [
+        "us-west-1": deployedServerGroups as Set<String>
+      ],
+      refreshedServerGroups: refreshedServerGroups.collect {
+        [asgName: it, serverGroupName: it, region: "us-west-1", account: "test"]
+      }
+    )
+
+    when:
+    def optionalTaskResult = task.performForceCacheRefresh("test", "aws", stageData)
+
+    then:
+    forceCacheUpdatedServerGroups.size() * task.oort.forceCacheUpdate("aws", "ServerGroup", _) >> {
+      return new Response('', executionStatus == SUCCEEDED ? 200 : 202, 'ok', [], new TypedString(""))
+    }
+    0 * task.oort._
+
+    optionalTaskResult.present == !forceCacheUpdatedServerGroups.isEmpty()
+    forceCacheUpdatedServerGroups.every {
+      optionalTaskResult.get().status == executionStatus
+      (optionalTaskResult.get().stageOutputs."refreshed.server.groups" as Set<Map>)*.serverGroupName == expectedRefreshedServerGroups
+    }
+    stageData.refreshedServerGroups*.serverGroupName == expectedRefreshedServerGroups
+
+    where:
+    deployedServerGroups | refreshedServerGroups || executionStatus || forceCacheUpdatedServerGroups || expectedRefreshedServerGroups
+    ["s-v001"]           | []                    || SUCCEEDED       || ["s-v001"]                    || ["s-v001"]
+    ["s-v001"]           | []                    || RUNNING         || ["s-v001"]                    || ["s-v001"]
+    ["s-v001", "s-v002"] | []                    || RUNNING         || ["s-v001", "s-v002"]          || ["s-v001", "s-v002"]
+    ["s-v001", "s-v002"] | ["s-v001"]            || RUNNING         || ["s-v002"]                    || ["s-v001", "s-v002"]
+    ["s-v001"]           | ["s-v001"]            || null            || []                            || ["s-v001"]
+  }
+
+  void "should only complete when all deployed server groups have been processed"() {
+    given:
+    def stageData = new ServerGroupCacheForceRefreshTask.StageData(
+      deployServerGroups: [
+        "us-west-1": deployedServerGroups as Set<String>
+      ]
+    )
+
+    when:
+    def processingComplete = task.processPendingForceCacheUpdates("test", "aws", stageData, 0, )
+
+    then:
+    1 * task.oort.pendingForceCacheUpdates("aws", "ServerGroup") >> { return pendingForceCacheUpdates }
+    processingComplete == expectedProcessingComplete
+
+    where:
+    deployedServerGroups | pendingForceCacheUpdates                      || expectedProcessingComplete
+    ["s-v001"]           | [pFCU("s-v001", 1, 1)]                        || true    // cacheTime && processedTime > startTime
+    ["s-v001", "s-v002"] | [pFCU("s-v001", 1, 1), pFCU("s-v002", 1, 1)]  || true    // cacheTime && processedTime > startTime
+    ["s-v001", "s-v002"] | [pFCU("s-v001", 1, 1), pFCU("s-v002", 1, -1)] || false   // cacheTime > startTime, processedTime < startTime
+    ["s-v001"]           | [pFCU("s-v001", -1, 1)]                       || false   // cacheTime < startTime, processedTime > startTime
+    ["s-v001"]           | [pFCU("s-v001", 1, -1)]                       || false   // cacheTime > startTime, processedTime < startTime
+    ["s-v001"]           | []                                            || false   // no pending force cache update
+  }
+
+  static Map pFCU(String serverGroupName, long cacheTime, long processedTime) {
+    return [
+      cacheTime    : cacheTime,
+      processedTime: processedTime,
+      details      : [serverGroup: serverGroupName, region: "us-west-1", account: "test"]
+    ]
   }
 }


### PR DESCRIPTION
… timeout occurs.

I've seen this occur if a forceCache is queued up for a subsequently deleted ASG ...
in these cases the ttl should expire the record after 10 minutes and the task re-forceCache refresh.

If we see a significant # of forceCacheRefreshes getting hung up around deletes, I'd suggest doing
a re-forceCache call every few minutes.

Otherwise, this change preserves the original behavior of a forceCacheRefresh being fire and forget.