### PR TITLE
record kato task history while task is running

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
@@ -67,18 +67,19 @@ class MonitorKatoTask implements RetryableTask {
         outputs["deploy.jobs"] = deployed
       }
     }
-    if (status == ExecutionStatus.SUCCEEDED || status == ExecutionStatus.TERMINAL) {
+    if (status == ExecutionStatus.SUCCEEDED || status == ExecutionStatus.TERMINAL || status == ExecutionStatus.RUNNING) {
       List<Map<String, Object>> katoTasks = []
       if (stage.context.containsKey("kato.tasks")) {
         katoTasks = stage.context."kato.tasks" as List<Map<String, Object>>
       }
+      katoTasks.removeIf { it.id == katoTask.id } // replace with updated version
       Map<String, Object> m = [
         id           : katoTask.id,
         status       : katoTask.status,
         history      : katoTask.history,
         resultObjects: katoTask.resultObjects
       ]
-      if (katoTask.resultObjects.find { it.type == "EXCEPTION" }) {
+      if (katoTask.resultObjects?.find { it.type == "EXCEPTION" }) {
         def exception = katoTask.resultObjects.find { it.type == "EXCEPTION" }
         m.exception = exception
       }


### PR DESCRIPTION
I'm really interested in this to present user feedback when performing migrations, since they are long-ish running tasks (up to 30 seconds), and it would be nice to let the user know something is happening.

This pumps the kato task history into the orca task history, updating it as the task progresses.

I asked for this almost two years ago and there were concerns about it, I think, but that was a long time ago.

@cfieber @robfletcher any concerns with this?