### PR TITLE
Avoid a possible NPE in the AmazonImageTagger if an image hasn't been…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageTagger.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageTagger.java
@@ -151,7 +151,7 @@ public class AmazonImageTagger implements ImageTagger, CloudProviderAware {
 
           List<String> imagesForRegion = matchedImage.amis.get(region);
           imagesForRegion.forEach(image -> {
-            Map<String, String> allImageTags = matchedImage.tagsByImageId.get(image);
+            Map<String, String> allImageTags = matchedImage.tagsByImageId.getOrDefault(image, new HashMap<>());
             targetImage.tags.entrySet().forEach(entry -> {
               // assert tag equality
               isUpserted.set(isUpserted.get() && entry.getValue().equals(allImageTags.get(entry.getKey())));


### PR DESCRIPTION
… fully indexed