### PR TITLE
Allow missing build info when resolving missing locations.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -169,8 +169,8 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
       }
 
       def deploymentDetailTemplate = imageSummaries.find { k, v -> v != null }.value[0]
-      if (!(deploymentDetailTemplate.image && deploymentDetailTemplate.buildInfo)) {
-        throw new IllegalStateException("Missing image or buildInfo on ${deploymentDetailTemplate}")
+      if (!deploymentDetailTemplate.image) {
+        throw new IllegalStateException("Missing image on ${deploymentDetailTemplate}")
       }
 
       def mkDeploymentDetail = { String imageName, String imageId ->
@@ -179,7 +179,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
           imageName      : imageName,
           serverGroupName: config.cluster,
           image          : deploymentDetailTemplate.image + [imageId: imageId, name: imageName],
-          buildInfo      : deploymentDetailTemplate.buildInfo
+          buildInfo      : deploymentDetailTemplate.buildInfo ?: [:]
         ]
       }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
@@ -228,6 +228,64 @@ class FindImageFromClusterTaskSpec extends Specification {
     ]
   }
 
+  def "should resolve images via find if not all regions exist in source server group without build info"() {
+    given:
+    def pipe = new Pipeline.Builder()
+      .withApplication("contextAppName") // Should be ignored.
+      .build()
+    def stage = new PipelineStage(pipe, "findImage", [
+      resolveMissingLocations: true,
+      cloudProvider    : "cloudProvider",
+      cluster          : "foo-test",
+      account          : "test",
+      selectionStrategy: "LARGEST",
+      onlyEnabled      : "false",
+      regions          : [location1.value, location2.value]
+    ])
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location1.value,
+      "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse1
+    1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location2.value,
+      "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> {
+      throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), null, Map)
+    }
+    1 * oortService.findImage("cloudProvider", "ami-012-name-ebs*", "test", null) >> imageSearchResult
+    assertNorth(result.globalOutputs?.deploymentDetails?.find { it.region == "north" } as Map, [imageName: "ami-012-name-ebs"])
+    assertSouth(result.globalOutputs?.deploymentDetails?.find { it.region == "south" } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
+
+    where:
+    location1 = new Location(type: Location.Type.REGION, value: "north")
+    location2 = new Location(type: Location.Type.REGION, value: "south")
+
+    oortResponse1 = [
+      summaries: [[
+        serverGroupName: "foo-test-v000",
+        imageId        : "ami-012",
+        imageName      : "ami-012-name-ebs",
+        image          : [imageId: "ami-012", name: "ami-012-name-ebs", foo: "bar"]
+      ]]
+    ]
+
+    imageSearchResult = [
+      [
+        imageName: "ami-012-name-ebs",
+        amis     : [
+          "north": ["ami-012"]
+        ]
+      ],
+      [
+        imageName: "ami-012-name-ebs1",
+        amis : [
+          "south": ["ami-234"]
+        ]
+      ]
+    ]
+  }
+
   def "should parse fail strategy error message"() {
     given:
       def stage = new PipelineStage(new Pipeline(), "whatever", [


### PR DESCRIPTION
Build info is not required without `defaultResolveMissingLocations` enabled, so it seems reasonable to not require it with `defaultResolveMissingLocations` enabled as well.