### PR TITLE
Travis support for orca

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
@@ -28,7 +28,7 @@ import groovy.transform.Immutable
 @Immutable(copyWith = true)
 @CompileStatic
 class BakeRequest {
-  static final Default = new BakeRequest(System.getProperty("user.name"), null, null, null, null, null, CloudProviderType.aws, Label.release, "ubuntu", null, null, null, null, null, null, null, null, null)
+  static final Default = new BakeRequest(System.getProperty("user.name"), null, null, null, null, null, null, CloudProviderType.aws, Label.release, "ubuntu", null, null, null, null, null, null, null, null, null)
 
   String user
   @JsonProperty("package") String packageName
@@ -36,6 +36,7 @@ class BakeRequest {
   String job
   String buildNumber
   String commitHash
+  String buildInfoUrl
   CloudProviderType cloudProviderType
   Label baseLabel
   String baseOs

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -75,6 +75,10 @@ class CreateBakeTask implements RetryableTask {
         previouslyBaked : bakeStatus.state == BakeStatus.State.COMPLETED
       ] as Map<String, ? extends Object>
 
+      if (bake.buildInfoUrl) {
+        stageOutputs.buildInfoUrl = bake.buildInfoUrl
+      }
+
       if (bake.buildHost) {
         stageOutputs << [
           buildHost  : bake.buildHost,
@@ -144,7 +148,7 @@ class CreateBakeTask implements RetryableTask {
     }
 
     if (!roscoApisEnabled) {
-      bakeRequest = bakeRequest.copyWith(templateFileName: null, extendedAttributes: null)
+      bakeRequest = bakeRequest.copyWith(templateFileName: null, extendedAttributes: null, buildInfoUrl: null)
     }
 
     return bakeRequest

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright 2014 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -88,7 +88,7 @@ class CreateBakeTaskSpec extends Specification {
   ]
 
   @Shared
-  def bakeConfigWithTemplateFileNameAndExtendedAttributes = [
+  def bakeConfigWithTemplateFileNameExtendedAttributesAndBuildInfoUrl = [
     region             : "us-west-1",
     package            : "hodor",
     user               : "bran",
@@ -99,7 +99,8 @@ class CreateBakeTaskSpec extends Specification {
     extendedAttributes : [
       playbook_file : "subdir1/site.yml",
       someOtherAttr : "someValue"
-    ]
+    ],
+    buildInfoUrl : "http://spinnaker.builds.test.netflix.net/job/SPINNAKER-package-echo/69/",
   ]
 
   @Shared
@@ -634,9 +635,9 @@ class CreateBakeTaskSpec extends Specification {
   }
 
   @Unroll
-  def "propagation of templateFileName and extendedAttributes is feature-flagged"() {
+  def "propagation of templateFileName, extendedAttributes and buildInfoUrl is feature-flagged"() {
     given:
-    Stage stage = new PipelineStage(new Pipeline(), "bake", bakeConfigWithTemplateFileNameAndExtendedAttributes).asImmutable()
+    Stage stage = new PipelineStage(new Pipeline(), "bake", bakeConfigWithTemplateFileNameExtendedAttributesAndBuildInfoUrl).asImmutable()
     def bake
     task.bakery = Mock(BakeryService) {
       if (roscoApisEnabled) {
@@ -660,11 +661,12 @@ class CreateBakeTaskSpec extends Specification {
     bake.baseLabel.name()   == bakeConfigWithCloudProviderType.baseLabel
     bake.templateFileName   == templateFileName
     bake.extendedAttributes == extendedAttributes
+    bake.buildInfoUrl       == buildInfoUrl
 
     where:
-    roscoApisEnabled | templateFileName          | extendedAttributes
-    false            | null                      | null
-    true             | "somePackerTemplate.json" | [playbook_file: "subdir1/site.yml", someOtherAttr: "someValue"]
+    roscoApisEnabled | templateFileName          | extendedAttributes                                               | buildInfoUrl
+    false            | null                      | null                                                             | null
+    true             | "somePackerTemplate.json" | [playbook_file: "subdir1/site.yml", someOtherAttr: "someValue"]  | bakeConfigWithTemplateFileNameExtendedAttributesAndBuildInfoUrl.buildInfoUrl
   }
 
   @Unroll

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractor.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractor.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.util
+
+class BuildDetailExtractor {
+
+  private final List<DetailExtractor> detailExtractors
+
+  BuildDetailExtractor() {
+    this.detailExtractors = [new DefaultDetailExtractor(), new LegacyJenkinsUrlDetailExtractor()]
+  }
+
+  public tryToExtractBuildDetails(Map buildInfo, Map request) {
+    // The first strategy to succeed ends the loop. That is: the DefaultDetailExtractor is trying first
+    // if it can not succeed the Legacy parser will be applied
+    detailExtractors.any {
+      it.tryToExtractBuildDetails(buildInfo, request)
+    }
+  }
+
+  //Legacy Details extractor for Jenkins. It parses the url to fill the request build parameters
+  @Deprecated
+  private static class LegacyJenkinsUrlDetailExtractor implements DetailExtractor {
+
+    boolean tryToExtractBuildDetails(Map buildInfo, Map request) {
+
+      if (buildInfo == null || request == null) {
+        return false
+      }
+      Map copyRequest = [:]
+      def buildInfoUrlParts
+      def buildInfoUrl = buildInfo.url
+      if (buildInfoUrl) {
+        buildInfoUrlParts = parseBuildInfoUrl(buildInfoUrl)
+        if (buildInfoUrlParts?.size == 3) {
+          copyRequest.put('buildInfoUrl', buildInfoUrl)
+          copyRequest.put('buildHost', buildInfoUrlParts[0].toString())
+          copyRequest.put('job', buildInfoUrlParts[1].toString())
+          copyRequest.put('buildNumber', buildInfoUrlParts[2].toString())
+          extractCommitHash(buildInfo, copyRequest)
+          request.putAll(copyRequest)
+          return true
+        }
+      }
+      return false
+    }
+
+    // Naming-convention for buildInfo.url is $protocol://$buildHost/job/$job/$buildNumber/.
+    // For example: http://spinnaker.builds.test.netflix.net/job/SPINNAKER-package-echo/69/
+    // Note that job names can contain slashes if using the Folders plugin.
+    // For example: http://spinnaker.builds.test.netflix.net/job/folder1/job/job1/69/
+    private parseBuildInfoUrl(String url) {
+      List<String> urlParts = url?.tokenize("/")
+      if (urlParts?.size >= 5) {
+        def buildNumber = urlParts.pop()
+        def job = urlParts[3..-1].join('/')
+
+        def buildHost = "${urlParts[0]}//${urlParts[1]}/"
+
+        return [buildHost, job, buildNumber]
+      }
+    }
+  }
+
+  //Default detail extractor. It expects to find url, name and number in the buildInfo
+  private static class DefaultDetailExtractor implements DetailExtractor {
+
+    boolean tryToExtractBuildDetails(Map buildInfo, Map request) {
+
+      if (buildInfo == null || request == null) {
+        return false
+      }
+      if (buildInfo.url && buildInfo.name && buildInfo.number) {
+        Map copyRequest = [:]
+        copyRequest.put('buildInfoUrl', buildInfo.url)
+        copyRequest.put('job', buildInfo.name)
+        copyRequest.put('buildNumber', buildInfo.number)
+        extractBuildHost(buildInfo.url, copyRequest)
+        extractCommitHash(buildInfo, copyRequest)
+        request.putAll(copyRequest)
+        return true
+      }
+      return false
+    }
+
+
+    private void extractBuildHost(String url, Map request) {
+      List<String> urlParts = url?.tokenize("/")
+      if (urlParts?.size >= 5) {
+        request.put('buildHost', "${urlParts[0]}//${urlParts[1]}/".toString())
+      }
+    }
+  }
+
+  //Common trait for DetailExtractor
+  private trait DetailExtractor {
+
+    abstract boolean tryToExtractBuildDetails(Map buildInfo, Map request)
+
+
+    void extractCommitHash(Map buildInfo, Map request) {
+      // buildInfo.scm contains a list of maps. Each map contains these keys: name, sha1, branch.
+      // If the list contains more than one entry, prefer the first one that is not master and is not develop.
+      def commitHash
+
+      if (buildInfo.scm?.size() >= 2) {
+        commitHash = buildInfo.scm.find {
+          it.branch != "master" && it.branch != "develop"
+        }?.sha1
+      }
+      if (!commitHash) {
+        commitHash = buildInfo.scm?.first()?.sha1
+      }
+      if (commitHash) {
+        request.put('commitHash', commitHash)
+      }
+    }
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/util/PackageInfoSpec.groovy
@@ -73,16 +73,7 @@ class PackageInfoSpec extends Specification {
     info.createAugmentedRequest(trigger, buildInfo, request, false).package == 'dos_1.0-h2'
   }
 
-  void "should parse the build info url into expected parts"() {
-    expect:
-    info.parseBuildInfoUrl(pattern) == expectedResult
 
-    where:
-    pattern                                          || expectedResult
-    "http://jenkins.com/job/jobName/123"             || ["http://jenkins.com/", "jobName", "123"]
-    "http://jenkins.com/job/folder/job/jobName/123"  || ["http://jenkins.com/", "folder/job/jobName", "123"]
-    "http://jenkins.com/job/folder/job/job name/123" || ["http://jenkins.com/", "folder/job/job name", "123"]
-  }
 
   @Unroll
   void "should throw an exception when a trigger has no artifacts"() {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractorSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipeline.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class BuildDetailExtractorSpec extends Specification {
+
+  @Autowired
+  ObjectMapper mapper
+
+  @Shared
+  BuildDetailExtractor buildDetailExtractor = new BuildDetailExtractor()
+
+  @Unroll
+  def "Default detail from buildInfo"() {
+
+    when:
+    buildDetailExtractor.tryToExtractBuildDetails(buildInfo, result)
+
+    then:
+    result == expectedResult
+
+    where:
+    buildInfo                                                                                                                                              | result | expectedResult
+    ["name": "SPINNAKER", "number": "9001", "url": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/"]                              | [:]    | ["job": "SPINNAKER", "buildNumber": "9001", "buildInfoUrl": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/", "buildHost": "http://spinnaker.jenkis.test.netflix.net/"]
+    ["name": "organization/SPINNAKER", "number": "9001", "url": "http://spinnaker.travis.test.netflix.net/organization/SPINNAKER-package-echo/builds/69/"] | [:]    | ["job": "organization/SPINNAKER", "buildNumber": "9001", "buildInfoUrl": "http://spinnaker.travis.test.netflix.net/organization/SPINNAKER-package-echo/builds/69/", "buildHost": "http://spinnaker.travis.test.netflix.net/"]
+  }
+
+  @Unroll
+  def "Legacy Jenkins detail from the url"() {
+
+    when:
+    buildDetailExtractor.tryToExtractBuildDetails(buildInfo, result)
+
+    then:
+    result == expectedResult
+
+    where:
+    buildInfo                                                                                 | result | expectedResult
+    ["url": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/"]        | [:]    | ["job": "SPINNAKER-package-echo", "buildNumber": "69", "buildInfoUrl": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/", "buildHost": "http://spinnaker.jenkis.test.netflix.net/"]
+    ["url": "http://spinnaker.jenkis.test.netflix.net/job/folderSPINNAKER/job/SPINNAKER/69/"] | [:]    | ["job": "folderSPINNAKER/job/SPINNAKER", "buildNumber": "69", "buildInfoUrl": "http://spinnaker.jenkis.test.netflix.net/job/folderSPINNAKER/job/SPINNAKER/69/", "buildHost": "http://spinnaker.jenkis.test.netflix.net/"]
+    ["url": "http://jenkins.com/job/folder/job/job name/123"]                                 | [:]    | ["job": "folder/job/job name", "buildNumber": "123", "buildInfoUrl": "http://jenkins.com/job/folder/job/job name/123", "buildHost": "http://jenkins.com/"]
+  }
+
+  @Unroll
+  def "Extract detail, missing fields and edge cases"() {
+
+    when:
+    buildDetailExtractor.tryToExtractBuildDetails(buildInfo, result)
+
+    then:
+    result == expectedResult
+
+    where:
+    buildInfo                                                                                               | result | expectedResult
+    ["name": "SPINNAKER", "url": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/"] | [:]    | ["job": "SPINNAKER-package-echo", "buildNumber": "69", "buildInfoUrl": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/", "buildHost": "http://spinnaker.jenkis.test.netflix.net/"]
+    ["name": "compose/SPINNAKER", "number": "9001", "url": null]                                            | [:]    | [:]
+    ["number": "9001"]                                                                                      | [:]    | [:]
+    [:]                                                                                                     | [:]    | [:]
+    null                                                                                                    | [:]    | [:]
+  }
+}


### PR DESCRIPTION
Part of a series of PR adding build info support for travis integration on AWS
by adding new build_info_url tag to the images in order to be able to full fill the build info correctly for travis.

This PR adds a build_info_url BakeRequest from Orca to Rosco
Rosco will add the build_infor_url as a ec2 tag.

This is the final result
![screen shot 2016-06-02 at 10 11 01](https://cloud.githubusercontent.com/assets/10425379/15742052/f7728296-28bc-11e6-8e98-40ece551ce62.png)

Related PRs
https://github.com/spinnaker/rosco/pull/102
https://github.com/spinnaker/clouddriver/pull/652
https://github.com/spinnaker/deck/pull/2304