### PR TITLE
Disable before scaling down old server groups in red/black

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategy.groovy
@@ -61,18 +61,18 @@ class RedBlackStrategy implements Strategy {
       LinearStage.injectAfter(stage, "shrinkCluster", shrinkClusterStage, shrinkContext)
     }
 
-    if (stageData.scaleDown) {
-      def scaleDown = baseContext + [
-          allowScaleDownActive         : true,
-          remainingFullSizeServerGroups: 1,
-          preferLargerOverNewer        : false
-      ]
-      LinearStage.injectAfter(stage, "scaleDown", scaleDownClusterStage, scaleDown)
-    }
-
     LinearStage.injectAfter(stage, "disableCluster", disableClusterStage, baseContext + [
         remainingEnabledServerGroups: 1,
         preferLargerOverNewer       : false
     ])
+
+    if (stageData.scaleDown) {
+      def scaleDown = baseContext + [
+        allowScaleDownActive         : false,
+        remainingFullSizeServerGroups: 1,
+        preferLargerOverNewer        : false
+      ]
+      LinearStage.injectAfter(stage, "scaleDown", scaleDownClusterStage, scaleDown)
+    }
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DeployStrategyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DeployStrategyStage.groovy
@@ -126,19 +126,20 @@ abstract class DeployStrategyStage extends AbstractCloudProviderAwareStage {
       injectAfter(stage, "shrinkCluster", shrinkClusterStage, shrinkContext)
     }
 
+    injectAfter(stage, "disableCluster", disableClusterStage, baseContext + [
+      remainingEnabledServerGroups: 1,
+      preferLargerOverNewer: false
+    ])
+
     if (stageData.scaleDown) {
       def scaleDown = baseContext + [
-        allowScaleDownActive: true,
+        allowScaleDownActive: false,
         remainingFullSizeServerGroups: 1,
         preferLargerOverNewer: false
       ]
       injectAfter(stage, "scaleDown", scaleDownClusterStage, scaleDown)
     }
 
-    injectAfter(stage, "disableCluster", disableClusterStage, baseContext + [
-      remainingEnabledServerGroups: 1,
-      preferLargerOverNewer: false
-    ])
   }
 
   protected void composeRollingPushFlow(Stage stage) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategySpec.groovy
@@ -81,9 +81,9 @@ class RedBlackStrategySpec extends Specification {
     then:
       stage.afterStages.size() == 3
       stage.afterStages[0].stageBuilder == shrinkClusterStage
-      stage.afterStages[1].stageBuilder == scaleDownClusterStage
-      stage.afterStages[1].context.allowScaleDownActive == true
-      stage.afterStages[2].stageBuilder == disableClusterStage
+      stage.afterStages[1].stageBuilder == disableClusterStage
+      stage.afterStages[2].stageBuilder == scaleDownClusterStage
+      stage.afterStages[2].context.allowScaleDownActive == false
 
   }
 }


### PR DESCRIPTION
The existing implementation was an attempt to speed things up by not waiting on the disable step for instances we were about to terminate, but not doing the disable is disruptive to active clients and causes unnecessary errors / retries

@spinnaker/netflix-reviewers PTAL