### PR TITLE
Allow to pass multiple packages down to the Bakery in the …

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
@@ -28,7 +28,7 @@ import groovy.transform.Immutable
 @Immutable(copyWith = true)
 @CompileStatic
 class BakeRequest {
-  static final Default = new BakeRequest(System.getProperty("user.name"), null, null, null, null, null, CloudProviderType.aws, Label.release, "ubuntu", null, null, null, null, null, null, null, null, null)
+  static final Default = new BakeRequest(System.getProperty("user.name"), null, null, null, null, null, CloudProviderType.aws, Label.release, "ubuntu", null, null, null, null, null, null, null, false, null, null)
 
   String user
   @JsonProperty("package") String packageName
@@ -46,6 +46,7 @@ class BakeRequest {
   Boolean enhancedNetworking
   String amiName
   String amiSuffix
+  Boolean allowMissingPackageInstallation
 
   String templateFileName
   Map extendedAttributes

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -140,7 +140,7 @@ class CreateBakeTask implements RetryableTask {
     }
 
     if (!roscoApisEnabled) {
-      bakeRequest = bakeRequest.copyWith(templateFileName: null, extendedAttributes: null)
+      bakeRequest = bakeRequest.copyWith(templateFileName: null, extendedAttributes: null, allowMissingPackageInstallation: null)
     }
 
     return bakeRequest

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -139,8 +139,10 @@ class CreateBakeTask implements RetryableTask {
       bakeRequest = bakeRequest.copyWith(cloudProviderType: null)
     }
 
+    // The allowMissingPackageInstallation only affect Orca behavior. We don't want to propagate it to any bakery
+    bakeRequest = bakeRequest.copyWith(allowMissingPackageInstallation: null)
     if (!roscoApisEnabled) {
-      bakeRequest = bakeRequest.copyWith(templateFileName: null, extendedAttributes: null, allowMissingPackageInstallation: null)
+      bakeRequest = bakeRequest.copyWith(templateFileName: null, extendedAttributes: null)
     }
 
     return bakeRequest

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -139,8 +139,9 @@ class CreateBakeTask implements RetryableTask {
       bakeRequest = bakeRequest.copyWith(cloudProviderType: null)
     }
 
-    // The allowMissingPackageInstallation only affect Orca behavior. We don't want to propagate it to any bakery
+    // The allowMissingPackageInstallation only affect Orca behavior. We don't want to propagate it to any bakery.
     bakeRequest = bakeRequest.copyWith(allowMissingPackageInstallation: null)
+
     if (!roscoApisEnabled) {
       bakeRequest = bakeRequest.copyWith(templateFileName: null, extendedAttributes: null)
     }

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -292,29 +292,6 @@ class CreateBakeTaskSpec extends Specification {
   }
 
   @Unroll
-  def "fails if pipeline trigger or context includes artifacts but no artifact for the bake package"() {
-    given:
-    Pipeline pipelineWithTrigger = new Pipeline.Builder().withTrigger([buildInfo: triggerInfo]).build()
-    Stage stage = new PipelineStage(pipelineWithTrigger, "bake", bakeConfig).asImmutable()
-    bakeConfig.buildInfo = contextInfo
-
-    when:
-    task.execute(stage)
-
-    then:
-    IllegalStateException ise = thrown(IllegalStateException)
-    ise.message.startsWith("Unable to find deployable artifact starting with hodor_ and ending with .deb in")
-
-    where:
-    contextInfo         | triggerInfo
-    null                | buildInfoNoMatch
-    buildInfoNoMatch    | null
-    buildInfoNoMatch    | buildInfoNoMatch
-    buildInfoNoMatch    | invalidArtifactList
-    invalidArtifactList | buildInfoNoMatch
-  }
-
-  @Unroll
   def "fails if pipeline trigger and context includes artifacts have a different match"() {
     given:
     Pipeline pipelineWithTrigger = new Pipeline.Builder().withTrigger([buildInfo: buildInfo]).build()

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -292,6 +292,29 @@ class CreateBakeTaskSpec extends Specification {
   }
 
   @Unroll
+  def "fails if pipeline trigger or context includes artifacts but no artifact for the bake package"() {
+    given:
+    Pipeline pipelineWithTrigger = new Pipeline.Builder().withTrigger([buildInfo: triggerInfo]).build()
+    Stage stage = new PipelineStage(pipelineWithTrigger, "bake", bakeConfig).asImmutable()
+    bakeConfig.buildInfo = contextInfo
+
+    when:
+    task.execute(stage)
+
+    then:
+    IllegalStateException ise = thrown(IllegalStateException)
+    ise.message.startsWith("Unable to find deployable artifact starting with [hodor_] and ending with .deb in")
+
+    where:
+    contextInfo         | triggerInfo
+    null                | buildInfoNoMatch
+    buildInfoNoMatch    | null
+    buildInfoNoMatch    | buildInfoNoMatch
+    buildInfoNoMatch    | invalidArtifactList
+    invalidArtifactList | buildInfoNoMatch
+  }
+
+  @Unroll
   def "fails if pipeline trigger and context includes artifacts have a different match"() {
     given:
     Pipeline pipelineWithTrigger = new Pipeline.Builder().withTrigger([buildInfo: buildInfo]).build()

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
@@ -91,8 +91,6 @@ class PackageInfo {
     }
 
     Boolean matched = false
-    String notMachedPrefix
-    String notMatchedFileExtension
     List<String> requestPackages = request.package.split(" ")
 
     requestPackages.eachWithIndex { requestPackage, index ->
@@ -139,10 +137,10 @@ class PackageInfo {
       }
 
       if (packageName) {
-        // At least one matched package must be present it the context.
-        if (!matched) {
-          notMachedPrefix = prefix
-          notMatchedFileExtension = fileExtension
+
+        // If it hasn't been possible to match a package and allowMissingPackageInstallation is false raise an exception.
+        if (!matched && !request.get("allowMissingPackageInstallation")) {
+          throw new IllegalStateException("Unable to find deployable artifact starting with ${prefix} and ending with ${fileExtension} in ${buildArtifacts} and ${triggerArtifacts}. Make sure your deb package file name complies with the naming convention: name_version-release_arch.")
         }
 
         requestPackages[index] = packageName
@@ -164,11 +162,6 @@ class PackageInfo {
           }
         }
       }
-    }
-
-    // If it hasn't been possible to match any package at all, raise an exception.
-    if (!matched) {
-      throw new IllegalStateException("Unable to find deployable artifact starting with ${notMachedPrefix} and ending with ${notMatchedFileExtension} in ${buildArtifacts} and ${triggerArtifacts}. Make sure your deb package file name complies with the naming convention: name_version-release_arch.")
     }
 
     request.replace('package', requestPackages.join(" "))

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipeline.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PackageInfoSpec extends Specification {
+
+  @Autowired
+  ObjectMapper mapper
+
+  @Unroll
+  def "All the matching packages get replaced with the build ones, while others just pass-through"() {
+    given:
+      Stage bakeStage = new PipelineStage()
+      PackageType packageType = PackageType.DEB
+      boolean extractBuildDetails = false
+      PackageInfo packageInfo = new PackageInfo(bakeStage,
+        packageType.packageType,
+        packageType.versionDelimiter,
+        extractBuildDetails,
+        false,
+        mapper)
+
+      Map trigger = ["buildInfo": ["artifacts": filename ]]
+      Map buildInfo = ["artifacts": []]
+      Map request = ["package": requestPackage]
+
+    when:
+      Map requestMap = packageInfo.createAugmentedRequest(trigger, buildInfo, request)
+
+    then:
+      requestMap.package == result
+
+    where:
+      filename                                      | requestPackage                                 | result
+      [["fileName": "test-package_1.0.0.deb"]]      | "test-package"                                 | "test-package_1.0.0"
+      [["fileName": "test-package_1.0.0.deb"]]      | "another-package"                              | "another-package"
+      [["fileName": "test-package_1.0.0.deb"]]      | "another-package test-package"                 | "another-package test-package_1.0.0"
+
+      [["fileName": "first-package_1.0.1.deb"],
+       ["fileName": "second-package_2.3.42.deb"]]   | "first-package another-package second-package" |  "first-package_1.0.1 another-package second-package_2.3.42"
+
+
+  }
+
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
@@ -76,13 +76,13 @@ class PackageInfoSpec extends Specification {
 
       Map trigger = ["buildInfo": ["artifacts": [["fileName": "test-package_1.0.0.deb"]]]]
       Map buildInfo = ["artifacts": []]
-      Map request = ["package": "another-package", "allowMissingPackageInstallation" : false]
+      Map request = ["package": "foo bar", "allowMissingPackageInstallation" : false]
 
     when:
       packageInfo.createAugmentedRequest(trigger, buildInfo, request)
 
     then:
       def exception = thrown(IllegalStateException)
-      exception.message == "Unable to find deployable artifact starting with another-package_ and ending with .deb in [] and [[fileName:test-package_1.0.0.deb]]. Make sure your deb package file name complies with the naming convention: name_version-release_arch."
+      exception.message == "Unable to find deployable artifact starting with [foo_, bar_] and ending with .deb in [] and [[fileName:test-package_1.0.0.deb]]. Make sure your deb package file name complies with the naming convention: name_version-release_arch."
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
@@ -42,7 +42,7 @@ class PackageInfoSpec extends Specification {
 
       Map trigger = ["buildInfo": ["artifacts": filename]]
       Map buildInfo = ["artifacts": []]
-      Map request = ["package": requestPackage]
+      Map request = ["package": requestPackage, "allowMissingPackageInstallation" : true]
 
     when:
       Map requestMap = packageInfo.createAugmentedRequest(trigger, buildInfo, request)
@@ -53,6 +53,7 @@ class PackageInfoSpec extends Specification {
     where:
       filename                                    | requestPackage                                 | result
       [["fileName": "test-package_1.0.0.deb"]]    | "test-package"                                 | "test-package_1.0.0"
+      [["fileName": "test-package_1.0.0.deb"]]    | "another-package"                              | "another-package"
       [["fileName": "test-package_1.0.0.deb"]]    | "another-package test-package"                 | "another-package test-package_1.0.0"
 
       [["fileName": "first-package_1.0.1.deb"],
@@ -61,7 +62,7 @@ class PackageInfoSpec extends Specification {
 
   }
 
-  def "At least one matching package should be in the context"() {
+  def "Raise an exception if allowMissingPackageInstallation is false and there's no match"() {
     given:
       Stage bakeStage = new PipelineStage()
       PackageType packageType = PackageType.DEB
@@ -75,7 +76,7 @@ class PackageInfoSpec extends Specification {
 
       Map trigger = ["buildInfo": ["artifacts": [["fileName": "test-package_1.0.0.deb"]]]]
       Map buildInfo = ["artifacts": []]
-      Map request = ["package": "another-package"]
+      Map request = ["package": "another-package", "allowMissingPackageInstallation" : false]
 
     when:
       packageInfo.createAugmentedRequest(trigger, buildInfo, request)


### PR DESCRIPTION
…Bake Stage

When a package match one of the packages coming from the trigger or from the previous stage its name get replaced
with the actual package name. Otherwise its just passed down to the bakery, letting the bakery to resolve it

This is someway related to: https://github.com/spinnaker/rosco/pull/88 to correctly handle multiple packages