### PR TITLE
Fix v2 stage notifications

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/StageStatusPropagationListener.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/StageStatusPropagationListener.groovy
@@ -35,15 +35,6 @@ class StageStatusPropagationListener implements StageListener {
     stage.startTime = stage.startTime ?: System.currentTimeMillis()
     stage.status = ExecutionStatus.RUNNING
 
-    if (stage.execution.executionEngine == "v2") {
-      stage.context.stageDetails = [
-        name       : stage.name,
-        type       : stage.type,
-        startTime  : stage.startTime,
-        isSynthetic: stage.syntheticStageOwner != null
-      ]
-    }
-
     persister.save(stage)
   }
 
@@ -86,10 +77,6 @@ class StageStatusPropagationListener implements StageListener {
       log.debug("***** $stage.execution.id Stage $stage.type terminal due to missing status")
       stage.endTime = System.currentTimeMillis()
       stage.status = ExecutionStatus.TERMINAL
-    }
-
-    if (stage.endTime && stage.execution.executionEngine == "v2") {
-      stage.context.stageDetails.endTime = stage.endTime
     }
 
     persister.save(stage)

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSupport.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSupport.java
@@ -81,8 +81,8 @@ public abstract class ExecutionRunnerSupport implements ExecutionRunner {
         .map(context ->
           newStage(
             stage.getExecution(),
-            context.get("type").toString(),
-            context.get("name").toString(),
+            context.getOrDefault("type", stage.getType()).toString(),
+            context.getOrDefault("name", stage.getName()).toString(),
             context,
             stage,
             STAGE_AFTER


### PR DESCRIPTION
Echo expects `stageDetails` key to be present in context. Because it wasn't there at the time the echo listener fires before the stage the "stage starting" notification was never triggered.