### PR TITLE
SPIN-1840: Fix Instance Rebooting

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTask.groovy
@@ -53,9 +53,7 @@ abstract class AbstractWaitForInstanceHealthChangeTask implements RetryableTask 
 
     def stillRunning = instanceIds.find {
       def instance = getInstance(account, region, it)
-      def healths = HealthHelper.filterHealths(instance, healthProviderTypesToCheck)
-
-      return !hasSucceeded(healths)
+      return !hasSucceeded(instance, healthProviderTypesToCheck)
     }
 
     return new DefaultTaskResult(stillRunning ? ExecutionStatus.RUNNING : ExecutionStatus.SUCCEEDED)
@@ -70,5 +68,5 @@ abstract class AbstractWaitForInstanceHealthChangeTask implements RetryableTask 
     return objectMapper.readValue(response.body.in().text, Map)
   }
 
-  abstract boolean hasSucceeded(List<Map> healthProviders);
+  abstract boolean hasSucceeded(Map instance, Collection<String> interestedHealthProviderNames);
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForDownInstanceHealthTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForDownInstanceHealthTask.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.instance
 
+import com.netflix.spinnaker.orca.clouddriver.utils.HealthHelper
 import groovy.transform.CompileStatic
 import org.springframework.stereotype.Component
 
