### PR TITLE
core: Serialize application task & stage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/serialize/SerializeApplicationStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/serialize/SerializeApplicationStage.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.serialize
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.serialize.SerializeApplicationTask
+import com.netflix.spinnaker.orca.pipeline.LinearStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.apache.commons.jxpath.ri.compiler.Step
+import org.springframework.stereotype.Component
+
+@Component
+class SerializeApplicationStage extends LinearStage {
+
+  public static final String PIPELINE_CONFIG_TYPE = "serializeApplication"
+
+  SerializeApplicationStage() {
+    super(PIPELINE_CONFIG_TYPE)
+  }
+
+  @Override
+  public List<Step> buildSteps(Stage stage) {
+    [
+      buildStep(stage, "serializeApplication", SerializeApplicationTask),
+      buildStep(stage, "monitorSerialization", MonitorKatoTask)
+    ]
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/serialize/SerializeApplicationTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/serialize/SerializeApplicationTask.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.serialize
+
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class SerializeApplicationTask extends AbstractCloudProviderAwareTask implements Task {
+
+  @Autowired
+  KatoService kato
+
+  @Override
+  TaskResult execute(Stage stage) {
+    String cloudProvider = getCloudProvider(stage)
+    String account = getCredentials(stage)
+    def taskId = kato.requestOperations(cloudProvider, [[serializeApplication: stage.context]])
+      .toBlocking()
+      .first()
+    Map outputs = [
+      "notification.type"  : "destroyjob",
+      "kato.last.task.id"  : taskId,
+      "delete.name"        : stage.context.jobName,
+      "delete.region"      : stage.context.region,
+      "delete.account.name": account
+    ]
+    return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, outputs)
+  }
+
+}


### PR DESCRIPTION
Created a stage and task for serializing an application. Modeled it closely after the stages and tasks in orca. I tested it by sending a curl command to gate and it properly forwards the request to clouddriver. @lwander @duftler PTAL.