### PR TITLE
Avoid fetching EntityTags from `clouddriver` when deleting

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -116,38 +116,4 @@ public interface OortService {
                       @Query("account") String account,
                       @Query("region") String region,
                       @QueryMap Map additionalFilters)
-
-  @GET("/tags/{id}")
-  EntityTags getEntityTags(@Path("id") String id)
-
-  static class EntityTags {
-    String id
-
-    Map<String, Object> tags = [:]
-    EntityRef entityRef
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    static class EntityRef {
-      private Map<String, Object> attributes = new HashMap<String, Object>()
-
-      String cloudProvider
-      String entityType
-      String entityId
-
-      @JsonAnyGetter
-      Map<String, Object> attributes() {
-        return attributes;
-      }
-
-      @JsonAnySetter
-      void set(String name, Object value) {
-        attributes.put(name, value);
-      }
-
-      String getEntityType() {
-        return entityType?.toLowerCase()
-      }
-    }
-  }
-
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/entitytags/DeleteEntityTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/entitytags/DeleteEntityTagsTask.java
@@ -21,15 +21,11 @@ import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.RetryableTask;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.clouddriver.KatoService;
-import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import com.netflix.spinnaker.orca.clouddriver.OortService.EntityTags;
-import retrofit.RetrofitError;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,25 +35,14 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class DeleteEntityTagsTask extends AbstractCloudProviderAwareTask implements RetryableTask {
   private final KatoService kato;
-  private final OortService oort;
 
   @Autowired
-  public DeleteEntityTagsTask(KatoService kato, OortService oort) {
+  public DeleteEntityTagsTask(KatoService kato) {
     this.kato = kato;
-    this.oort = oort;
   }
 
   @Override
   public TaskResult execute(Stage stage) {
-    try {
-      oort.getEntityTags((String) stage.getContext().get("id"));
-    } catch (RetrofitError e) {
-      if (e.getResponse() != null && e.getResponse().getStatus() == 404) {
-        // tag doesn't exist, nothing to delete
-        return new DefaultTaskResult(ExecutionStatus.SUCCEEDED);
-      }
-    }
-
     TaskId taskId = kato.requestOperations(Collections.singletonList(
       new HashMap<String, Map>() {{
         put("deleteEntityTags", stage.getContext());


### PR DESCRIPTION
- Clouddriver will short circuit if the entity tags do not exist