### PR TITLE
Ensure that each server group is inspected (at least once) when force…

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
@@ -118,6 +118,7 @@ class ServerGroupCacheForceRefreshTaskSpec extends Specification {
     ["s-v001"]           | ["s-v001"]            || null            || []                            || ["s-v001"]
   }
 
+  @Unroll
   void "should only complete when all deployed server groups have been processed"() {
     given:
     def stageData = new ServerGroupCacheForceRefreshTask.StageData(


### PR DESCRIPTION
…CacheRefresh'ing

- Avoid using .every() and instead inspect each 'deploy.server.groups'