### PR TITLE
Invert from and to

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
@@ -122,7 +122,7 @@ class GetCommitsTask implements DiffTask {
 
   List getCommitsList(String repoType, String projectKey, String repositorySlug, String sourceCommit, String targetCommit) {
     List commitsList = []
-    List commits = buildService.compareCommits(repoType, projectKey, repositorySlug, [to: sourceCommit, from: targetCommit, limit: 100])
+    List commits = buildService.compareCommits(repoType, projectKey, repositorySlug, [from: sourceCommit, to: targetCommit, limit: 100])
     commits.each {
       // add commits to the task output
       commitsList << [displayId: it.displayId, id: it.id, authorDisplayName: it.authorDisplayName,

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
@@ -204,7 +204,7 @@ class GetCommitsTaskSpec extends Specification {
     def stage = new PipelineStage(pipeline, "stash", contextMap)//.asImmutable()
 
     task.buildService = Stub(BuildService) {
-      compareCommits("stash", "projectKey", "repositorySlug", ['to':'186605b', 'from':'a86305d', 'limit':100]) >> [[message: "my commit", displayId: "abcdab", id: "abcdabcdabcdabcd", authorDisplayName: "Joe Coder", timestamp: 1432081865000, commitUrl: "http://stash.com/abcdabcdabcdabcd"],
+      compareCommits("stash", "projectKey", "repositorySlug", ['from':'186605b', 'to':'a86305d', 'limit':100]) >> [[message: "my commit", displayId: "abcdab", id: "abcdabcdabcdabcd", authorDisplayName: "Joe Coder", timestamp: 1432081865000, commitUrl: "http://stash.com/abcdabcdabcdabcd"],
                                                                                                                    [message: "bug fix", displayId: "efghefgh", id: "efghefghefghefghefgh", authorDisplayName: "Jane Coder", timestamp: 1432081256000, commitUrl: "http://stash.com/efghefghefghefghefgh"]]
     }
 
@@ -275,7 +275,7 @@ class GetCommitsTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    1 * buildService.compareCommits("stash", "projectKey", "repositorySlug", ['to':'186605b', 'from':'a86305d', 'limit':100]) >> {
+    1 * buildService.compareCommits("stash", "projectKey", "repositorySlug", ['from':'186605b', 'to':'a86305d', 'limit':100]) >> {
       throw new RetrofitError(null, null,
         new Response("http://stash.com", 500, "test reason", [], null), null, null, null, null)
     }
@@ -332,7 +332,7 @@ class GetCommitsTaskSpec extends Specification {
 
     and:
     task.buildService = Stub(BuildService) {
-      compareCommits("stash", "projectKey", "repositorySlug", ['to':'186605b', 'from':'a86305d', 'limit':100]) >> [[message: "my commit", displayId: "abcdab", id: "abcdabcdabcdabcd", authorDisplayName: "Joe Coder", timestamp: 1432081865000, commitUrl: "http://stash.com/abcdabcdabcdabcd"],
+      compareCommits("stash", "projectKey", "repositorySlug", ['from':'186605b', 'to':'a86305d', 'limit':100]) >> [[message: "my commit", displayId: "abcdab", id: "abcdabcdabcdabcd", authorDisplayName: "Joe Coder", timestamp: 1432081865000, commitUrl: "http://stash.com/abcdabcdabcdabcd"],
                                                                                                                    [message: "bug fix", displayId: "efghefgh", id: "efghefghefghefghefgh", authorDisplayName: "Jane Coder", timestamp: 1432081256000, commitUrl: "http://stash.com/efghefghefghefghefgh"]]
     }
 
@@ -382,7 +382,7 @@ class GetCommitsTaskSpec extends Specification {
 
     and:
     task.buildService = Stub(BuildService) {
-      compareCommits("stash", "projectKey", "repositorySlug", ['to':'186605b', 'from':'a86305d', 'limit':100]) >> [[message: "my commit", displayId: "abcdab", id: "abcdabcdabcdabcd", authorDisplayName: "Joe Coder", timestamp: 1432081865000, commitUrl: "http://stash.com/abcdabcdabcdabcd"],
+      compareCommits("stash", "projectKey", "repositorySlug", ['from':'186605b', 'to':'a86305d', 'limit':100]) >> [[message: "my commit", displayId: "abcdab", id: "abcdabcdabcdabcd", authorDisplayName: "Joe Coder", timestamp: 1432081865000, commitUrl: "http://stash.com/abcdabcdabcdabcd"],
                                                                                                                    [message: "bug fix", displayId: "efghefgh", id: "efghefghefghefghefgh", authorDisplayName: "Jane Coder", timestamp: 1432081256000, commitUrl: "http://stash.com/efghefghefghefghefgh"]]
     }
 
@@ -450,7 +450,7 @@ class GetCommitsTaskSpec extends Specification {
 
     and:
     task.buildService = Stub(BuildService) {
-      compareCommits("stash", "projectKey", "repositorySlug", ['to':'186605b', 'from':'a86305d', 'limit':100]) >> {
+      compareCommits("stash", "projectKey", "repositorySlug", ['from':'186605b', 'to':'a86305d', 'limit':100]) >> {
         throw new RetrofitError(null, null, new Response("http://stash.com", 404, "test reason", [], null), null, null, null, null)
       }
     }


### PR DESCRIPTION
The source commit should be the `from` and the target commit the `to`.
If it's not in the right order, the commits list will be empty (at least when using github)
