### PR TITLE
(aws) watch for appended security groups in monitor task

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonSecurityGroupUpserter.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonSecurityGroupUpserter.groovy
@@ -94,6 +94,9 @@ class AmazonSecurityGroupUpserter implements SecurityGroupUpserter, CloudProvide
       Set mortSecurityGroupIngress = filterForSecurityGroupIngress(mortService, existingSecurityGroup) as Set
       Set targetSecurityGroupIngress = Arrays.asList(stage.mapTo("/securityGroupIngress",
                                                                  MortService.SecurityGroup.SecurityGroupIngress[]))
+      if (stage.context.ingressAppendOnly) {
+        return mortSecurityGroupIngress.containsAll(targetSecurityGroupIngress)
+      }
       return mortSecurityGroupIngress == targetSecurityGroupIngress
     } catch (RetrofitError e) {
       if (e.response?.status != 404) {


### PR DESCRIPTION
The monitor task will never complete if performed from an API call, since it's looking for all the declared ingress rules. This takes care of that case.