### PR TITLE
`FindImageFromTags` should emit `deploymentDetails` to the global con…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
@@ -46,9 +46,11 @@ public class FindImageFromTagsTask extends AbstractCloudProviderAwareTask implem
       .orElseThrow(() -> new IllegalStateException("ImageFinder not found for cloudProvider " + cloudProvider));
 
     StageData stageData = (StageData) stage.mapTo(StageData.class);
+    Collection<ImageFinder.ImageDetails> imageDetails = imageFinder.byTags(stage, stageData.packageName, stageData.tags);
     return new DefaultTaskResult(
       ExecutionStatus.SUCCEEDED,
-      Collections.singletonMap("amiDetails", imageFinder.byTags(stage, stageData.packageName, stageData.tags))
+      Collections.singletonMap("amiDetails", imageDetails),
+      Collections.singletonMap("deploymentDetails", imageDetails)
     );
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/ImageFinder.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/ImageFinder.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.image;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 public interface ImageFinder {
@@ -28,5 +29,14 @@ public interface ImageFinder {
   interface ImageDetails {
     String getImageId();
     String getImageName();
+    JenkinsDetails getJenkins();
+  }
+
+  class JenkinsDetails extends HashMap<String, String> {
+    public JenkinsDetails(String host, String name, String number) {
+      put("host", host);
+      put("name", name);
+      put("number", number);
+    }
   }
 }


### PR DESCRIPTION
…text

- `deck` expects jenkins build info to exist in `deploymentDetails`

![image](https://cloud.githubusercontent.com/assets/388652/17608908/c3190ae2-5fe4-11e6-8c77-79238e7c8768.png)
