### PR TITLE
Add installDist to buildRPM task for orca-web

### DIFF
--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -142,3 +142,6 @@ buildDeb {
   dependsOn installDist
 }
 
+buildRpm {
+  dependsOn installDist
+}


### PR DESCRIPTION
Without the installDist dependency, the RPM is malformed.