### PR TITLE
Only no-op a previously completed task if the stage is NOT optional

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/TaskTasklet.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/TaskTasklet.groovy
@@ -77,8 +77,8 @@ class TaskTasklet implements Tasklet {
         setStopStatus(chunkContext, ExitStatus.STOPPED, ExecutionStatus.CANCELED)
         contribution.exitStatus = ExitStatus.STOPPED
         return cancel(stage)
-      } else if (task.status.complete || task.status.halt) {
-        // no-op
+      } else if (!OptionalStageSupport.isOptional(stage) && (task.status.complete || task.status.halt)) {
+        // no-op if task is already complete AND stage is NOT optional
         log.warn "Skipping task $task.name because its status is $task.status"
         chunkContext.stepContext.stepExecution.executionContext.put("orcaTaskStatus", task.status)
 

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/adapters/TaskTaskletSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/adapters/TaskTaskletSpec.groovy
@@ -118,6 +118,24 @@ class TaskTaskletSpec extends Specification {
     taskStatus << ExecutionStatus.values().findAll { it.complete }
   }
 
+  def "should skip the task if the stage is optional"() {
+    given:
+    stage.tasks.each { it.status = STOPPED }
+    stage.context.stageEnabled = [
+      expression: "false",
+      type      : "expression"
+    ]
+    executionRepository.store(pipeline)
+
+    when:
+    tasklet.execute(stepContribution, chunkContext)
+
+    then:
+    0 * task.execute(_)
+
+    stepContext.stepExecution.executionContext.get("orcaTaskStatus") == SKIPPED
+  }
+
   def "should pass the correct stage to the task"() {
     given:
     Stage stageArgument = null


### PR DESCRIPTION
Handles the following situation:

`Jenkins` -> `Manual Judgment` -> `Deploy`

- `Manual Judgment` is conditional on `Jenkins` being FAILED_CONTINUE.
- `Manual Judgment` is set to not fail the pipeline on failure

A problem arises if `Jenkins` is FAILED_CONTINUE and `Manual Judgment` is STOPPED.

If `Jenkins` is restarted and passes, `Manual Judgment` should be skipped ... even if it
was STOPPED previously.