### PR TITLE
Specify services.fiat.baseUrl.

### DIFF
--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -26,6 +26,10 @@ bakery:
   roscoApisEnabled: true
   allowMissingPackageInstallation: false
 
+services:
+  fiat:
+    baseUrl: http://localhost:7003
+ 
 redis:
   connection: ${REDIS_URL:redis://localhost:6379}
 


### PR DESCRIPTION
@ttomsu Going to push this through temporarily so Orca can start up.
Not sure how you intend to configure this, and guessing Clouddriver might need the same treatment.