### PR TITLE
provide status info in execution context on AbstractInstanceCheckTasks

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
@@ -32,6 +32,11 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
     return true
   }
 
+  @Override
+  Map getAdditionalRunningStageContext(Stage stage, Map serverGroup) {
+    [ targetDesiredSize: calculateTargetDesiredSize(stage, serverGroup) ]
+  }
+
   static boolean allInstancesMatch(Stage stage, Map serverGroup, List<Map> instances, Collection<String> interestingHealthProviderNames) {
     if (!(serverGroup?.capacity)) {
       return false
@@ -66,7 +71,7 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
     return healthyCount >= targetDesiredSize
   }
 
-  private static int calculateTargetDesiredSize(Stage stage, Map serverGroup) {
+  static int calculateTargetDesiredSize(Stage stage, Map serverGroup) {
     // favor using configured target capacity whenever available (rather than in-progress server group's desiredCapacity)
     Map capacity = (Map) serverGroup.capacity
     Integer targetDesiredSize = capacity.desired as Integer

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTask.groovy
@@ -25,9 +25,17 @@ import org.springframework.stereotype.Component
 @Slf4j
 @Component
 class WaitForCapacityMatchTask extends AbstractInstancesCheckTask {
+
   @Override
   protected Map<String, List<String>> getServerGroups(Stage stage) {
     (Map<String, List<String>>) stage.context."deploy.server.groups"
+  }
+
+  @Override
+  Map getAdditionalRunningStageContext(Stage stage, Map serverGroup) {
+    return serverGroup.disabled ?
+      [:] :
+      [ targetDesiredSize: WaitForUpInstancesTask.calculateTargetDesiredSize(stage, serverGroup) ]
   }
 
   @Override


### PR DESCRIPTION
We get a lot of confused users when instances are not coming up for some reason. It might be a problem with their code, or their server group configuration, or capacity constraints on AWS. When it happens, though, it's pretty opaque to the user - the deploy (or resize) stage just spins until it times after after two hours.

I'm not 100% sure what it will look like, but I would like to feed this info into the running execution UI to provide more context to users.

There's more work to be done, e.g. if there are issues with the launch configuration, that almost certainly won't be surfaced by this info. 

But this should at least get us started on adding that visibility.

@ajordens PTAL