### PR TITLE
Server groups should be deployed with min = desired (initial)

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStage.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
+import com.netflix.spinnaker.orca.pipeline.LinearStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.batch.core.Step
+import org.springframework.stereotype.Component
+
+/**
+ * Ensure that external scaling policies do not adversely affect a server group as it is in the process of being deployed.
+ *
+ * It accomplishes this by:
+ * - capturing the source server group 'min' capacity prior to this deploy ({@link CaptureSourceServerGroupCapacityTask})
+ * - creating a new server group with min = desired ({@link CaptureSourceServerGroupCapacityTask})
+ * - restoring min after the deploy has completed ({@link ApplySourceServerGroupCapacityTask})
+ */
+@Component
+class ApplySourceServerGroupCapacityStage extends LinearStage {
+  public static final String PIPELINE_CONFIG_TYPE = "applySourceServerGroupCapacity"
+
+  ApplySourceServerGroupCapacityStage() {
+    super(PIPELINE_CONFIG_TYPE)
+  }
+
+  @Override
+  public List<Step> buildSteps(Stage stage) {
+    [
+      buildStep(stage, "restoreMinCapacity", ApplySourceServerGroupCapacityTask),
+      buildStep(stage, "waitForCapacityMatch", MonitorKatoTask),
+      buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
+    ]
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.batch.StageBuilder
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.ResizeServerGroupStage
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.AbstractServerGroupTask
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Slf4j
+@Component
+class ApplySourceServerGroupCapacityTask extends AbstractServerGroupTask {
+  String serverGroupAction = ResizeServerGroupStage.TYPE
+
+  @Autowired
+  OortHelper oortHelper
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  @Autowired
+  ExecutionRepository executionRepository
+
+  @Override
+  Map convert(Stage stage) {
+    try {
+      def ancestorDeployStage = getAncestorDeployStage(executionRepository, stage)
+      def ancestorDeployStageData = ancestorDeployStage.mapTo(DeployStageData)
+
+      def deployServerGroup = oortHelper.getTargetServerGroup(
+        ancestorDeployStageData.account,
+        ancestorDeployStageData.deployedServerGroupName,
+        ancestorDeployStageData.region,
+        getCloudProvider(ancestorDeployStage)
+      ).get()
+
+      return [
+        credentials    : getCredentials(stage),
+        regions        : [ancestorDeployStageData.region],
+        region         : ancestorDeployStageData.region,
+        asgName        : deployServerGroup.name,
+        serverGroupName: deployServerGroup.name,
+        capacity       : deployServerGroup.capacity + [
+          // only update the min capacity, desired + max should be inherited from the current server group
+          min: ancestorDeployStageData.sourceServerGroupCapacitySnapshot.min
+        ]
+      ]
+    } catch (Exception e) {
+      log.error("Unable to apply source server group capacity (executionId: ${stage.execution.id})", e)
+      return null
+    }
+  }
+
+  /**
+   * Look up the ancestor deploy stage that contains the source server group's capacity snapshot.
+   *
+   * This can either be in the current pipeline or a dependent child pipeline in the event of a 'custom' deploy strategy.
+   */
+  static Stage getAncestorDeployStage(ExecutionRepository executionRepository, Stage stage) {
+    def deployStage = stage.ancestors { Stage ancestorStage, StageBuilder stageBuilder ->
+      ancestorStage.context.containsKey("sourceServerGroupCapacitySnapshot")
+    }[0].stage
+
+    if (deployStage.context.strategy == "custom") {
+      def pipelineStage = stage.execution.stages.find {
+        it.type == "pipeline" && it.parentStageId == deployStage.id
+      }
+      def pipeline = executionRepository.retrievePipeline(pipelineStage.context.executionId as String)
+      deployStage = pipeline.stages.find { it.context.type == "createServerGroup" }
+    }
+
+    return deployStage
+  }
+
+  static class DeployStageData extends StageData {
+    @JsonProperty("deploy.server.groups")
+    Map<String, Set<String>> deployServerGroups = [:]
+
+    Map sourceServerGroupCapacitySnapshot
+    String zone
+
+    @JsonIgnore
+    String getDeployedServerGroupName() {
+      return deployServerGroups.values().flatten().first()
+    }
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/AwsDeployStagePreProcessor.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/AwsDeployStagePreProcessor.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.DeployStagePreProcessor
+import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class AwsDeployStagePreProcessor implements DeployStagePreProcessor {
+  @Autowired
+  ApplySourceServerGroupCapacityStage applySourceServerGroupSnapshotStage
+
+  @Override
+  List<DeployStagePreProcessor.StepDefinition> additionalSteps() {
+    return [
+        new DeployStagePreProcessor.StepDefinition(
+          name: "snapshotSourceServerGroup",
+          taskClass: CaptureSourceServerGroupCapacityTask
+        )
+    ]
+  }
+
+  @Override
+  List<DeployStagePreProcessor.StageDefinition> afterStageDefinitions() {
+    return [
+        new DeployStagePreProcessor.StageDefinition(
+          name: "restoreMinCapcityFromSnapshot",
+          stageBuilder: applySourceServerGroupSnapshotStage,
+          context: [:]
+        )
+    ]
+  }
+
+  @Override
+  boolean supports(Stage stage) {
+    def stageData = stage.mapTo(StageData)
+    return stageData.useSourceCapacity && stageData.cloudProvider == "aws"
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/CaptureSourceServerGroupCapacityTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/CaptureSourceServerGroupCapacityTask.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class CaptureSourceServerGroupCapacityTask implements Task {
+  @Autowired
+  OortHelper oortHelper
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  @Override
+  TaskResult execute(Stage stage) {
+    def stageOutputs = [:]
+    def stageData = stage.mapTo(StageData)
+    if (stageData.useSourceCapacity) {
+      def sourceServerGroup = oortHelper.getTargetServerGroup(
+        stageData.source.account,
+        stageData.source.asgName,
+        stageData.source.region,
+        stageData.providerType
+      ).orElse(null)
+
+      if (sourceServerGroup) {
+        // capture the source server group's capacity AND specify an explicit capacity to use when deploying the next
+        // server group (ie. no longer use source capacity)
+        stageData.setUseSourceCapacity(false)
+        stageData.source.useSourceCapacity = false
+        stageOutputs = [
+          useSourceCapacity                : false,
+          source                           : stageData.source,
+          sourceServerGroupCapacitySnapshot: sourceServerGroup.capacity,
+          capacity                         : [
+            min    : sourceServerGroup.capacity.desired,
+            desired: sourceServerGroup.capacity.desired,
+            max    : sourceServerGroup.capacity.max
+          ]
+        ]
+      }
+    }
+
+    return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, stageOutputs)
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/DeployStagePreProcessor.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/DeployStagePreProcessor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies;
+
+import com.netflix.spinnaker.orca.batch.StageBuilder;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Supports generic modification of a Deploy stage.
+ *
+ * Common use-cases:
+ * - injecting synthetic stages before/after a deploy
+ * - injecting steps (will be added prior to the deploy stage steps)
+ */
+public interface DeployStagePreProcessor {
+  boolean supports(Stage stage);
+
+  default List<StepDefinition> additionalSteps() {
+    return Collections.emptyList();
+  }
+
+  default List<StageDefinition> beforeStageDefinitions() {
+    return Collections.emptyList();
+  }
+
+  default List<StageDefinition> afterStageDefinitions() {
+    return Collections.emptyList();
+  }
+
+  class StepDefinition {
+    String name;
+    Class taskClass;
+  }
+
+  class StageDefinition {
+    String name;
+    StageBuilder stageBuilder;
+    Map context;
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
@@ -58,6 +58,11 @@ abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask im
     String account = getCredentials(stage)
 
     def operation = convert(stage)
+    if (!operation) {
+      // nothing to do but succeed
+      return new DefaultTaskResult(ExecutionStatus.SUCCEEDED)
+    }
+
     def taskId = kato.requestOperations(cloudProvider, [[(serverGroupAction): operation]])
         .toBlocking()
         .first()

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageData.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageData.groovy
@@ -59,6 +59,14 @@ class StageData {
     region ?: availabilityZones?.keySet()?.getAt(0)
   }
 
+  Boolean getUseSourceCapacity() {
+    if (source?.useSourceCapacity != null) {
+      return source.useSourceCapacity
+    }
+
+    return useSourceCapacity ?: false
+  }
+
   static class Source {
     String account
     String region

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ApplySourceServerGroupSnapshotTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ApplySourceServerGroupSnapshotTaskSpec.groovy
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ApplySourceServerGroupCapacityTask
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import com.netflix.spinnaker.orca.pipeline.model.AbstractStage
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
+import org.springframework.context.ApplicationContext
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class ApplySourceServerGroupSnapshotTaskSpec extends Specification {
+  def oortHelper = Mock(OortHelper)
+  def executionRepository = Mock(ExecutionRepository)
+  def stageNavigator = new StageNavigator(Mock(ApplicationContext))
+
+  @Subject
+  def task = new ApplySourceServerGroupCapacityTask(
+    oortHelper: oortHelper,
+    executionRepository: executionRepository,
+    objectMapper: new ObjectMapper()
+  )
+
+  void "should support ancestor deploy stages w/ a custom strategy"() {
+    given:
+    def parentPipeline = new Pipeline()
+    parentPipeline.stages << new PipelineStage(parentPipeline, "", [
+      strategy                         : "custom",
+      sourceServerGroupCapacitySnapshot: [
+        min    : 0,
+        desired: 5,
+        max    : 10
+      ]
+    ])
+    parentPipeline.stages << new PipelineStage(parentPipeline, "", [
+      executionId: "execution-id"
+    ])
+    ((AbstractStage) parentPipeline.stages[0]).id = "stage-1"
+    ((AbstractStage) parentPipeline.stages[1]).parentStageId = "stage-1"
+    ((AbstractStage) parentPipeline.stages[1]).type = "pipeline"
+
+    def childPipeline = new Pipeline()
+    childPipeline.stages << new PipelineStage(childPipeline, "", [
+      type: "doSomething"
+    ])
+    childPipeline.stages << new PipelineStage(childPipeline, "", [
+      type: "createServerGroup"
+    ])
+
+    (parentPipeline.stages + childPipeline.stages).each {
+      ((AbstractStage) it).setStageNavigator(stageNavigator)
+    }
+
+    when:
+    def ancestorDeployStage = ApplySourceServerGroupCapacityTask.getAncestorDeployStage(
+      executionRepository, parentPipeline.stages[-1]
+    )
+
+    then:
+    1 * executionRepository.retrievePipeline("execution-id") >> childPipeline
+
+    ancestorDeployStage == childPipeline.stages[1]
+  }
+
+  @Unroll
+  void "should support ancestor deploy stages w/ a #strategy strategy"() {
+    given:
+    def stage = new PipelineStage(new Pipeline(), "", [
+      strategy                         : strategy,
+      sourceServerGroupCapacitySnapshot: [
+        min    : 0,
+        desired: 5,
+        max    : 10
+      ]
+    ])
+    ((AbstractStage) stage).setStageNavigator(stageNavigator)
+
+    expect:
+    ApplySourceServerGroupCapacityTask.getAncestorDeployStage(null, stage) == stage
+
+    where:
+    strategy   || _
+    "redblack" || _
+    null       || _
+  }
+
+  void "should construct resizeServerGroup context with source `min` + target `desired` and `max` capacity"() {
+    given:
+    def pipeline = new Pipeline()
+    pipeline.stages << new PipelineStage(pipeline, "", [
+      "deploy.server.groups"           : [
+        "us-east-1": ["application-stack-v001"]
+      ],
+      application                      : "application",
+      stack                            : "stack",
+      account                          : "test",
+      region                           : "us-east-1",
+      sourceServerGroupCapacitySnapshot: [
+        min    : 0,
+        desired: 10,
+        max    : 20
+      ]
+    ])
+    pipeline.stages << new PipelineStage(pipeline, "", [account: "test"])
+    pipeline.stages.each {
+      ((AbstractStage) it).setStageNavigator(stageNavigator)
+    }
+
+    ((AbstractStage) pipeline.stages[0]).id = "stage-1"
+    ((AbstractStage) pipeline.stages[1]).parentStageId = "stage-1"
+
+    and:
+    def targetServerGroup = new TargetServerGroup()
+    targetServerGroup.serverGroup = [
+      name    : "application-stack-v001",
+      capacity: [
+        min    : 5,
+        desired: 5,
+        max    : 10
+      ]
+    ]
+
+    when:
+    def result = task.convert(pipeline.stages[-1])
+
+    then:
+    1 * oortHelper.getTargetServerGroup(
+      "test",
+      "application-stack-v001",
+      "us-east-1",
+      "aws"
+    ) >> Optional.of(targetServerGroup)
+
+    result == [
+      credentials    : "test",
+      asgName        : "application-stack-v001",
+      serverGroupName: "application-stack-v001",
+      regions        : ["us-east-1"],
+      region         : "us-east-1",
+      capacity       : [
+        min    : 0,
+        desired: 5,
+        max    : 10
+      ]
+    ]
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CaptureSourceServerGroupCapacityTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CaptureSourceServerGroupCapacityTaskSpec.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.CaptureSourceServerGroupCapacityTask
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class CaptureSourceServerGroupCapacityTaskSpec extends Specification {
+  def oortHelper = Mock(OortHelper)
+
+  @Subject
+  def task = new CaptureSourceServerGroupCapacityTask(oortHelper: oortHelper, objectMapper: new ObjectMapper())
+
+  @Unroll
+  void "should no-op if useSourceCapacity is false"() {
+    given:
+    def stage = new PipelineStage(new Pipeline(), "", stageContext)
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.globalOutputs.isEmpty()
+    result.stageOutputs.isEmpty()
+    stage.context == stageContext
+
+    where:
+    stageContext                         || _
+    [useSourceCapacity: false]           || _
+    [source: [useSourceCapacity: false]] || _
+  }
+
+  void "should capture source server group capacity and update target capacity"() {
+    given:
+    def stage = new PipelineStage(new Pipeline(), "", [
+      useSourceCapacity: true,
+      capacity         : [
+        min    : 0,
+        desired: 5,
+        max    : 10
+      ],
+      application      : "application",
+      providerType     : "aws",
+      source           : [
+        account: "test",
+        asgName: "application-v001",
+        region : "us-west-1"
+      ]
+    ])
+
+    and:
+    def targetServerGroup = new TargetServerGroup()
+    targetServerGroup.serverGroup = [
+      capacity: [
+        min    : 0,
+        desired: 5,
+        max    : 10
+      ]
+    ]
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * oortHelper.getTargetServerGroup(
+      stage.context.source.account as String,
+      stage.context.source.asgName as String,
+      stage.context.source.region as String,
+      stage.context.providerType as String
+    ) >> Optional.of(targetServerGroup)
+
+    result.stageOutputs.useSourceCapacity == false
+    result.stageOutputs.source.useSourceCapacity == false
+    result.stageOutputs.capacity == [
+      min    : 5,
+      desired: 5,
+      max    : 10
+    ]
+    result.stageOutputs.sourceServerGroupCapacitySnapshot == [
+      min    : 0,
+      desired: 5,
+      max    : 10
+
+    ]
+    result.globalOutputs.isEmpty()
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageDataSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageDataSpec.groovy
@@ -76,4 +76,20 @@ class StageDataSpec extends Specification {
       "test"  | null        || "test"
       null    | "test"      || "test"
   }
+
+  @Unroll
+  void "should check both useSourceCapacity and source.useSourceCapacity"() {
+    expect:
+    new StageData(useSourceCapacity: useSourceCapacity, source: source).getUseSourceCapacity() == expectedUseSourceCapacity
+
+    where:
+    useSourceCapacity | source                                         || expectedUseSourceCapacity
+    true              | null                                           || true
+    true              | new StageData.Source(useSourceCapacity: true)  || true
+    true              | new StageData.Source(useSourceCapacity: false) || false
+    false             | new StageData.Source(useSourceCapacity: true)  || true
+    false             | null                                           || false
+    null              | new StageData.Source()                         || false
+    null              | null                                           || false
+  }
 }


### PR DESCRIPTION
This avoids situations where AWS scaling policies manipulate the `desired` capacity of a newly deployed server group due to the cluster being double provisioned (old ASG is still active while new ASG is deploying)

- Only applies to AWS deploys that have `useSourceCapacity: true`
- The `min` will be restored after the deploy has completed (based on the source server group)