### PR TITLE
allow ShrinkClusterStage to succeed if shrinking to 0, none present

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ShrinkClusterStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ShrinkClusterStage.groovy
@@ -51,7 +51,8 @@ class ShrinkClusterStage extends AbstractClusterWideClouddriverOperationStage {
     if (stage.context.allowDeleteActive == true) {
       injectBefore(stage, "disableCluster", disableClusterStage, stage.context + [
         remainingEnabledServerGroups: stage.context.shrinkToSize,
-        preferLargerOverNewer       : stage.context.retainLargerOverNewer
+        preferLargerOverNewer       : stage.context.retainLargerOverNewer,
+        continueIfClusterNotFound   : stage.context.shrinkToSize == 0
       ])
     }
     return super.buildSteps(stage)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
@@ -92,6 +92,9 @@ abstract class AbstractClusterWideClouddriverTask extends AbstractCloudProviderA
                                                   clusterSelection.cluster,
                                                   clusterSelection.cloudProvider)
     if (!cluster.isPresent()) {
+      if (stage.context.continueIfClusterNotFound) {
+        return DefaultTaskResult.SUCCEEDED;
+      }
       return missingClusterResult(stage, clusterSelection)
     }
 


### PR DESCRIPTION
If a user tries to shrink a non-existent cluster to zero server groups, the operation will only succeed if the `allowDeleteActive` flag is set to `false`. When it's set to `true`, we inject a `DisableClusterStage`, which will fail if no cluster is found.

This change introduces a `continueIfClusterNotFound` flag to the stage, which will cause the task to succeed immediately if the cluster is not found.

Tested locally to verify it succeeds to placate the @ajordens , who should review this, or let @cfieber review it.