### PR TITLE
Add the ability to delete a Fast Property via Pipeline Stage

### DIFF
--- a/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
+++ b/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
@@ -41,8 +41,14 @@ class CreatePropertiesTask implements Task {
     List propertyIdList = []
 
     properties.forEach { Map prop ->
-      log.info("Upserting Property: ${prop}")
-      Response response = maheService.upsertProperty(prop)
+      Response response
+      if (stage.context.delete) {
+        log.info("Deleting Property: ${prop.property.propertyId} on execution ${stage.execution.id}")
+        response = maheService.deleteProperty(prop.property.propertyId, 'delete', prop.property.env)
+      } else {
+        log.info("Upserting Property: ${prop}")
+        response = maheService.upsertProperty(prop)
+      }
       if (response.status == 200 && response.body.mimeType().startsWith('application/')) {
         propertyIdList << mapper.readValue(response.body.in().text, Map)
       } else {


### PR DESCRIPTION
Allows for a boolean flag be set on the stage context to make a call to
delete one or more fast properties via a pipeline stage.

This will be primarily used for the new Global Fast Property work that is in flight.