### PR TITLE
Don't retry network errors for non-idempotent requests

### DIFF
--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
@@ -60,9 +60,13 @@ class RetrofitExceptionHandler implements ExceptionHandler<RetrofitError> {
       response.details.kind = e.kind
       response.details.status = properties.status ?: null
       response.details.url = properties.url ?: null
-      response.shouldRetry = (e.kind == NETWORK && findHttpMethodAnnotation(e) in ["GET", "HEAD"])
+      response.shouldRetry = (e.kind == NETWORK && isIdempotentRequest(e))
       return response
     }
+  }
+
+  private static boolean isIdempotentRequest(RetrofitError e) {
+    findHttpMethodAnnotation(e) in ["GET", "HEAD", "DELETE", "PUT"]
   }
 
   private static String findHttpMethodAnnotation(RetrofitError exception) {

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
@@ -17,9 +17,13 @@
 
 package com.netflix.spinnaker.orca.retrofit.exceptions
 
+import java.lang.annotation.Annotation
+import java.lang.reflect.Method
 import com.netflix.spinnaker.orca.batch.exceptions.ExceptionHandler
 import retrofit.RetrofitError
+import retrofit.http.RestMethod
 import retrofit.mime.TypedByteArray
+import static retrofit.RetrofitError.Kind.NETWORK
 
 class RetrofitExceptionHandler implements ExceptionHandler<RetrofitError> {
   @Override
@@ -56,8 +60,31 @@ class RetrofitExceptionHandler implements ExceptionHandler<RetrofitError> {
       response.details.kind = e.kind
       response.details.status = properties.status ?: null
       response.details.url = properties.url ?: null
-      response.shouldRetry = (e.kind == RetrofitError.Kind.NETWORK)
+      response.shouldRetry = (e.kind == NETWORK && findHttpMethodAnnotation(e) in ["GET", "HEAD"])
       return response
+    }
+  }
+
+  private static String findHttpMethodAnnotation(RetrofitError exception) {
+    exception.stackTrace.findResult { StackTraceElement frame ->
+      try {
+        Class.forName(frame.className)
+          .interfaces
+          .findResult { Class<?> iface ->
+          iface.declaredMethods.findAll { Method m ->
+            m.name == frame.methodName
+          }.findResult { Method m ->
+            m.declaredAnnotations.findResult { Annotation annotation ->
+              annotation
+                .annotationType()
+                .getAnnotation(RestMethod)?.value()
+            }
+          }
+        }
+      } catch (ClassNotFoundException e) {
+        // inner class or something non-accessible
+        return null
+      }
     }
   }
 }

--- a/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandlerSpec.groovy
+++ b/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandlerSpec.groovy
@@ -118,13 +118,13 @@ class RetrofitExceptionHandlerSpec extends Specification {
     Response post(@Body String data)
 
     @PUT("/whatever")
-    Response put(@Body String data)
+    Response put()
 
     @PATCH("/whatever")
     Response patch(@Body String data)
 
-    @DELETE("/{whatever}")
-    Response delete(@Path("whatever") String data)
+    @DELETE("/whatever")
+    Response delete()
   }
 
   @Unroll
@@ -153,7 +153,7 @@ class RetrofitExceptionHandlerSpec extends Specification {
     }
 
     where:
-    httpMethod << ["POST", "PUT", "PATCH", "DELETE"]
+    httpMethod << ["POST", "PATCH"]
     methodName = httpMethod.toLowerCase()
   }
 
@@ -183,7 +183,7 @@ class RetrofitExceptionHandlerSpec extends Specification {
     }
 
     where:
-    httpMethod << ["GET", "HEAD"]
+    httpMethod << ["GET", "HEAD", "DELETE", "PUT"]
     methodName = httpMethod.toLowerCase()
   }
 

