### PR TITLE
Update logrotate file permissions

### DIFF
--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -123,6 +123,7 @@ ospackage {
     into('/etc/logrotate.d')
     user = 'root'
     permissionGroup = 'root'
+    fileMode = 0644
     fileType = CONFIG | NOREPLACE
   }
 }


### PR DESCRIPTION
This change will fix problems where logrotate ignores
/etc/logrotate.d/orca due to 'bad file mode.'

For Spinnaker issue [#904](https://github.com/spinnaker/spinnaker/issues/904)