### PR TITLE
Fixing stage state when restarting a ACA Task.

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStage.groovy
@@ -65,6 +65,9 @@ class AcaTaskStage implements StageDefinitionBuilder, CancellableStage, Restarta
       stage.context.canary.remove("canaryResult")
       stage.context.canary.remove("status")
       stage.context.canary.remove("health")
+
+      //Canceling the canary marks the stage as CANCELED preventing it from restarting.
+      stage.setStatus(ExecutionStatus.NOT_STARTED)
     }
 
 
@@ -81,6 +84,7 @@ class AcaTaskStage implements StageDefinitionBuilder, CancellableStage, Restarta
   CancellableStage.Result cancel(Stage stage) {
     log.info("Cancelling stage (stageId: ${stage.id}, executionId: ${stage.execution.id}, context: ${stage.context as Map})")
     def cancelCanaryResults = cancelCanary(stage, "Pipeline execution (${stage.execution?.id}) canceled");
+    log.info("Canceled AcaTaskStage for pipeline: ${stage.execution?.id} with results: ${cancelCanaryResults}")
     return new CancellableStage.Result(stage, ["canary": cancelCanaryResults])
   }
 

--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStageSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStageSpec.groovy
@@ -57,6 +57,7 @@ class AcaTaskStageSpec extends Specification {
     result.context.canary.canaryResult == null
     result.context.canary.status == null
     result.context.canary.health == null
+    result.status == ExecutionStatus.NOT_STARTED
 
     and: "reset the tasks"
     stage.tasks.each { task ->
@@ -99,6 +100,7 @@ class AcaTaskStageSpec extends Specification {
     result.context.canary.canaryResult == null
     result.context.canary.status == null
     result.context.canary.health == null
+    result.status == ExecutionStatus.NOT_STARTED
 
     and: "reset the tasks"
     stage.tasks.each { task ->


### PR DESCRIPTION
Restarting an ACA Task stage will cancel the Canary and, in doing so will put the stage into a STOPED state, preventing the
restarted pipeline from continuing.

This fix just put the stage state back to the RUNNING state that the 'prepareStageForRestart' puts it in.

@robfletcher PTAL 
