### PR TITLE
fallback to region if regions not found

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
@@ -111,7 +111,7 @@ abstract class AbstractClusterWideClouddriverTask extends AbstractCloudProviderA
       new TargetServerGroup(serverGroup: it)
     }.groupBy { it.getLocation() }
 
-    def locations = stage.context.regions ?: stage.context.zones ?: []
+    def locations = stage.context.regions ?: stage.context.zones ?: stage.context.region ? [stage.context.region] : []
     List<TargetServerGroup> filteredServerGroups = locations.collect {
       TargetServerGroup.Support.locationFromCloudProviderValue(clusterSelection.cloudProvider, it)
     }.findResults { Location l ->


### PR DESCRIPTION
It's possible there are other scenarios in which we'll need to apply something similar; this one fixes the issue where nothing happens on cluster-wide tasks, e.g. deployments with strategies.