### PR TITLE
Minor adjustment to how an <optional> expression is interpreted

### DIFF
--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupportSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupportSpec.groovy
@@ -45,12 +45,15 @@ class OptionalStageSupportSpec extends Specification {
 
     where:
     optionalConfig                                                                                                   || expectedOptionality
+    [:]                                                                                                              || false
     [type: "expression"]                                                                                             || false
     [type: "expression", expression: ""]                                                                             || false
     [type: "expression", expression: null]                                                                           || false
-    [type: "expression", expression: "execution.stages.?[name == 'Test2'][0]['status'].name() == 'FAILED_CONTINUE'"] || false
-    [type: "expression", expression: "execution.stages.?[name == 'Test1'][0]['status'].name() == 'FAILED_CONTINUE'"] || true
-    [type: "expression", expression: "parameters.p1 == 'v1'"]                                                        || true
-    [type: "expression", expression: "true"]                                                                         || true
+    [type: "expression", expression: "parameters.p1 == 'v1'"]                                                        || false
+    [type: "expression", expression: "parameters.p1 == 'v2'"]                                                        || true
+    [type: "expression", expression: "execution.stages.?[name == 'Test2'][0]['status'].name() == 'FAILED_CONTINUE'"] || true
+    [type: "expression", expression: "execution.stages.?[name == 'Test1'][0]['status'].name() == 'FAILED_CONTINUE'"] || false
+    [type: "expression", expression: "true"]                                                                         || false
+    [type: "expression", expression: "false"]                                                                        || true
   }
 }


### PR DESCRIPTION
- Aligns with a UI that now prompts for an expression that determines whether a stage should run (vs determining that a stage should not run)
- Any issue evaluating an expression will result in the stage being executed