### PR TITLE
Continues ACATask Stage if ACA health is UNKNOWN.

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/CompleteCanaryTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/CompleteCanaryTask.groovy
@@ -32,7 +32,7 @@ class CompleteCanaryTask implements Task {
       return new DefaultTaskResult(ExecutionStatus.CANCELED)
     } else if (canary.canaryResult?.overallResult == 'SUCCESS') {
       return new DefaultTaskResult(ExecutionStatus.SUCCEEDED)
-    } else if (stage.context.continueOnUnhealthy && canary.health.health == "UNHEALTHY") {
+    } else if (stage.context.continueOnUnhealthy && canary.health.health in ["UNHEALTHY", "UNKNOWN"]) {
       return new DefaultTaskResult(ExecutionStatus.FAILED_CONTINUE)
     } else {
       throw new IllegalStateException("Canary failed")

--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/tasks/CompleteCanaryTaskSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/tasks/CompleteCanaryTaskSpec.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class CompleteCanaryTaskSpec extends Specification {
 
@@ -59,12 +60,13 @@ class CompleteCanaryTaskSpec extends Specification {
     taskResult.status == ExecutionStatus.SUCCEEDED
   }
 
-  def "Canaries is marked with continueOnUnhealthy and canary IS unhealthy then return ExecutionStatus.FAILED_CONTINUE"() {
+  @Unroll
+  def "Canary is marked with continueOnUnhealthy and canary heath is #health then return ExecutionStatus.FAILED_CONTINUE"() {
     given:
     def stage = new PipelineStage(new Pipeline(), "ACATask", "ACATask", [
       canary: [
         health: [
-            health: "UNHEALTHY"
+            health: health
         ]
       ],
       continueOnUnhealthy: true
@@ -75,6 +77,12 @@ class CompleteCanaryTaskSpec extends Specification {
 
     then:
     taskResult.status == ExecutionStatus.FAILED_CONTINUE
+
+    where:
+    health      | _
+    "UNHEALTHY" | _
+    "UNKNOWN"   | _
+
   }
 
   def "Canaries NOT marked with continueOnUnhealthy and canary IS unhealthy then return throw exception"() {


### PR DESCRIPTION
If continueOnUnhelthy is checked and the ACA has a health status of UNKNOWN the stage
will be marked as FAILED_CONTINUE. Presently this will just throw an IlleagialStateException and cancel the pipeline.

@robfletcher PTAL