### PR TITLE
move quip version determination into a task so it runs at stage execution time not stage evaluation time

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
@@ -16,27 +16,17 @@
 
 package com.netflix.spinnaker.orca.kato.pipeline
 
-import java.util.concurrent.ConcurrentHashMap
-import groovy.util.logging.Slf4j
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.bakery.api.BakeryService
-import com.netflix.spinnaker.orca.clouddriver.InstanceService
-import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import com.netflix.spinnaker.orca.kato.tasks.quip.ResolveQuipVersionTask
 import com.netflix.spinnaker.orca.pipeline.LinearStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.pipeline.util.OperatingSystem
-import com.netflix.spinnaker.orca.pipeline.util.PackageInfo
-import com.netflix.spinnaker.orca.pipeline.util.PackageType
-import com.squareup.okhttp.OkHttpClient
+import groovy.util.logging.Slf4j
 import org.springframework.batch.core.Step
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import retrofit.RestAdapter
-import retrofit.RetrofitError
-import retrofit.client.OkClient
+
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Wrapper stage over BuilkQuickPatchStage.  We do this so we can reuse the same steps whether or not we are doing
@@ -52,26 +42,9 @@ class QuickPatchStage extends LinearStage {
   BulkQuickPatchStage bulkQuickPatchStage
 
   @Autowired
-  OortService oortService
-
-  @Autowired
-  BakeryService bakeryService
-
-  @Value('${bakery.roscoApisEnabled:false}')
-  boolean roscoApisEnabled
-
-  @Value('${bakery.allowMissingPackageInstallation:false}')
-  boolean allowMissingPackageInstallation
-
-  @Autowired
-  ObjectMapper objectMapper
-
-  @Autowired
   OortHelper oortHelper
 
   public static final String PIPELINE_CONFIG_TYPE = "quickPatch"
-
-  private static INSTANCE_VERSION_SLEEP = 10000
 
   QuickPatchStage() {
     super(PIPELINE_CONFIG_TYPE)
@@ -79,103 +52,36 @@ class QuickPatchStage extends LinearStage {
 
   @Override
   List<Step> buildSteps(Stage stage) {
-    List<Step> steps = []
-
-    PackageType packageType
-    if (roscoApisEnabled) {
-      def baseImage = bakeryService.getBaseImage(stage.context.cloudProviderType as String,
-                                                 stage.context.baseOs as String).toBlocking().single()
-      packageType = baseImage.packageType
-    } else {
-      OperatingSystem operatingSystem = OperatingSystem.valueOf(stage.context.baseOs as String)
-      packageType = operatingSystem.packageType
-    }
-    PackageInfo packageInfo = new PackageInfo(stage,
-                                              packageType.packageType,
-                                              packageType.versionDelimiter,
-                                              true /* extractBuildDetails */,
-                                              true /* extractVersion */,
-                                              objectMapper)
-    String version = stage.context?.patchVersion ?:  packageInfo.findTargetPackage(allowMissingPackageInstallation)?.packageVersion
-
-    stage.context.put("version", version) // so the ui can display the discovered package version and we can verify for skipUpToDate
     def instances = getInstancesForCluster(stage)
-
-    if(instances.size() == 0) {
-      // skip since nothing to do
-    } else if(stage.context.rollingPatch) { // rolling means instances in the asg will be updated sequentially
-      instances.each { key, value ->
-        def instance = [:]
-        instance.put(key, value)
+    List<Step> steps = []
+    if (instances) {
+      steps << buildStep(stage, 'foo', ResolveQuipVersionTask)
+      if (stage.context.rollingPatch) {
+        instances.each { key, value ->
+          def instance = [:]
+          instance.put(key, value)
+          def nextStageContext = [:]
+          nextStageContext.putAll(stage.context)
+          nextStageContext << [instances: instance]
+          injectAfter(stage, "bulkQuickPatchStage", bulkQuickPatchStage, nextStageContext)
+        }
+      } else { // quickpatch all instances in the asg at once
         def nextStageContext = [:]
         nextStageContext.putAll(stage.context)
-        nextStageContext << [instances : instance]
-        nextStageContext.put("instanceIds", [key]) // for WaitForDown/UpInstancesTask
+        nextStageContext << [instances: instances]
         injectAfter(stage, "bulkQuickPatchStage", bulkQuickPatchStage, nextStageContext)
       }
-    } else { // quickpatch all instances in the asg at once
-      def nextStageContext = [:]
-      nextStageContext.putAll(stage.context)
-      nextStageContext << [instances : instances]
-      nextStageContext.put("instanceIds", instances.collect {key, value -> key}) // for WaitForDown/UpInstancesTask
-      injectAfter(stage, "bulkQuickPatchStage", bulkQuickPatchStage, nextStageContext)
+    } else {
+      stage.initializationStage = true
+      // mark as SUCCEEDED otherwise a stage w/o child tasks will remain in NOT_STARTED
+      stage.status = ExecutionStatus.SUCCEEDED
     }
-
-    stage.initializationStage = true
-    // mark as SUCCEEDED otherwise a stage w/o child tasks will remain in NOT_STARTED
-    stage.status = ExecutionStatus.SUCCEEDED
     return steps
   }
 
   Map getInstancesForCluster(Stage stage) {
     ConcurrentHashMap instances = new ConcurrentHashMap(oortHelper.getInstancesForCluster(stage.context, null, true, false))
-    ConcurrentHashMap skippedMap = new ConcurrentHashMap()
-
-    if(stage.context.skipUpToDate) {
-      instances.each { instanceId, instanceInfo ->
-        // optionally check the installed package version and skip if == target version
-        if(getAppVersion(instanceInfo.hostName, stage.context.package) == stage.context.version) {
-          skippedMap.put(instanceId, instanceInfo)
-          instances.remove(instanceId)
-        }
-      }
-    }
-
-    stage.context.put("skippedInstances", skippedMap)
     return instances
   }
 
-  String getAppVersion(String hostName, String packageName) {
-    InstanceService instanceService = createInstanceService("http://${hostName}:5050")
-    int retries = 5;
-    def instanceResponse
-    String version
-
-    while(retries) {
-      try {
-        instanceResponse  = instanceService.getCurrentVersion(packageName)
-        version = objectMapper.readValue(instanceResponse.body.in().text, Map)?.version
-      } catch (RetrofitError e) {
-        //retry
-      }
-
-      if(!version || version.isEmpty()) {
-        sleep(INSTANCE_VERSION_SLEEP)
-      } else {
-        break
-      }
-      --retries
-    }
-
-    // instead of failing the stage if we can't detect the version, try to install new version anyway
-    return version
-  }
-
-  InstanceService createInstanceService(String address) {
-    RestAdapter restAdapter = new RestAdapter.Builder()
-      .setEndpoint(address)
-      .setClient(new OkClient(new OkHttpClient(retryOnConnectionFailure: false)))
-      .build()
-    return restAdapter.create(InstanceService.class)
-  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/ResolveQuipVersionTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/ResolveQuipVersionTask.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.tasks.quip
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.bakery.api.BakeryService
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.OperatingSystem
+import com.netflix.spinnaker.orca.pipeline.util.PackageInfo
+import com.netflix.spinnaker.orca.pipeline.util.PackageType
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+import java.util.concurrent.TimeUnit
+
+@Component
+class ResolveQuipVersionTask implements RetryableTask {
+
+  final long backoffPeriod = TimeUnit.SECONDS.toMillis(5)
+
+  final long timeout = TimeUnit.SECONDS.toMillis(30)
+
+  @Autowired
+  BakeryService bakeryService
+
+  @Value('${bakery.roscoApisEnabled:false}')
+  boolean roscoApisEnabled
+
+  @Value('${bakery.allowMissingPackageInstallation:false}')
+  boolean allowMissingPackageInstallation
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  @Override
+  TaskResult execute(Stage stage) {
+    PackageType packageType
+    if (roscoApisEnabled) {
+      def baseImage = bakeryService.getBaseImage(stage.context.cloudProviderType as String,
+        stage.context.baseOs as String).toBlocking().single()
+      packageType = baseImage.packageType
+    } else {
+      OperatingSystem operatingSystem = OperatingSystem.valueOf(stage.context.baseOs as String)
+      packageType = operatingSystem.packageType
+    }
+    PackageInfo packageInfo = new PackageInfo(stage,
+      packageType.packageType,
+      packageType.versionDelimiter,
+      true, // extractBuildDetails
+      true, // extractVersion
+      objectMapper)
+    String version = stage.context?.patchVersion ?:  packageInfo.findTargetPackage(allowMissingPackageInstallation)?.packageVersion
+
+    return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [version: version])
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTask.groovy
@@ -45,19 +45,18 @@ class VerifyQuipTask extends AbstractQuipTask implements Task {
     String cluster = stage.context?.clusterName
     String region = stage.context?.region
     String account = stage.context?.account
-    String app = stage.context?.application
     Map instances = stage.context?.instances
     ArrayList healthProviders = stage.context?.healthProviders
     Map stageOutputs = [:]
     ExecutionStatus executionStatus = ExecutionStatus.SUCCEEDED
-    if (cluster && region && account && healthProviders != null && app && instances) {
+    if (cluster && region && account && healthProviders != null && instances) {
       stageOutputs.put("interestingHealthProviderNames", healthProviders) // for waitForUpInstanceHealthTask
 
       if(!checkInstancesForQuip(instances)) {
         throw new RuntimeException("quip is not running on all instances : ${instances}")
       }
     } else {
-      throw new RuntimeException("one or more of these parameters is missing : cluster || region || account || healthProviders || app")
+      throw new RuntimeException("one or more of these parameters is missing : cluster || region || account || healthProviders")
     }
     return new DefaultTaskResult(executionStatus, stageOutputs, [:])
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStageSpec.groovy
@@ -16,302 +16,125 @@
 
 package com.netflix.spinnaker.orca.kato.pipeline
 
-import com.netflix.spectator.api.NoopRegistry
-import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
-import com.netflix.spinnaker.orca.batch.TaskTaskletAdapter
-import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
-import com.netflix.spinnaker.orca.clouddriver.InstanceService
-import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
-import com.netflix.spinnaker.orca.pipeline.persistence.jedis.JedisExecutionRepository
-import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
-import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
-import org.springframework.batch.core.repository.JobRepository
-import org.springframework.context.ApplicationContext
-import org.springframework.transaction.PlatformTransactionManager
-import redis.clients.jedis.Jedis
-import redis.clients.util.Pool
-import retrofit.RetrofitError
-import retrofit.client.Response
-import retrofit.mime.TypedByteArray
-import spock.lang.AutoCleanup
-import spock.lang.Shared
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.transform.InheritConstructors
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.StepExecutionListener
 import spock.lang.Specification
 import spock.lang.Subject
 
 class QuickPatchStageSpec extends Specification {
 
-  @Shared @AutoCleanup("destroy") EmbeddedRedis embeddedRedis
-
-  @Shared
-  def stageNavigator = new StageNavigator(Mock(ApplicationContext))
-
-  def setupSpec() {
-    embeddedRedis = EmbeddedRedis.embed()
-  }
-
-  def cleanup() {
-    embeddedRedis.jedis.withCloseable { it.flushDB() }
-  }
-
-  Pool<Jedis> jedisPool = embeddedRedis.pool
-
-  @Subject quickPatchStage = Spy(QuickPatchStage)
-  def oort = Mock(OortService)
-
   def oortHelper = Mock(OortHelper)
-  def bulkQuickPatchStage = Spy(BulkQuickPatchStage)
+  def bulkQuickPatchStage = Mock(BulkQuickPatchStage)
+  def step = Stub(Step)
 
-  def objectMapper = new OrcaObjectMapper()
-  def executionRepository = new JedisExecutionRepository(new NoopRegistry(), jedisPool, 1, 50)
-  InstanceService instanceService = Mock(InstanceService)
+  @Subject quickPatchStage = new NoBatchQuickPatchStage(oortHelper: oortHelper, bulkQuickPatchStage: bulkQuickPatchStage, step: step)
 
-  void setup() {
-    GroovyMock(OortHelper, global: true)
-
-    quickPatchStage.applicationContext = Stub(ApplicationContext) {
-      getBean(_) >> { Class type -> type.newInstance() }
-    }
-    quickPatchStage.objectMapper = objectMapper
-    quickPatchStage.steps = new StepBuilderFactory(Stub(JobRepository), Stub(PlatformTransactionManager))
-    quickPatchStage.taskTaskletAdapter = new TaskTaskletAdapter(executionRepository, [], stageNavigator)
-    quickPatchStage.oortService = oort
-    quickPatchStage.bulkQuickPatchStage = bulkQuickPatchStage
-    quickPatchStage.INSTANCE_VERSION_SLEEP = 1
-    quickPatchStage.oortHelper = oortHelper
-  }
-
-  def "quick patch can't run due to too many asgs"() {
+  def "no-ops if there are no instances"() {
     given:
-    def config = [
-      application: "deck",
-      clusterName: "deck-cluster",
-      account    : "account",
-      region     : "us-east-1",
-      baseOs     : "ubuntu"
-    ]
+    def stage = new PipelineStage(new Pipeline(), "quickPatch", context)
 
-    and:
-    def stage = new PipelineStage(new Pipeline(), "quickPatch", config)
-    stage.beforeStages = new NeverClearedArrayList()
-    stage.afterStages = new NeverClearedArrayList()
+    expect:
+    !stage.initializationStage
+    stage.status == ExecutionStatus.NOT_STARTED
 
     when:
-    quickPatchStage.buildSteps(stage)
+    def steps = quickPatchStage.buildSteps(stage)
 
     then:
-    1 * oortHelper.getInstancesForCluster(config, null, true, false) >> { throw new RuntimeException("too many asgs!") }
-
-    and:
-    thrown(RuntimeException)
+    1 * oortHelper.getInstancesForCluster(_, null, true, false) >> [:]
+    steps.isEmpty()
+    stage.initializationStage
+    stage.status == ExecutionStatus.SUCCEEDED
+    0 * _
 
     where:
-    asgNames = ["deck-prestaging-v300", "deck-prestaging-v303", "deck-prestaging-v304"]
+    context = [:]
   }
-
   def "configures bulk quickpatch"() {
     given:
-    def config = [
-      application: "deck",
-      clusterName: "deck-cluster",
-      account    : "account",
-      region     : "us-east-1",
-      baseOs     : "ubuntu"
-    ]
-
-    and:
-    1 * oortHelper.getInstancesForCluster(config, null, true, false) >> expectedInstances
-
-    def stage = new PipelineStage(new Pipeline(), "quickPatch", config)
-    stage.beforeStages = new NeverClearedArrayList()
-    stage.afterStages = new NeverClearedArrayList()
+    def stage = new PipelineStage(new Pipeline(), "quickPatch", stageContext)
 
     when:
-    quickPatchStage.buildSteps(stage)
+    def steps = quickPatchStage.buildSteps(stage)
 
     then:
-    1 == stage.afterStages.size()
-
-    and:
-    stage.afterStages*.stageBuilder.unique() == [bulkQuickPatchStage]
-
-    and:
-    with(stage.afterStages[0].context) {
-      application == "deck"
-      account == "account"
-      region == "us-east-1"
-      clusterName == "deck-cluster"
-      instanceIds == ["i-1234", "i-2345"]
-      instances.size() == expectedInstances.size()
-      instances.every {
-        it.value.hostName == expectedInstances.get(it.key).hostName
-        it.value.healthCheck == expectedInstances.get(it.key).healthCheck
-      }
+    1 * oortHelper.getInstancesForCluster(_, null, true, false) >> instances
+    steps == [step]
+    !stage.initializationStage
+    stage.status == ExecutionStatus.NOT_STARTED
+    stage.afterStages.size() == 1
+    with(stage.afterStages[0]) {
+      name == "bulkQuickPatchStage"
+      stageBuilder == bulkQuickPatchStage
+      context.instances == instances
     }
+    0 * _
 
     where:
-    asgNames = ["deck-prestaging-v300"]
-    instance1 = [instanceId: "i-1234", publicDnsName: "foo.com", health: [[foo: "bar"], [healthCheckUrl: "http://foo.com:7001/healthCheck"]]]
-    instance2 = [instanceId: "i-2345", publicDnsName: "foo2.com", health: [[foo2: "bar"], [healthCheckUrl: "http://foo2.com:7001/healthCheck"]]]
-    expectedInstances = ["i-1234": [hostName: "foo.com", healthCheckUrl: "http://foo.com:7001/healthCheck"], "i-2345": [hostName: "foo2.com", healthCheckUrl: "http://foo.com:7001/healthCheck"]]
+    instances = (1..10).collect(this.&mkInstance).collectEntries { [(it.instanceId):it] }
+    stageContext = [
+      rollingPatch: false
+    ]
   }
 
   def "configures rolling quickpatch"() {
     given:
-    def stage = new PipelineStage(new Pipeline(), "quickPatch", config)
-    stage.beforeStages = new NeverClearedArrayList()
-    stage.afterStages = new NeverClearedArrayList()
+    def stage = new PipelineStage(new Pipeline(), "quickPatch", stageContext)
 
     when:
-    quickPatchStage.buildSteps(stage)
+    def steps = quickPatchStage.buildSteps(stage)
 
     then:
-    1 * oortHelper.getInstancesForCluster(config, null, true, false) >> expectedInstances
-
-    and:
-    2 == stage.afterStages.size()
-
-    and:
-    stage.afterStages*.stageBuilder.unique() == [bulkQuickPatchStage]
-
-    and:
-    with(stage.afterStages[0].context) {
-      application == "deck"
-      account == "account"
-      region == "us-east-1"
-      clusterName == config.clusterName
-      instanceIds == ["i-1234"]
-      instances.size() == 1
-      instances.every {
-        it.value.hostName == expectedInstances.get(it.key).hostName
-        it.value.healthCheck == expectedInstances.get(it.key).healthCheck
+    1 * oortHelper.getInstancesForCluster(_, null, true, false) >> instances
+    steps == [step]
+    !stage.initializationStage
+    stage.status == ExecutionStatus.NOT_STARTED
+    stage.afterStages.size() == instances.size()
+    def stageInstances = [] as Set
+    stage.afterStages.each {
+      with(it) {
+        name == "bulkQuickPatchStage"
+        stageBuilder == bulkQuickPatchStage
+        context.instances.size() == 1
+        stageInstances.addAll(context.instances.keySet()) == true
       }
     }
-
-    and:
-    with(stage.afterStages[1].context) {
-      application == "deck"
-      account == "account"
-      region == "us-east-1"
-      clusterName == config.clusterName
-      instanceIds == ["i-2345"]
-      instances.size() == 1
-      instances.every {
-        it.value.hostName == expectedInstances.get(it.key).hostName
-        it.value.healthCheck == expectedInstances.get(it.key).healthCheck
-      }
-    }
+    stageInstances.sort() == instances.keySet().sort()
+    0 * _
 
     where:
-    asgNames = ["deck-prestaging-v300"]
-    instance1 = [instanceId: "i-1234", publicDnsName: "foo.com", health: [[foo: "bar"], [healthCheckUrl: "http://foo.com:7001/healthCheck"]]]
-    instance2 = [instanceId: "i-2345", publicDnsName: "foo2.com", health: [[foo2: "bar"], [healthCheckUrl: "http://foo2.com:7001/healthCheck"]]]
-    expectedInstances = ["i-1234": [hostName: "foo.com", healthCheckUrl: "http://foo.com:7001/healthCheck"], "i-2345": [hostName: "foo2.com", healthCheckUrl: "http://foo.com:7001/healthCheck"]]
-
-    config | _
-    [application: "deck", clusterName: "deck-cluster", account: "account", region: "us-east-1", rollingPatch: true, baseOs: "ubuntu"] | _
-    [application: "deck", clusterName: "deck", account: "account", region: "us-east-1", rollingPatch: true, baseOs: "ubuntu"] | _
+    instances = (1..10).collect(this.&mkInstance).collectEntries { [(it.instanceId):it] }
+    stageContext = [
+      rollingPatch: true
+    ]
   }
 
-  def "some instances are skipped due to skipUpToDate"() {
-    given:
-    def config = [
-      application : application,
-      clusterName : "deck-cluster",
-      account     : account,
-      region      : region,
-      baseOs      : "ubuntu",
-      skipUpToDate: true,
-      patchVersion: "1.2",
-      package     : "deck"
+  private Map mkInstance(int id) {
+    [
+      instanceId: "i-$id".toString(),
+      hostName: "h${id}.foo.com",
+      healthCheckUrl: "/health"
     ]
-    def stage = new PipelineStage(null, "quickPatch", config)
-
-    and:
-    stage.beforeStages = new NeverClearedArrayList()
-    stage.afterStages = new NeverClearedArrayList()
-    expectedInstances.size() * quickPatchStage.createInstanceService(_) >> instanceService
-    1 * instanceService.getCurrentVersion(_) >>> new Response(
-      "foo", 200, "ok", [],
-      new TypedByteArray(
-        "application/json",
-        objectMapper.writeValueAsBytes(["version": "1.21"])
-      )
-    )
-    1 * instanceService.getCurrentVersion(_) >>> new Response(
-      "foo", 200, "ok", [],
-      new TypedByteArray(
-        "application/json",
-        objectMapper.writeValueAsBytes(["version": "1.2"])
-      )
-    )
-    when:
-    quickPatchStage.buildSteps(stage)
-
-    then:
-    1 * oortHelper.getInstancesForCluster(config, null, true, false) >> expectedInstances
-
-    and:
-    stage.context.skippedInstances.'i-2345'
-    stage.afterStages.size() == 1
-    with(stage.afterStages[0].context) {
-      application == application
-      account == account
-      region == region
-      clusterName == config.clusterName
-      instanceIds == ["i-1234"]
-      instances.size() == 1
-      instances.every {
-        it.value.hostName == expectedInstances.get(it.key).hostName
-        it.value.healthCheck == expectedInstances.get(it.key).healthCheck
-      }
-    }
-    where:
-    application = "deck"
-    region = "us-east-1"
-    account = "account"
-    asgNames = ["deck-prestaging-v300"]
-    instance1 = [instanceId: "i-1234", publicDnsName: "foo.com", health: [[foo: "bar"], [healthCheckUrl: "http://foo.com:7001/healthCheck"]]]
-    instance2 = [instanceId: "i-2345", publicDnsName: "foo2.com", health: [[foo2: "bar"], [healthCheckUrl: "http://foo2.com:7001/healthCheck"]]]
-    expectedInstances = ["i-1234": [hostName: "foo.com", healthCheckUrl: "http://foo.com:7001/healthCheck"], "i-2345": [hostName: "foo2.com", healthCheckUrl: "http://foo.com:7001/healthCheck"]]
   }
 
-  def "skipUpToDate with getVersion retries"() {
-    given:
-    def config = [
-      application : application,
-      clusterName : "deck-cluster",
-      account     : account,
-      region      : region,
-      baseOs      : "ubuntu",
-      skipUpToDate: true,
-      patchVersion: "1.2",
-      package     : "deck"
-    ]
-    def stage = new PipelineStage(null, "quickPatch", config)
-    1 * quickPatchStage.createInstanceService(_) >> instanceService
-    4 * instanceService.getCurrentVersion(_) >> { throw new RetrofitError(null, null, null, null, null, null, null) }
-    1 * instanceService.getCurrentVersion(_) >>> new Response(
-      "foo", 200, "ok", [],
-      new TypedByteArray(
-        "application/json",
-        objectMapper.writeValueAsBytes(["version": "1.21"])
-      )
-    )
+  /**
+   * This noops out the spring batch aspects of stage building which aren't really a concern for the purposes
+   * of this test
+   */
+  @InheritConstructors
+  static class NoBatchQuickPatchStage extends QuickPatchStage {
+    Step step
 
-    when:
-    quickPatchStage.buildSteps(stage)
-
-    then:
-    1 * oortHelper.getInstancesForCluster(config, null, true, false) >> expectedInstances
-
-    where:
-    application = "deck"
-    region = "us-east-1"
-    account = "account"
-    asgNames = ["deck-prestaging-v300"]
-    expectedInstances = ["i-1234": [hostName: "foo.com", healthCheckUrl: "http://foo.com:7001/healthCheck"]]
+    @Override
+    protected Step buildStep(Stage stage, String taskName, Class<? extends Task> taskType, StepExecutionListener... listeners) {
+      return step
+    }
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.groovy
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import groovy.transform.CompileStatic
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -90,7 +92,7 @@ interface Stage<T extends Execution> {
    * Gets all ancestor stages that satisfy {@code matcher}, including the current stage.
    * @return
    */
-  List<StageNavigator.Result> ancestors(Closure<Boolean> matcher)
+  List<StageNavigator.Result> ancestors(@ClosureParams(value=SimpleType, options="com.netflix.spinnaker.orca.pipeline.model.Stage, com.netflix.spinnaker.orca.batch.StageBuilder") Closure<Boolean> matcher)
 
   /**
    * Gets all ancestor stages, including the current stage.

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/StageNavigator.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/StageNavigator.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.pipeline.util
 
 import com.netflix.spinnaker.orca.batch.StageBuilder
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.transform.Canonical
 import groovy.transform.CompileStatic
 import org.springframework.context.ApplicationContext
 
@@ -38,7 +39,7 @@ class StageNavigator {
       def stageBuilder = stageBuilders.find { it.type == stage.type }
       return matcher.call(stage, stageBuilder)
     }.collect { Stage stage ->
-      new Result(stage: stage, stageBuilder: stageBuilders.find { it.type == stage.type })
+      new Result(stage, stageBuilders.find { it.type == stage.type })
     }
 
     return results
@@ -65,8 +66,10 @@ class StageNavigator {
     }
   }
 
+
+  @Canonical
   static class Result {
-    Stage stage
-    StageBuilder stageBuilder
+    final Stage stage
+    final StageBuilder stageBuilder
   }
 }


### PR DESCRIPTION
the quick patch stage used to do work at stage evaluation time in order to determine how many synthetic stages to add for the rolling patch case

it still does some (it looks up all the instances in the cluster) which is not great, but with this change the resolution of which version to deploy happens in a task

this means that the `bulkQuickPatch` stage now has to handle the "skip if up to date" behaviour, and the retrieval of the version from the context has to traverse back up to the parent stage's context

this change enables a pipeline that has `[some random stages]-->[jenkins stage]-->[quick patch]`