### PR TITLE
(core) enhance katoResultExpected feature by declaring expected keys

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
@@ -75,6 +75,7 @@ abstract class AbstractInstancesCheckTask extends AbstractCloudProviderAwareTask
     Map<String, List<String>> serverGroups = getServerGroups(stage)
 
     if (!serverGroups || !serverGroups?.values()?.flatten()) {
+      log.info("No server groups found for stage ${stage.id}; terminating task")
       return new DefaultTaskResult(ExecutionStatus.TERMINAL)
     }
     Names names = Names.parseName(serverGroups.values().flatten()[0])

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
@@ -46,6 +46,7 @@ class AmazonServerGroupCreator implements ServerGroupCreator, DeploymentDetailsA
   List<String> defaultSecurityGroups = DEFAULT_SECURITY_GROUPS
 
   boolean katoResultExpected = true
+  String katoResultKeyExpected = "serverGroupNames"
   String cloudProvider = "aws"
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureServerGroupCreator.groovy
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component
 class AzureServerGroupCreator implements ServerGroupCreator, DeploymentDetailsAware {
 
   boolean katoResultExpected = false
+  String katoResultKeyExpected = null
   String cloudProvider = "azure"
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.groovy
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Component
 class CloudFoundryServerGroupCreator implements ServerGroupCreator {
 
   boolean katoResultExpected = false
+  String katoResultKeyExpected = null
   String cloudProvider = "cf"
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreator.groovy
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component
 class GoogleServerGroupCreator implements ServerGroupCreator, DeploymentDetailsAware {
 
   boolean katoResultExpected = false
+  String katoResultKeyExpected = null
   String cloudProvider = "gce"
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesServerGroupCreator.groovy
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Component
 class KubernetesServerGroupCreator implements ServerGroupCreator {
 
   boolean katoResultExpected = false
+  String katoResultKeyExpected = null
   String cloudProvider = "kubernetes"
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/openstack/OpenstackServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/openstack/OpenstackServerGroupCreator.groovy
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Component
 class OpenstackServerGroupCreator implements ServerGroupCreator, DeploymentDetailsAware {
 
   boolean katoResultExpected = false
+  String katoResultKeyExpected = null
   String cloudProvider = 'openstack'
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTask.groovy
@@ -54,11 +54,14 @@ class CreateServerGroupTask extends AbstractCloudProviderAwareTask implements Re
     def taskId = kato.requestOperations(cloudProvider, ops).toBlocking().first()
 
     Map outputs = [
-        "notification.type"   : "createdeploy",
-        "kato.result.expected": creator.katoResultExpected,
-        "kato.last.task.id"   : taskId,
-        "deploy.account.name" : credentials
+        "notification.type"        : "createdeploy",
+        "kato.result.expected"     : creator.katoResultExpected,
+        "kato.last.task.id"        : taskId,
+        "deploy.account.name"      : credentials
     ]
+    if (creator.katoResultKeyExpected) {
+      outputs.put("kato.result.key.expected", creator.katoResultKeyExpected)
+    }
 
     if (stage.context.suspendedProcesses?.contains("AddToLoadBalancer")) {
       outputs.interestingHealthProviderNames = HealthHelper.getInterestingHealthProviderNames(stage, ["Amazon"])

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCreator.groovy
@@ -37,6 +37,11 @@ interface ServerGroupCreator {
   boolean isKatoResultExpected()
 
   /**
+   * @return an expected key in the resultObjects map indicating the task is complete
+   */
+  String getKatoResultKeyExpected()
+
+  /**
    * @return The cloud provider type that this object supports.
    */
   String getCloudProvider()

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
@@ -119,14 +119,18 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    if (expectedKey) {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected, "kato.result.key.expected": expectedKey]
+    } else {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    }
 
     where:
-    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | 0             | "image"           | false              || "some-ami-name"
-    "gce"                  | null              | 0             | "image"           | false              || "some-ami-name"
-    "aws"                  | "aws"             | 1             | "imageId"         | true               || "some-ami-name"
-    "aws"                  | null              | 1             | "imageId"         | true               || "some-ami-name"
+    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey || katoResultExpected | expectedKey        | expectedImageId
+    "gce"                  | "gce"             | 0             | "image"           || false              | null               | "some-ami-name"
+    "gce"                  | null              | 0             | "image"           || false              | null               | "some-ami-name"
+    "aws"                  | "aws"             | 1             | "imageId"         || true               | 'serverGroupNames' | "some-ami-name"
+    "aws"                  | null              | 1             | "imageId"         || true               | 'serverGroupNames' | "some-ami-name"
   }
 
   @Unroll
@@ -170,14 +174,18 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    if (expectedKey) {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected, "kato.result.key.expected": expectedKey]
+    } else {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    }
 
     where:
-    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | 0             | "image"           | false              || "parent-ami"
-    "gce"                  | null              | 0             | "image"           | false              || "parent-ami"
-    "aws"                  | "aws"             | 1             | "imageId"         | true               || "parent-ami"
-    "aws"                  | null              | 1             | "imageId"         | true               || "parent-ami"
+    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey || expectedKey        | katoResultExpected | expectedImageId
+    "gce"                  | "gce"             | 0             | "image"           || null               | false              | "parent-ami"
+    "gce"                  | null              | 0             | "image"           || null               | false              | "parent-ami"
+    "aws"                  | "aws"             | 1             | "imageId"         || "serverGroupNames" | true               | "parent-ami"
+    "aws"                  | null              | 1             | "imageId"         || "serverGroupNames" | true               | "parent-ami"
   }
 
   @Unroll
@@ -241,14 +249,18 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    if (expectedKey) {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected, "kato.result.key.expected": expectedKey]
+    } else {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    }
 
     where:
-    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | 0             | "image"           | false              || "grandparent-ami"
-    "gce"                  | null              | 0             | "image"           | false              || "grandparent-ami"
-    "aws"                  | "aws"             | 1             | "imageId"         | true               || "grandparent-ami"
-    "aws"                  | null              | 1             | "imageId"         | true               || "grandparent-ami"
+    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey || expectedKey        | katoResultExpected | expectedImageId
+    "gce"                  | "gce"             | 0             | "image"           || null               | false              | "grandparent-ami"
+    "gce"                  | null              | 0             | "image"           || null               | false              | "grandparent-ami"
+    "aws"                  | "aws"             | 1             | "imageId"         || "serverGroupNames" | true               | "grandparent-ami"
+    "aws"                  | null              | 1             | "imageId"         || "serverGroupNames" | true               | "grandparent-ami"
   }
 
   @Unroll
@@ -292,14 +304,19 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    if (expectedKey) {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected, "kato.result.key.expected": expectedKey]
+    } else {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    }
+
 
     where:
