### PR TITLE
Any failure in a canary stage should auto cancel (ie. cleanup) the cr…

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionStatus.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionStatus.groovy
@@ -95,6 +95,7 @@ enum ExecutionStatus {
   final ExitStatus exitStatus
 
   private static final Collection<ExecutionStatus> SUCCESSFUL = [SUCCEEDED, STOPPED, SKIPPED]
+  private static final Collection<ExecutionStatus> FAILURE = [TERMINAL, STOPPED, FAILED_CONTINUE]
 
   ExecutionStatus(boolean complete, boolean halt, ExitStatus exitStatus) {
     this.complete = complete
@@ -104,5 +105,9 @@ enum ExecutionStatus {
 
   boolean isSuccessful() {
     return SUCCESSFUL.contains(this)
+  }
+
+  boolean isFailure() {
+    return FAILURE.contains(this)
   }
 }


### PR DESCRIPTION
…eated clusters

- If the executing stage fails (TERMINAL, STOPPED, FAILED_CONTINUE) and is `Cancellable`, it should be canceled
- Improved resilience when canceling canaries that failed prior to registration