### PR TITLE
Resume a previously paused pipeline when restarting

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/StageBuilder.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/StageBuilder.groovy
@@ -172,6 +172,11 @@ abstract class StageBuilder implements ApplicationContextAware {
     stage.endTime = null
     executionRepository.storeStage((PipelineStage) stage)
 
+    if (stage.execution.paused?.isPaused()) {
+      // pipeline appears to be PAUSED and should be resumed regardless of current TERMINAL status
+      executionRepository.resume(stage.execution.id, AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"), true)
+    }
+
     return stage
   }
 

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/RetryableTaskTasklet.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/RetryableTaskTasklet.groovy
@@ -42,7 +42,7 @@ import static com.netflix.spinnaker.orca.pipeline.model.Stage.STAGE_TIMEOUT_OVER
 
 @CompileStatic
 class RetryableTaskTasklet extends TaskTasklet {
-  static final long MAX_PAUSE_TIME_MS = TimeUnit.HOURS.toMillis(12)
+  static final long MAX_PAUSE_TIME_MS = TimeUnit.DAYS.toMillis(3)
 
   private final Clock clock
   private final long timeoutMs

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.groovy
@@ -34,6 +34,7 @@ interface ExecutionRepository {
 
   void pause(String id, String user)
   void resume(String id, String user)
+  void resume(String id, String user, boolean ignoreCurrentStatus)
 
   boolean isCanceled(String id)
   void updateStatus(String id, ExecutionStatus status)

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -186,11 +186,11 @@ class JedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
-  void resume(String id, String user) {
+  void resume(String id, String user, boolean ignoreCurrentStatus = false) {
     String key = fetchKey(id)
     withJedis(getJedisPoolForId(key)) { Jedis jedis ->
       def currentStatus = ExecutionStatus.valueOf(jedis.hget(key, "status"))
-      if (currentStatus != ExecutionStatus.PAUSED) {
+      if (!ignoreCurrentStatus && currentStatus != ExecutionStatus.PAUSED) {
         throw new IllegalStateException("Unable to resume pipeline that is not PAUSED (executionId: ${id}, currentStatus: ${currentStatus})")
       }
 


### PR DESCRIPTION
Previously a pipeline that was paused for 12hrs would automatically go TERMINAL and
subsequent attempts to restart would fail.

- Adjusted max pause time upwards from 12hrs -> 72hrs to handle pausing over a weekend