### PR TITLE
Propagate status correctly on parallel tasks

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/pipeline/DeploymentStrategiesExecutionSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/pipeline/DeploymentStrategiesExecutionSpec.groovy
@@ -41,6 +41,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.parallel.WaitForRequisiteCompletionStage
 import com.netflix.spinnaker.orca.pipeline.parallel.WaitForRequisiteCompletionTask
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.tasks.NoOpTask
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.test.batch.BatchTestConfiguration
 import org.spockframework.spring.xml.SpockMockFactoryBean
@@ -68,7 +69,7 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 @ContextConfiguration(classes = [
   StageNavigator, WaitForRequisiteCompletionTask, Config,
   WaitForRequisiteCompletionStage, ParallelDeployStage, CreateServerGroupStage,
-  TestStrategy, NoStrategy, TestStage
+  TestStrategy, NoStrategy, TestStage, NoOpTask
 ])
 @DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 abstract class DeploymentStrategiesExecutionSpec<R extends ExecutionRunner> extends Specification {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/DefaultTaskResult.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/DefaultTaskResult.groovy
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.orca
 
-import com.google.common.collect.ImmutableMap
 import groovy.transform.CompileStatic
+import com.google.common.collect.ImmutableMap
 
 @CompileStatic
 final class DefaultTaskResult implements TaskResult {
@@ -29,8 +29,8 @@ final class DefaultTaskResult implements TaskResult {
   final DefaultTaskResult SUCCEEDED = new DefaultTaskResult(ExecutionStatus.SUCCEEDED)
 
   final ExecutionStatus status
-  final ImmutableMap<String, Object> outputs
-  final ImmutableMap<String, Object> globalOutputs
+  final ImmutableMap<String, Serializable> outputs
+  final ImmutableMap<String, Serializable> globalOutputs
 
   DefaultTaskResult(ExecutionStatus status) {
     this(status, [:], [:])
@@ -50,7 +50,7 @@ final class DefaultTaskResult implements TaskResult {
   }
 
   @Override
-  ImmutableMap<String, Object> getStageOutputs() {
+  ImmutableMap<String, Serializable> getStageOutputs() {
     return outputs
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
@@ -21,12 +21,13 @@ import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.pipeline.model.*;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import static com.netflix.spinnaker.orca.pipeline.TaskNode.Builder;
+import static com.netflix.spinnaker.orca.pipeline.TaskNode.GraphType.FULL;
 import static java.util.Collections.emptyList;
 
 public interface StageDefinitionBuilder {
 
   default <T extends Execution<T>> TaskNode.TaskGraph buildTaskGraph(Stage<T> stage) {
-    Builder graphBuilder = Builder();
+    Builder graphBuilder = Builder(FULL);
     taskGraph(stage, graphBuilder);
     return graphBuilder.build();
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/tasks/NoOpTask.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/tasks/NoOpTask.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.tasks;
+
+import com.netflix.spinnaker.orca.DefaultTaskResult;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.stereotype.Component;
+import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED;
+
+@Component
+public class NoOpTask implements Task {
+  @Override
+  public TaskResult execute(Stage ignored) {
+    return new DefaultTaskResult(SUCCEEDED);
+  }
+}

--- a/orca-spring-batch/src/main/java/com/netflix/spinnaker/orca/batch/SpringBatchExecutionRunner.java
+++ b/orca-spring-batch/src/main/java/com/netflix/spinnaker/orca/batch/SpringBatchExecutionRunner.java
@@ -259,7 +259,7 @@ public class SpringBatchExecutionRunner extends ExecutionRunnerSupport {
     AtomicReference<Step> loopStart = new AtomicReference<>();
     AtomicReference<Step> loopEnd = new AtomicReference<>();
 
-    planTasks(stage, taskGraph, false, task -> {
+    planTasks(stage, taskGraph, task -> {
       Step step = buildStepForTask(stage, task);
       if (task.isLoopStart()) {
         loopStart.set(step);

--- a/orca-spring-batch/src/test/groovy/com/netflix/spinnaker/orca/batch/SpringBatchExecutionRunnerSpec.groovy
+++ b/orca-spring-batch/src/test/groovy/com/netflix/spinnaker/orca/batch/SpringBatchExecutionRunnerSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.orca.pipeline.ExecutionRunner
 import com.netflix.spinnaker.orca.pipeline.ExecutionRunnerSpec
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.tasks.NoOpTask
 import com.netflix.spinnaker.orca.test.batch.BatchTestConfiguration
 import org.spockframework.spring.xml.SpockMockFactoryBean
 import org.springframework.beans.factory.FactoryBean
@@ -37,7 +38,7 @@ import org.springframework.test.context.ContextConfiguration
 @ContextConfiguration(
   classes = [
     BatchTestConfiguration, TaskTaskletAdapterImpl,
-    SpringBatchExecutionListenerProvider, Config
+    SpringBatchExecutionListenerProvider, Config, NoOpTask
   ]
 )
 class SpringBatchExecutionRunnerSpec extends ExecutionRunnerSpec {

--- a/orca-test/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSpec.groovy
+++ b/orca-test/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSpec.groovy
@@ -42,6 +42,7 @@ import static com.netflix.spinnaker.orca.ExecutionStatus.REDIRECT
 import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import static com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.StageDefinitionBuilderSupport.getType
 import static com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.StageDefinitionBuilderSupport.newStage
+import static com.netflix.spinnaker.orca.pipeline.TaskNode.GraphType.FULL
 import static com.netflix.spinnaker.orca.pipeline.TaskNode.TaskDefinition
 import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_AFTER
 import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_BEFORE
@@ -91,7 +92,7 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
     given:
     def stageDefBuilder = Stub(StageDefinitionBuilder) {
       getType() >> stageType
-      buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("1", Task)])
+      buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("1", Task)])
     }
     @Subject def runner = create(stageDefBuilder)
 
@@ -113,7 +114,7 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
     given:
     def stageDefBuilder = Stub(StageDefinitionBuilder) {
       getType() >> stageType
-      buildTaskGraph(_) >> new TaskNode.TaskGraph((1..numTasks).collect { i -> new TaskDefinition("$i", Task) })
+      buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, (1..numTasks).collect { i -> new TaskDefinition("$i", Task) })
     }
     @Subject def runner = create(stageDefBuilder)
 
@@ -142,7 +143,7 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
       [
         Stub(StageDefinitionBuilder) {
           getType() >> stageType
-          buildTaskGraph() >> new TaskNode.TaskGraph([new TaskDefinition("${stageType}_1", Task)])
+          buildTaskGraph() >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("${stageType}_1", Task)])
           aroundStages(_) >> [preStage1, preStage2]
         },
         Stub(StageDefinitionBuilder) {
@@ -177,7 +178,7 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
       [
         Stub(StageDefinitionBuilder) {
           getType() >> stageType
-          buildTaskGraph() >> new TaskNode.TaskGraph([new TaskDefinition("${stageType}_1", Task)])
+          buildTaskGraph() >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("${stageType}_1", Task)])
           aroundStages(_) >> [postStage1, postStage2]
         },
         Stub(StageDefinitionBuilder) {
@@ -210,16 +211,16 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
     def postStage = after(new PipelineStage(execution, "${stageType}_post"))
     def stageDefBuilder = Stub(StageDefinitionBuilder) {
       getType() >> stageType
-      buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("${stageType}_1", Task)])
+      buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("${stageType}_1", Task)])
       aroundStages(_) >> [preStage, postStage]
     }
     def preStageDefBuilder = Stub(StageDefinitionBuilder) {
       getType() >> "${stageType}_pre"
-      buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("${stageType}_pre_1", Task)])
+      buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("${stageType}_pre_1", Task)])
     }
     def postStageDefBuilder = Stub(StageDefinitionBuilder) {
       getType() >> "${stageType}_post"
-      buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("${stageType}_post_1", Task)])
+      buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("${stageType}_post_1", Task)])
     }
     @Subject def runner = create(stageDefBuilder, preStageDefBuilder, postStageDefBuilder)
 
