### PR TITLE
Avoid sending fields to the bakery that we shouldn't

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -139,6 +139,19 @@ class CreateBakeTask implements RetryableTask {
 
     Map requestMap = packageInfo.findTargetPackage(allowMissingPackageInstallation)
 
+    if (!roscoApisEnabled) {
+      requestMap.remove("ami")
+      requestMap.remove("ctime")
+      requestMap.remove("mtime")
+      requestMap.remove("history")
+      requestMap.remove("id")
+      requestMap.remove("log")
+      requestMap.remove("status")
+      requestMap.remove("statusId")
+      requestMap.remove("statusUri")
+      requestMap.remove("uri")
+    }
+
     return mapper.convertValue(requestMap, BakeRequest)
   }
 }

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -139,19 +139,10 @@ class CreateBakeTask implements RetryableTask {
 
     Map requestMap = packageInfo.findTargetPackage(allowMissingPackageInstallation)
 
+    def request = mapper.convertValue(requestMap, BakeRequest)
     if (!roscoApisEnabled) {
-      requestMap.remove("ami")
-      requestMap.remove("ctime")
-      requestMap.remove("mtime")
-      requestMap.remove("history")
-      requestMap.remove("id")
-      requestMap.remove("log")
-      requestMap.remove("status")
-      requestMap.remove("statusId")
-      requestMap.remove("statusUri")
-      requestMap.remove("uri")
+      request.other.clear()
     }
-
-    return mapper.convertValue(requestMap, BakeRequest)
+    return request
   }
 }


### PR DESCRIPTION
Because we now use `@JsonAnySetter` we can send all kinds of garbage to the Bakery. Recently we've had problems where `status` gets sent and breaks the bake request.