### PR TITLE
Fix for build stage with empty package name.

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
@@ -21,7 +21,9 @@ import com.google.common.annotations.VisibleForTesting
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.transform.CompileDynamic
+import groovy.util.logging.Slf4j
 
+@Slf4j
 class PackageInfo {
   ObjectMapper mapper
   Stage stage
@@ -77,7 +79,7 @@ class PackageInfo {
     List<Map> triggerArtifacts = trigger?.buildInfo?.artifacts ?: trigger?.parentExecution?.trigger?.buildInfo?.artifacts
     List<Map> buildArtifacts = buildInfo?.artifacts
 
-    if (isUrl(request.package)) {
+    if (isUrl(request.package) || request.package?.isEmpty()) {
       return request
     }
 


### PR DESCRIPTION
This is to take care of a use case for Google to allow the build stage to have an empty package name, and not extract a package name from the trigger context or stage generated artifacts.

@duftler PTAL and let me know if this doesn't fix your issue.