### PR TITLE
Propagate 'interestingHealthProviderNames' in synthesized stages.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ShrinkClusterStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ShrinkClusterStage.groovy
@@ -49,8 +49,14 @@ class ShrinkClusterStage extends AbstractClusterWideClouddriverOperationStage {
         remainingEnabledServerGroups  : stage.context.shrinkToSize,
         preferLargerOverNewer         : stage.context.retainLargerOverNewer,
         continueIfClusterNotFound     : stage.context.shrinkToSize == 0,
-        interestingHealthProviderNames: stage.context.interestingHealthProviderNames
       ]
+
+      // We don't want the key propagated if interestingHealthProviderNames isn't defined, since this prevents
+      // health providers from the stage's 'determineHealthProviders' task to be added to the context.
+      if (stage.context.interestingHealthProviderNames != null) {
+        context.interestingHealthProviderNames = stage.context.interestingHealthProviderNames
+      }
+
       return [
         StageDefinitionBuilder.StageDefinitionBuilderSupport.newStage(
           stage.execution, disableClusterStage.type, "disableCluster", context, stage, SyntheticStageOwner.STAGE_BEFORE

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/HighlanderStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/HighlanderStrategy.groovy
@@ -50,8 +50,13 @@ class HighlanderStrategy implements Strategy, ApplicationContextAware {
         shrinkToSize                           : 1,
         allowDeleteActive                      : true,
         retainLargerOverNewer                  : false,
-        interestingHealthProviderNames         : stage.context.interestingHealthProviderNames
     ]
+
+    // We don't want the key propagated if interestingHealthProviderNames isn't defined, since this prevents
+    // health providers from the stage's 'determineHealthProviders' task to be added to the context.
+    if (stage.context.interestingHealthProviderNames != null) {
+      shrinkContext.interestingHealthProviderNames = stage.context.interestingHealthProviderNames
+    }
 
     return [
       newStage(

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategy.groovy
@@ -57,8 +57,13 @@ class RedBlackStrategy implements Strategy, ApplicationContextAware {
       cluster                                : cleanupConfig.cluster,
       credentials                            : cleanupConfig.account,
       cloudProvider                          : cleanupConfig.cloudProvider,
-      interestingHealthProviderNames         : stage.context.interestingHealthProviderNames
     ]
+
+    // We don't want the key propagated if interestingHealthProviderNames isn't defined, since this prevents
+    // health providers from the stage's 'determineHealthProviders' task to be added to the context.
+    if (stage.context.interestingHealthProviderNames != null) {
+      baseContext.interestingHealthProviderNames = stage.context.interestingHealthProviderNames
+    }
 
     if (stageData?.maxRemainingAsgs && (stageData?.maxRemainingAsgs > 0)) {
       Map shrinkContext = baseContext + [

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/HighlanderStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/HighlanderStrategySpec.groovy
@@ -50,14 +50,16 @@ class HighlanderStrategySpec extends Specification {
 
     when:
       def syntheticStages = strat.composeFlow(stage)
-    def beforeStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_BEFORE }
-    def afterStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_AFTER }
+      def beforeStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_BEFORE }
+      def afterStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_AFTER }
 
     then:
       beforeStages.isEmpty()
       afterStages.size() == 1
       afterStages.last().type == shrinkClusterStage.type
-      afterStages.last().context == [
+
+      if (interestingHealthProviderNames) {
+        afterStages.last().context == [
           credentials                   : "testAccount",
           (locationType)                : locationValue,
           cluster                       : "unit-tests",
@@ -66,7 +68,18 @@ class HighlanderStrategySpec extends Specification {
           retainLargerOverNewer         : false,
           allowDeleteActive             : true,
           interestingHealthProviderNames: propagatedInterestingHealthProviderNames
-      ]
+        ]
+      } else {
+        afterStages.last().context == [
+          credentials                   : "testAccount",
+          (locationType)                : locationValue,
+          cluster                       : "unit-tests",
+          cloudProvider                 : cloudProvider,
+          shrinkToSize                  : 1,
+          retainLargerOverNewer         : false,
+          allowDeleteActive             : true,
+        ]
+      }
 
     where:
       cloudProvider | locationType | locationValue | interestingHealthProviderNames | propagatedInterestingHealthProviderNames

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategySpec.groovy
@@ -49,8 +49,8 @@ class RedBlackStrategySpec extends Specification {
 
     when:
       def syntheticStages = strat.composeFlow(stage)
-    def beforeStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_BEFORE }
-    def afterStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_AFTER }
+      def beforeStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_BEFORE }
+      def afterStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_AFTER }
 
     then:
       beforeStages.isEmpty()
@@ -63,15 +63,14 @@ class RedBlackStrategySpec extends Specification {
           region                        : "north",
           remainingEnabledServerGroups  : 1,
           preferLargerOverNewer         : false,
-          interestingHealthProviderNames: null
       ]
 
     when:
       ctx.maxRemainingAsgs = 10
       stage = new PipelineStage(new Pipeline(), "whatever", ctx)
       syntheticStages = strat.composeFlow(stage)
-    beforeStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_BEFORE }
-    afterStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_AFTER }
+      beforeStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_BEFORE }
+      afterStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_AFTER }
 
     then:
       beforeStages.isEmpty()
@@ -84,8 +83,8 @@ class RedBlackStrategySpec extends Specification {
       ctx.scaleDown = true
       stage = new PipelineStage(new Pipeline(), "whatever", ctx)
       syntheticStages = strat.composeFlow(stage)
-    beforeStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_BEFORE }
-    afterStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_AFTER }
+      beforeStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_BEFORE }
+      afterStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_AFTER }
 
     then:
       beforeStages.isEmpty()
@@ -93,7 +92,19 @@ class RedBlackStrategySpec extends Specification {
       afterStages[0].type == shrinkClusterStage.type
       afterStages[1].type == disableClusterStage.type
       afterStages[2].type == scaleDownClusterStage.type
-    afterStages[2].context.allowScaleDownActive == false
+      afterStages[2].context.allowScaleDownActive == false
 
+    when:
+      ctx.interestingHealthProviderNames = ["Google"]
+      stage = new PipelineStage(new Pipeline(), "whatever", ctx)
+      syntheticStages = strat.composeFlow(stage)
+      beforeStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_BEFORE }
+      afterStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_AFTER }
+
+    then:
+      beforeStages.isEmpty()
+      afterStages.size() == 3
+      afterStages.first().type == shrinkClusterStage.type
+      afterStages.first().context.interestingHealthProviderNames == ["Google"]
   }
 }


### PR DESCRIPTION
@duftler @ajordens please review. If 'consider only platform health' is enabled and 'show health override for each stage' is disabled, synthesized stages don't inherit `interestingHealthProviderNames` properly from the `determineHealthProvider` task if that key is present in the stage context.