### PR TITLE
Use parentPipelineId and not isPipeline to identify parent executions

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
@@ -133,7 +133,7 @@ trait DeploymentDetailsAware {
     if (execution instanceof Pipeline) {
       if (execution.trigger.parentExecution instanceof Pipeline) {
         return execution.trigger.parentExecution
-      } else if (execution.trigger?.isPipeline) {
+      } else if (execution.trigger?.parentPipelineId) {
         return pipelineObjectMapper.convertValue(execution.trigger.parentExecution, Pipeline)
       }
     }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
@@ -202,7 +202,7 @@ class CreateServerGroupTaskSpec extends Specification {
     ]
     // Building these as maps instead of using the pipeline model objects since this configuration was observed in testing.
     def parentTrigger = [
-      isPipeline: true,
+      parentPipelineId: "abc",
       parentExecution: [
         name: "grandparent",
         context: grandparentGlobalContext,
@@ -214,7 +214,7 @@ class CreateServerGroupTaskSpec extends Specification {
     ]
 
     def childTrigger = [
-      isPipeline: true,
+      parentPipelineId: "abc",
       parentExecution: [
         name: "parent",
         trigger: parentTrigger

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -54,8 +54,7 @@ class DependentPipelineStarter implements ApplicationContextAware {
       parentPipelineId         : parentPipeline.id,
       parentPipelineApplication: parentPipeline.application,
       parentStatus             : parentPipeline.status,
-      parentExecution          : parentPipeline,
-      isPipeline               : false
+      parentExecution          : parentPipeline
     ]
 
     if (parentPipelineStageId) {
@@ -64,7 +63,6 @@ class DependentPipelineStarter implements ApplicationContextAware {
 
     if( parentPipeline instanceof Pipeline){
       pipelineConfig.trigger.parentPipelineName = parentPipeline.name
-      pipelineConfig.trigger.isPipeline = true
     }
 
     if (pipelineConfig.parameterConfig || !suppliedParameters.empty) {


### PR DESCRIPTION
Use parentPipelineId to identify that there is a parent pipeline. isPipeline does not get set when triggering pipelines manually with a specified parent execution. This change should make orca treat manual and automatic triggers the same way.