### PR TITLE
Fix for Canaries Timing out

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterAcaTaskTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterAcaTaskTask.groovy
@@ -74,9 +74,10 @@ class RegisterAcaTaskTask implements Task {
   }
 
   private static Long getMonitorTimeout(Map canary) {
+    def timeoutPaddingMin = 120
     def lifetimeHours = canary.canaryConfig.lifetimeHours?.toString() ?: "46"
-    def warmupMinutes = canary.canaryConfig.canaryAnalysisConfig?.beginCanaryAnalysisAfterMins?.toString() ?: "120"
-    int timeoutMinutes = HOURS.toMinutes(lifetimeHours.isInteger() ? lifetimeHours.toInteger() : 46) + (warmupMinutes.isInteger() ? warmupMinutes.toInteger() : 120)
+    def warmupMinutes = canary.canaryConfig.canaryAnalysisConfig?.beginCanaryAnalysisAfterMins?.toString() ?: "0"
+    int timeoutMinutes = HOURS.toMinutes(lifetimeHours.isInteger() ? lifetimeHours.toInteger() : 46) + (warmupMinutes.isInteger() ? warmupMinutes.toInteger() + timeoutPaddingMin : timeoutPaddingMin)
     return MINUTES.toMillis(timeoutMinutes)
   }
 }

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTask.groovy
@@ -78,9 +78,10 @@ class RegisterCanaryTask implements Task {
   }
 
   private static Long getMonitorTimeout(Map canary) {
+    def timeoutPaddingMin = 120
     def lifetimeHours = canary.canaryConfig.lifetimeHours?.toString() ?: "46"
-    def warmupMinutes = canary.canaryConfig.canaryAnalysisConfig?.beginCanaryAnalysisAfterMins?.toString() ?: "120"
-    int timeoutMinutes = HOURS.toMinutes(lifetimeHours.isInteger() ? lifetimeHours.toInteger() : 46) + (warmupMinutes.isInteger() ? warmupMinutes.toInteger() : 120)
+    def warmupMinutes = canary.canaryConfig.canaryAnalysisConfig?.beginCanaryAnalysisAfterMins?.toString() ?: "0"
+    int timeoutMinutes = HOURS.toMinutes(lifetimeHours.isInteger() ? lifetimeHours.toInteger() : 46) + (warmupMinutes.isInteger() ? warmupMinutes.toInteger() + timeoutPaddingMin : timeoutPaddingMin)
     return MINUTES.toMillis(timeoutMinutes)
   }
 }

--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTaskSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTaskSpec.groovy
@@ -161,8 +161,8 @@ class RegisterCanaryTaskSpec extends Specification {
     0             | null          || 2
     1             | null          || 3
     8             | null          || 10
-    1             | 60            || 2
-    1             | 180           || 4
+    1             | 60            || 4
+    1             | 180           || 6
 
     canary = [
       canaryConfig:


### PR DESCRIPTION
There is an edge case when a canary is with both a duration and warm-up periods are set the canary times out before completion.
Basically there was no padding built into the stage timeout time.

This add a 2 hour padding to the time out to allow for the canary to complete and report back before timeout.