### PR TITLE
core: getPreviousStageWithImage considers missing cloud provider

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
@@ -52,9 +52,13 @@ trait DeploymentDetailsAware {
   Stage getPreviousStageWithImage(Stage stage, String targetRegion, String targetCloudProvider) {
     getAncestors(stage).find {
       def regions = (it.context.region ? [it.context.region] : it.context.regions) as Set<String>
-      (it.context.containsKey("ami") || it.context.containsKey("amiDetails")) &&
-      (!targetRegion || regions?.contains(targetRegion)) &&
-      (targetCloudProvider == it.context.cloudProvider || targetCloudProvider == it.context.cloudProviderType)
+      def cloudProviderFromContext = it.context.cloudProvider ?: it.context.cloudProviderType
+      boolean hasTargetRegion = !targetRegion || regions?.contains(targetRegion)
+      boolean hasImage = it.context.containsKey("ami") || it.context.containsKey("amiDetails")
+      if (!cloudProviderFromContext) {
+        return hasImage && hasTargetRegion
+      }
+      return hasImage && hasTargetRegion && targetCloudProvider == cloudProviderFromContext
     }
   }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreatorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreatorSpec.groovy
@@ -184,7 +184,7 @@ class AmazonServerGroupCreatorSpec extends Specification {
 
     and:
     def findImageStage =
-      new PipelineStage(stage.execution, "findImage", [regions: [deployRegion], amiDetails: [[ami: amiName]], cloudProvider: "aws"])
+      new PipelineStage(stage.execution, "findImage", [regions: [deployRegion], amiDetails: [[ami: amiName]]])
     findImageStage.id = UUID.randomUUID()
     findImageStage.refId = "1a"
     stage.execution.stages << findImageStage


### PR DESCRIPTION
@duftler does this make sense to you? We're seeing cases where our bake stages do not supply the `cloudProvider` or `cloudProvider` type fields, so we're not picking up an image in downstream deployment stages, which fails the deployment.