### PR TITLE
prefer accounts passed in when updating applications

### DIFF
--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/UpsertApplicationTask.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/UpsertApplicationTask.groovy
@@ -40,7 +40,9 @@ class UpsertApplicationTask extends AbstractFront50Task {
     if (existingApplication) {
       outputs.previousState = existingApplication
 
-      application.updateAccounts((existingApplication.listAccounts() << account) as Set)
+      if (!application.accounts) {
+        application.updateAccounts((existingApplication.listAccounts() << account) as Set)
+      }
 
       log.info("Updating application (name: ${application.name})")
       front50Service.update(application.name, application)


### PR DESCRIPTION
We currently ignore the accounts that are passed in when updating an application.

@robzienert or @jeyrschabu PTAL