### PR TITLE
Persist `executionEngine` as part of the Execution

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineLauncher.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineLauncher.java
@@ -20,7 +20,9 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,6 +68,7 @@ public class PipelineLauncher extends ExecutionLauncher<Pipeline> {
       .withLimitConcurrent(getBoolean(config, "limitConcurrent"))
       .withKeepWaitingPipelines(getBoolean(config, "keepWaitingPipelines"))
       .withExecutingInstance(currentInstanceId)
+      .withExecutionEngine(Execution.V2_EXECUTION_ENGINE)
       .withNotifications((List<Map<String, Object>>) config.get("notifications"))
       .withId()
       .build();

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarter.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarter.groovy
@@ -56,6 +56,7 @@ class PipelineStarter extends ExecutionStarter<Pipeline> {
       .withLimitConcurrent(config.limitConcurrent as Boolean)
       .withKeepWaitingPipelines(config.keepWaitingPipelines as Boolean)
       .withExecutingInstance(currentInstanceId)
+      .withExecutionEngine(config.executionEngine?.toString())
       .withNotifications((List<Map<String, Object>>) config.notifications)
       .build()
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.groovy
@@ -24,9 +24,14 @@ import static com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED
 
 @CompileStatic
 abstract class Execution<T extends Execution<T>> implements Serializable {
+  public static final String V1_EXECUTION_ENGINE = "v1"
+  public static final String V2_EXECUTION_ENGINE = "v2"
+  public static final String DEFAULT_EXECUTION_ENGINE = V1_EXECUTION_ENGINE
+
   String id
   String application
   String executingInstance
+  String executionEngine = DEFAULT_EXECUTION_ENGINE
 
   Long buildTime
 
@@ -61,6 +66,14 @@ abstract class Execution<T extends Execution<T>> implements Serializable {
   @JsonIgnore
   Set<Object> getBuiltPipelineObjects() {
     return builtPipelineObjects
+  }
+
+  void setExecutionEngine(String executionEngine) {
+    this.executionEngine = executionEngine
+  }
+
+  String getExecutionEngine() {
+    return executionEngine ?: DEFAULT_EXECUTION_ENGINE
   }
 
   static class AuthenticationDetails implements Serializable {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Pipeline.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Pipeline.groovy
@@ -133,6 +133,11 @@ class Pipeline extends Execution<Pipeline> {
       return this
     }
 
+    Builder withExecutionEngine(String executionEngine) {
+      pipeline.executionEngine = executionEngine
+      return this
+    }
+
     Builder withId(id = UUID.randomUUID().toString()) {
       pipeline.id = id
       return this

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -465,6 +465,7 @@ class JedisExecutionRepository implements ExecutionRepository {
       startTime           : execution.startTime?.toString(),
       endTime             : execution.endTime?.toString(),
       executingInstance   : execution.executingInstance,
+      executionEngine     : execution.executionEngine,
       status              : execution.status?.name(),
       authentication      : mapper.writeValueAsString(execution.authentication),
       paused              : mapper.writeValueAsString(execution.paused),
@@ -533,6 +534,7 @@ class JedisExecutionRepository implements ExecutionRepository {
       execution.startTime = map.startTime?.toLong()
       execution.endTime = map.endTime?.toLong()
       execution.executingInstance = map.executingInstance
+      execution.executionEngine = map.executionEngine
       execution.status = map.status ? ExecutionStatus.valueOf(map.status) : null
       execution.authentication = mapper.readValue(map.authentication, Execution.AuthenticationDetails)
       execution.paused = map.paused ? mapper.readValue(map.paused, Execution.PausedDetails) : null

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -17,17 +17,22 @@
 package com.netflix.spinnaker.orca.front50
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.pipeline.PipelineLauncher
 import com.netflix.spinnaker.orca.pipeline.PipelineStarter
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import groovy.util.logging.Slf4j
+import org.springframework.beans.BeansException
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
 import org.springframework.stereotype.Component
 
 @Component
 @Slf4j
-class DependentPipelineStarter {
+class DependentPipelineStarter implements ApplicationContextAware {
+  private ApplicationContext applicationContext
 
   @Autowired
   ObjectMapper objectMapper
@@ -79,7 +84,11 @@ class DependentPipelineStarter {
     def t1 = new Thread(new Runnable() {
       @Override
       public void run() {
-        pipeline = pipelineStarter.start(json)
+        if (parentPipeline.executionEngine == Execution.V2_EXECUTION_ENGINE) {
+          pipeline = pipelineLauncher().start(json)
+        } else {
+          pipeline = pipelineStarter.start(json)
+        }
       }
     })
 
@@ -97,4 +106,16 @@ class DependentPipelineStarter {
 
   }
 
+  /**
+   * There is a circular dependency between DependentPipelineStarter <-> DependentPipelineExecutionListener <->
+   * SpringBatchExecutionListener that prevents a PipelineLauncher from being @Autowired.
+   */
+  PipelineLauncher pipelineLauncher() {
+    return applicationContext.getBean(PipelineLauncher)
+  }
+
+  @Override
+  void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    this.applicationContext = applicationContext
+  }
 }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.igor.BuildService
 import com.netflix.spinnaker.orca.pipeline.OrchestrationStarter
 import com.netflix.spinnaker.orca.pipeline.PipelineLauncher
 import com.netflix.spinnaker.orca.pipeline.PipelineStarter
+import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
@@ -170,7 +171,7 @@ class OperationsController {
     log.info('requested pipeline: {}', json)
 
     def pipeline
-    if (config.executionEngine == "v2") {
+    if (config.executionEngine == Execution.V2_EXECUTION_ENGINE) {
       pipeline = pipelineLauncher.start(json)
     } else {
       pipeline = pipelineStarter.start(json)


### PR DESCRIPTION
- Dependent pipelines should be launched with the executionEngine of their parent pipeline