### PR TITLE
STOPPED stage in a branch should not fail the pipeline if all requisite stages succeeded

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/parallel/WaitForRequisiteCompletionTask.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/parallel/WaitForRequisiteCompletionTask.groovy
@@ -76,9 +76,9 @@ class WaitForRequisiteCompletionTask implements RetryableTask {
     }
 
     // we don't want to fail this join point on a STOPPED upstream until all upstreams are in a completed state.
-    //  STOPPED shouldn't fail execution of the pipeline, but is not a legitimate join state
+    //  STOPPED shouldn't fail execution of the pipeline
     if (allRequisiteStagesAreComplete && stoppedStageNames) {
-      throw new IllegalStateException("Requisite stages were stopped: ${stoppedStageNames.join(',')}")
+      return new DefaultTaskResult(STOPPED)
     }
 
     return new DefaultTaskResult(allRequisiteStagesAreComplete ? SUCCEEDED : RUNNING)


### PR DESCRIPTION
- Replaced explicitly exception throw with a STOPPED return result