### PR TITLE
Added `DetermineHealthProvidersTask` to stages that otherwise rely on…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/AbstractClusterWideClouddriverOperationStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/AbstractClusterWideClouddriverOperationStage.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.cluster
 
+import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideClouddriverTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractWaitForClusterWideClouddriverTask
@@ -51,11 +52,13 @@ abstract class AbstractClusterWideClouddriverOperationStage extends LinearStage 
     String opName = Introspector.decapitalize(name)
     def waitTask = waitForTask
     String waitName = Introspector.decapitalize(getStepName(waitTask.simpleName))
-    [buildStep(stage, opName, operationTask),
-     buildStep(stage, "monitor${name}", MonitorKatoTask),
-     buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
-     buildStep(stage, waitName, waitTask),
-     buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
+    [
+      buildStep(stage, "determineHealthProviders", DetermineHealthProvidersTask),
+      buildStep(stage, opName, operationTask),
+      buildStep(stage, "monitor${name}", MonitorKatoTask),
+      buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
+      buildStep(stage, waitName, waitTask),
+      buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
     ]
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/instance/RebootInstancesStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/instance/RebootInstancesStage.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.instance
 
+import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.RebootInstancesTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForDownInstanceHealthTask
@@ -37,10 +38,11 @@ class RebootInstancesStage extends LinearStage {
 
   @Override
   public List<Step> buildSteps(Stage stage) {
+    def step0 = buildStep(stage, "determineHealthProviders", DetermineHealthProvidersTask)
     def step1 = buildStep(stage, "rebootInstances", RebootInstancesTask)
     def step2 = buildStep(stage, "monitorReboot", MonitorKatoTask)
     def step3 = buildStep(stage, "waitForDownInstances", WaitForDownInstanceHealthTask)
     def step4 = buildStep(stage, "waitForUpInstances", WaitForUpInstanceHealthTask)
-    [step1, step2, step3, step4]
+    [step0, step1, step2, step3, step4]
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage
+import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForUpInstancesTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CloneServerGroupTask
@@ -43,11 +44,12 @@ class CloneServerGroupStage extends AbstractDeployStrategyStage {
   @Override
   List<Step> basicSteps(Stage stage) {
     [
-        buildStep(stage, "cloneServerGroup", CloneServerGroupTask),
-        buildStep(stage, "monitorDeploy", MonitorKatoTask),
-        buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
-        buildStep(stage, "waitForUpInstances", WaitForUpInstancesTask),
-        buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
+      buildStep(stage, "determineHealthProviders", DetermineHealthProvidersTask),
+      buildStep(stage, "cloneServerGroup", CloneServerGroupTask),
+      buildStep(stage, "monitorDeploy", MonitorKatoTask),
+      buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
+      buildStep(stage, "waitForUpInstances", WaitForUpInstancesTask),
+      buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),
     ]
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DisableServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DisableServerGroupStage.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport
+import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.DisableServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
@@ -37,6 +38,7 @@ class DisableServerGroupStage extends TargetServerGroupLinearStageSupport {
   public List<Step> buildSteps(Stage stage) {
     composeTargets(stage)
     [
+      buildStep(stage, "determineHealthProviders", DetermineHealthProvidersTask),
       buildStep(stage, "disableServerGroup", DisableServerGroupTask),
       buildStep(stage, "monitorServerGroup", MonitorKatoTask),
       buildStep(stage, "waitForDownInstances", WaitForAllInstancesDownTask),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/EnableServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/EnableServerGroupStage.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport
+import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForUpInstancesTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.EnableServerGroupTask
@@ -39,6 +40,7 @@ class EnableServerGroupStage extends TargetServerGroupLinearStageSupport {
     composeTargets(stage)
 
     [
+      buildStep(stage, "determineHealthProviders", DetermineHealthProvidersTask),
       buildStep(stage, "enableServerGroup", EnableServerGroupTask),
       buildStep(stage, "monitorServerGroup", MonitorKatoTask),
       buildStep(stage, "waitForUpInstances", WaitForUpInstancesTask),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
 import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ModifyAwsScalingProcessStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport
+import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ResizeServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
@@ -51,6 +52,7 @@ class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
     composeTargets(stage)
 
     return [
+      buildStep(stage, "determineHealthProviders", DetermineHealthProvidersTask),
       buildStep(stage, "resizeServerGroup", ResizeServerGroupTask),
       buildStep(stage, "monitorServerGroup", MonitorKatoTask),
       buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
@@ -17,10 +17,9 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies
 
 import com.netflix.spinnaker.orca.clouddriver.pipeline.AbstractCloudProviderAwareStage
-import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ApplySourceServerGroupCapacityStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
-import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.CaptureSourceServerGroupCapacityTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
 import com.netflix.spinnaker.orca.kato.pipeline.strategy.DetermineSourceServerGroupTask
 import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
 import com.netflix.spinnaker.orca.kato.tasks.DiffTask
@@ -64,7 +63,10 @@ abstract class AbstractDeployStrategyStage extends AbstractCloudProviderAwareSta
     strategy.composeFlow(stage)
 
     // TODO(ttomsu): This is currently an AWS-only stage. I need to add and support the "useSourceCapacity" option.
-    List<Step> steps = [buildStep(stage, "determineSourceServerGroup", DetermineSourceServerGroupTask)]
+    List<Step> steps = [
+      buildStep(stage, "determineSourceServerGroup", DetermineSourceServerGroupTask),
+      buildStep(stage, "determineHealthProviders", DetermineHealthProvidersTask)
+    ]
 
     def stageData = stage.mapTo(StageData)
     deployStagePreProcessors.findAll { it.supports(stage) }.each {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
@@ -62,6 +62,11 @@ class AmazonServerGroupCreator implements ServerGroupCreator, DeploymentDetailsA
     return ops
   }
 
+  @Override
+  Optional<String> getHealthProviderName() {
+    return Optional.of("Amazon")
+  }
+
   def createServerGroupOperation(Stage stage) {
     def operation = [:]
     def context = stage.context

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureServerGroupCreator.groovy
@@ -49,4 +49,9 @@ class AzureServerGroupCreator implements ServerGroupCreator, DeploymentDetailsAw
 
     return [[(ServerGroupCreator.OPERATION): operation]]
   }
+
+  @Override
+  Optional<String> getHealthProviderName() {
+    return Optional.empty()
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.groovy
@@ -78,4 +78,9 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
 
     return [[(ServerGroupCreator.OPERATION): operation]]
   }
+
+  @Override
+  Optional<String> getHealthProviderName() {
+    return Optional.empty()
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreator.groovy
@@ -58,4 +58,9 @@ class GoogleServerGroupCreator implements ServerGroupCreator, DeploymentDetailsA
 
     return [[(ServerGroupCreator.OPERATION): operation]]
   }
+
+  @Override
+  Optional<String> getHealthProviderName() {
+    return Optional.of("Google")
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesServerGroupCreator.groovy
@@ -43,4 +43,9 @@ class KubernetesServerGroupCreator implements ServerGroupCreator {
 
     return [[(OPERATION): operation]]
   }
+
+  @Override
+  Optional<String> getHealthProviderName() {
+    return Optional.empty()
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/openstack/OpenstackServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/openstack/OpenstackServerGroupCreator.groovy
@@ -61,4 +61,9 @@ class OpenstackServerGroupCreator implements ServerGroupCreator, DeploymentDetai
 
     return [[(OPERATION): operation]]
   }
+
+  @Override
+  Optional<String> getHealthProviderName() {
+    return Optional.of("Openstack")
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/titus/TitusServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/titus/TitusServerGroupCreator.groovy
@@ -38,4 +38,8 @@ class TitusServerGroupCreator implements ServerGroupCreator {
   String getCloudProvider() {
     return cloudProvider
   }
+
+  Optional<String> getHealthProviderName() {
+    return Optional.of("Titus")
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCreator.groovy
@@ -40,4 +40,9 @@ interface ServerGroupCreator {
    * @return The cloud provider type that this object supports.
    */
   String getCloudProvider()
+
+  /**
+   * @return The platform health provider name for this cloud provider
+   */
+  Optional<String> getHealthProviderName()
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/DisableAsgStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/DisableAsgStage.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.kato.pipeline
 
 import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.kato.pipeline.support.TargetReferenceLinearStageSupport
@@ -44,11 +45,12 @@ class DisableAsgStage extends TargetReferenceLinearStageSupport {
   public List<Step> buildSteps(Stage stage) {
     composeTargets(stage)
 
+    def step0 = buildStep(stage, "determineHealthProviders", DetermineHealthProvidersTask)
     def step1 = buildStep(stage, "disableAsg", DisableAsgTask)
     def step2 = buildStep(stage, "monitorAsg", MonitorKatoTask)
     def step3 = buildStep(stage, "waitForDownInstances", waitForAllInstancesDownOnDisableTaskType)
     def step4 = buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask)
-    [step1, step2, step3, step4]
+    [step0, step1, step2, step3, step4]
   }
 
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ResizeAsgStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ResizeAsgStage.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.kato.pipeline
 
 import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForCapacityMatchTask
@@ -67,11 +68,12 @@ class ResizeAsgStage extends LinearStage {
       stage.status = ExecutionStatus.SUCCEEDED
       return []
     } else {
+      def step0 = buildStep(stage, "determineHealthProviders", DetermineHealthProvidersTask)
       def step1 = buildStep(stage, "resizeAsg", ResizeAsgTask)
       def step2 = buildStep(stage, "monitorAsg", MonitorKatoTask)
       def step3 = buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask)
       def step4 = buildStep(stage, "waitForCapacityMatch", WaitForCapacityMatchTask)
-      return [step1, step2, step3, step4]
+      return [step0, step1, step2, step3, step4]
     }
   }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStageSpec.groovy
@@ -41,6 +41,7 @@ class AbstractDeployStrategyStageSpec extends Specification {
     given:
       // Step mocks
       Step mockDSSGStep = Stub(Step) { getName() >> "determineSourceServerGroup" }
+      Step mockDHPStep = Stub(Step) { getName() >> "determineHealthProviders" }
       Step mockSupportStep = Stub(Step) { getName() >> "testSupportStep" }
 
       AbstractDeployStrategyStage testStage = Spy(AbstractDeployStrategyStage)
@@ -57,11 +58,13 @@ class AbstractDeployStrategyStageSpec extends Specification {
     then:
       // The actual goings on in the buildStep method are not relevant here, so just replace it.
       1 * testStage.buildStep(*_) >> mockDSSGStep
+      1 * testStage.buildStep(*_) >> mockDHPStep
       1 * testStage.basicSteps(*_) >> [mockSupportStep]
       steps
-      steps.size() == 2
+      steps.size() == 3
       steps[0] == mockDSSGStep
-      steps[1] == mockSupportStep
+      steps[1] == mockDHPStep
+      steps[2] == mockSupportStep
 
     where:
       specifiedStrategy | strategyObject

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTaskSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.tasks
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.AmazonServerGroupCreator
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.gce.GoogleServerGroupCreator
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.kubernetes.KubernetesServerGroupCreator
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.model.Application
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class DetermineHealthProvidersTaskSpec extends Specification {
+  def front50Service = Mock(Front50Service)
+
+  @Subject
+  def task = new DetermineHealthProvidersTask(
+    front50Service,
+    [new KubernetesServerGroupCreator(), new AmazonServerGroupCreator(), new GoogleServerGroupCreator()]
+  )
+
+  @Unroll
+  def "should set interestingHealthProviderNames based on application config"() {
+    given:
+    def stage = new PipelineStage(new Pipeline(), "", stageContext)
+
+    if (application) {
+      1 * front50Service.get("default", application.name) >> application
+    }
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    taskResult.status == ExecutionStatus.SUCCEEDED
+    (taskResult.getStageOutputs() as Map) == expectedStageOutputs
+
+    where:
+    stageContext                                  | application            || expectedStageOutputs
+    [interestingHealthProviderNames: []]          | null                   || [:]
+    [interestingHealthProviderNames: null]        | null                   || [:]
+    [application: "app"]                          | bA("app", true, false) || [interestingHealthProviderNames: ["Amazon"]]
+    [application: "app", cloudProvider: "gce"]    | bA("app", true, false) || [interestingHealthProviderNames: ["Google"]]
+    [application: "app"]                          | bA("app", true, true)  || [:]                                           // no health provider names when platformHealthOnlyShowOverride is true
+    [application: "app", cloudProvider: "random"] | null                   || [:]                                           // no health provider names when cloud provider is unsupported/unknown
+    [application: "app"]                          | null                   || [:]                                           // no health provider names when an exception is raised
+  }
+
+  private static bA(String applicationName, Boolean platformHealthOnly, Boolean platformHealthOnlyShowOverride) {
+    return new Application(
+      name: applicationName,
+      platformHealthOnly: platformHealthOnly,
+      platformHealthOnlyShowOverride: platformHealthOnlyShowOverride
+    )
+  }
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/model/Application.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/model/Application.groovy
@@ -22,24 +22,26 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonIgnore
 
-class Application {
-  String name
-  String description
-  String email
-  String accounts
-  String updateTs
-  String createTs
+public class Application {
+  public String name
+  public String description
+  public String email
+  public String accounts
+  public String updateTs
+  public String createTs
+  public Boolean platformHealthOnly
+  public Boolean platformHealthOnlyShowOverride
 
   private Map<String, Object> details = new HashMap<String, Object>()
 
   @JsonAnyGetter
   public Map<String,Object> details() {
-    return details;
+    return details
   }
 
   @JsonAnySetter
   public void set(String name, Object value) {
-    details.put(name, value);
+    details.put(name, value)
   }
 
   @JsonIgnore


### PR DESCRIPTION
… instance health

`deck` will no longer automatically include `interestingHealthProviderNames` when
`platformHealthOnly` is true.

The expectation is that `orca` will determine whether or not `interestingHealthProviderNames`
are required dynamically at the point in time that an individual stage is executed.

Relates to spinnaker/deck#2615