### PR TITLE
provider/kubernetes: Find image by stage id

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -207,7 +207,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
           imageId          : summary.imageId,
           imageName        : summary.imageName,
           cloudProvider    : cloudProvider,
-          imageNamePattern : config.imageNamePattern,
+          refId            : stage.refId,
           sourceServerGroup: summary.serverGroupName
         ]
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesServerGroupCreator.groovy
@@ -48,8 +48,10 @@ class KubernetesServerGroupCreator implements ServerGroupCreator {
     containers.forEach { container ->
       if (container.imageDescription.fromContext) {
         def image = deploymentDetails.find {
-          def cluster = Names.parseName(it.sourceServerGroup).cluster
-          cluster == container.imageDescription.cluster && it.imageName ==~ container.imageDescription.pattern
+          // stageId is used here to match the source of the image to the find image stage specified by the user.
+          // Previously, this was done by matching the pattern used to the pattern selected in the deploy stage, but
+          // if the deploy stage's selected pattern wasn't updated before submitting the stage, this step here could fail.
+          it.refId == container.imageDescription.stageId
         }
         if (!image) {
           throw new IllegalStateException("No image found in context for pattern $container.imageDescription.pattern.")


### PR DESCRIPTION
Previously, it was possible to create a pipeline `FindImage -> ... -> Deploy`, go back and edit `FindImage` and have the pipeline fail, because the `Deploy` stage's pattern selector no longer matched that of the `FindImage` stage. Referring to the `RefId` of the `FindImage` stage in `Deploy` fixes that.

This only changes behavior for the Kubernetes provider, since it's the only one use a pattern to select images. Requires https://github.com/spinnaker/deck/pull/2056

@duftler 