### PR TITLE
(core) Nest completion details for easy retrieval

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -64,12 +64,12 @@ public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implemen
       switch ((String)job.jobState) {
         case "Succeeded":
           status = ExecutionStatus.SUCCEEDED
-          outputs = job.completionDetails
+          outputs.completionDetails = job.completionDetails
           return
 
         case "Failed":
           status = ExecutionStatus.TERMINAL
-          outputs = job.completionDetails
+          outputs.completionDetails = job.completionDetails
           return
       }
     }


### PR DESCRIPTION
The idea is to make it easier to render the completed job information in the executionDetails view in deck.

@danielpeach FYI @duftler PTAL