### PR TITLE
core: Added a pipeline stage for restoring infrastructure

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/serialize/RestoreSnapshotStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/serialize/RestoreSnapshotStage.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.serialize
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.serialize.RestoreSnapshotTask
+import com.netflix.spinnaker.orca.pipeline.LinearStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.apache.commons.jxpath.ri.compiler.Step
+import org.springframework.stereotype.Component
+
+@Component
+class RestoreSnapshotStage extends LinearStage {
+
+  public static final String PIPELINE_CONFIG_TYPE = "restoreSnapshot"
+
+  RestoreSnapshotStage() {
+    super(PIPELINE_CONFIG_TYPE)
+  }
+
+  @Override
+  public List<Step> buildSteps(Stage stage) {
+    [
+      buildStep(stage, "restoreSnapshot", RestoreSnapshotTask),
+      buildStep(stage, "monitorRestore", MonitorKatoTask)
+    ]
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/serialize/RestoreSnapshotTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/serialize/RestoreSnapshotTask.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.serialize
+
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class RestoreSnapshotTask extends AbstractCloudProviderAwareTask implements Task {
+
+  @Autowired
+  KatoService kato
+
+  @Override
+  TaskResult execute(Stage stage) {
+    String cloudProvider = getCloudProvider(stage)
+    String account = getCredentials(stage)
+    //TODO(nwwebb) emit events to echo for every resource that is being restored or destroyed
+    def taskId = kato.requestOperations(cloudProvider, [[restoreSnapshot: stage.context]])
+      .toBlocking()
+      .first()
+    Map outputs = [
+      "notification.type"       : "restoresnapshot",
+      "kato.last.task.id"       : taskId,
+      "restore.application" : stage.context.applicationName,
+      "restore.snapshot"    : stage.context.snapshotTimestamp,
+      "restore.account.name": account
+    ]
+    return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, outputs)
+  }
+
+}


### PR DESCRIPTION
Added a pipeline stage for restoring infrastructure. Named this deserialization for now to match the serialization pipeline stage, I will soon change them to restoreSnapshot and saveSnapshot to match front50. PTAL @lwander @duftler 