@@ -245,7 +246,7 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
     and:
     def stageDefinitionBuilder = Stub(StageDefinitionBuilder) {
       getType() >> stageType
-      buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("test", TestTask)])
+      buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("test", TestTask)])
     }
     @Subject runner = create(stageDefinitionBuilder)
 
@@ -273,7 +274,7 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
     def stageDefinitionBuilders = [
       Stub(StageDefinitionBuilder) {
         getType() >> stageType
-        buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("test", TestTask)])
+        buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("test", TestTask)])
         aroundStages(_) >> { Stage<Pipeline> parentStage ->
           [
             newStage(execution, "before_${stageType}_2", "before", [:], parentStage, STAGE_BEFORE),
@@ -284,15 +285,15 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
       },
       Stub(StageDefinitionBuilder) {
         getType() >> "before_${stageType}_1"
-        buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("before_test_1", TestTask)])
+        buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("before_test_1", TestTask)])
       },
       Stub(StageDefinitionBuilder) {
         getType() >> "before_${stageType}_2"
-        buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("before_test_2", TestTask)])
+        buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("before_test_2", TestTask)])
       },
       Stub(StageDefinitionBuilder) {
         getType() >> "after_$stageType"
-        buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("after_test", TestTask)])
+        buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("after_test", TestTask)])
       }
     ]
     @Subject runner = create(*stageDefinitionBuilders)