--- a/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandlerSpec.groovy
+++ b/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandlerSpec.groovy
@@ -17,13 +17,17 @@
 package com.netflix.spinnaker.orca.retrofit.exceptions
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import retrofit.RestAdapter
 import retrofit.RetrofitError
+import retrofit.client.Client
 import retrofit.client.Response
 import retrofit.converter.JacksonConverter
+import retrofit.http.*
 import retrofit.mime.TypedByteArray
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
+import static retrofit.RetrofitError.Kind.NETWORK
 
 class RetrofitExceptionHandlerSpec extends Specification {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
@@ -52,7 +56,7 @@ class RetrofitExceptionHandlerSpec extends Specification {
 
     expect:
     with(handler.handle(stepName, retrofitError)) {
-      shouldRetry == false
+      !shouldRetry
       exceptionType == "RetrofitError"
       operation == stepName
       details.url == url
@@ -83,7 +87,7 @@ class RetrofitExceptionHandlerSpec extends Specification {
 
     expect:
     with(handler.handle(stepName, retrofitError)) {
-      shouldRetry == false
+      !shouldRetry
       exceptionType == "RetrofitError"
       operation == stepName
       details.url == url
@@ -103,19 +107,93 @@ class RetrofitExceptionHandlerSpec extends Specification {
     message = "Something bad happened"
   }
 
-  def "should retry on NETWORK errors"() {
-    given:
-    def retrofitError = RetrofitError.networkError(
-      url, new IOException()
-    )
+  private interface DummyRetrofitApi {
+    @GET("/whatever")
+    Response get()
 
-    expect:
-    with(handler.handle(stepName, retrofitError)) {
-      shouldRetry == true
+    @HEAD("/whatever")
+    Response head()
+
+    @POST("/whatever")
+    Response post(@Body String data)
+
+    @PUT("/whatever")
+    Response put(@Body String data)
+
+    @PATCH("/whatever")
+    Response patch(@Body String data)
+
+    @DELETE("/{whatever}")
+    Response delete(@Path("whatever") String data)
+  }
+
+  @Unroll
+  def "should not retry a network error on a #httpMethod request"() {
+    given:
+    def client = Stub(Client) {
+      execute(_) >> { throw new IOException("network error") }
+    }
+
+    and:
+    def api = new RestAdapter.Builder()
+      .setEndpoint("http://localhost:1337")
+      .setClient(client)
+      .build()
+      .create(DummyRetrofitApi)
+
+    when:
+    def ex = expectingException {
+      api."$methodName"("whatever")
+    }
+
+    then:
+    with(handler.handle("whatever", ex)) {
+      details.kind == NETWORK
+      !shouldRetry
     }
 
     where:
-    stepName = "Step"
-    url = "http://www.google.com"
+    httpMethod << ["POST", "PUT", "PATCH", "DELETE"]
+    methodName = httpMethod.toLowerCase()
   }
+
+  @Unroll
+  def "should retry a network error on a #httpMethod request"() {
+    given:
+    def client = Stub(Client) {
+      execute(_) >> { throw new IOException("network error") }
+    }
+
+    and:
+    def api = new RestAdapter.Builder()
+      .setEndpoint("http://localhost:1337")
+      .setClient(client)
+      .build()
+      .create(DummyRetrofitApi)
+
+    when:
+    def ex = expectingException {
+      api."$methodName"()
+    }
+
+    then:
+    with(handler.handle("whatever", ex)) {
+      details.kind == NETWORK
+      shouldRetry
+    }
+
+    where:
+    httpMethod << ["GET", "HEAD"]
+    methodName = httpMethod.toLowerCase()
+  }
+
+  private static RetrofitError expectingException(Closure action) {
+    try {
+      action()
+      throw new IllegalStateException("Closure did not throw an exception")
+    } catch (RetrofitError e) {
+      return e
+    }
+  }
+
 }


### PR DESCRIPTION
This fixes an issue where we'll retry things like create server group on CloudDriver if we get a network error. We should only ever retry things that are known to be idempotent.