### PR TITLE
add scaling policy upsert/delete stages/tasks

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/scalingpolicy/DeleteScalingPolicyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/scalingpolicy/DeleteScalingPolicyStage.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.scalingpolicy
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.scalingpolicy.DeleteScalingPolicyTask
+import com.netflix.spinnaker.orca.pipeline.LinearStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.batch.core.Step
+import org.springframework.stereotype.Component
+
+@Component
+class DeleteScalingPolicyStage extends LinearStage {
+
+  public static final String PIPELINE_CONFIG_TYPE = "deleteScalingPolicy"
+
+  DeleteScalingPolicyStage() {
+    super(PIPELINE_CONFIG_TYPE)
+  }
+
+  @Override
+  public List<Step> buildSteps(Stage stage) {
+    [
+        buildStep(stage, "deleteScalingPolicy", DeleteScalingPolicyTask),
+        buildStep(stage, "monitorUpsert", MonitorKatoTask),
+        buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask)
+    ]
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/scalingpolicy/UpsertScalingPolicyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/scalingpolicy/UpsertScalingPolicyStage.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.scalingpolicy
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.scalingpolicy.UpsertScalingPolicyTask
+import com.netflix.spinnaker.orca.pipeline.LinearStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.batch.core.Step
+import org.springframework.stereotype.Component
+
+@Component
+class UpsertScalingPolicyStage extends LinearStage {
+
+  public static final String PIPELINE_CONFIG_TYPE = "upsertScalingPolicy"
+
+  UpsertScalingPolicyStage() {
+    super(PIPELINE_CONFIG_TYPE)
+  }
+
+  @Override
+  public List<Step> buildSteps(Stage stage) {
+    [
+        buildStep(stage, "upsertScalingPolicy", UpsertScalingPolicyTask),
+        buildStep(stage, "monitorUpsert", MonitorKatoTask),
+        buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask)
+    ]
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/DeleteScalingPolicyTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/DeleteScalingPolicyTask.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.scalingpolicy
+
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class DeleteScalingPolicyTask extends AbstractCloudProviderAwareTask implements Task {
+
+  @Autowired
+  KatoService kato
+
+  @Override
+  TaskResult execute(Stage stage) {
+    def taskId = kato.requestOperations(getCloudProvider(stage), [[deleteScalingPolicy: stage.context]])
+        .toBlocking()
+        .first()
+
+    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [
+        "deploy.account.name" : stage.context.credentials,
+        "kato.last.task.id"   : taskId,
+        "deploy.server.groups": [(stage.context.region): [stage.context.serverGroupName]]
+    ])
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/UpsertScalingPolicyTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/UpsertScalingPolicyTask.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.scalingpolicy
+
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class UpsertScalingPolicyTask extends AbstractCloudProviderAwareTask implements Task {
+
+  @Autowired
+  KatoService kato
+
+  @Override
+  TaskResult execute(Stage stage) {
+    def taskId = kato.requestOperations(getCloudProvider(stage), [[upsertScalingPolicy: stage.context]])
+        .toBlocking()
+        .first()
+
+    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [
+        "deploy.account.name" : stage.context.credentials,
+        "kato.last.task.id"   : taskId,
+        "deploy.server.groups": [(stage.context.region): [stage.context.serverGroupName]]
+    ])
+  }
+}


### PR DESCRIPTION
These are simple pass-through tasks, with stages that do their jobs, refresh their server groups, and call it a day.

@ttomsu still cleaning up the Clouddriver and Deck bits (I have it all working locally, still need to write tests and clean up the contracts between them), but does this look good to you on the Orca side?