@@ -346,15 +347,15 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
     def startStageDefinitionBuilder = stageDefinition(startStage.type) { builder -> builder.withTask("test", TestTask) }
     def branchAStageDefinitionBuilder = Stub(StageDefinitionBuilder) {
       getType() >> branchAStage.type
-      buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("test", TestTask)])
+      buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("test", TestTask)])
     }
     def branchBStageDefinitionBuilder = Stub(StageDefinitionBuilder) {
       getType() >> branchBStage.type
-      buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("test", TestTask)])
+      buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("test", TestTask)])
     }
     def endStageDefinitionBuilder = Stub(StageDefinitionBuilder) {
       getType() >> endStage.type
-      buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("test", TestTask)])
+      buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("test", TestTask)])
     }
     @Subject runner = create(startStageDefinitionBuilder, branchAStageDefinitionBuilder, branchBStageDefinitionBuilder, endStageDefinitionBuilder)
 
@@ -445,6 +446,41 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
     contexts = [[region: "a"], [region: "b"]]
   }
 
+  def "does not consider before tasks of an internal parallel stage to complete the stage"() {
+    given:
+    def stage = new PipelineStage(execution, "branching")
+    execution.stages << stage
+
+    executionRepository.retrievePipeline(execution.id) >> execution
+
+    and:
+    def stageDefinitionBuilder = stageDefinition("branching", contexts, { builder ->
+      builder.withTask("start", StartLoopTask)
+    }, { builder ->
+      builder.withTask("branch", TestTask)
+    }, { builder ->
+      builder.withTask("end", EndLoopTask)
+    })
+
+    @Subject runner = create(stageDefinitionBuilder)
+
+    when:
+    runner.start(execution)
+
+    then:
+    with(stage.tasks) {
+      size() == 2
+      first().stageStart
+      !first().stageEnd
+      !last().stageStart
+      last().stageEnd
+    }
+
+    where:
+    execution = Pipeline.builder().withId("1").withParallel(true).build()
+    contexts = [[region: "a"], [region: "b"]]
+  }
+
   @Unroll
   def "parallel stages can optionally rename the base stage"() {
     given:
@@ -490,7 +526,7 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
     and:
     def stageDefinitionBuilder = Stub(StageDefinitionBuilder) {
       getType() >> stageType
-      buildTaskGraph(_) >> new TaskNode.TaskGraph([new TaskDefinition("test", TestTask)])
+      buildTaskGraph(_) >> new TaskNode.TaskGraph(FULL, [new TaskDefinition("test", TestTask)])
     }
     @Subject runner = create(stageDefinitionBuilder)
 


### PR DESCRIPTION
- inject a no-op task if there are no tasks before the parallel part of the stage
- fix handling of status propagation in v2