### PR TITLE
(core) allow limit parameter when retrieving tasks

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -325,13 +325,18 @@ class JedisExecutionRepository implements ExecutionRepository {
           }
         }
       }
+      filteredOrchestrationIds = filteredOrchestrationIds.subList(0, Math.min(criteria.limit, filteredOrchestrationIds.size()))
     }
 
     return retrieveObservable(Orchestration, allOrchestrationsKey, new Func1<String, Iterable<String>>() {
       @Override
       Iterable<String> call(String key) {
         withJedis { Jedis jedis ->
-          return filteredOrchestrationIds != null ? filteredOrchestrationIds : jedis.smembers(key)
+          if (filteredOrchestrationIds != null) {
+            return filteredOrchestrationIds
+          }
+          def unfiltered = jedis.smembers(key).toList()
+          return unfiltered.subList(0, Math.min(criteria.limit, unfiltered.size()))
         }
       }
     }, queryByAppScheduler)

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -64,9 +64,11 @@ class TaskController {
 
   @RequestMapping(value = "/applications/{application}/tasks", method = RequestMethod.GET)
   List<Orchestration> list(@PathVariable String application,
+                           @RequestParam(value = "limit", defaultValue = "2500") int limit,
                            @RequestParam(value = "statuses", required = false) String statuses) {
     statuses = statuses ?: ExecutionStatus.values()*.toString().join(",")
     def executionCriteria = new ExecutionRepository.ExecutionCriteria(
+      limit: limit,
       statuses: (statuses.split(",") as Collection)
     )
 


### PR DESCRIPTION
We have this functionality on pipelines, and we already propagate the `limit` parameter from Gate - we just ignore it.

@ajordens PTAL