### PR TITLE
implement pipeline migration

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/MigratePipelineStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/MigratePipelineStage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline;
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.pipeline.MigratePipelineClustersTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.pipeline.UpdateMigratedPipelineTask;
+import com.netflix.spinnaker.orca.pipeline.LinearStage;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.batch.core.Step;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class MigratePipelineStage extends LinearStage {
+
+  public static final String PIPELINE_CONFIG_TYPE = "migratePipeline";
+
+  MigratePipelineStage() {
+    super(PIPELINE_CONFIG_TYPE);
+  }
+
+  @Override
+  public List<Step> buildSteps(Stage stage) {
+    List<Step> steps = new ArrayList<>();
+    steps.add(buildStep(stage, "migratePipelineClusters", MigratePipelineClustersTask.class));
+    steps.add(buildStep(stage, "monitorMigration", MonitorKatoTask.class));
+    if (!Boolean.TRUE.equals(stage.getContext().get("dryRun"))) {
+      steps.add(buildStep(stage, "updateMigratedPipeline", UpdateMigratedPipelineTask.class));
+    }
+    return steps;
+  }
+
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MigrateTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MigrateTask.java
@@ -31,19 +31,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class MigrateTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+public abstract class MigrateTask extends AbstractCloudProviderAwareTask {
 
   public abstract String getCloudOperationType();
-
-  @Override
-  public long getBackoffPeriod() {
-    return 2000L;
-  }
-
-  @Override
-  public long getTimeout() {
-    return 300000;
-  }
 
   @Autowired
   KatoService kato;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/PipelineClusterExtractor.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/PipelineClusterExtractor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.cluster;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public interface PipelineClusterExtractor {
+
+  String getStageType();
+
+  void updateStageClusters(Map stage, List<Map> replacements);
+
+  List<Map> extractClusters(Map stage);
+
+  static Optional<PipelineClusterExtractor> getExtractor(Map stage, List<PipelineClusterExtractor> extractors) {
+    return extractors.stream().filter(e -> e.getStageType().equals(stage.get("type"))).findFirst();
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/MigratePipelineClustersTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/MigratePipelineClustersTask.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.pipeline;
+
+import com.netflix.spinnaker.orca.DefaultTaskResult;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.KatoService;
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.PipelineClusterExtractor;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class MigratePipelineClustersTask extends AbstractCloudProviderAwareTask {
+
+  @Autowired
+  KatoService katoService;
+
+  @Autowired
+  Front50Service front50Service;
+
+  @Autowired
+  List<PipelineClusterExtractor> extractors;
+
+  @Override
+  public TaskResult execute(Stage stage) {
+
+    Map<String, Object> context = stage.getContext();
+    Optional<Map<String, Object>> pipelineMatch = getPipeline(context);
+
+    if (!pipelineMatch.isPresent()) {
+      return pipelineNotFound(context);
+    }
+
+    List<Map> sources = getSources(pipelineMatch.get());
+    List<Map<String, Map>> operations = generateKatoOperation(context, sources);
+
+    TaskId taskId = katoService.requestOperations(getCloudProvider(stage), operations)
+      .toBlocking()
+      .first();
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put("notification.type", "migratepipelineclusters");
+    outputs.put("kato.last.task.id", taskId);
+    outputs.put("source.pipeline", pipelineMatch.get());
+    return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, outputs);
+  }
+
+  private List<Map> getSources(Map<String, Object> pipeline) {
+    List<Map> stages = (List<Map>) pipeline.getOrDefault("stages", new ArrayList<>());
+    return stages.stream().map(s -> {
+      Optional<PipelineClusterExtractor> extractor = PipelineClusterExtractor.getExtractor(s, extractors);
+      if (extractor.isPresent()) {
+        return extractor.get().extractClusters(s).stream()
+          .map(c -> Collections.singletonMap("cluster", c))
+          .collect(Collectors.toList());
+      }
+      return new ArrayList<Map>();
+    }).flatMap(Collection::stream).collect(Collectors.toList());
+  }
+
+  private List<Map<String, Map>> generateKatoOperation(Map<String, Object> context, List<Map> sources) {
+    Map<String, Object> migrateOperation = new HashMap<>();
+    migrateOperation.put("sources", sources);
+    Map<String, Map> operation = new HashMap<>();
+    operation.put("migrateClusterConfigurations", migrateOperation);
+    addMappings(context, migrateOperation);
+
+    List<Map<String, Map>> operations = new ArrayList<>();
+    operations.add(operation);
+    return operations;
+  }
+
+  private void addMappings(Map<String, Object> context, Map<String, Object> operation) {
+    operation.put("regionMapping", context.getOrDefault("regionMapping", new HashMap<>()));
+    operation.put("accountMapping", context.getOrDefault("accountMapping", new HashMap<>()));
+    operation.put("subnetTypeMapping", context.getOrDefault("subnetTypeMapping", new HashMap<>()));
+    operation.put("iamRoleMapping", context.getOrDefault("iamRoleMapping", new HashMap<>()));
+    operation.put("keyPairMapping", context.getOrDefault("keyPairMapping", new HashMap<>()));
+    operation.put("dryRun", context.getOrDefault("dryRun", false));
+  }
+
+  private Optional<Map<String, Object>> getPipeline(Map<String, Object> context) {
+    String application = (String) context.get("application");
+    String pipelineId = (String) context.get("pipelineConfigId");
+    return front50Service.getPipelines(application).stream()
+      .filter(p -> pipelineId.equals(p.get("id"))).findFirst();
+  }
+
+  private TaskResult pipelineNotFound(Map<String, Object> context) {
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put("exception", "Could not find pipeline with ID " + context.get("pipelineConfigId"));
+    return new DefaultTaskResult(ExecutionStatus.TERMINAL, outputs);
+  }
+
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/UpdateMigratedPipelineTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/UpdateMigratedPipelineTask.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.pipeline;
+
+import com.netflix.spinnaker.orca.DefaultTaskResult;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.PipelineClusterExtractor;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class UpdateMigratedPipelineTask extends AbstractCloudProviderAwareTask {
+
+  @Autowired
+  Front50Service front50Service;
+
+  @Autowired
+  List<PipelineClusterExtractor> extractors;
+
+  @Override
+  public TaskResult execute(Stage stage) {
+    Map<String, Object> context = stage.getContext();
+    Map<String, Object> pipeline = (Map<String, Object>) context.get("source.pipeline");
+
+    List<Map> stages = (List<Map>) pipeline.getOrDefault("stages", new ArrayList<>());
+    List<Map> katoTasks = (List<Map>) context.get("kato.tasks");
+    List<Map> resultObjects = (List<Map>) katoTasks.get(0).get("resultObjects");
+    List<Map> replacements = new ArrayList<>(resultObjects.stream().map(o -> (Map) o.get("cluster")).collect(Collectors.toList()));
+    stages.forEach(s ->
+      PipelineClusterExtractor.getExtractor(s, extractors).ifPresent(e -> e.updateStageClusters(s, replacements))
+    );
+    String newName = (String) context.getOrDefault("newPipelineName", pipeline.get("name") + " - migrated");
+    pipeline.put("name", newName);
+    pipeline.remove("id");
+    front50Service.savePipeline(pipeline);
+    String application = (String) context.get("application");
+    Optional<Map<String, Object>> newPipeline = front50Service.getPipelines(application).stream()
+      .filter(p -> newName.equals(p.get("name"))).findFirst();
+    if (!newPipeline.isPresent()) {
+      Map<String, Object> outputs = new HashMap<>();
+      outputs.put("exception", "Pipeline migration was successful but could not find new pipeline with name " + newName);
+      return new DefaultTaskResult(ExecutionStatus.TERMINAL, outputs);
+    }
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put("newPipelineId", newPipeline.get().get("id"));
+    return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, outputs);
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployClusterExtractor.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployClusterExtractor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.pipeline;
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.PipelineClusterExtractor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ParallelDeployClusterExtractor implements PipelineClusterExtractor {
+
+  @Override
+  public String getStageType() {
+    return ParallelDeployStage.PIPELINE_CONFIG_TYPE;
+  }
+
+  @Override
+  public void updateStageClusters(Map stage, List<Map> replacements) {
+    List<Map> clusters = (List<Map>) stage.get("clusters");
+    stage.put("clusters", new ArrayList<>(replacements.subList(0, clusters.size())));
+    replacements.removeAll((List<Map>) stage.get("clusters"));
+  }
+
+  @Override
+  public List<Map> extractClusters(Map stage) {
+    return (List<Map>) stage.getOrDefault("clusters", new ArrayList<Map>());
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MigratePipelineClustersTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MigratePipelineClustersTaskSpec.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import com.netflix.spinnaker.orca.clouddriver.tasks.pipeline.MigratePipelineClustersTask
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.kato.pipeline.ParallelDeployClusterExtractor
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import spock.lang.Specification
+import spock.lang.Subject
+
+class MigratePipelineClustersTaskSpec extends Specification {
+
+  @Subject
+  MigratePipelineClustersTask task = new MigratePipelineClustersTask()
+
+  Front50Service front50Service
+  KatoService katoService
+
+  void setup() {
+    front50Service = Mock()
+    katoService = Mock()
+    task.front50Service = front50Service
+    task.katoService = katoService
+    task.extractors = [new ParallelDeployClusterExtractor()]
+  }
+
+  void 'returns terminal status when pipeline not found'() {
+    when:
+    def result = task.execute(new PipelineStage(null, "migratePipelineCluster", "migrate", [pipelineConfigId: 'abc', application: 'theapp']))
+
+    then:
+    1 * front50Service.getPipelines('theapp') >> [[id: 'def']]
+    result.status == ExecutionStatus.TERMINAL
+    result.stageOutputs.exception == "Could not find pipeline with ID abc"
+  }
+
+  void 'extracts clusters, sends them to clouddriver, and puts pipeline into context for later retrieval'() {
+    given:
+    def pipeline = [
+      id    : 'abc',
+      stages: [
+        [type: 'deploy', clusters: [[id: 1], [id: 2]]],
+        [type: 'not-a-deploy', clusters: [[id: 3], [id: 4]]],
+        [type: 'deploy', clusters: [[id: 5], [id: 6]]]
+      ]
+    ]
+    def context = [
+      pipelineConfigId: 'abc',
+      application     : 'theapp',
+      regionMapping   : ['us-east-1': 'us-west-1']
+    ]
+    def stage = new PipelineStage(null, "mpc", "m", context)
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * front50Service.getPipelines('theapp') >> [pipeline]
+    1 * katoService.requestOperations('aws', {
+      it[0].migrateClusterConfigurations.sources.cluster.id == [1,2,3,4]
+      it[0].migrateClusterConfigurations.regionMapping == ['us-east-1': 'us-west-1']
+    }) >> rx.Observable.from([new TaskId(id: "1")])
+    result.stageOutputs['source.pipeline'] == pipeline
+  }
+
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/UpdateMigratedPipelineTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/UpdateMigratedPipelineTaskSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import com.netflix.spinnaker.orca.clouddriver.tasks.pipeline.UpdateMigratedPipelineTask
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.kato.pipeline.ParallelDeployClusterExtractor
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import spock.lang.Specification
+import spock.lang.Subject
+
+class UpdateMigratedPipelineTaskSpec extends Specification {
+
+  @Subject
+  UpdateMigratedPipelineTask task = new UpdateMigratedPipelineTask()
+
+  Front50Service front50Service
+  KatoService katoService
+  Map pipeline
+
+  void setup() {
+    front50Service = Mock()
+    katoService = Mock()
+    task.front50Service = front50Service
+    task.extractors = [new ParallelDeployClusterExtractor()]
+    pipeline = [
+      id    : 'abc',
+      name  : 'to migrate',
+      stages: [
+        [type: 'deploy', clusters: [[id: 1], [id: 2]]],
+        [type: 'not-a-deploy', clusters: [[id: 3], [id: 4]]],
+        [type: 'deploy', clusters: [[id: 5], [id: 6]]]
+      ]
+    ]
+  }
+
+  void 'applies new clusters to pipeline, removes id, updates name, saves, adds new ID to output'() {
+    when:
+    def context = [
+      application      : 'theapp',
+      "source.pipeline": pipeline,
+      "kato.tasks"     : [
+        [
+          resultObjects: [
+            [cluster: [id: 10]], [cluster: [id: 11]], [cluster: [id: 12]], [cluster: [id: 13]],
+          ]
+        ]
+      ]
+    ]
+    def result = task.execute(new PipelineStage(null, "updatePipeline", "migrate", context))
+
+    then:
+    1 * front50Service.savePipeline({
+      it.id == null
+      it.stages[0].clusters.id == [10, 11]
+      it.stages[1].clusters.id == [3, 4]
+      it.stages[2].clusters.id == [12, 13]
+    })
+    1 * front50Service.getPipelines("theapp") >> [pipeline.clone(), [id: 'def', name: 'to migrate - migrated']]
+    result.status == ExecutionStatus.SUCCEEDED
+  }
+
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployClusterExtractorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployClusterExtractorSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.pipeline
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class ParallelDeployClusterExtractorSpec extends Specification {
+
+  @Shared
+  ParallelDeployClusterExtractor extractor = new ParallelDeployClusterExtractor()
+
+  void 'updateStageClusters replaces existing clusters, removing from queue'() {
+    setup:
+    def queue = [ [id: 1], [id: 2], [id: 3] ]
+    Map stage = [ "clusters": [ [id: 4], [id: 5] ] ]
+
+    when:
+    extractor.updateStageClusters(stage, queue)
+
+    then:
+    stage.clusters == [ [id: 1], [id: 2] ]
+    queue == [ [id: 3] ]
+  }
+
+  void 'extractClusters returns empty list when no clusters present'() {
+    expect:
+    extractor.extractClusters([ id: 4 ]) == []
+  }
+
+  void 'extractClusters returns clusters'() {
+    expect:
+    extractor.extractClusters([ clusters: [[id: 1]], otherStuff: [id: 2]]) == [ [id: 1] ]
+  }
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -43,6 +43,9 @@ interface Front50Service {
   @GET("/pipelines/{application}")
   List<Map<String, Object>> getPipelines(@Path("application") String application)
 
+  @POST("/pipelines")
+  Response savePipeline(@Body Map pipeline)
+
   @GET("/strategies/{application}")
   List<Map<String, Object>> getStrategies(@Path("application") String application)
 

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryPipelineClusterExtractor.java
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryPipelineClusterExtractor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.mine.pipeline;
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.PipelineClusterExtractor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class CanaryPipelineClusterExtractor implements PipelineClusterExtractor {
+  @Override
+  public String getStageType() {
+    return CanaryStage.PIPELINE_CONFIG_TYPE;
+  }
+
+  @Override
+  public void updateStageClusters(Map stage, List<Map> replacements) {
+    List<Map> clusterPairs = (List<Map>) stage.get("clusterPairs");
+    clusterPairs.forEach( pair -> {
+      pair.put("baseline", replacements.remove(0));
+      pair.put("canary", replacements.remove(0));
+    });
+  }
+
+  @Override
+  public List<Map> extractClusters(Map stage) {
+    List<Map> results = new ArrayList<>();
+    List<Map> clusterPairs = (List<Map>) stage.getOrDefault("clusterPairs", new ArrayList<>());
+    clusterPairs.forEach( pair -> {
+      results.add((Map) pair.get("baseline"));
+      results.add((Map) pair.get("canary"));
+    });
+    return results;
+  }
+}

--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryPipelineClusterExtractorSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryPipelineClusterExtractorSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.mine.pipeline
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class CanaryPipelineClusterExtractorSpec extends Specification {
+
+  @Shared
+  CanaryPipelineClusterExtractor extractor = new CanaryPipelineClusterExtractor()
+
+  void 'updateStageClusters replaces existing clusters, removing from queue'() {
+    setup:
+    def queue = [ [id: 1], [id: 2], [id: 3], [id: 4], [id: 5] ]
+    Map stage = [
+      "clusterPairs": [
+        [ "baseline": [id: 6], "canary": [id: 7] ],
+        [ "baseline": [id: 9], "canary": [id: 9] ]
+      ]
+    ]
+
+    when:
+    extractor.updateStageClusters(stage, queue)
+
+    then:
+    queue == [ [id: 5] ]
+    stage.clusterPairs[0].baseline.id == 1
+    stage.clusterPairs[0].canary.id == 2
+    stage.clusterPairs[1].baseline.id == 3
+    stage.clusterPairs[1].canary.id == 4
+  }
+
+  void 'extractClusters returns empty list when no clusters present'() {
+    expect:
+    extractor.extractClusters([ id: 4 ]) == []
+  }
+
+  void 'extractClusters returns clusters in order'() {
+    setup:
+    Map stage = [
+      "clusterPairs": [
+        [ "baseline": [id: 6], "canary": [id: 7] ],
+        [ "baseline": [id: 8], "canary": [id: 9] ]
+      ]
+    ]
+    expect:
+    extractor.extractClusters(stage) == [ [id: 6], [id: 7], [id: 8], [id: 9] ]
+  }
+
+}


### PR DESCRIPTION
Extractor components are responsible for plucking any clusters out of stages, then putting them back into the stages after Clouddriver completes the migration.

@cfieber PTAL