### PR TITLE
retain minimal instance fields on TargetServerGroup

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -31,6 +31,14 @@ class TargetServerGroup {
   @Delegate private final Map<String, Object> serverGroup
 
   TargetServerGroup(Map<String, Object> serverGroupData) {
+    if (serverGroupData.instances && serverGroupData.instances instanceof Collection) {
+      serverGroupData.instances = serverGroupData.instances.collect {
+        [name: it.name, launchTime: it.launchTime, health: it.health, healthState: it.healthState, zone: it.zone]
+      }
+    }
+    if (serverGroupData.containsKey("asg") && serverGroupData.asg instanceof Map) {
+      ((Map) serverGroupData.get("asg")).remove("instances")
+    }
     serverGroup = new HashMap(serverGroupData).asImmutable()
   }
 


### PR DESCRIPTION
When we retrieve clusters from Clouddriver, we get their instances, which can have a lot of fields we'll never care about. If there are thousands of instances, we end up with a very bloated JSON representation of the pipeline. Further, on AWS clusters, the ASG itself has a collection of the instances, which we never look at.

As far as I can tell, we only ever care about four fields: name (for sorting), launch time (for sorting), health (for platform health checks), and health status (for active server group filtering). By retaining just those fields, we should be able to slim down the pipeline payload substantially.

@spinnaker/reviewers PTAL. It's frankly a little hard to track where all we use `TargetServerGroup`s and their fields.
