### PR TITLE
provider/kubernetes: Match against imageNamePattern

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -201,7 +201,11 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
     }
 
     List<Map> deploymentDetails = imageSummaries.collect { location, summaries ->
-      summaries.collect { summary ->
+      summaries.findResults { summary ->
+        if (config.imageNamePattern && !(summary.imageName ==~ config.imageNamePattern)) {
+          return null
+        }
+
         def result = [
           ami              : summary.imageId, // TODO(ttomsu): Deprecate and remove this value.
           imageId          : summary.imageId,


### PR DESCRIPTION
Removed this in an earlier PR, but forgot it's needed to disambiguate between multiple images. 

@duftler 