### PR TITLE
avoid potential NPE from v1 execution engine where requisiteStageRefI…

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
@@ -97,8 +97,8 @@ public interface StageDefinitionBuilder {
         .stream()
         .filter(it -> {
           Collection<String> requisiteStageRefIds = Optional.ofNullable(it.getRequisiteStageRefIds()).orElse(emptySet());
-          if (it.getContext().containsKey("requisiteIds")) {
-            requisiteStageRefIds.addAll((Collection<? extends String>) it.getContext().get("requisiteIds"));
+          if (it.getContext().get("requisiteIds") != null) {
+            requisiteStageRefIds.addAll((Collection<String>) it.getContext().get("requisiteIds"));
           }
 
           // only want to consider completed child stages


### PR DESCRIPTION
…ds can be null