### PR TITLE
when regexing image names to account for bakery dupe handling, if the image name doesn't match the regex, consider it as is

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -241,7 +241,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
     def nameCleaner = ~/(.*(?:-ebs|-s3)){1}.*/
     imageNames.findResults {
       def matcher = nameCleaner.matcher(it)
-      matcher.matches() ? matcher.group(1) : null
+      matcher.matches() ? matcher.group(1) : it
     }.toSet()
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
@@ -165,7 +165,8 @@ class FindImageFromClusterTaskSpec extends Specification {
     ['foo-120.2-h180.ffea4c7-x86_64-20160218235358-trusty-pv-ebs']  | ['foo-120.2-h180.ffea4c7-x86_64-20160218235358-trusty-pv-ebs'] as Set
     ['foo-120.2-h180.ffea4c7-x86_64-20160218235358-trusty-pv-ebs1'] | ['foo-120.2-h180.ffea4c7-x86_64-20160218235358-trusty-pv-ebs'] as Set
     ['foo-120.2-h180.ffea4c7-x86_64-20160218235358-trusty-pv-s3']   | ['foo-120.2-h180.ffea4c7-x86_64-20160218235358-trusty-pv-s3'] as Set
-    ['foo-120.2-h180.ffea4c7-x86_64-20160218235358-trusty-pv-s4']   | [] as Set
+    ['foo-120.2-h180.ffea4c7-x86_64-20160218235358-trusty-pv-s4']   | ['foo-120.2-h180.ffea4c7-x86_64-20160218235358-trusty-pv-s4'] as Set
+    ['foo-x86_64-201603232351']                                     | ['foo-x86_64-201603232351'] as Set
   }
 
   def "should resolve images via find if not all regions exist in source server group"() {


### PR DESCRIPTION
@spinnaker/netflix-reviewers PTAL fixes SPIN-1607