@@ -23,13 +24,7 @@ import org.springframework.stereotype.Component
 @CompileStatic
 class WaitForDownInstanceHealthTask extends AbstractWaitForInstanceHealthChangeTask {
   @Override
-  boolean hasSucceeded(List<Map> healthProviders) {
-    if (!healthProviders) {
-      return true
-    }
-
-    boolean someAreDown = healthProviders.any { it.state == 'Down' || it.state == 'OutOfService' }
-    boolean noneAreUp = !healthProviders.any { it.state == 'Up' }
-    someAreDown && noneAreUp
+  boolean hasSucceeded(Map instance, Collection<String> interestedHealthProviderNames) {
+    return HealthHelper.someAreDownAndNoneAreUp(instance, interestedHealthProviderNames)
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstanceHealthTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstanceHealthTask.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.instance
 
+import com.netflix.spinnaker.orca.clouddriver.utils.HealthHelper
 import groovy.transform.CompileStatic
 import org.springframework.stereotype.Component
 
@@ -23,15 +24,7 @@ import org.springframework.stereotype.Component
 @CompileStatic
 class WaitForUpInstanceHealthTask extends AbstractWaitForInstanceHealthChangeTask {
   @Override
-  boolean hasSucceeded(List<Map> healthProviders) {
-    if (!healthProviders) {
-      return false
-    }
-
-    if (healthProviders.any { it.state != "Up"}) {
-      return false
-    }
-
-    return true
+  boolean hasSucceeded(Map instance, Collection<String> interestedHealthProviderNames) {
+    HealthHelper.someAreUpAndNoneAreDown(instance, interestedHealthProviderNames)
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
@@ -54,13 +54,9 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
     }
 
     def healthyCount = instances.count { Map instance ->
-      List<Map> healths = HealthHelper.filterHealths(instance, interestingHealthProviderNames)
-      boolean someAreUp = healths.any { Map health -> health.state == 'Up' }
-      someAreUp = HealthHelper.areSomeUpConsideringPlatformHealth(healths, interestingHealthProviderNames, someAreUp)
-
-      boolean noneAreDown = !healths.any { Map health -> health.state == 'Down' }
-      someAreUp && noneAreDown
+      HealthHelper.someAreUpAndNoneAreDown(instance, interestingHealthProviderNames)
     }
+
     log.info("${serverGroup.name}: Instances up check - healthy: $healthyCount, target: $targetDesiredSize")
     return healthyCount >= targetDesiredSize
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForAllInstancesDownTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForAllInstancesDownTask.groovy
@@ -32,21 +32,7 @@ class WaitForAllInstancesDownTask extends AbstractWaitingForInstancesTask {
     }
 
     instances.every { instance ->
-      List<Map> healths = HealthHelper.filterHealths(instance, interestingHealthProviderNames)
-
-      if (!interestingHealthProviderNames && !healths) {
-        // No health indications (and no specific providers to check), consider instance to be down.
-        return true
-      }
-
-      if (HealthHelper.isDownConsideringPlatformHealth(healths)) {
-        return true
-      }
-
-      boolean someAreDown = healths.any { it.state == 'Down' || it.state == 'OutOfService' }
-      boolean noneAreUp = !healths.any { it.state == 'Up' }
-
-      return someAreDown && noneAreUp
+      return HealthHelper.someAreDownAndNoneAreUp(instance, interestingHealthProviderNames)
     }
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/HealthHelper.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/HealthHelper.groovy
@@ -82,4 +82,33 @@ class HealthHelper {
       health.healthClass == 'platform'
     } as Map
   }
+
+
+  static boolean someAreDownAndNoneAreUp(Map instance, Collection<String> interestingHealthProviderNames) {
+
+    List<Map> healths = filterHealths(instance, interestingHealthProviderNames)
+
+    if (!interestingHealthProviderNames && !healths) {
+      // No health indications (and no specific providers to check), consider instance to be down.
+      return true
+    }
+
+    if (isDownConsideringPlatformHealth(healths)) {
+      return true
+    }
+
+    boolean someAreDown = healths.any { it.state == 'Down' || it.state == 'OutOfService' }
+    boolean noneAreUp = !healths.any { it.state == 'Up' }
+
+    return someAreDown && noneAreUp
+  }
+
+  static boolean someAreUpAndNoneAreDown(Map instance, Collection<String> interestingHealthProviderNames) {
+    List<Map> healths = filterHealths(instance, interestingHealthProviderNames)
+    boolean someAreUp = healths.any { Map health -> health.state == 'Up' }
+    someAreUp = areSomeUpConsideringPlatformHealth(healths, interestingHealthProviderNames, someAreUp)
+
+    boolean noneAreDown = !healths.any { Map health -> health.state == 'Down' }
+    return someAreUp && noneAreDown
+  }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTaskSpec.groovy
@@ -65,7 +65,7 @@ class AbstractWaitForInstanceHealthChangeTaskSpec extends Specification {
     [[instanceId: "1", health: [h("LB", "Down"), h("D", "Down")]]] | null                            | ExecutionStatus.SUCCEEDED
     [[instanceId: "1", health: [h("LB", "Down"), h("D", "Down")]]] | []                              | ExecutionStatus.SUCCEEDED
     [[instanceId: "1", health: [h("LB", "Up"), h("D", "Down")]]]   | ["D"]                           | ExecutionStatus.SUCCEEDED
-    [[instanceId: "1", health: []]]                                | ["D"]                           | ExecutionStatus.SUCCEEDED
+    [[instanceId: "1", health: []]]                                | ["D"]                           | ExecutionStatus.RUNNING
   }
 
   @Unroll

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstanceHealthTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstanceHealthTaskSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.instance
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class WaitForUpInstanceHealthTaskSpec extends Specification {
+  @Unroll("#interestedHealthProviderNames instance: #instance => shouldBeUp: #shouldBeUp")
+  def "test if instance with a given interested health provider name should be considered up"() {
+    expect:
+    new WaitForUpInstanceHealthTask().hasSucceeded(instance, interestedHealthProviderNames) == shouldBeUp
+
+    where:
+    interestedHealthProviderNames || instance                                                                                                            || shouldBeUp
+    []                            || [health: []]                                                                                                        || false
+    []                            || [health: null]                                                                                                      || false
+    ["Amazon"]                    || [health: [[type: "Amazon", healthClass: "platform", state: "Unknown"]]]                                             || true
+    ["Amazon", "Discovery"]       || [health: [[type: "Amazon", healthClass: "platform", state: "Unknown"], [type: "Discovery", state: "Down"]]]         || false
+    ["Amazon", "Discovery"]       || [health: [[type: "Amazon", healthClass: "platform", state: "Unknown"], [type: "Discovery", state: "OutOfService"]]] || true
+    ["Discovery"]                 || [health: [[type: "Discovery", state: "Down"]]]                                                                      || false
+    ["Discovery"]                 || [health: [[type: "Discovery", state: "OutOfService"]]]                                                              || false
+    ["Discovery", "Other"]        || [health: [[type: "Other", state: "Down"]]]                                                                          || false
+    ["Amazon"]                    || [health: []]                                                                                                        || false
+    ["Amazon"]                    || [health: [[type: "Amazon", healthClass: "platform", state: "Up"]]]                                                  || true
+    ["Amazon", "Discovery"]       || [health: [[type: "Amazon", healthClass: "platform", state: "Unknown"], [type: "Discovery", state: "Up"]]]           || true
+    ["Discovery"]                 || [health: [[type: "Discovery", state: "Up"]]]                                                                        || true
+    ["Discovery"]                 || [health: [[type: "Other", state: "Up"]]]                                                                            || false
+    ["Discovery", "Other"]        || [health: [[type: "Other", state: "Up"]]]                                                                            || true
+    ["Discovery"]                 || [health: [[type: "Other", state: "Down"]]]                                                                          || false
+  }
+
+}


### PR DESCRIPTION
The WaitForUpInstanceHealthTask & WaitForDownInstanceHealthTasks would never get into a success state when the Aamzon health state (which is always "Unknown") was used in determining health.

This would cause the "Reboot Instance Task" to hang on these tasks.  The reboot of the instance would complete but the task would appear hung, causing end user confusion.

This fix simply allows success of the tasks if the only health state is Unknown.

In the case of multiple health checks:
For "Up" health check it will accept combinations of "Up" and "Unknown" state for success
For "Down" a combination of "Down", "OutOfService", & "Unknown" state for success