### PR TITLE
Increased the default limit for tasks from 2500 -> 3500

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -68,7 +68,7 @@ class TaskController {
   @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ')")
   @RequestMapping(value = "/applications/{application}/tasks", method = RequestMethod.GET)
   List<Orchestration> list(@PathVariable String application,
-                           @RequestParam(value = "limit", defaultValue = "2500") int limit,
+                           @RequestParam(value = "limit", defaultValue = "3500") int limit,
                            @RequestParam(value = "statuses", required = false) String statuses) {
     statuses = statuses ?: ExecutionStatus.values()*.toString().join(",")
     def executionCriteria = new ExecutionRepository.ExecutionCriteria(


### PR DESCRIPTION
We have an agent running hourly to cap the # of tasks at 2500 but
any tasks created after the agent run (> 2500) are non-deterministically
returned by the /applications/{application}/tasks endpoint.

This would be unnecessary if the backing set was sorted (future)