### PR TITLE
core/bake: Don't strip extraneous attributes from bake requests sent to Netflix's internal bakery.

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -52,9 +52,6 @@ class CreateBakeTask implements RetryableTask {
   @Value('${bakery.roscoApisEnabled:false}')
   boolean roscoApisEnabled
 
-  @Value('${bakery.propagateCloudProviderType:false}')
-  boolean propagateCloudProviderType
-
   @Value('${bakery.allowMissingPackageInstallation:false}')
   boolean allowMissingPackageInstallation
 
@@ -141,16 +138,7 @@ class CreateBakeTask implements RetryableTask {
                                               mapper)
 
     Map requestMap = packageInfo.findTargetPackage(allowMissingPackageInstallation)
-    BakeRequest bakeRequest = mapper.convertValue(requestMap, BakeRequest)
 
-    if (!propagateCloudProviderType) {
-      bakeRequest = bakeRequest.copyWith(cloudProviderType: null)
-    }
-
-    if (!roscoApisEnabled) {
-      bakeRequest = bakeRequest.copyWith(templateFileName: null, extendedAttributes: null, buildInfoUrl: null, instanceType: null)
-    }
-
-    return bakeRequest
+    return mapper.convertValue(requestMap, BakeRequest)
   }
 }


### PR DESCRIPTION
core/bake: Temporarily comment-out logic that strips extraneous attributes from bake requests sent to Netflix's internal bakery.