### PR TITLE
Remove `targetReferences` from any successful completed execution

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.groovy
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.orca.config
 
+import com.netflix.spinnaker.orca.listeners.CompositeExecutionListener
+import com.netflix.spinnaker.orca.listeners.ExecutionCleanupListener
+
 import java.time.Clock
 import java.time.Duration
 import java.util.concurrent.ThreadPoolExecutor
@@ -162,15 +165,11 @@ class OrcaConfiguration {
   }
 
   @Bean
-  ExecutionPropagationListener executionPropagationListenerBefore() {
-    // need a dedicated beforeJob listener due to how spring boot ordered listeners
-    new ExecutionPropagationListener(true, false)
-  }
-
-  @Bean
-  ExecutionPropagationListener executionPropagationListenerAfter() {
-    // need a dedicated afterJob listener due to how spring boot ordered listeners
-    new ExecutionPropagationListener(false, true)
+  CompositeExecutionListener executionListeners() {
+    new CompositeExecutionListener(
+      new ExecutionCleanupListener(),
+      new ExecutionPropagationListener()
+    )
   }
 
   @Bean

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/CompositeExecutionListener.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/CompositeExecutionListener.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.listeners;
+
+import com.google.common.collect.Lists;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Listener that delegates to other listeners in "onion order".
+ */
+public class CompositeExecutionListener implements ExecutionListener {
+  private final List<ExecutionListener> delegates;
+  private final List<ExecutionListener> reversed;
+
+  public CompositeExecutionListener(ExecutionListener ... delegates) {
+    this.delegates = Arrays.asList(delegates);
+    this.reversed = Lists.reverse(this.delegates);
+  }
+
+  @Override
+  public void beforeExecution(Persister persister, Execution execution) {
+    delegates.forEach(it -> it.beforeExecution(persister, execution));
+  }
+
+  @Override
+  public void afterExecution(Persister persister, Execution execution, ExecutionStatus executionStatus, boolean wasSuccessful) {
+    reversed.forEach(it -> it.afterExecution(persister, execution, executionStatus, wasSuccessful));
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/ExecutionCleanupListener.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/ExecutionCleanupListener.java
@@ -1,0 +1,35 @@
+package com.netflix.spinnaker.orca.listeners;
+
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+
+import java.util.List;
+
+public class ExecutionCleanupListener implements ExecutionListener {
+  @Override
+  public void beforeExecution(Persister persister, Execution execution) {
+    // do nothing
+  }
+
+  @Override
+  public void afterExecution(Persister persister,
+                             Execution execution,
+                             ExecutionStatus executionStatus,
+                             boolean wasSuccessful) {
+    if (!execution.getStatus().isSuccessful()) {
+      // only want to cleanup executions that successfully completed
+      return;
+    }
+
+    List<Stage> stages = execution.getStages();
+    stages.forEach(it -> {
+      if (it.getContext().containsKey("targetReferences")) {
+        // remove `targetReferences` as it's large and unnecessary after a pipeline has completed
+        it.getContext().remove("targetReferences");
+        persister.save(it);
+      }
+    });
+  }
+
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/ExecutionPropagationListener.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/ExecutionPropagationListener.groovy
@@ -26,20 +26,8 @@ import static com.netflix.spinnaker.orca.ExecutionStatus.*
 @Slf4j
 @CompileStatic
 class ExecutionPropagationListener implements ExecutionListener {
-  private boolean isBeforeJobEnabled = false
-  private boolean isAfterJobEnabled = false
-
-  ExecutionPropagationListener(boolean isBeforeJobEnabled, boolean isAfterJobEnabled) {
-    this.isBeforeJobEnabled = isBeforeJobEnabled
-    this.isAfterJobEnabled = isAfterJobEnabled
-  }
-
   @Override
   void beforeExecution(Persister persister, Execution execution) {
-    if (!isBeforeJobEnabled) {
-      return
-    }
-
     persister.updateStatus(execution.id, RUNNING)
     log.info("Marked ${execution.id} as $RUNNING (beforeJob)");
   }
@@ -49,10 +37,6 @@ class ExecutionPropagationListener implements ExecutionListener {
                              Execution execution,
                              ExecutionStatus executionStatus,
                              boolean wasSuccessful) {
-    if (!isAfterJobEnabled) {
-      return
-    }
-
     if (persister.isCanceled(execution.id) && executionStatus != TERMINAL) {
       executionStatus = CANCELED
     }
@@ -67,18 +51,5 @@ class ExecutionPropagationListener implements ExecutionListener {
 
     persister.updateStatus(execution.id, executionStatus)
     log.info("Marked ${execution.id} as ${executionStatus} (afterJob)")
-  }
-
-  @Override
-  int getOrder() {
-    if (isBeforeJobEnabled) {
-      return HIGHEST_PRECEDENCE
-    }
-
-    if (isAfterJobEnabled) {
-      return LOWEST_PRECEDENCE
-    }
-
-    return 0
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/listeners/CompositeExecutionListenerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/listeners/CompositeExecutionListenerSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.listeners
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
+
+class CompositeExecutionListenerSpec extends Specification {
+  def listener1 = Mock(ExecutionListener)
+  def listener2 = Mock(ExecutionListener)
+
+  @Subject
+  def composite = new CompositeExecutionListener(listener1, listener2)
+
+  def persister = Stub(Persister)
+  def execution = Stub(Execution)
+
+  def "delegates beforeExecution to wrapped listeners in forward order"() {
+    when:
+    composite.beforeExecution(persister, execution)
+
+    then:
+    1 * listener1.beforeExecution(*_)
+
+    then:
+    1 * listener2.beforeExecution(*_)
+  }
+
+  def "delegates afterExecution to wrapped listeners in reverse order"() {
+    when:
+    composite.afterExecution(persister, execution, SUCCEEDED, true)
+
+    then:
+    1 * listener2.afterExecution(*_)
+
+    then:
+    1 * listener1.afterExecution(*_)
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/listeners/ExecutionCleanupListenerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/listeners/ExecutionCleanupListenerSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.listeners
+
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import static com.netflix.spinnaker.orca.ExecutionStatus.*
+
+class ExecutionCleanupListenerSpec extends Specification {
+  @Subject
+  def executionCleanupListener = new ExecutionCleanupListener()
+
+  def persister = Mock(Persister)
+
+  @Unroll
+  def "should only cleanup successfully completed pipelines"() {
+    given:
+    def pipeline = new Pipeline()
+    pipeline.status = executionStatus
+    pipeline.stages << new PipelineStage(pipeline, "", [
+      targetReferences: "my-target-reference"
+    ])
+    pipeline.stages << new PipelineStage(pipeline, "", [
+      targetReferences: "my-other-target-reference"
+    ])
+
+    when:
+    executionCleanupListener.afterExecution(persister, pipeline, pipeline.status, true)
+
+    then:
+    pipeline.stages.count { it.context.containsKey("targetReferences") } == targetReferencesCount
+
+    persistCountPerStage * persister.save(pipeline.stages[0])
+    persistCountPerStage * persister.save(pipeline.stages[1])
+
+    where:
+    executionStatus || targetReferencesCount || persistCountPerStage
+    SUCCEEDED       || 0                     || 1         // should remove targetReferences and persist each stage
+    TERMINAL        || 2                     || 0
+
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/listeners/ExecutionPropagationListenerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/listeners/ExecutionPropagationListenerSpec.groovy
@@ -28,40 +28,32 @@ class ExecutionPropagationListenerSpec extends Specification {
     _ * getId() >> { return "1" }
   }
 
-  @Unroll
   void "beforeExecution should mark as RUNNING"() {
     given:
-    def listener = new ExecutionPropagationListener(isBeforeJobEnabled, false)
+    def listener = new ExecutionPropagationListener()
 
     when:
     listener.beforeExecution(persister, execution)
 
     then:
-    invocations * persister.updateStatus("1", RUNNING)
-
-    where:
-    isBeforeJobEnabled || invocations
-    true               || 1
-    false              || 0
+    1 * persister.updateStatus("1", RUNNING)
   }
 
-  @Unroll
   void "afterExecution should update execution status"() {
     given:
-    def listener = new ExecutionPropagationListener(false, isAfterJobEnabled)
+    def listener = new ExecutionPropagationListener()
 
     when:
     listener.afterExecution(persister, execution, sourceExecutionStatus, true)
 
     then:
-    invocations * persister.updateStatus("1", expectedExecutionStatus)
+    1 * persister.updateStatus("1", expectedExecutionStatus)
 
     where:
-    isAfterJobEnabled | sourceExecutionStatus || invocations || expectedExecutionStatus
-    false             | null                  || 0           || null
-    true              | SUCCEEDED             || 1           || SUCCEEDED
-    true              | CANCELED              || 1           || CANCELED
-    true              | STOPPED               || 1           || SUCCEEDED // treat STOPPED as a non-failure
-    true              | null                  || 1           || TERMINAL  // if no source execution status can be derived, consider the execution TERMINAL
+    sourceExecutionStatus || expectedExecutionStatus
+    SUCCEEDED             || SUCCEEDED
+    CANCELED              || CANCELED
+    STOPPED               || SUCCEEDED // treat STOPPED as a non-failure
+    null                  || TERMINAL  // if no source execution status can be derived, consider the execution TERMINAL
   }
 }


### PR DESCRIPTION
- `targetReferences` contains complete asg/instance details and is no longer
necessary after an execution has completed