### PR TITLE
include amiName if present in bake results

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/Bake.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/Bake.groovy
@@ -33,6 +33,7 @@ import groovy.transform.ToString
 class Bake {
   String id
   String ami
+  String amiName
   String imageName
   // TODO(duftler): Add a cloudProviderType property here? Will be straightforward once rosco is backed by redis.
 }

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
@@ -46,8 +46,8 @@ class CompletedBakeTask implements Task {
      * Problem with "imageName" is that docker images have two components - imageName and imageVersion,
      * so "imageName" is not really a unique identifier. - sthadeshwar
      */
-    if (bake.imageName) {
-      results.imageName = bake.imageName
+    if (bake.imageName || bake.amiName) {
+      results.imageName = bake.imageName ?: bake.amiName
     }
     new DefaultTaskResult(ExecutionStatus.SUCCEEDED, results)
   }


### PR DESCRIPTION
The Netflix bakery provides the `amiName` - we're just not capturing it as part of the `CompleteBakeTask`. It would be nice to supply that in the UI if it's present.

@duftler @spinnaker/netflix-reviewers PTAL