-    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | 0             | "image"           | false              || "parent-name"
-    "gce"                  | null              | 0             | "image"           | false              || "parent-name"
-    "aws"                  | "aws"             | 1             | "imageId"         | true               || "parent-name"
-    "aws"                  | null              | 1             | "imageId"         | true               || "parent-name"
+    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey || expectedKey        | katoResultExpected | expectedImageId
+    "gce"                  | "gce"             | 0             | "image"           || null               | false              | "parent-name"
+    "gce"                  | null              | 0             | "image"           || null               | false              | "parent-name"
+    "aws"                  | "aws"             | 1             | "imageId"         || "serverGroupNames" | true               | "parent-name"
+    "aws"                  | null              | 1             | "imageId"         || "serverGroupNames" | true               | "parent-name"
   }
 
   @Unroll
@@ -351,14 +368,18 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    if (expectedKey) {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected, "kato.result.key.expected": expectedKey]
+    } else {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    }
 
     where:
-    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | 0             | "image"           | false              || "grandparent-name"
-    "gce"                  | null              | 0             | "image"           | false              || "grandparent-name"
-    "aws"                  | "aws"             | 1             | "imageId"         | true               || "grandparent-name"
-    "aws"                  | null              | 1             | "imageId"         | true               || "grandparent-name"
+    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey || expectedKey        | katoResultExpected | expectedImageId
+    "gce"                  | "gce"             | 0             | "image"           || null               | false              | "grandparent-name"
+    "gce"                  | null              | 0             | "image"           || null               | false              | "grandparent-name"
+    "aws"                  | "aws"             | 1             | "imageId"         || "serverGroupNames" | true               | "grandparent-name"
+    "aws"                  | null              | 1             | "imageId"         || "serverGroupNames" | true               | "grandparent-name"
   }
 
   @Unroll
