### PR TITLE
Additional sanity checks around jar diffs

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/OortHelper.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/OortHelper.groovy
@@ -157,7 +157,11 @@ class OortHelper {
         throw new RuntimeException("at least one instance is DOWN or in the STARTING state, exiting")
       }
 
-      Map instanceInfo = [hostName : hostName, healthCheckUrl : healthCheckUrl]
+      Map instanceInfo = [
+        hostName : hostName,
+        healthCheckUrl : healthCheckUrl,
+        privateIpAddress: instance.privateIpAddress
+      ]
       instanceMap.put(instance.instanceId, instanceInfo)
     }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTaskSpec.groovy
@@ -114,6 +114,18 @@ class JarDiffsTaskSpec extends Specification {
     result == [ lib1, lib2, lib3 ]
   }
 
+  void "getJarList will short circuit after 5 attempts"() {
+    given:
+    5 * task.createInstanceService("http://bar:8077") >> instanceService
+
+    when:
+    5 * instanceService.getJars() >> {throw new RetrofitError(null, null, null, null, null, null, null)}
+    def result = task.getJarList((1..5).collectEntries { ["${it}": [hostName : "bar"]] })
+
+    then:
+    result.isEmpty()
+  }
+
   void "getJarList stops when finds a jar list"() {
     given:
     1 * task.createInstanceService("http://bar:8077") >> instanceService


### PR DESCRIPTION
- Prefer using privateIpAddress (over host name which may be public)
- Short-circuit after unsuccessfully checking 5 instances