### PR TITLE
(core) get health providers from stage context

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
@@ -101,10 +101,7 @@ abstract class AbstractInstancesCheckTask extends AbstractCloudProviderAwareTask
         }
 
         seenServerGroup[name] = true
-        Collection<String> interestingHealthProviderNames = stage.execution.appConfig.interestingHealthProviderNames as Collection
-        if (interestingHealthProviderNames == null) {
-          interestingHealthProviderNames = stage.context?.appConfig?.interestingHealthProviderNames as Collection
-        }
+        Collection<String> interestingHealthProviderNames = stage.context.interestingHealthProviderNames as Collection
         def isComplete = hasSucceeded(stage, serverGroup, serverGroup.instances ?: [], interestingHealthProviderNames)
         if (!isComplete) {
           Map newContext = [:]

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTaskSpec.groovy
@@ -77,12 +77,12 @@ class AbstractInstancesCheckTaskSpec extends Specification {
     task.hasSucceededSpy = Mock(HasSucceededSpy)
 
     def pipeline = new Pipeline()
-    pipeline.appConfig.interestingHealthProviderNames = ["JustTrustMeBroItIsHealthy"]
     def stage = new PipelineStage(pipeline, "whatever", [
       "account.name"                  : "test",
       "targetop.asg.enableAsg.name"   : "front50-v000",
       "targetop.asg.enableAsg.regions": ["us-west-1"]
     ])
+    stage.context.interestingHealthProviderNames = ["JustTrustMeBroItIsHealthy"]
 
     when:
     task.execute(stage)


### PR DESCRIPTION
@robfletcher @ajordens @duftler PTAL

Kubernetes uses different health providers for different tasks, so the health providers need to be pulled from the stage context. Is there a neater/more consistent way for Kubernetes to get its health providers?