### PR TITLE
Don't inject an allowLaunch operation if there is no amiName

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
@@ -124,17 +124,15 @@ class AmazonServerGroupCreator implements ServerGroupCreator, DeploymentDetailsA
 
   def allowLaunchOperations(Map createServerGroupOp) {
     def ops = []
-    if (createServerGroupOp.credentials != defaultBakeAccount) {
-      if (createServerGroupOp.availabilityZones) {
-        ops.addAll(createServerGroupOp.availabilityZones.collect { String region, List<String> azs ->
-          [account    : createServerGroupOp.credentials,
-           credentials: defaultBakeAccount,
-           region     : region,
-           amiName    : createServerGroupOp.amiName]
-        })
+    if (createServerGroupOp.amiName && createServerGroupOp.availabilityZones && createServerGroupOp.credentials != defaultBakeAccount) {
+      ops.addAll(createServerGroupOp.availabilityZones.collect { String region, List<String> azs ->
+        [account    : createServerGroupOp.credentials,
+         credentials: defaultBakeAccount,
+         region     : region,
+         amiName    : createServerGroupOp.amiName]
+      })
 
-        log.info("Generated `allowLaunchDescriptions` (allowLaunchDescriptions: ${ops})")
-      }
+      log.info("Generated `allowLaunchDescriptions` (allowLaunchDescriptions: ${ops})")
     }
     return ops
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreatorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreatorSpec.groovy
@@ -102,6 +102,18 @@ class AmazonServerGroupCreatorSpec extends Specification {
       operations.findAll { it.containsKey("allowLaunchDescription") }.empty
   }
 
+  def "don't create allowLaunch tasks when no amiName present"() {
+    given:
+    deployConfig.amiName = null
+
+    when:
+    def operations = creator.getOperations(stage)
+
+    then:
+    operations.findAll { it.containsKey("allowLaunchDescription") }.empty
+  }
+
+
   def "can include optional parameters"() {
     given:
       stage.context.stack = stackValue


### PR DESCRIPTION
This is a legitimate case if issuing a cloneServerGroup wanting to inherit the AMI from the
source serverGroup

@spinnaker/netflix-reviewers PTAL