### PR TITLE
convert day of week strings to ints in execution windows

### DIFF
--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindowSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindowSpec.groovy
@@ -144,7 +144,8 @@ class RestrictExecutionDuringTimeWindowSpec extends AbstractBatchLifecycleSpec {
     date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [5]             || date("02/27 06:00:00")
     date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [3]             || date("03/04 06:00:00")
     date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [3,4,5]         || date("02/26 06:00:00")
-
+    date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [3,5]           || date("02/27 06:00:00")
+    date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | ['3','5']       || date("02/27 06:00:00")
   }
 
   void 'stage should be scheduled at #expectedTime when triggered at #scheduledTime with time windows #stage in stage context'() {


### PR DESCRIPTION
We're seeing an issue where execution window calculations go awry if they are scheduled for a day of the week in the future. The JSON in the execution context looks correct, so I'm really just guessing at the underlying issue here and hoping the log message sheds some light on things.