### PR TITLE
Handle multiple rpm artifacts in random order

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
@@ -209,8 +209,25 @@ class PackageInfo {
 
   @CompileDynamic
   private Map filterArtifacts(List<Map> artifacts, String prefix, String fileExtension) {
-    artifacts.find {
-      it.fileName?.startsWith(prefix) && it.fileName?.endsWith(fileExtension)
+    if (packageType == 'rpm') {
+      filterRPMArtifacts(artifacts, prefix)
+    } else {
+      artifacts.find {
+        it.fileName?.startsWith(prefix) && it.fileName?.endsWith(fileExtension)
+      }
+    }
+  }
+
+  @CompileDynamic
+  private Map filterRPMArtifacts(List<Map> artifacts, String prefix) {
+    artifacts.find { artifact ->
+      List<String> parts = artifact.fileName?.tokenize(versionDelimiter)
+      if (parts.size >= 3) {
+        parts.pop()
+        parts.pop()
+        String appName = parts.join(versionDelimiter)
+        return "${appName}${versionDelimiter}" == prefix
+      }
     }
   }
 


### PR DESCRIPTION
Because of the `-` delimiter being nondeterministic, we have to have sophisticated parsing to extract the package name from rpm file names. We found this in our installation when a build produced two rpms, myapp and myapp-someotherpackage. When the bakery was told to install myapp, orca matched the myapp-someotherpackage and the bakery installed the wrong package.