### PR TITLE
A proof of concept extension point for running actions directly on in…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/CaptureInstanceUptimeTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/CaptureInstanceUptimeTask.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.instance
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.commands.InstanceUptimeCommand
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Slf4j
+@Component
+class CaptureInstanceUptimeTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+  long backoffPeriod = 15000
+  long timeout = 300000
+
+  @Autowired(required = false)
+  InstanceUptimeCommand instanceUptimeCommand;
+
+  @Autowired
+  OortService oortService
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  @Override
+  TaskResult execute(Stage stage) {
+    if (!instanceUptimeCommand) {
+      return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [instanceUptimes: [:]])
+    }
+
+    def cloudProvider = getCloudProvider(stage)
+    def region = stage.context.region as String
+    def account = (stage.context.account ?: stage.context.credentials) as String
+
+    def instanceUptimes = stage.context.instanceIds.inject([:]) { Map accumulator, String instanceId ->
+      def instance = getInstance(account, region, instanceId)
+      try {
+        accumulator[instanceId] = instanceUptimeCommand.uptime(cloudProvider, instance).seconds
+      } catch (Exception e) {
+        log.warn("Unable to capture uptime (instanceId: ${instanceId}), reason: ${e.message}")
+      }
+
+      return accumulator
+    }
+
+    new DefaultTaskResult(ExecutionStatus.SUCCEEDED, [
+      "instanceUptimes": instanceUptimes
+    ])
+  }
+
+  protected Map getInstance(String account, String region, String instanceId) {
+    def response = oortService.getInstance(account, region, instanceId)
+    return objectMapper.readValue(response.body.in().text, Map)
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/VerifyInstanceUptimeTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/VerifyInstanceUptimeTask.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.instance
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.commands.InstanceUptimeCommand
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Slf4j
+@Component
+class VerifyInstanceUptimeTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+  long backoffPeriod = 30000
+  long timeout = 600000
+
+  @Autowired(required = false)
+  InstanceUptimeCommand instanceUptimeCommand;
+
+  @Autowired
+  OortService oortService
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  @Override
+  TaskResult execute(Stage stage) {
+    if (!instanceUptimeCommand || !stage.context.instanceUptimes) {
+      return new DefaultTaskResult(ExecutionStatus.SUCCEEDED)
+    }
+
+    def cloudProvider = getCloudProvider(stage)
+    def account = (stage.context.account ?: stage.context.credentials) as String
+    def region = stage.context.region as String
+
+    def instanceUptimes = stage.context.instanceUptimes as Map<String, Integer>
+    def allInstancesHaveRebooted = instanceUptimes.every { String instanceId, int uptime ->
+      def instance = getInstance(account, region, instanceId);
+
+      try {
+        InstanceUptimeCommand.InstanceUptimeResult result = instanceUptimeCommand.uptime(cloudProvider, instance)
+        return result.seconds < uptime
+      } catch (Exception e) {
+        log.warn("Unable to determine uptime for ${instance.instanceId} via ${instanceUptimeCommand.class.simpleName}, reason: ${e.message}")
+        return false
+      }
+    }
+
+    return new DefaultTaskResult(allInstancesHaveRebooted ? ExecutionStatus.SUCCEEDED : ExecutionStatus.RUNNING)
+  }
+
+  protected Map getInstance(String account, String region, String instanceId) {
+    def response = oortService.getInstance(account, region, instanceId)
+    return objectMapper.readValue(response.body.in().text, Map)
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/CaptureInstanceUptimeTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/CaptureInstanceUptimeTaskSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.instance
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.commands.InstanceUptimeCommand
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import spock.lang.Specification
+
+class CaptureInstanceUptimeTaskSpec extends Specification {
+  def "should noop if `instanceUptimeCommand` is not available"() {
+    given:
+    def task = new CaptureInstanceUptimeTask(instanceUptimeCommand: null)
+    def stage = new PipelineStage()
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.status == ExecutionStatus.SUCCEEDED
+    (result.stageOutputs as Map) == [instanceUptimes: [:]]
+  }
+
+  def "should capture instance uptime for every instanceId"() {
+    given:
+    def task = new CaptureInstanceUptimeTask() {
+      @Override
+      protected Map getInstance(String account, String region, String instanceId) {
+        return [
+            instanceId: instanceId
+        ]
+      }
+    }
+    task.instanceUptimeCommand = Mock(InstanceUptimeCommand)
+    def stage = new PipelineStage(new Pipeline(), "", [instanceIds: ["1", "2", "3"]])
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.status == ExecutionStatus.SUCCEEDED
+    (result.stageOutputs as Map) == [instanceUptimes: ["1": 1, "2": 2]]
+
+    1 * task.instanceUptimeCommand.uptime("aws", [instanceId: "1"]) >> {
+      return new InstanceUptimeCommand.InstanceUptimeResult(1)
+    }
+    1 * task.instanceUptimeCommand.uptime("aws", [instanceId: "2"]) >> {
+      return new InstanceUptimeCommand.InstanceUptimeResult(2)
+    }
+    1 * task.instanceUptimeCommand.uptime("aws", [instanceId: "3"]) >> {
+      throw new RuntimeException("Should be skipped!")
+    }
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/commands/InstanceUptimeCommand.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/commands/InstanceUptimeCommand.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.commands;
+
+import java.util.Map;
+
+public interface InstanceUptimeCommand {
+  InstanceUptimeResult uptime(String cloudProvider, Map instanceDetails);
+
+  class InstanceUptimeResult {
+    private final int seconds;
+
+    public InstanceUptimeResult(int seconds) {
+      this.seconds = seconds;
+    }
+
+    public int getSeconds() {
+      return seconds;
+    }
+  }
+}

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
@@ -23,6 +23,7 @@ import com.squareup.okhttp.ConnectionPool
 import com.squareup.okhttp.Interceptor
 import com.squareup.okhttp.Response
 import groovy.transform.CompileStatic
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -53,7 +54,7 @@ class RetrofitConfiguration {
 
    @Bean(name = ["retrofitClient", "okClient"])
    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-   OkClient retrofitClient(OkHttpClientConfiguration okHttpClientConfig) {
+   OkClient retrofitClient(@Qualifier("okHttpClientConfiguration") OkHttpClientConfiguration okHttpClientConfig) {
      final String userAgent = "Spinnaker-${System.getProperty('spring.application.name', 'unknown')}/${getClass().getPackage().implementationVersion ?: '1.0'}"
      def cfg = okHttpClientConfig.create()
      cfg.networkInterceptors().add(new Interceptor() {


### PR DESCRIPTION
…stances.

This particular PR introduces an uptime capture/verification check into the
reboot cycle.

Currently, Spinnaker often does not detect an instance going down/coming up
when only the platform health provider is used. A supplemental check on instance
 uptime is helpful.

Backstory:
We have some internal tooling that allows us to easily distribute scripts that can be
run on instance (w/ stdout/stderr) captured.