@@ -405,14 +426,18 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    if (expectedKey) {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected, "kato.result.key.expected": expectedKey]
+    } else {
+      result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    }
 
     where:
-    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | 0             | "image"           | false              || "parent-ami"
-    "gce"                  | null              | 0             | "image"           | false              || "parent-ami"
-    "aws"                  | "aws"             | 1             | "imageId"         | true               || "parent-ami"
-    "aws"                  | null              | 1             | "imageId"         | true               || "parent-ami"
+    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey || expectedKey        | katoResultExpected | expectedImageId
+    "gce"                  | "gce"             | 0             | "image"           || null               | false              | "parent-ami"
+    "gce"                  | null              | 0             | "image"           || null               | false              | "parent-ami"
+    "aws"                  | "aws"             | 1             | "imageId"         || "serverGroupNames" | true               || "parent-ami"
+    "aws"                  | null              | 1             | "imageId"         || "serverGroupNames" | true               || "parent-ami"
   }
 
   @Unroll
@@ -490,7 +515,12 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    resultA?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    if (expectedKey) {
+      resultA?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    } else {
+      resultA?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected, "kato.result.key.expected": expectedKey]
+    }
+
 
     when:
     def resultB = deployTaskB.execute(deployStageB)
@@ -502,14 +532,18 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    resultB?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    if (expectedKey) {
+      resultB?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected, "kato.result.key.expected": expectedKey]
+    } else {
+      resultB?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    }
 
     where:
-    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey | katoResultExpected || expectedImageIdBranchA | expectedImageIdBranchB
-    "gce"                  | "gce"             | 0             | "image"           | false              || "parent-name-branch-a" | "parent-name-branch-b"
-    "gce"                  | null              | 0             | "image"           | false              || "parent-name-branch-a" | "parent-name-branch-b"
-    "aws"                  | "aws"             | 1             | "imageId"         | true               || "parent-name-branch-a" | "parent-name-branch-b"
-    "aws"                  | null              | 1             | "imageId"         | true               || "parent-name-branch-a" | "parent-name-branch-b"
+    operationCloudProvider | bakeCloudProvider | createOpIndex | imageAttributeKey || katoResultExpected | expectedKey        | expectedImageIdBranchA | expectedImageIdBranchB
+    "gce"                  | "gce"             | 0             | "image"           || false              | null               | "parent-name-branch-a" | "parent-name-branch-b"
+    "gce"                  | null              | 0             | "image"           || false              | null               | "parent-name-branch-a" | "parent-name-branch-b"
+    "aws"                  | "aws"             | 1             | "imageId"         || true               | "serverGroupNames" | "parent-name-branch-a" | "parent-name-branch-b"
+    "aws"                  | null              | 1             | "imageId"         || true               | "serverGroupNames" | "parent-name-branch-a"  | "parent-name-branch-b"
   }
 
   private def buildBakeConfig(String imageId, String deployRegion, String cloudProvider) {


### PR DESCRIPTION
On extremely rare occasions, Clouddriver ends up in a weird race condition where Redis is not reflecting the actual state of a completed task: the task is marked completed, but when Orca retrieves the task, the `resultObject` is either not returned or only partially returned.

We've tried to trace this through on the Clouddriver side but have never been able to find the cause. About a year ago, we coded around this scenario in Orca, adding `kato.result.expected` to stages to handle the case where the `resultObject` was not returned.

Today (and possibly other times), we saw the `resultObject` _partially_ populated: it had the `ancestorServerGroupNameByRegion` map, but not the `serverGroupNames` map. Since that is the field we really need to start monitoring for up instances, I'm adding a check for that specific field on Amazon server group creation.

@ajordens PTAL - you and I worked on the original code to handle this scenario.