### PR TITLE
Expose allowMissingPackageInstallation as a configuration property

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
@@ -28,7 +28,7 @@ import groovy.transform.Immutable
 @Immutable(copyWith = true)
 @CompileStatic
 class BakeRequest {
-  static final Default = new BakeRequest(System.getProperty("user.name"), null, null, null, null, null, CloudProviderType.aws, Label.release, "ubuntu", null, null, null, null, null, null, null, false, null, null)
+  static final Default = new BakeRequest(System.getProperty("user.name"), null, null, null, null, null, CloudProviderType.aws, Label.release, "ubuntu", null, null, null, null, null, null, null, null, null)
 
   String user
   @JsonProperty("package") String packageName
@@ -46,7 +46,6 @@ class BakeRequest {
   Boolean enhancedNetworking
   String amiName
   String amiSuffix
-  Boolean allowMissingPackageInstallation
 
   String templateFileName
   Map extendedAttributes

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -55,6 +55,9 @@ class CreateBakeTask implements RetryableTask {
   @Value('${bakery.propagateCloudProviderType:false}')
   boolean propagateCloudProviderType
 
+  @Value('${bakery.allowMissingPackageInstallation:false}')
+  boolean allowMissingPackageInstallation
+
   @Override
   TaskResult execute(Stage stage) {
     String region = stage.context.region
@@ -132,15 +135,13 @@ class CreateBakeTask implements RetryableTask {
                                               extractBuildDetails,
                                               false /* extractVersion */,
                                               mapper)
-    Map requestMap = packageInfo.findTargetPackage()
+
+    Map requestMap = packageInfo.findTargetPackage(allowMissingPackageInstallation)
     BakeRequest bakeRequest = mapper.convertValue(requestMap, BakeRequest)
 
     if (!propagateCloudProviderType) {
       bakeRequest = bakeRequest.copyWith(cloudProviderType: null)
     }
-
-    // The allowMissingPackageInstallation only affect Orca behavior. We don't want to propagate it to any bakery.
-    bakeRequest = bakeRequest.copyWith(allowMissingPackageInstallation: null)
 
     if (!roscoApisEnabled) {
       bakeRequest = bakeRequest.copyWith(templateFileName: null, extendedAttributes: null)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
@@ -60,6 +60,9 @@ class QuickPatchStage extends LinearStage {
   @Value('${bakery.roscoApisEnabled:false}')
   boolean roscoApisEnabled
 
+  @Value('${bakery.allowMissingPackageInstallation:false}')
+  boolean allowMissingPackageInstallation
+
   @Autowired
   ObjectMapper objectMapper
 
@@ -96,7 +99,7 @@ class QuickPatchStage extends LinearStage {
                                               true /* extractBuildDetails */,
                                               true /* extractVersion */,
                                               objectMapper)
-    String version = stage.context?.patchVersion ?:  packageInfo.findTargetPackage()?.packageVersion
+    String version = stage.context?.patchVersion ?:  packageInfo.findTargetPackage(allowMissingPackageInstallation)?.packageVersion
 
     stage.context.put("version", version) // so the ui can display the discovered package version and we can verify for skipUpToDate
     def instances = getInstancesForCluster(stage)

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
@@ -44,7 +44,7 @@ class PackageInfo {
     potentialUrl ==~ /\b(https?|ssh):\/\/.*/
   }
 
-  public Map findTargetPackage() {
+  public Map findTargetPackage(boolean allowMissingPackageInstallation) {
     Map requestMap = [:]
     // copy the context since we may modify it in createAugmentedRequest
     requestMap.putAll(stage.execution.context)
@@ -56,7 +56,7 @@ class PackageInfo {
       if (requestMap.buildInfo) { // package was built as part of the pipeline
         buildInfo = mapper.convertValue(requestMap.buildInfo, Map)
       }
-      return createAugmentedRequest(trigger, buildInfo, requestMap)
+      return createAugmentedRequest(trigger, buildInfo, requestMap, allowMissingPackageInstallation)
     }
     return requestMap
   }
@@ -72,7 +72,7 @@ class PackageInfo {
    */
   @CompileDynamic
   @VisibleForTesting
-  private Map createAugmentedRequest(Map trigger, Map buildInfo, Map request) {
+  private Map createAugmentedRequest(Map trigger, Map buildInfo, Map request, boolean allowMissingPackageInstallation) {
 
     List<Map> triggerArtifacts = trigger?.buildInfo?.artifacts ?: trigger?.parentExecution?.trigger?.buildInfo?.artifacts
     List<Map> buildArtifacts = buildInfo?.artifacts
@@ -166,7 +166,7 @@ class PackageInfo {
     }
 
     // If it hasn't been possible to match a package and allowMissingPackageInstallation is false raise an exception.
-    if (missingPrefixes && !request.allowMissingPackageInstallation) {
+    if (missingPrefixes && !allowMissingPackageInstallation) {
       throw new IllegalStateException("Unable to find deployable artifact starting with ${missingPrefixes} and ending with ${fileExtension} in ${buildArtifacts} and ${triggerArtifacts}. Make sure your deb package file name complies with the naming convention: name_version-release_arch.")
     }
 

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/util/PackageInfoSpec.groovy
@@ -64,13 +64,13 @@ class PackageInfoSpec extends Specification {
   void "should skip package validation if a url is provided as package"() {
     Map request = ['package': 'http://www.m.com']
     expect:
-    info.createAugmentedRequest(trigger, buildInfo, request).package == request.package
+    info.createAugmentedRequest(trigger, buildInfo, request, false).package == request.package
   }
 
   void "should resolve the correct package"() {
     Map request = ['package': 'dos']
     expect:
-    info.createAugmentedRequest(trigger, buildInfo, request).package == 'dos_1.0-h2'
+    info.createAugmentedRequest(trigger, buildInfo, request, false).package == 'dos_1.0-h2'
   }
 
   void "should parse the build info url into expected parts"() {
@@ -88,7 +88,7 @@ class PackageInfoSpec extends Specification {
   void "should throw an exception when a trigger has no artifacts"() {
     when:
     Map request = ['package': 'dos']
-    info.createAugmentedRequest(providedTrigger, null, request)
+    info.createAugmentedRequest(providedTrigger, null, request, false)
 
     then:
     def exception = thrown(IllegalStateException)

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -22,6 +22,7 @@ bakery:
   # Rosco exposes more endpoints than Netflix's internal bakery. This disables
   # the use of those endpoints.
   roscoApisEnabled: true
+  allowMissingPackageInstallation: false
 
 redis:
   connection: ${REDIS_URL:redis://localhost:6379}


### PR DESCRIPTION
Please note the `allowMissingPackageInstallation` parameter is not used internally and never passed down to the bakery, in any case so it has been just removed from the BakeRequest