### PR TITLE
updates retrofit okclient construction.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import retrofit.RestAdapter
 import retrofit.RetrofitError
+import retrofit.client.Client
 
 import java.util.concurrent.ConcurrentHashMap
 
@@ -64,6 +65,9 @@ class QuickPatchStage extends LinearStage {
 
   @Autowired
   OortHelper oortHelper
+
+  @Autowired
+  Client retrofitClient
 
   public static final String PIPELINE_CONFIG_TYPE = "quickPatch"
 
@@ -170,6 +174,7 @@ class QuickPatchStage extends LinearStage {
   InstanceService createInstanceService(String address) {
     RestAdapter restAdapter = new RestAdapter.Builder()
       .setEndpoint(address)
+      .setClient(retrofitClient)
       .build()
     return restAdapter.create(InstanceService.class)
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/AbstractQuipTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/AbstractQuipTask.groovy
@@ -3,14 +3,15 @@ package com.netflix.spinnaker.orca.kato.tasks.quip
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.clouddriver.InstanceService
 import retrofit.RestAdapter
+import retrofit.client.Client
 
-/**
- * Created by dzapata on 4/21/15.
- */
 abstract class AbstractQuipTask implements Task {
+  protected abstract Client getRetrofitClient()
+
   InstanceService createInstanceService(String address) {
     RestAdapter restAdapter = new RestAdapter.Builder()
       .setEndpoint(address)
+      .setClient(retrofitClient)
       .build()
     return restAdapter.create(InstanceService.class)
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/InstanceHealthCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/InstanceHealthCheckTask.groovy
@@ -10,6 +10,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
+import retrofit.client.Client
 
 @Component
 class InstanceHealthCheckTask extends AbstractQuipTask implements RetryableTask  {
@@ -20,6 +21,9 @@ class InstanceHealthCheckTask extends AbstractQuipTask implements RetryableTask 
 
   @Autowired
   OortHelper oortHelper
+
+  @Autowired
+  Client retrofitClient
 
   @Override
   TaskResult execute(Stage stage) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/MonitorQuipTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/MonitorQuipTask.groovy
@@ -9,10 +9,13 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
+import retrofit.client.Client
 
 @Component
 class MonitorQuipTask extends AbstractQuipTask implements RetryableTask {
   @Autowired ObjectMapper objectMapper
+
+  @Autowired Client retrofitClient
 
   long backoffPeriod = 10000
   long timeout = 600000 // 10mins

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTask.groovy
@@ -9,10 +9,13 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
+import retrofit.client.Client
 
 @Component
 class TriggerQuipTask extends AbstractQuipTask implements RetryableTask  {
   @Autowired ObjectMapper objectMapper
+
+  @Autowired Client retrofitClient
 
   long backoffPeriod = 10000
   long timeout = 60000 // 1min

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTask.groovy
@@ -10,6 +10,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
+import retrofit.client.Client
 
 @Component
 class VerifyQuipTask extends AbstractQuipTask implements Task {
@@ -19,6 +20,9 @@ class VerifyQuipTask extends AbstractQuipTask implements Task {
 
   @Autowired
   ObjectMapper objectMapper
+
+  @Autowired
+  Client retrofitClient
 
   @Override
   TaskResult execute(Stage stage) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/InstanceHealthCheckTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/InstanceHealthCheckTaskSpec.groovy
@@ -23,6 +23,8 @@ import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import retrofit.RetrofitError
+import retrofit.client.Client
+import retrofit.client.OkClient
 import retrofit.client.Response
 import retrofit.mime.TypedString
 import spock.lang.Specification
@@ -37,6 +39,7 @@ class InstanceHealthCheckTaskSpec extends Specification {
 
   def setup() {
     task.objectMapper = new ObjectMapper()
+    task.retrofitClient = Stub(Client)
   }
 
   @Unroll

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/MonitorQuipTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/MonitorQuipTaskSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.orca.clouddriver.InstanceService
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import retrofit.RetrofitError
+import retrofit.client.Client
 import retrofit.client.Response
 import retrofit.mime.TypedString
 import spock.lang.Specification
@@ -36,6 +37,7 @@ class MonitorQuipTaskSpec extends Specification {
 
   def setup() {
     task.objectMapper = new ObjectMapper()
+    task.retrofitClient = Stub(Client)
   }
 
   @Unroll

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTaskSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.orca.clouddriver.InstanceService
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import retrofit.RetrofitError
+import retrofit.client.Client
 import retrofit.client.Response
 import retrofit.mime.TypedString
 import spock.lang.Shared
@@ -37,6 +38,7 @@ class TriggerQuipTaskSpec extends Specification {
 
   def setup() {
     task.objectMapper = new ObjectMapper()
+    task.retrofitClient = Stub(Client)
   }
 
   @Shared

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTaskSpec.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import retrofit.RetrofitError
+import retrofit.client.Client
 import retrofit.client.Response
 import retrofit.mime.TypedString
 import spock.lang.Specification
@@ -73,6 +74,7 @@ class VerifyQuipTaskSpec extends Specification {
   def setup() {
     task.oortService = oortService
     task.objectMapper = new ObjectMapper()
+    task.retrofitClient = Stub(Client)
   }
 
   @Unroll


### PR DESCRIPTION
main goal of this change it just to expose some configuration around the okclient creation to experiment with addressing the EOFExceptions.  

* adds extra configuration for okclient connection pool and retry (defaults to the existing default values)
* updates a couple of classes that were not explicitly passing a retrofit client
* fixed a bug where the retrofit client user agent interceptor wasn't actually getting applied


