### PR TITLE
Bug fixes

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
@@ -58,6 +58,13 @@ class ApplySourceServerGroupCapacityTask extends AbstractServerGroupTask {
         getCloudProvider(ancestorDeployStage)
       ).get()
 
+      def minCapacity = Math.min(
+        ancestorDeployStageData.sourceServerGroupCapacitySnapshot.min as Long,
+        deployServerGroup.capacity.min as Long
+      )
+
+      log.info("Restoring capacity of ${ancestorDeployStageData.region}/${deployServerGroup.name} to ${minCapacity} (currentMin: ${deployServerGroup.capacity.min}, snapshotMin: ${ancestorDeployStageData.sourceServerGroupCapacitySnapshot.min})")
+
       return [
         credentials    : getCredentials(stage),
         regions        : [ancestorDeployStageData.region],
@@ -66,7 +73,7 @@ class ApplySourceServerGroupCapacityTask extends AbstractServerGroupTask {
         serverGroupName: deployServerGroup.name,
         capacity       : deployServerGroup.capacity + [
           // only update the min capacity, desired + max should be inherited from the current server group
-          min: ancestorDeployStageData.sourceServerGroupCapacitySnapshot.min
+          min: minCapacity
         ]
       ]
     } catch (Exception e) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStage.groovy
@@ -135,6 +135,10 @@ class ParallelDeployStage extends ParallelStage {
             }
           }
         }
+
+        // Avoid passing 'stageEnabled' configuration on to the deploy stage in a strategy pipeline
+        cluster.remove("stageEnabled")
+
         stage.context.clusters = [cluster as Map<String, Object>]
       }
     }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ApplySourceServerGroupSnapshotTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ApplySourceServerGroupSnapshotTaskSpec.groovy
@@ -69,9 +69,9 @@ class ApplySourceServerGroupSnapshotTaskSpec extends Specification {
       type: "createServerGroup"
     ])
     childPipeline.stages << new PipelineStage(childPipeline, "", [
-      type: "createServerGroup",
+      type                  : "createServerGroup",
       "deploy.server.groups": [
-          "us-west-1": ["asg-v001"]
+        "us-west-1": ["asg-v001"]
       ]
     ])
 
@@ -113,6 +113,7 @@ class ApplySourceServerGroupSnapshotTaskSpec extends Specification {
     null       || _
   }
 
+  @Unroll
   void "should construct resizeServerGroup context with source `min` + target `desired` and `max` capacity"() {
     given:
     def pipeline = new Pipeline()
@@ -125,7 +126,7 @@ class ApplySourceServerGroupSnapshotTaskSpec extends Specification {
       account                          : "test",
       region                           : "us-east-1",
       sourceServerGroupCapacitySnapshot: [
-        min    : 0,
+        min    : originalMinCapacity,
         desired: 10,
         max    : 20
       ]
@@ -166,10 +167,15 @@ class ApplySourceServerGroupSnapshotTaskSpec extends Specification {
       regions        : ["us-east-1"],
       region         : "us-east-1",
       capacity       : [
-        min    : 0,
+        min    : expectedMinCapacity,
         desired: 5,
         max    : 10
       ]
     ]
+
+    where:
+    originalMinCapacity || expectedMinCapacity
+    0                   || 0            // min(currentMin, snapshotMin) == 0
+    10                  || 5            // min(currentMin, snapshotMin) == 5
   }
 }


### PR DESCRIPTION
- Avoid passing 'stageEnabled' down to the child pipeline strategies deploy
- Apply the min(snapshotMin, currentMin) capacity when restoring a snapshot in order to avoid situations where the currentDesired < snapshotMin