### PR TITLE
provider/kubernetes: Use image tag resolved at runtime (from trigger) if needed

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -126,6 +126,10 @@ class OperationsController {
           trigger.job as String
         )
       }
+    } else if (trigger?.registry && trigger?.repository && trigger?.tag) {
+      trigger.buildInfo = [
+        taggedImages: [[registry: trigger.registry, repository: trigger.repository, tag: trigger.tag]]
+      ]
     }
   }
 


### PR DESCRIPTION
When a user leaves their image tag blank for a docker trigger, the tag is now resolved in the deploy phase.

@duftler 