### PR TITLE
(core) wait for server group during up instance check

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
@@ -27,6 +27,11 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
 
   static final int MIN_ZERO_INSTANCE_RETRY_COUNT = 12
 
+  // We do not want to fail before the server group has been created.
+  boolean waitForUpServerGroup() {
+    return true
+  }
+
   static boolean allInstancesMatch(Stage stage, Map serverGroup, List<Map> instances, Collection<String> interestingHealthProviderNames) {
     if (!(serverGroup?.capacity)) {
       return false
@@ -90,5 +95,4 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
   protected boolean hasSucceeded(Stage stage, Map serverGroup, List<Map> instances, Collection<String> interestingHealthProviderNames) {
     allInstancesMatch(stage, serverGroup, instances, interestingHealthProviderNames)
   }
-
 }


### PR DESCRIPTION
It's possible to have the "wait for up instances to fail" task if a server group isn't caught in the "force cache refresh" preceding it. This is easy to verify by modifying deploy handler to deploy nothing (but report deployment details), causing the "force cache refresh" task to simply report that the server doesn't exist (and attempt to evict it from the cache), which succeeds happily. Finally "wait for up instances" tries to verify that the server group exists, which throws an exception.

This only happens when a no blocking action happens during a deploy stage, and takes around a minute after the deploy for the server group to even show up (ignoring instances).

@ajordens @duftler 