### PR TITLE
Only cleanup canary if `MonitorCanaryStage` fails prior to a successf…

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/TaskTasklet.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/batch/adapters/TaskTasklet.groovy
@@ -96,13 +96,6 @@ class TaskTasklet implements Tasklet {
 
         logResult(result, stage, chunkContext)
 
-        if (result.status == ExecutionStatus.TERMINAL) {
-          setStopStatus(chunkContext, ExitStatus.FAILED, result.status)
-          // cancel execution which will halt any parallel branches and run
-          // cancellation routines
-          executionRepository.cancel(stage.execution.id)
-        }
-
         if (result.status.isFailure()) {
           try {
             // ensure that any cleanup behavior is invoked when a task fails (if stage is `Cancellable`)
@@ -110,6 +103,13 @@ class TaskTasklet implements Tasklet {
           } catch (Exception e) {
             log.error("Error occurred canceling stage '${stage.id}' in execution '${stage.execution.id}'", e)
           }
+        }
+
+        if (result.status == ExecutionStatus.TERMINAL) {
+          setStopStatus(chunkContext, ExitStatus.FAILED, result.status)
+          // cancel execution which will halt any parallel branches and run
+          // cancellation routines
+          executionRepository.cancel(stage.execution.id)
         }
 
         def stageOutputs = new HashMap(result.stageOutputs)

--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/MonitorCanaryStageSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/MonitorCanaryStageSpec.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.orca.mine.pipeline
+
+import com.netflix.spinnaker.orca.CancellableStage
+import com.netflix.spinnaker.orca.mine.MineService
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.util.function.BiFunction
+
+class MonitorCanaryStageSpec extends Specification {
+  def mineService = Mock(MineService)
+
+  @Subject
+  def monitorCanaryStage = new MonitorCanaryStage(mineService: mineService)
+
+  def "should short-circuit if canary registered but execution not explicitly canceled"() {
+    given:
+    def stage = new PipelineStage(new Pipeline(), "pipelineStage", [
+      canary: [id: "canaryId"]
+    ])
+
+    when:
+    stage.execution.canceled = false
+    def result = monitorCanaryStage.cancel(stage)
+
+    then:
+    result == null
+    0 * mineService.cancelCanary(_, _)
+  }
+
+  def "should propagate cancel upstream if canary registered and execution explicitly canceled"() {
+    given:
+    def canaryStage = Mock(CanaryStage)
+    def stage = new PipelineStage(new Pipeline(), "pipelineStage", [
+      canary: [id: "canaryId"]
+    ]) {
+      @Override
+      List<StageNavigator.Result> ancestors(BiFunction<Stage<Pipeline>, StageDefinitionBuilder, Boolean> matcher) {
+        return [new StageNavigator.Result(this, canaryStage)]
+      }
+    }
+
+    when:
+    stage.execution.canceled = true
+    def result = monitorCanaryStage.cancel(stage)
+
+    then:
+    result.details.canary == [canceled: true]
+    1 * canaryStage.cancel(stage) >> { return new CancellableStage.Result(stage, [:]) }
+    1 * mineService.cancelCanary("canaryId", _) >> { return [canceled: true] }
+  }
+
+  def "should raise exception if no upstream canary stage found"() {
+    def stage = new PipelineStage(new Pipeline(), "pipelineStage", [
+      canary: [id: "canaryId"]
+    ])
+
+    when:
+    stage.execution.canceled = true
+    monitorCanaryStage.cancel(stage)
+
+    then:
+    thrown(IllegalStateException)
+  }
+}


### PR DESCRIPTION
…ul registration

The existing `CleanupCanaryTask` behavior should fire when the failure occurs after registration.