### PR TITLE
Disable (when run as part of a Destroy) should only wait until there …

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.DestroyServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.DisableServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
-import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForAllInstancesDownTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForAllInstancesNotUpTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForDestroyedServerGroupTask
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.batch.core.Step
@@ -47,7 +47,7 @@ class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport {
       [
         buildStep(stage, "disableServerGroup", DisableServerGroupTask),
         buildStep(stage, "monitorServerGroup", MonitorKatoTask),
-        buildStep(stage, "waitForDownInstances", WaitForAllInstancesDownTask),
+        buildStep(stage, "waitForNotUpInstances", WaitForAllInstancesNotUpTask),
         buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
 
         buildStep(stage, "destroyServerGroup", DestroyServerGroupTask),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForAllInstancesNotUpTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForAllInstancesNotUpTask.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.instance.AbstractWaitingForInstancesTask
+import com.netflix.spinnaker.orca.clouddriver.utils.HealthHelper
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.stereotype.Component
+
+@Component
+class WaitForAllInstancesNotUpTask extends AbstractWaitingForInstancesTask {
+  @Override
+  protected boolean hasSucceeded(Stage stage, Map serverGroup, List<Map> instances, Collection<String> interestingHealthProviderNames) {
+    if (interestingHealthProviderNames != null && interestingHealthProviderNames.isEmpty()) {
+      return true
+    }
+
+    instances.every { instance ->
+      List<Map> healths = HealthHelper.filterHealths(instance, interestingHealthProviderNames)
+
+      if (!interestingHealthProviderNames && !healths) {
+        // No health indications (and no specific providers to check), consider instance to be down.
+        return true
+      }
+
+      boolean noneAreUp = !healths.any { it.state == 'Up' }
+      return noneAreUp
+    }
+  }
+}
+

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForAllInstancesNotUpTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForAllInstancesNotUpTaskSpec.groovy
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
+
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class WaitForAllInstancesNotUpTaskSpec extends Specification {
+  @Subject task = new WaitForAllInstancesNotUpTask()
+
+  @Unroll
+  void "should succeed as #hasSucceeded based on instance providers #healthProviderNames for instances #instances"() {
+    given:
+    def stage = new PipelineStage(new Pipeline(), "")
+
+    expect:
+    hasSucceeded == task.hasSucceeded(stage, [minSize: 0], instances, healthProviderNames)
+
+    where:
+    hasSucceeded || healthProviderNames   | instances
+    true         || null                  | []
+    true         || null                  | [ [ health: [ ] ] ]
+    true         || ['a']                 | []
+    true         || null                  | [ [ health: [ [ type: 'a', state : 'Down' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ] ] ] ]
+    true         || ['a']                 | [ [ health: [ [ type: 'a', state : 'Down' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ] ] ] ]
+    true         || ['b']                 | [ [ health: [ [ type: 'a', state : 'Down' ] ] ] ]
+    true         || ['b']                 | [ [ health: [ [ type: 'a', state : 'Up' ] ] ] ]
+    true         || ['a']                 | [ [ health: [ [ type: 'a', state: 'OutOfService' ] ] ] ]
+
+    // Multiple health providers.
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Up' ] ] ] ]
+    true         || null                  | [ [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Down' ] ] ] ]
+    true         || ['b']                 | [ [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    true         || ['b']                 | [ [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    true         || ['a']                 | [ [ health: [ [ type: 'a', state : 'Unknown' ], [ type: 'b', state : 'Down' ] ] ] ]
+    true         || ['b']                 | [ [ health: [ [ type: 'a', state : 'Unknown' ], [ type: 'b', state : 'Down' ] ] ] ]
+    true         || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Unknown' ], [ type: 'b', state : 'Down' ] ] ] ]
+    true         || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Unknown' ], [ type: 'b', state : 'OutOfService' ] ] ] ]
+
+    // Multiple instances.
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ] ] ] ]
+    true         || null                  | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Down' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Down' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'b', state : 'Up' ] ] ] ]
+    true         || null                  | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'b', state : 'Down' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ] ] ] ]
+    true         || ['a']                 | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Down' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Down' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'b', state : 'Up' ] ] ] ]
+    true         || ['a']                 | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ] ] ] ]
+    true         || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Down' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Down' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'b', state : 'Up' ] ] ] ]
+    true         || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'b', state : 'Down' ] ] ] ]
+
+    // Multiple instances with multiple health providers.
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Up' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Up' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || null                  | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    true         || null                  | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Down' ] ] ] ]
+    true         || null                  | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Up' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Up' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a']                 | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    true         || ['a']                 | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Down' ] ] ] ]
+    true         || ['a']                 | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Up' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Up' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Down' ] ] ] ]
+    false        || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Up' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+    true         || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Down' ] ] ] ]
+    true         || ['a', 'b']            | [ [ health: [ [ type: 'a', state : 'Down' ] ] ], [ health: [ [ type: 'a', state : 'Down' ], [ type: 'b', state : 'Unknown' ] ] ] ]
+
+    // Ignoring health.
+    true         || []                    | [ [ health: [ [ type: 'a', state : 'Up' ] ] ], [ health: [ [ type: 'a', state : 'Up'], [ type: 'b', state : 'Unknown' ] ] ] ]
+  }
+}


### PR DESCRIPTION
…are no UP instances (vs. waiting for DOWN instances)

- It's possible the server group is bad and will never go UP or DOWN but it should still be destroyable
- Current workaround involves a resize to 0 prior to a destroy