### PR TITLE
provider/core: allow diff tasks to be skipped on deploys

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
@@ -88,7 +88,7 @@ abstract class AbstractDeployStrategyStage extends AbstractCloudProviderAwareSta
     if (!strategy.replacesBasicSteps()) {
       steps.addAll((basicSteps(stage) ?: []) as List<Step>)
 
-      if (diffTasks) {
+      if (diffTasks && !stage.context.skipDiffs) {
         diffTasks.each { DiffTask diffTask ->
           try {
             steps << buildStep(stage, getDiffTaskName(diffTask.class.simpleName), diffTask.class)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/DeployStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/DeployStage.groovy
@@ -52,7 +52,7 @@ class DeployStage extends DeployStrategyStage {
     steps << buildStep(stage, "waitForUpInstances", WaitForUpInstancesTask)
     steps << buildStep(stage, "forceCacheRefresh", ServerGroupCacheForceRefreshTask)
 
-    if (diffTasks) {
+    if (diffTasks && !stage.context.skipDiffs) {
       diffTasks.each { DiffTask diffTask ->
         steps << buildStep(stage, getDiffTaskName(diffTask.class.simpleName), diffTask.class)
       }

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
@@ -141,7 +141,7 @@ class DeployCanaryStage extends ParallelDeployStage implements CloudProviderAwar
               buildId: cluster.buildUrl
             ]
           }
-          if (diffTasks) {
+          if (diffTasks && !stage.context.skipDiffs) {
             diffTasks.each {
               it.execute(stage)
             }


### PR DESCRIPTION
A number of folks have mentioned they want to skip the JarDiffs task on deploys, since it add a bit of time to the deploy operation.

Throwing this out there for consideration: allow the user to add `skipDiffs` as a flag in the stage context.

Alternative: `skipDiffs` as a list of `DiffTask`s they want to skip. There are currently just two diff tasks: JarDiffs and GetCommits - not sure if anyone would want just one or the other.