### PR TITLE
remove unused dependency on commons-collections

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -28,7 +28,6 @@ dependencies {
   compile spinnaker.dependency('rxJava')
   compile spinnaker.dependency('spectatorApi')
   compile spinnaker.dependency('kork')
-  compile ("commons-collections:commons-collections:3.2.2")
   testCompile project(":orca-test")
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.3"
 }


### PR DESCRIPTION
It looks like we are not actually using commons-collections anywhere, just declaring the dependency. We probably _were_ using it at some point, but, according to gradle's dependency report, we aren't now.

You can see it getting pulled in by `spring-batch-test` in the `orca-test` project, but that shouldn't affect the runtime path of the application. 

To see `commons-collection` coming in, run `./gradlew orca-core:dependencies`:
```
\--- project :orca-test
     ...
     +--- org.springframework.batch:spring-batch-test:3.0.4.RELEASE -> 3.0.3.RELEASE
     |    +--- commons-collections:commons-collections:3.2.1
```

Then run `./gradlew orca-web:dependencies --configuration runtime` to see what should be on the classpath when the application actually runs.

Someone who's more familiar with gradle should sanity check this.