### PR TITLE
Support propagation the authentication context of a Manual Judgment s…

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStageSpec.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.persistence.jedis.JedisExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
 import org.springframework.batch.core.repository.JobRepository
 import org.springframework.context.ApplicationContext
@@ -43,6 +44,9 @@ import spock.lang.Subject
 class QuickPatchStageSpec extends Specification {
 
   @Shared @AutoCleanup("destroy") EmbeddedRedis embeddedRedis
+
+  @Shared
+  def stageNavigator = new StageNavigator(Mock(ApplicationContext))
 
   def setupSpec() {
     embeddedRedis = EmbeddedRedis.embed()
@@ -72,7 +76,7 @@ class QuickPatchStageSpec extends Specification {
     }
     quickPatchStage.objectMapper = objectMapper
     quickPatchStage.steps = new StepBuilderFactory(Stub(JobRepository), Stub(PlatformTransactionManager))
-    quickPatchStage.taskTaskletAdapter = new TaskTaskletAdapter(executionRepository, [])
+    quickPatchStage.taskTaskletAdapter = new TaskTaskletAdapter(executionRepository, [], stageNavigator)
     quickPatchStage.oortService = oort
     quickPatchStage.bulkQuickPatchStage = bulkQuickPatchStage
     quickPatchStage.INSTANCE_VERSION_SLEEP = 1

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/ResizeAsgStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/ResizeAsgStageSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.orca.kato.pipeline.support.TargetReferenceSupport
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.persistence.jedis.JedisExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
 import org.springframework.batch.core.repository.JobRepository
 import org.springframework.context.ApplicationContext
@@ -38,6 +39,9 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class ResizeAsgStageSpec extends Specification {
+
+  @Shared
+  def stageNavigator = new StageNavigator(Mock(ApplicationContext))
 
   @Shared
   @AutoCleanup("destroy")
@@ -61,7 +65,7 @@ class ResizeAsgStageSpec extends Specification {
 
   def setup() {
     stageBuilder.steps = new StepBuilderFactory(Stub(JobRepository), Stub(PlatformTransactionManager))
-    stageBuilder.taskTaskletAdapter = new TaskTaskletAdapter(executionRepository, [])
+    stageBuilder.taskTaskletAdapter = new TaskTaskletAdapter(executionRepository, [], stageNavigator)
     stageBuilder.applicationContext = Stub(ApplicationContext) {
       getBean(_) >> { Class type -> type.newInstance() }
     }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/AuthenticatedStage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/AuthenticatedStage.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.security.User;
+
+/**
+ * This marker interface allows an implementing StageBuilder to override the default pipeline authentication context.
+ *
+ * @see com.netflix.spinnaker.orca.batch.adapters.TaskTasklet
+ */
+public interface AuthenticatedStage {
+  Optional<User> authenticatedUser(Stage stage);
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/RetryableTaskTasklet.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/RetryableTaskTasklet.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.orca.batch.retry.PollRequiresRetry
 import com.netflix.spinnaker.orca.pipeline.model.Execution.PausedDetails
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import groovy.transform.CompileStatic
 import org.joda.time.Duration
 import org.joda.time.format.PeriodFormat
@@ -50,8 +51,9 @@ class RetryableTaskTasklet extends TaskTasklet {
                        ExecutionRepository executionRepository,
                        List<ExceptionHandler> exceptionHandlers,
                        Registry registry,
+                       StageNavigator stageNavigator,
                        Clock clock = Clock.systemUTC()) {
-    super(task, executionRepository, exceptionHandlers, registry)
+    super(task, executionRepository, exceptionHandlers, registry, stageNavigator)
     this.clock = clock
     this.timeoutMs = task.timeout
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.groovy
@@ -139,8 +139,9 @@ class OrcaConfiguration {
   @Bean
   TaskTaskletAdapter taskTaskletAdapter(ExecutionRepository executionRepository,
                                         List<ExceptionHandler> exceptionHandlers,
+                                        StageNavigator stageNavigator,
                                         Registry registry) {
-    new TaskTaskletAdapter(executionRepository, exceptionHandlers, registry)
+    new TaskTaskletAdapter(executionRepository, exceptionHandlers, stageNavigator, registry)
   }
 
   @Bean

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AbstractStage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AbstractStage.groovy
@@ -60,6 +60,8 @@ abstract class AbstractStage<T extends Execution> implements Stage<T>, Serializa
   List<InjectedStageConfiguration> afterStages = []
   long scheduledTime
 
+  LastModifiedDetails lastModified
+
   @JsonIgnore
   AtomicInteger stageCounter = new AtomicInteger(0)
 
@@ -198,5 +200,11 @@ abstract class AbstractStage<T extends Execution> implements Stage<T>, Serializa
         ((ObjectNode) destNode).replace(fieldName, sourceFieldValue)
       }
     }
+  }
+
+  static class LastModifiedDetails implements Serializable {
+    String user
+    Collection<String> allowedAccounts
+    Long lastModifiedTime
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/ImmutableStageSupport.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/ImmutableStageSupport.groovy
@@ -111,6 +111,11 @@ class ImmutableStageSupport {
     }
 
     @Override
+    AbstractStage.LastModifiedDetails getLastModified() {
+      return self.getLastModified()
+    }
+
+    @Override
     Stage preceding(String type) {
       self.preceding(type)?.asImmutable()
     }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.groovy
@@ -223,4 +223,5 @@ interface Stage<T extends Execution> {
    */
   void resolveStrategyParams()
 
+  AbstractStage.LastModifiedDetails getLastModified()
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/ExecutionCancellationSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/ExecutionCancellationSpec.groovy
@@ -24,13 +24,20 @@ import com.netflix.spinnaker.orca.batch.TaskTaskletAdapter
 import com.netflix.spinnaker.orca.pipeline.LinearStage
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import org.springframework.batch.core.ExitStatus
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.Step
 import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.context.ApplicationContext
+import spock.lang.Shared
+
 import static com.netflix.spinnaker.orca.batch.PipelineInitializerTasklet.initializationStep
 
 class ExecutionCancellationSpec extends AbstractBatchLifecycleSpec {
+  @Shared
+  def stageNavigator = new StageNavigator(Mock(ApplicationContext))
+
   def startTask = Mock(Task)
   def endTask = Mock(Task)
   def detailsTask = Stub(Task) {
@@ -75,7 +82,7 @@ class ExecutionCancellationSpec extends AbstractBatchLifecycleSpec {
       .flow(initializationStep(steps, pipeline))
     def stageBuilder = new CancellationStageBuilder(
       steps: steps,
-      taskTaskletAdapter: new TaskTaskletAdapter(executionRepository, [])
+      taskTaskletAdapter: new TaskTaskletAdapter(executionRepository, [], stageNavigator)
     )
     stageBuilder.applicationContext = applicationContext
     stageBuilder.build(builder, stage).build().build()

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/FailureRecoveryExecutionSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/FailureRecoveryExecutionSpec.groovy
@@ -20,14 +20,20 @@ import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.batch.TaskTaskletAdapter
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import org.springframework.batch.core.ExitStatus
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.context.ApplicationContext
 import spock.lang.Ignore
+import spock.lang.Shared
+
 import static com.netflix.spinnaker.orca.ExecutionStatus.*
 import static com.netflix.spinnaker.orca.batch.PipelineInitializerTasklet.initializationStep
 
 class FailureRecoveryExecutionSpec extends AbstractBatchLifecycleSpec {
+  @Shared
+  def stageNavigator = new StageNavigator(Mock(ApplicationContext))
 
   def startTask = Stub(Task)
   def recoveryTask = Mock(Task)
@@ -79,7 +85,7 @@ class FailureRecoveryExecutionSpec extends AbstractBatchLifecycleSpec {
         startTask: startTask,
         recoveryTask: recoveryTask,
         endTask: endTask,
-        taskTaskletAdapter: new TaskTaskletAdapter(executionRepository, [])
+        taskTaskletAdapter: new TaskTaskletAdapter(executionRepository, [], stageNavigator)
     ).build(builder, pipeline.namedStage("failureRecovery"))
      .build()
      .build()

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/LinearStageSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/LinearStageSpec.groovy
@@ -25,15 +25,22 @@ import com.netflix.spinnaker.orca.pipeline.LinearStage
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import groovy.transform.CompileStatic
 import org.springframework.batch.core.*
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
 import org.springframework.batch.core.job.builder.FlowBuilder
 import org.springframework.batch.core.job.builder.JobBuilder
 import org.springframework.batch.core.step.AbstractStep
+import org.springframework.context.ApplicationContext
+import spock.lang.Shared
+
 import static com.netflix.spinnaker.orca.batch.PipelineInitializerTasklet.initializationStep
 
 class LinearStageSpec extends AbstractBatchLifecycleSpec {
+  @Shared
+  def stageNavigator = new StageNavigator(Mock(ApplicationContext))
+
   List<StepExecutionListener> listeners = [new StageStatusPropagationListener(executionRepository)]
 
   Map<String, Object> ctx1 = [a: 1]
@@ -149,7 +156,7 @@ class LinearStageSpec extends AbstractBatchLifecycleSpec {
   protected Job configureJob(JobBuilder jobBuilder) {
     def stage = pipeline.namedStage("stage2")
     def builder = jobBuilder.flow(initializationStep(steps, pipeline))
-    def stageBuilder = new InjectStageBuilder(steps, new TaskTaskletAdapter(executionRepository, []))
+    def stageBuilder = new InjectStageBuilder(steps, new TaskTaskletAdapter(executionRepository, [], stageNavigator))
     stageBuilder.applicationContext = applicationContext
     stageBuilder.build(builder, stage).build().build()
   }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/ManualInterventionExecutionSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/ManualInterventionExecutionSpec.groovy
@@ -20,15 +20,21 @@ import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.batch.TaskTaskletAdapter
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import org.springframework.batch.core.ExitStatus
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.job.builder.JobBuilder
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException
+import org.springframework.context.ApplicationContext
 import spock.lang.Ignore
+import spock.lang.Shared
+
 import static com.netflix.spinnaker.orca.ExecutionStatus.*
 import static com.netflix.spinnaker.orca.batch.PipelineInitializerTasklet.initializationStep
 
 class ManualInterventionExecutionSpec extends AbstractBatchLifecycleSpec {
+  @Shared
+  def stageNavigator = new StageNavigator(Mock(ApplicationContext))
 
   def preInterventionTask = Stub(Task)
   def postInterventionTask = Mock(Task)
@@ -120,7 +126,7 @@ class ManualInterventionExecutionSpec extends AbstractBatchLifecycleSpec {
         preInterventionTask: preInterventionTask,
         postInterventionTask: postInterventionTask,
         finalTask: finalTask,
-        taskTaskletAdapter: new TaskTaskletAdapter(executionRepository, [])
+        taskTaskletAdapter: new TaskTaskletAdapter(executionRepository, [], stageNavigator)
     ).build(builder, pipeline.namedStage("manualIntervention"))
      .build()
      .build()

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/StartAndMonitorExecutionSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/lifecycle/StartAndMonitorExecutionSpec.groovy
@@ -20,14 +20,20 @@ import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.batch.TaskTaskletAdapter
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import org.springframework.batch.core.ExitStatus
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.context.ApplicationContext
+import spock.lang.Shared
+
 import static com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
 import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import static com.netflix.spinnaker.orca.batch.PipelineInitializerTasklet.initializationStep
 
 class StartAndMonitorExecutionSpec extends AbstractBatchLifecycleSpec {
+  @Shared
+  def stageNavigator = new StageNavigator(Mock(ApplicationContext))
 
   def startTask = Stub(Task)
   def monitorTask = Mock(Task)
@@ -94,7 +100,7 @@ class StartAndMonitorExecutionSpec extends AbstractBatchLifecycleSpec {
       startTask: startTask,
       detailsTask: detailsTask,
       monitorTask: monitorTask,
-      taskTaskletAdapter: new TaskTaskletAdapter(executionRepository, [])
+      taskTaskletAdapter: new TaskTaskletAdapter(executionRepository, [], stageNavigator)
     )
     stageBuilder.applicationContext = applicationContext
     stageBuilder.build(flowBuilder, pipeline.namedStage("startAndMonitor"))

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/TestStage.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/TestStage.groovy
@@ -22,10 +22,12 @@ import com.netflix.spinnaker.orca.batch.TaskTaskletAdapter
 import com.netflix.spinnaker.orca.pipeline.LinearStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import groovy.transform.CompileStatic
 import org.springframework.batch.core.Step
 import org.springframework.batch.core.StepExecutionListener
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
+import org.springframework.context.support.GenericApplicationContext
 
 /**
  * A stub +Stage+ implementation for unit tests that doesn't need to be Spring-wired in order to work. It will
@@ -39,7 +41,10 @@ class TestStage extends LinearStage {
   TestStage(String name, StepBuilderFactory steps, ExecutionRepository executionRepository, Task... tasks) {
     super(name)
     this.steps = steps
-    this.taskTaskletAdapter = new TaskTaskletAdapter(executionRepository, [])
+
+    def applicationContext = new GenericApplicationContext()
+    applicationContext.refresh()
+    this.taskTaskletAdapter = new TaskTaskletAdapter(executionRepository, [], new StageNavigator(applicationContext))
     this.taskListeners = [
       new StageStatusPropagationListener(executionRepository)
     ] as List<StepExecutionListener>

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineJobBuilderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineJobBuilderSpec.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.orca.pipeline.parallel.PipelineInitializationTask
 import com.netflix.spinnaker.orca.pipeline.parallel.WaitForRequisiteCompletionStage
 import com.netflix.spinnaker.orca.pipeline.parallel.WaitForRequisiteCompletionTask
 import com.netflix.spinnaker.orca.pipeline.persistence.jedis.JedisExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.test.batch.BatchTestConfiguration
 import org.springframework.batch.core.job.builder.FlowJobBuilder
 import org.springframework.batch.core.job.builder.JobBuilderHelper
@@ -38,6 +39,7 @@ import org.springframework.batch.core.job.flow.support.SimpleFlow
 import org.springframework.batch.core.listener.StepExecutionListenerSupport
 import org.springframework.batch.core.repository.support.SimpleJobRepository
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
 import org.springframework.context.support.AbstractApplicationContext
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ContextConfiguration
@@ -53,6 +55,9 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 @DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 class PipelineJobBuilderSpec extends Specification {
   @Shared @AutoCleanup("destroy") EmbeddedRedis embeddedRedis
+
+  @Shared
+  def stageNavigator = new StageNavigator(Mock(ApplicationContext))
 
   def setupSpec() {
     embeddedRedis = EmbeddedRedis.embed()
@@ -71,7 +76,7 @@ class PipelineJobBuilderSpec extends Specification {
 
   def pipelineInitializationStage = new PipelineInitializationStage()
   def waitForRequisiteCompletionStage = new WaitForRequisiteCompletionStage()
-  def taskTaskletAdapter = new TaskTaskletAdapter(executionRepository, [])
+  def taskTaskletAdapter = new TaskTaskletAdapter(executionRepository, [], stageNavigator)
 
   @Shared
   def jobBuilder

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindowSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindowSpec.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.config.OrcaConfiguration
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.test.TestConfiguration
 import com.netflix.spinnaker.orca.test.redis.EmbeddedRedisConfiguration
 import org.springframework.batch.core.Job
@@ -33,6 +34,7 @@ import org.springframework.batch.core.job.builder.JobBuilder
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.test.context.ContextConfiguration
+import spock.lang.Shared
 import spock.lang.Unroll
 
 import java.text.SimpleDateFormat
@@ -45,6 +47,9 @@ import static com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWin
 @Unroll
 @ContextConfiguration(classes = [EmbeddedRedisConfiguration, JesqueConfiguration, OrcaConfiguration, TestConfiguration])
 class RestrictExecutionDuringTimeWindowSpec extends AbstractBatchLifecycleSpec {
+
+  @Shared
+  def stageNavigator = new StageNavigator(Mock(ApplicationContext))
 
   @Autowired ApplicationContext applicationContext;
   def listeners = [new StageStatusPropagationListener(executionRepository)]
@@ -176,7 +181,7 @@ class RestrictExecutionDuringTimeWindowSpec extends AbstractBatchLifecycleSpec {
   protected Job configureJob(JobBuilder jobBuilder) {
     def stage = pipeline.namedStage("stage2")
     def builder = jobBuilder.flow(initializationStep(steps, pipeline))
-    def stageBuilder = new InjectStageBuilder(applicationContext, steps, new TaskTaskletAdapter(executionRepository, []))
+    def stageBuilder = new InjectStageBuilder(applicationContext, steps, new TaskTaskletAdapter(executionRepository, [], stageNavigator))
     stageBuilder.build(builder, stage).build().build()
   }
 

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -236,7 +236,10 @@ class TaskControllerSpec extends Specification {
       ]
     }
     1 * executionRepository.storeStage({ stage ->
-      stage.id == "s1" && stage.context == [
+        stage.id == "s1" &&
+        stage.lastModified.allowedAccounts == [] &&
+        stage.lastModified.user == "anonymous" &&
+        stage.context == [
         judgmentStatus: "stop", value: "1", lastModifiedBy: "anonymous"
       ]
                                        } as PipelineStage)


### PR DESCRIPTION
…tage's approver

 Handles the scenario where a pipeline was triggered by credentials that did not allow
 access to a particular account.

 In such a situation it would be nice if the pipeline could continue to run under the context
 of the individual that approved a manual judgment step.