### PR TITLE
set sensible default for canary monitor stage

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/MonitorCanaryStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/MonitorCanaryStage.groovy
@@ -45,6 +45,13 @@ class MonitorCanaryStage extends LinearStage implements CancellableStage {
 
   @Override
   List<Step> buildSteps(Stage stage) {
+
+    // unless explicitly defined, default the stage timeout to two hours longer than the canary lifetime
+    if (!stage.context.stageTimeoutMs) {
+      int timeoutHours = (stage.context.canary?.canaryConfig?.lifetimeHours ?: 0) + 2
+      stage.context.stageTimeoutMs = timeoutHours * 60 * 60 * 1000
+    }
+
     [
       buildStep(stage, "registerCanary", RegisterCanaryTask),
       buildStep(stage, "monitorCanary", MonitorCanaryTask),


### PR DESCRIPTION
The current behavior of the monitor canary task is to timeout after two days, which is not great if the canary is scheduled to run for 48 hours or longer.

This sets a timeout to two hours _longer_ than the canary lifetime, which will avoid canaries crashing/burning/not getting cleaned up in the above scenario.

The downside is that timeouts apply at the _stage_ level, not the _task_ level, so now every task in the canary could potentially spin for a very long time without failing - registering the canary, cleaning up the canary, completing the canary. This isn't a terrible downside, I suppose.

@ajordens or @cfieber your review is appreciated