### PR TITLE
skip disable steps for titus destroy operation

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -44,17 +44,26 @@ class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport {
   public List<Step> buildSteps(Stage stage) {
     try {
       composeTargets(stage)
-      [
-        buildStep(stage, "disableServerGroup", DisableServerGroupTask),
-        buildStep(stage, "monitorServerGroup", MonitorKatoTask),
-        buildStep(stage, "waitForNotUpInstances", WaitForAllInstancesNotUpTask),
-        buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
 
+      List steps = []
+
+      //TODO(cfieber) - need to remove this once proper enable / disable has been implemented in Titus.
+      if (!stage.context.cloudProvider || stage.context.cloudProvider != 'titan') {
+        steps += [
+          buildStep(stage, "disableServerGroup", DisableServerGroupTask),
+          buildStep(stage, "monitorServerGroup", MonitorKatoTask),
+          buildStep(stage, "waitForNotUpInstances", WaitForAllInstancesNotUpTask),
+          buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
+        ]
+      }
+
+      steps + [
         buildStep(stage, "destroyServerGroup", DestroyServerGroupTask),
         buildStep(stage, "monitorServerGroup", MonitorKatoTask),
         buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
         buildStep(stage, "waitForDestroyedServerGroup", WaitForDestroyedServerGroupTask),
       ]
+
     } catch (TargetServerGroup.NotFoundException ignored) {
       [buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask)]
     }


### PR DESCRIPTION
titus currently doesn't provide a good way to disable a server group. 

will remove this workaround once we've integrated service discovery properly. 