### PR TITLE
Consider `stage.context.region` when determining whether a server gro…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -52,7 +52,6 @@ class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport {
         buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
         buildStep(stage, "destroyServerGroup", DestroyServerGroupTask),
         buildStep(stage, "monitorServerGroup", MonitorKatoTask),
-        buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
         buildStep(stage, "waitForDestroyedServerGroup", WaitForDestroyedServerGroupTask),
       ]
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDestroyedServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDestroyedServerGroupTask.groovy
@@ -46,7 +46,7 @@ class WaitForDestroyedServerGroupTask extends AbstractCloudProviderAwareTask imp
   TaskResult execute(Stage stage) {
     String cloudProvider = getCloudProvider(stage)
     String account = getCredentials(stage)
-    String serverGroupRegion = (stage.context.regions as Collection)?.getAt(0)
+    String serverGroupRegion = (stage.context.regions as Collection)?.getAt(0) ?: stage.context.region
     String serverGroupName = (stage.context.serverGroupName ?: stage.context.asgName) as String // TODO: Retire asgName
     Names names = Names.parseName(serverGroupName)
     try {


### PR DESCRIPTION
…up has been destroyed or not

Removed the second `ServerGroupCacheForceRefreshTask` to pushing more complication into
clouddriver's ClusterCachingAgent ... specifically around folding in OnDemand changes vs. Edda.

This potentially adds ~20-30s to the overall execution time but is arguably simpler.