### PR TITLE
Evidently needed an @Slf4j even though it's an upstream 'abstract' cl…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForAllInstancesNotUpTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForAllInstancesNotUpTask.groovy
@@ -20,8 +20,10 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.AbstractWaitingForInstancesTask
 import com.netflix.spinnaker.orca.clouddriver.utils.HealthHelper
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
+@Slf4j
 @Component
 class WaitForAllInstancesNotUpTask extends AbstractWaitingForInstancesTask {
   @Override


### PR DESCRIPTION
…ass doing the logging (which has a @Slf4j)