### PR TITLE
core: Run job task & stage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -57,6 +57,12 @@ interface OortService {
                                             @Path("summaryType") String summaryType,
                                             @Query("onlyEnabled") String onlyEnabled)
 
+  @GET("/applications/{app}/jobs/{account}/{region}/{id}")
+  Response getJob(@Path("app") String app,
+                  @Path("account") String account,
+                  @Path("region") String region,
+                  @Path("id") String id)
+
   @GET("/search")
   Response getSearchResults(@Query("q") String searchTerm,
                             @Query("type") String type,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.job
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.job.JobForceCacheRefreshTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.job.RunJobTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.job.WaitOnJobCompletion
+import com.netflix.spinnaker.orca.pipeline.LinearStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.batch.core.Step
+import org.springframework.stereotype.Component
+
+@Component
+class RunJobStage extends LinearStage {
+  public static final String PIPELINE_CONFIG_TYPE = "runJob"
+
+  RunJobStage() {
+    super(PIPELINE_CONFIG_TYPE)
+  }
+
+  @Override
+  List<Step> buildSteps(Stage stage) {
+    [
+        buildStep(stage, "runJob", RunJobTask),
+        buildStep(stage, "monitorDeploy", MonitorKatoTask),
+        buildStep(stage, "forceCacheRefresh", JobForceCacheRefreshTask),
+        buildStep(stage, "waitOnJobCompletion", WaitOnJobCompletion),
+    ]
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
@@ -56,8 +56,14 @@ class MonitorKatoTask implements RetryableTask {
     }
 
     Map<String, ? extends Object> outputs = [:]
-    if (status == ExecutionStatus.SUCCEEDED && !stage.context.containsKey("deploy.server.groups")) {
-      outputs["deploy.server.groups"] = getServerGroupNames(katoTask)
+    if (status == ExecutionStatus.SUCCEEDED) {
+      def deployed = getDeployedNames(katoTask)
+      if (!stage.context.containsKey("deploy.server.groups")) {
+        outputs["deploy.server.groups"] = getServerGroupNames(katoTask)
+      }
+      if (!stage.context.containsKey("deploy.jobs") && deployed) {
+        outputs["deploy.jobs"] = deployed
+      }
     }
     if (status == ExecutionStatus.SUCCEEDED || status == ExecutionStatus.TERMINAL) {
       List<Map<String, Object>> katoTasks = []
@@ -96,8 +102,11 @@ class MonitorKatoTask implements RetryableTask {
     }
   }
 
-  // This is crappy logic
-  // TODO clean this up in Kato
+  /**
+   * @param The task being inspected for region/server group mappings.
+   * @return Server group names keyed by region.
+   * @deprecate In favor of getDeployedNames(Task task).
+   */
   @CompileStatic(TypeCheckingMode.SKIP)
   private static Map<String, List<String>> getServerGroupNames(Task task) {
     def result = [:]
@@ -126,5 +135,13 @@ class MonitorKatoTask implements RetryableTask {
       }
     }
     result
+  }
+
+  private static Map<String, List<String>> getDeployedNames(Task task) {
+    Map result = task.resultObjects?.find {
+      it?.deployedNamesByLocation
+    } ?: [:]
+
+    return (Map<String, List<String>>) result.deployedNamesByLocation
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobForceCacheRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobForceCacheRefreshTask.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.job
+
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.MortService
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+public class JobForceCacheRefreshTask extends AbstractCloudProviderAwareTask implements Task {
+  static final String REFRESH_TYPE = "Job"
+
+  @Autowired
+  OortService oortService
+
+  @Override
+  TaskResult execute(Stage stage) {
+    String cloudProvider = getCloudProvider(stage)
+    String account = getCredentials(stage)
+
+    stage.context."deploy.jobs"?.each { String region, List names ->
+      names.each { name ->
+        oortService.forceCacheUpdate(
+          cloudProvider, REFRESH_TYPE, [account: account, jobName: name, region: region]
+        )
+      }
+    }
+
+    new DefaultTaskResult(ExecutionStatus.SUCCEEDED)
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobRunner.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobRunner.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.job
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+
+/**
+ * Deployments of server groups vary wildly across cloud providers. A JobRunner
+ * is a cloud-provider specific way to hook into the Orca infrastructure.
+ */
+interface JobRunner {
+  public static final String OPERATION = "runJob"
+
+  /**
+   * @return a list of operation descriptors. Each operation should be a single entry map keyed by the operation name,
+   * with the operation map as the value.
+   */
+  List<Map> getOperations(Stage stage)
+
+  /**
+   * @return true if the resulting value from the Kato call should be used.
+   */
+  boolean isKatoResultExpected()
+
+  /**
+   * @return The cloud provider type that this object supports.
+   */
+  String getCloudProvider()
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/RunJobTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/RunJobTask.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.job
+
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Slf4j
+@Component
+class RunJobTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+
+  @Autowired
+  KatoService kato
+
+  @Autowired
+  List<JobRunner> jobRunners
+
+  long backoffPeriod = 2000
+  long timeout = 60000
+
+  @Override
+  TaskResult execute(Stage stage) {
+    String credentials = getCredentials(stage)
+    String cloudProvider = getCloudProvider(stage)
+
+    def creator = jobRunners.find { it.cloudProvider == cloudProvider }
+    if (!creator) {
+      throw new IllegalStateException("JobRunner not found for cloudProvider $cloudProvider")
+    }
+
+    def ops = creator.getOperations(stage)
+    def taskId = kato.requestOperations(cloudProvider, ops).toBlocking().first()
+
+    Map outputs = [
+        "notification.type"   : "runjob",
+        "kato.result.expected": creator.katoResultExpected,
+        "kato.last.task.id"   : taskId,
+        "deploy.account.name" : credentials,
+    ]
+
+    return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, outputs)
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.job
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.MortService
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import java.util.concurrent.TimeUnit
+
+@Component
+public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implements RetryableTask {
+  long backoffPeriod = TimeUnit.SECONDS.toMillis(10)
+  long timeout = TimeUnit.DAYS.toMillis(1)
+
+  @Autowired
+  OortService oortService
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  static final String REFRESH_TYPE = "Job"
+
+  @Override
+  TaskResult execute(Stage stage) {
+    String account = getCredentials(stage)
+    Map<String, List<String>> jobs = stage.context."deploy.jobs"
+
+    def status = ExecutionStatus.RUNNING;
+
+    if (!jobs) {
+      throw new IllegalStateException("No jobs in stage context.")
+    }
+
+    jobs.each { location, names ->
+      if (!names) {
+        return
+      }
+
+      Map job = objectMapper.readValue(oortService.getJob("*", account, location, names[0]).body.in(), new TypeReference<Map>() {})
+
+      switch ((String)job.jobState) {
+        case "Succeeded":
+          status = ExecutionStatus.SUCCEEDED
+          return
+
+        case "Failed":
+          status = ExecutionStatus.TERMINAL
+          return
+      }
+    }
+
+    new DefaultTaskResult(status)
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesContainerFinder.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesContainerFinder.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.kubernetes
+
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+
+class KubernetesContainerFinder {
+  static void populateFromStage(Map operation, Stage stage) {
+    // If this is a stage in a pipeline, look in the context for the baked image.
+    def deploymentDetails = (stage.context.deploymentDetails ?: []) as List<Map>
+
+    def containers = (List<Map<String, Object>>) operation.containers
+
+    containers.forEach { container ->
+      if (container.imageDescription.fromContext) {
+        def image = deploymentDetails.find {
+          // stageId is used here to match the source of the image to the find image stage specified by the user.
+          // Previously, this was done by matching the pattern used to the pattern selected in the deploy stage, but
+          // if the deploy stage's selected pattern wasn't updated before submitting the stage, this step here could fail.
+          it.refId == container.imageDescription.stageId
+        }
+        if (!image) {
+          throw new IllegalStateException("No image found in context for pattern $container.imageDescription.pattern.")
+        } else {
+          container.imageDescription = [registry: image.registry, tag: image.tag, repository: image.repository]
+        }
+      }
+
+      if (container.imageDescription.fromTrigger) {
+        if (stage.execution instanceof Pipeline) {
+          Map trigger = ((Pipeline) stage.execution).trigger
+
+          def matchingTag = trigger?.buildInfo?.taggedImages?.findResult { info ->
+            if (container.imageDescription.registry == info.getAt("registry") &&
+                container.imageDescription.repository == info.getAt("repository")) {
+              return info.tag
+            }
+          }
+
+          container.imageDescription.tag = matchingTag
+        }
+
+        if (!container.imageDescription.tag) {
+          throw new IllegalStateException("No tag found for image ${container.imageDescription.registry}/${container.imageDescription.repository} in trigger context.")
+        }
+      }
+    }
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunner.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunner.groovy
@@ -16,14 +16,14 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.kubernetes
 
-import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCreator
+import com.netflix.spinnaker.orca.clouddriver.tasks.job.JobRunner
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
 @Slf4j
 @Component
-class KubernetesServerGroupCreator implements ServerGroupCreator {
+class KubernetesJobRunner implements JobRunner {
 
   boolean katoResultExpected = false
   String cloudProvider = "kubernetes"
@@ -44,3 +44,4 @@ class KubernetesServerGroupCreator implements ServerGroupCreator {
     return [[(OPERATION): operation]]
   }
 }
+


### PR DESCRIPTION
Closely modeled after the deploy server group stage; however, the force cache refresh doesn't wait for the refresh to take place since the job could easily have completed by the time the refresh finishes.

@duftler 