### PR TITLE
cloneServerGroupTask ami handling updates

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
@@ -124,7 +124,7 @@ class AmazonServerGroupCreator implements ServerGroupCreator, DeploymentDetailsA
 
   def allowLaunchOperations(Map createServerGroupOp) {
     def ops = []
-    if (createServerGroupOp.amiName && createServerGroupOp.availabilityZones && createServerGroupOp.credentials != defaultBakeAccount) {
+    if (createServerGroupOp.availabilityZones && createServerGroupOp.credentials != defaultBakeAccount) {
       ops.addAll(createServerGroupOp.availabilityZones.collect { String region, List<String> azs ->
         [account    : createServerGroupOp.credentials,
          credentials: defaultBakeAccount,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTask.groovy
@@ -49,8 +49,8 @@ class DetermineSourceServerGroupTask implements RetryableTask {
   @Override
   TaskResult execute(Stage stage) {
     def stageData = stage.mapTo(StageData)
-    if (!stageData.region && !stageData.availabilityZones) {
-      throw new IllegalStateException("No 'region' or 'availabilityZones' in stage context")
+    if (!stageData.source && !stageData.region && !stageData.availabilityZones) {
+      throw new IllegalStateException("No 'source' or 'region' or 'availabilityZones' in stage context")
     }
     Exception lastException = null
     try {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreatorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreatorSpec.groovy
@@ -102,18 +102,6 @@ class AmazonServerGroupCreatorSpec extends Specification {
       operations.findAll { it.containsKey("allowLaunchDescription") }.empty
   }
 
-  def "don't create allowLaunch tasks when no amiName present"() {
-    given:
-    deployConfig.amiName = null
-
-    when:
-    def operations = creator.getOperations(stage)
-
-    then:
-    operations.findAll { it.containsKey("allowLaunchDescription") }.empty
-  }
-
-
   def "can include optional parameters"() {
     given:
       stage.context.stack = stackValue

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTaskSpec.groovy
@@ -103,6 +103,22 @@ class DetermineSourceServerGroupTaskSpec extends Specification {
     notThrown(IllegalStateException)
   }
 
+  void 'should NOT fail if there is source and no region and no availabilityZones in context'() {
+    given:
+    Stage stage = new PipelineStage(new Pipeline(), 'deploy', 'deploy', [
+      account    : 'test',
+      source: [ region    : 'us-east-1', account: 'test', asgName: 'foo-test-v000' ],
+      application: 'foo'])
+
+    def resolver = Mock(SourceResolver)
+
+    when:
+    new DetermineSourceServerGroupTask(sourceResolver: resolver).execute(stage)
+
+    then:
+    notThrown(IllegalStateException)
+  }
+
   void 'should fail if there is no availabilityZones and no region in context'() {
     given:
     Stage stage = new PipelineStage(new Pipeline(), 'deploy', 'deploy', [
@@ -116,7 +132,7 @@ class DetermineSourceServerGroupTaskSpec extends Specification {
 
     then:
     def ex = thrown(IllegalStateException)
-    ex.message == "No 'region' or 'availabilityZones' in stage context"
+    ex.message == "No 'source' or 'region' or 'availabilityZones' in stage context"
   }
 
   void 'should retry on exception from source resolver'() {


### PR DESCRIPTION
Should not fail, but should not inject an allowLaunch operation for a clone with no amiName
Uses DeploymentDetailsAware trait to resolve an image rather than looking only for a preceeding bake (allow clone in a pipeline)
Reverts a change to AmazonServerGroupCreator that was checking for null amiName - that path is only used during a createServerGroup