### PR TITLE
handle decimal numbers in restrict execution window days

### DIFF
--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindowSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindowSpec.groovy
@@ -145,7 +145,6 @@ class RestrictExecutionDuringTimeWindowSpec extends AbstractBatchLifecycleSpec {
     date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [3]             || date("03/04 06:00:00")
     date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [3,4,5]         || date("02/26 06:00:00")
     date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [3,5]           || date("02/27 06:00:00")
-    date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | ['3','5']       || date("02/27 06:00:00")
   }
 
   void 'stage should be scheduled at #expectedTime when triggered at #scheduledTime with time windows #stage in stage context'() {


### PR DESCRIPTION
~~From the logs, I am seeing that somewhere, somehow, something is converting our nice, clean `Integer`s into `Float`s when performing execution window calculations. This started around 10/11/16, but I can't see anything that would have caused this. So I'm just hacking away at the symptom here.~~

EDIT: there are other places in this class that are coercing floats back to integers. Going to assume this is not a new issue and I'm just bad at testing.