### PR TITLE
allow shrink cluster to succeed when empty cluster exists somehow

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
@@ -101,6 +101,9 @@ abstract class AbstractClusterWideClouddriverTask extends AbstractCloudProviderA
     List<Map> serverGroups = cluster.get().serverGroups
 
     if (!serverGroups) {
+      if (stage.context.continueIfClusterNotFound) {
+        return DefaultTaskResult.SUCCEEDED;
+      }
       return emptyClusterResult(stage, clusterSelection, cluster.get())
     }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTaskSpec.groovy
@@ -122,6 +122,30 @@ class AbstractClusterWideClouddriverTaskSpec extends Specification {
 
   }
 
+  def "should succeed immediately if cluster is empty and continueIfClusterNotFound flag set in context"() {
+    given:
+    def pipeline = new Pipeline()
+    def stage = new PipelineStage(pipeline, DisableServerGroupStage.PIPELINE_CONFIG_TYPE, [
+        continueIfClusterNotFound: true
+    ])
+    def task = new AbstractClusterWideClouddriverTask() {
+      @Override
+      String getClouddriverOperation() {
+        return null
+      }
+    }
+    def oortHelper = Mock(OortHelper)
+    task.oortHelper = oortHelper;
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * oortHelper.getCluster(_, _, _, _) >> Optional.of([ serverGroups: [] ])
+    result == DefaultTaskResult.SUCCEEDED
+
+  }
+
   static TargetServerGroup sg(String name, String region = "us-west-1", int createdTime = System.currentTimeMillis()) {
     new TargetServerGroup(serverGroup: [name: name, region: region, createdTime: createdTime])
   }


### PR DESCRIPTION
Follow-up to https://github.com/spinnaker/orca/pull/743

Sometimes Clouddriver returns an empty cluster with no server groups. In this scenario, the task should also succeed.

@cfieber or @ajordens or @robfletcher please review