### PR TITLE
Corresponding timeouts for igorservice in orca

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/IgorConfiguration.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/IgorConfiguration.groovy
@@ -31,7 +31,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import retrofit.Endpoint
 import retrofit.RestAdapter
-import retrofit.client.Client
 import retrofit.client.OkClient
 import retrofit.converter.JacksonConverter
 

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/IgorConfiguration.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/IgorConfiguration.groovy
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.igor.IgorService
 import com.netflix.spinnaker.orca.retrofit.RetrofitConfiguration
 import com.netflix.spinnaker.orca.retrofit.logging.RetrofitSlf4jLog
+import com.squareup.okhttp.OkHttpClient
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -31,7 +32,11 @@ import org.springframework.context.annotation.Import
 import retrofit.Endpoint
 import retrofit.RestAdapter
 import retrofit.client.Client
+import retrofit.client.OkClient
 import retrofit.converter.JacksonConverter
+
+import java.util.concurrent.TimeUnit
+
 import static retrofit.Endpoints.newFixedEndpoint
 
 @Configuration
@@ -41,8 +46,13 @@ import static retrofit.Endpoints.newFixedEndpoint
 @ComponentScan("com.netflix.spinnaker.orca.igor")
 class IgorConfiguration {
 
-  @Autowired Client retrofitClient
   @Autowired RestAdapter.LogLevel retrofitLogLevel
+
+  @Value('${client.connectTimeout:20000}')
+  int clientConnectTimeout
+
+  @Value('${client.readTimeout:30000}')
+  int clientReadTimeout
 
   @Bean
   Endpoint igorEndpoint(
@@ -52,9 +62,13 @@ class IgorConfiguration {
 
   @Bean
   IgorService igorService(Endpoint igorEndpoint, ObjectMapper mapper) {
+    OkHttpClient httpClient = new OkHttpClient()
+    httpClient.setReadTimeout(clientReadTimeout, TimeUnit.MILLISECONDS)
+    httpClient.setConnectTimeout(clientConnectTimeout,TimeUnit.MILLISECONDS)
+
     new RestAdapter.Builder()
       .setEndpoint(igorEndpoint)
-      .setClient(retrofitClient)
+      .setClient(new OkClient(httpClient))
       .setLogLevel(retrofitLogLevel)
       .setLog(new RetrofitSlf4jLog(IgorService))
       .setConverter(new JacksonConverter(mapper))


### PR DESCRIPTION
Recently Igor externalized a timeout properties for jenkins API calls. However, there's no corresponding timeout in orca. Hence pipeline execution UI shows timeout errors during jenkin stage. 

Apr  1 15:46:49 ip-205-203-56 orca: 2016-04-01 15:46:49.329  INFO 24872 --- [cTaskExecutor-3] c.n.spinnaker.orca.igor.IgorService      : java.io.InterruptedIOException: timeout