### PR TITLE
retry retrofit requests, include clientRequestId in kato/ops calls

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestService.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver
+
+import com.netflix.spinnaker.orca.clouddriver.model.Task
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import retrofit.http.Body
+import retrofit.http.GET
+import retrofit.http.POST
+import retrofit.http.Path
+import retrofit.http.Query
+import rx.Observable
+
+/**
+ * An interface to the Kato REST API for Amazon cloud. See {@link http://kato.test.netflix.net:7001/manual/index.html}.
+ */
+interface KatoRestService {
+
+  /**
+   * @deprecated Use {@code /{cloudProvider}/ops} instead
+   */
+  @Deprecated
+  @POST("/ops")
+  Observable<TaskId> requestOperations(@Query("clientRequestId") String clientRequestId, @Body Collection<? extends Map<String, Map>> operations)
+
+  @POST("/{cloudProvider}/ops")
+  Observable<TaskId> requestOperations(@Query("clientRequestId") String clientRequestId, @Path("cloudProvider") String cloudProvider,
+                                       @Body Collection<? extends Map<String, Map>> operations)
+
+  @GET("/task")
+  Observable<List<Task>> listTasks()
+
+  @GET("/task/{id}")
+  Observable<Task> lookupTask(@Path("id") String id)
+
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,40 +14,36 @@
  * limitations under the License.
  */
 
-
-
-
-
 package com.netflix.spinnaker.orca.clouddriver
 
 import com.netflix.spinnaker.orca.clouddriver.model.Task
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
 import retrofit.http.Body
-import retrofit.http.GET
-import retrofit.http.POST
-import retrofit.http.Path
 import rx.Observable
 
-/**
- * An interface to the Kato REST API for Amazon cloud. See {@link http://kato.test.netflix.net:7001/manual/index.html}.
- */
-interface KatoService {
+@Component
+class KatoService {
 
-  /**
-   * @deprecated Use {@code /{cloudProvider}/ops} instead
-   */
-  @Deprecated
-  @POST("/ops")
-  Observable<TaskId> requestOperations(@Body Collection<? extends Map<String, Map>> operations)
+  @Autowired
+  private KatoRestService katoRestService
 
-  @POST("/{cloudProvider}/ops")
-  Observable<TaskId> requestOperations(@Path("cloudProvider") String cloudProvider,
-                                       @Body Collection<? extends Map<String, Map>> operations)
+  Observable<TaskId> requestOperations(Collection<? extends Map<String, Map>> operations) {
+    String clientRequestId = UUID.randomUUID().toString()
+    katoRestService.requestOperations(clientRequestId, operations)
+  }
 
-  @GET("/task")
-  Observable<List<Task>> listTasks()
+  Observable<TaskId> requestOperations(String cloudProvider, @Body Collection<? extends Map<String, Map>> operations) {
+    String clientRequestId = UUID.randomUUID().toString()
+    katoRestService.requestOperations(clientRequestId, cloudProvider, operations)
+  }
 
-  @GET("/task/{id}")
-  Observable<Task> lookupTask(@Path("id") String id)
+  Observable<List<Task>> listTasks() {
+    katoRestService.listTasks()
+  }
 
+  Observable<Task> lookupTask(String id) {
+    katoRestService.lookupTask(id)
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.clouddriver.KatoRestService
 import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.MortService
 import com.netflix.spinnaker.orca.clouddriver.OortService
@@ -95,7 +96,7 @@ class CloudDriverConfiguration {
   }
 
   @Bean
-  KatoService katoDeployService(
+  KatoRestService katoDeployService(
     @Value('${kato.baseUrl}') String katoBaseUrl, ObjectMapper mapper) {
     new RestAdapter.Builder()
       .setRequestInterceptor(spinnakerRequestInterceptor)
@@ -105,6 +106,6 @@ class CloudDriverConfiguration {
       .setLog(new RetrofitSlf4jLog(KatoService))
       .setConverter(new JacksonConverter(mapper))
       .build()
-      .create(KatoService)
+      .create(KatoRestService)
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
@@ -28,13 +28,13 @@ import static java.net.HttpURLConnection.HTTP_ACCEPTED
 import static java.net.HttpURLConnection.HTTP_OK
 import static retrofit.RestAdapter.LogLevel.FULL
 
-class KatoServiceSpec extends Specification {
+class KatoRestServiceSpec extends Specification {
 
   @Rule
   HttpServerRule httpServer = new HttpServerRule()
 
   @Subject
-  KatoService service
+  KatoRestService service
 
   RequestInterceptor noopInterceptor = new RequestInterceptor() {
     @Override
@@ -62,7 +62,7 @@ class KatoServiceSpec extends Specification {
     def operation = [:]
 
     expect: "kato should return the details of the task it created"
-    with(service.requestOperations([operation]).toBlocking().first()) {
+    with(service.requestOperations(UUID.randomUUID().toString(), [operation]).toBlocking().first()) {
       it.id == taskId
     }
   }

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
@@ -48,7 +48,7 @@ class RetrofitConfiguration {
    @Value('${okHttpClient.connectionPool.keepAliveDurationMs:300000}')
    int keepAliveDurationMs
 
-   @Value('${okHttpClient.retryOnConnectionFailure:false}')
+   @Value('${okHttpClient.retryOnConnectionFailure:true}')
    boolean retryOnConnectionFailure
 
    @Bean


### PR DESCRIPTION
companion PR to https://github.com/spinnaker/clouddriver/pull/928

Sends a unique identifier to Clouddriver requests so that Clouddriver can dedupe requests in the scenario where Clouddriver successfully performs an operation but its response is dropped.

@spinnaker/netflix-reviewers PTAL