### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -28,7 +28,7 @@ dependencies {
   compile spinnaker.dependency('rxJava')
   compile spinnaker.dependency('spectatorApi')
   compile spinnaker.dependency('kork')
-  compile ("commons-collections:commons-collections:3.2.1")
+  compile ("commons-collections:commons-collections:3.2.2")
   testCompile project(":orca-test")
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.3"
 }


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/

Also, do consider using Guava in the future.