### PR TITLE
convert FAILED status to TERMINAL

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -72,13 +72,13 @@ class MonitorBakeTask implements RetryableTask {
   private ExecutionStatus mapStatus(BakeStatus newStatus) {
     switch (newStatus.state) {
       case BakeStatus.State.COMPLETED:
-        return newStatus.result == BakeStatus.Result.SUCCESS ? ExecutionStatus.SUCCEEDED : ExecutionStatus.FAILED
+        return newStatus.result == BakeStatus.Result.SUCCESS ? ExecutionStatus.SUCCEEDED : ExecutionStatus.TERMINAL
       // Rosco returns CANCELED.
       case BakeStatus.State.CANCELED:
-        return ExecutionStatus.FAILED
+        return ExecutionStatus.TERMINAL
       // Netflix's internal bakery returns CANCELLED.
       case BakeStatus.State.CANCELLED:
-        return ExecutionStatus.FAILED
+        return ExecutionStatus.TERMINAL
       default:
         return ExecutionStatus.RUNNING
     }

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTaskSpec.groovy
@@ -56,8 +56,8 @@ class MonitorBakeTaskSpec extends Specification {
     BakeStatus.State.PENDING   | null                      || ExecutionStatus.RUNNING
     BakeStatus.State.RUNNING   | null                      || ExecutionStatus.RUNNING
     BakeStatus.State.COMPLETED | BakeStatus.Result.SUCCESS || ExecutionStatus.SUCCEEDED
-    BakeStatus.State.COMPLETED | BakeStatus.Result.FAILURE || ExecutionStatus.FAILED
-    BakeStatus.State.COMPLETED | null                      || ExecutionStatus.FAILED
+    BakeStatus.State.COMPLETED | BakeStatus.Result.FAILURE || ExecutionStatus.TERMINAL
+    BakeStatus.State.COMPLETED | null                      || ExecutionStatus.TERMINAL
     BakeStatus.State.SUSPENDED | null                      || ExecutionStatus.RUNNING
 
     id = randomUUID().toString()

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
@@ -65,7 +65,7 @@ abstract class AbstractInstancesCheckTask extends AbstractCloudProviderAwareTask
     Map<String, List<String>> serverGroups = getServerGroups(stage)
 
     if (!serverGroups || !serverGroups?.values()?.flatten()) {
-      return new DefaultTaskResult(ExecutionStatus.FAILED)
+      return new DefaultTaskResult(ExecutionStatus.TERMINAL)
     }
     Names names = Names.parseName(serverGroups.values().flatten()[0])
     try {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTask.groovy
@@ -48,7 +48,7 @@ abstract class AbstractWaitForInstanceHealthChangeTask implements RetryableTask 
 
     def instanceIds = getInstanceIds(stage)
     if (!instanceIds) {
-      return new DefaultTaskResult(ExecutionStatus.FAILED)
+      return new DefaultTaskResult(ExecutionStatus.TERMINAL)
     }
 
     def stillRunning = instanceIds.find {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerResultObjectExtrapolationTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerResultObjectExtrapolationTask.groovy
@@ -34,7 +34,7 @@ class UpsertLoadBalancerResultObjectExtrapolationTask implements Task {
     def lastKatoTask = katoTasks.find { it.id.toString() == lastTaskId.id }
 
     if (!lastKatoTask) {
-      return new DefaultTaskResult(ExecutionStatus.FAILED)
+      return new DefaultTaskResult(ExecutionStatus.TERMINAL)
     }
 
     def resultObjects = lastKatoTask.resultObjects as List<Map>

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTaskSpec.groovy
@@ -48,7 +48,7 @@ class AbstractWaitForInstanceHealthChangeTaskSpec extends Specification {
 //TODO(duftler): Explain the new behavior here...
     where:
     instanceDetails                                                | interestingHealthProviderNames || expectedResult
-    []                                                             | null                            | ExecutionStatus.FAILED
+    []                                                             | null                            | ExecutionStatus.TERMINAL
     []                                                             | []                              | ExecutionStatus.SUCCEEDED
     [[instanceId: "1", health: [h("LB", "Up"), h("D", "Up")]]]     | null                            | ExecutionStatus.RUNNING
     [[instanceId: "1", health: [h("LB", "Up"), h("D", "Up")]]]     | []                              | ExecutionStatus.SUCCEEDED
@@ -89,7 +89,7 @@ class AbstractWaitForInstanceHealthChangeTaskSpec extends Specification {
 //TODO(duftler): Explain the new behavior here...
     where:
     instanceDetails                                                | interestingHealthProviderNames || expectedResult
-    []                                                             | null                            | ExecutionStatus.FAILED
+    []                                                             | null                            | ExecutionStatus.TERMINAL
     []                                                             | []                              | ExecutionStatus.SUCCEEDED
     [[instanceId: "1", health: [h("LB", "Up"), h("D", "Down")]]]   | null                            | ExecutionStatus.RUNNING
     [[instanceId: "1", health: [h("LB", "Up"), h("D", "Down")]]]   | []                              | ExecutionStatus.SUCCEEDED

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionStatus.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionStatus.groovy
@@ -51,12 +51,6 @@ enum ExecutionStatus {
     SUCCEEDED(true, false, ExitStatus.COMPLETED),
 
   /**
-   * The task failed and the pipeline should be able to recover through
-   * subsequent steps.
-   */
-    FAILED(true, true, ExitStatus.FAILED),
-
-  /**
    * The task failed and the failure was terminal. The pipeline will not
    * progress any further.
    */

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/BatchStepStatus.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/BatchStepStatus.groovy
@@ -37,7 +37,6 @@ class BatchStepStatus {
         return new BatchStepStatus(RepeatStatus.FINISHED, result.status.exitStatus, BatchStatus.COMPLETED)
       case ExecutionStatus.SUSPENDED:
         return new BatchStepStatus(RepeatStatus.FINISHED, result.status.exitStatus, BatchStatus.STOPPED)
-      case ExecutionStatus.FAILED:
       case ExecutionStatus.TERMINAL:
         return new BatchStepStatus(RepeatStatus.FINISHED, result.status.exitStatus, BatchStatus.FAILED)
       case ExecutionStatus.RUNNING:

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindow.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindow.groovy
@@ -71,7 +71,7 @@ class RestrictExecutionDuringTimeWindow extends LinearStage {
       try {
         scheduledTime = getTimeInWindow(stage, getCurrentDate())
       } catch (Exception e) {
-        return new DefaultTaskResult(ExecutionStatus.FAILED, [failureReason: 'Exception occurred while calculating time window: ' + e.message])
+        return new DefaultTaskResult(ExecutionStatus.TERMINAL, [failureReason: 'Exception occurred while calculating time window: ' + e.message])
       }
       if (now >= scheduledTime) {
         return new DefaultTaskResult(ExecutionStatus.SUCCEEDED)

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/ExecutionPropagationListenerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/ExecutionPropagationListenerSpec.groovy
@@ -117,7 +117,6 @@ class ExecutionPropagationListenerSpec extends Specification {
     stageStatus | expectedStatus
     ExecutionStatus.CANCELED | ExecutionStatus.CANCELED
     ExecutionStatus.TERMINAL | ExecutionStatus.TERMINAL
-    ExecutionStatus.FAILED | ExecutionStatus.CANCELED
   }
 
   private static StepExecution stepExecution(String stepName,

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/adapters/TaskTaskletSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/adapters/TaskTaskletSpec.groovy
@@ -144,7 +144,6 @@ class TaskTaskletSpec extends Specification {
     where:
     taskResultStatus | repeatStatus             | exitStatus
     SUCCEEDED        | RepeatStatus.FINISHED    | ExitStatus.COMPLETED
-    FAILED           | RepeatStatus.FINISHED    | ExitStatus.FAILED
     RUNNING          | RepeatStatus.CONTINUABLE | ExitStatus.EXECUTING
     SUSPENDED        | RepeatStatus.FINISHED    | ExitStatus.STOPPED
     TERMINAL         | RepeatStatus.FINISHED    | ExitStatus.FAILED
@@ -166,7 +165,6 @@ class TaskTaskletSpec extends Specification {
     where:
     taskResultStatus | _
     SUCCEEDED        | _
-    FAILED           | _
     RUNNING          | _
     SUSPENDED        | _
   }
@@ -187,7 +185,6 @@ class TaskTaskletSpec extends Specification {
     where:
     taskStatus | _
     RUNNING    | _
-    FAILED     | _
     SUCCEEDED  | _
 
     outputs = [foo: "bar", baz: "qux", appConfig: [:]]

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/FailureRecoveryExecutionSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/FailureRecoveryExecutionSpec.groovy
@@ -50,21 +50,6 @@ class FailureRecoveryExecutionSpec extends AbstractBatchLifecycleSpec {
     jobExecution.exitStatus == ExitStatus.COMPLETED
   }
 
-  def "if the first task fails the recovery task is run"() {
-    given:
-    startTask.execute(_) >> new DefaultTaskResult(FAILED)
-
-    when:
-    def jobExecution = launchJob()
-
-    then:
-    1 * recoveryTask.execute(_) >> new DefaultTaskResult(SUCCEEDED)
-    1 * endTask.execute(_) >> new DefaultTaskResult(SUCCEEDED)
-
-    and:
-    jobExecution.exitStatus == ExitStatus.COMPLETED
-  }
-
   @Ignore
   def "if a task is TERMINAL, the pipeline stops"() {
     given:

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/ManualInterventionExecutionSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/ManualInterventionExecutionSpec.groovy
@@ -48,7 +48,7 @@ class ManualInterventionExecutionSpec extends AbstractBatchLifecycleSpec {
 
   def "pipeline will stop if the first task fails"() {
     given:
-    preInterventionTask.execute(null) >> new DefaultTaskResult(FAILED)
+    preInterventionTask.execute(null) >> new DefaultTaskResult(TERMINAL)
 
     when:
     launchJob()

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -305,7 +305,6 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     execution                  | status
     new Pipeline(buildTime: 0) | CANCELED
     new Orchestration()        | SUCCEEDED
-    new Orchestration()        | FAILED
     new Orchestration()        | TERMINAL
 
     type = execution.getClass().simpleName

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/restart/PipelineRecoveryListenerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/restart/PipelineRecoveryListenerSpec.groovy
@@ -126,7 +126,6 @@ class PipelineRecoveryListenerSpec extends Specification {
     status    | _
     CANCELED  | _
     SUCCEEDED | _
-    FAILED    | _
     TERMINAL  | _
     SUSPENDED | _
 

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoEventSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoEventSpec.groovy
@@ -35,7 +35,6 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 class EchoEventSpec extends Specification {
 
   public static final taskSuccess = new DefaultTaskResult(ExecutionStatus.SUCCEEDED)
-  public static final taskFailed = new DefaultTaskResult(ExecutionStatus.FAILED)
   public static final taskTerminal = new DefaultTaskResult(ExecutionStatus.TERMINAL)
   public static final taskMustRepeat = new DefaultTaskResult(ExecutionStatus.RUNNING)
 
@@ -143,7 +142,7 @@ class EchoEventSpec extends Specification {
                             "orca:pipeline:failed"]
 
     where:
-    failure << [taskFailed, taskTerminal]
+    failure << [taskTerminal]
   }
 
   /**

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
@@ -62,7 +62,6 @@ class MonitorPipelineTaskSpec extends Specification {
     ExecutionStatus.SUSPENDED   || ExecutionStatus.RUNNING
     ExecutionStatus.CANCELED    || ExecutionStatus.TERMINAL
     ExecutionStatus.TERMINAL    || ExecutionStatus.TERMINAL
-    ExecutionStatus.FAILED      || ExecutionStatus.TERMINAL
     ExecutionStatus.REDIRECT    || ExecutionStatus.RUNNING
   }
 }

--- a/orca-rush/src/main/groovy/com/netflix/spinnaker/orca/rush/tasks/MonitorDockerTask.groovy
+++ b/orca-rush/src/main/groovy/com/netflix/spinnaker/orca/rush/tasks/MonitorDockerTask.groovy
@@ -50,7 +50,7 @@ class MonitorDockerTask implements RetryableTask {
     if (execution.status == 'SUCCESSFUL') {
       return ExecutionStatus.SUCCEEDED
     } else if (execution.status == 'FAILURE') {
-      return ExecutionStatus.FAILED
+      return ExecutionStatus.TERMINAL
     } else {
       return ExecutionStatus.RUNNING
     }


### PR DESCRIPTION
As much as it pains me to do this, I'm suggesting we remove the `FAILED` status value and just go with `TERMINAL` everywhere. We don't seem to be doing anything useful with `FAILED`, unless confusing our UI developers and other consumers of our APIs is considered useful.

This would leave us with "only" eight status values to consider in the UI. I should probably remove the quotes around "only" because we "literally" deal with "fifteen" different potential status values right now (https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.js#L139-L163). I frankly have no idea where those fifteen values come from. Looking at the history of that enum file, I don't see most of them, which makes me think we can get probably align those values in the UI, or remove that method altogether.

@ajordens @cfieber @duftler let me know if there are any problems with doing this, e.g. if you know of any downstream consumers that expect `FAILED`...