### PR TITLE
Adds orca-extension module to define extension interfaces.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,14 +94,10 @@ allprojects {
     }
   }
 }
-
 subprojects {
   dependencies {
     spinnaker.group('spockBase')
-    compile spinnaker.dependency('groovy')
-    compile spinnaker.dependency('guava')
-    compile spinnaker.dependency('slf4jApi')
-    testRuntime spinnaker.dependency('slf4jSimple')
+    testCompile spinnaker.dependency('groovy')
   }
 }
 

--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -17,6 +17,12 @@
 apply plugin: "io.franzbecker.gradle-lombok"
 
 dependencies {
+  compile project(":orca-extensionpoint")
+  compile spinnaker.dependency('groovy')
+  compile spinnaker.dependency('guava')
+  compile spinnaker.dependency('slf4jApi')
+  testRuntime spinnaker.dependency('slf4jSimple')
+
   spinnaker.group('jackson')
 
   compile spinnaker.dependency('batch')

--- a/orca-extensionpoint/README.md
+++ b/orca-extensionpoint/README.md
@@ -1,0 +1,4 @@
+Extension interfaces for orca.
+
+This is (and should remain) a low/no dependency module that defines extension interfaces for extending
+orca with custom functionality.

--- a/orca-extensionpoint/orca-extensionpoint.gradle
+++ b/orca-extensionpoint/orca-extensionpoint.gradle
@@ -1,0 +1,3 @@
+tasks.compileGroovy.enabled = false
+
+

--- a/orca-extensionpoint/src/main/java/com/netflix/spinnaker/orca/extensionpoint/pipeline/PipelinePreprocessor.java
+++ b/orca-extensionpoint/src/main/java/com/netflix/spinnaker/orca/extensionpoint/pipeline/PipelinePreprocessor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.extensionpoint.pipeline;
+
+import java.util.Map;
+
+public interface PipelinePreprocessor {
+  Map<String, Object> process(Map<String, Object> pipeline);
+}

--- a/orca-pipelinetemplate/README.md
+++ b/orca-pipelinetemplate/README.md
@@ -1,0 +1,6 @@
+UNSTABLE
+
+Note - this module is currently a work in progress and under active development.
+
+Expect breaking changes in the model and execution engine backing this feature for the time being.
+

--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -1,0 +1,7 @@
+tasks.compileGroovy.enabled = false
+
+dependencies {
+  compile project(":orca-extensionpoint")
+  compile spinnaker.dependency("bootAutoConfigure")
+  compile spinnaker.dependency("springContext")
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.config;
+
+import com.netflix.spinnaker.orca.pipelinetemplate.PipelineTemplateModule;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.ComponentScan;
+
+@ConditionalOnProperty("pipelineTemplate.enabled")
+@ComponentScan(basePackageClasses = PipelineTemplateModule.class)
+public class PipelineTemplateConfiguration {
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateModule.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateModule.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipelinetemplate;
+
+/**
+ * Marker interface for package component scanning.
+ */
+public interface PipelineTemplateModule {
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipelinetemplate;
+
+import com.netflix.spinnaker.orca.extensionpoint.pipeline.PipelinePreprocessor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class PipelineTemplatePipelinePreprocessor implements PipelinePreprocessor {
+
+  @Override
+  public Map<String, Object> process(Map<String, Object> pipeline) {
+    return pipeline;
+  }
+}

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -44,6 +44,7 @@ dependencies {
   compile project(":orca-igor")
   compile project(":orca-eureka")
   compile project(":orca-spring-batch")
+  compile project(":orca-pipelinetemplate")
 
 //  Replace below with this line when fiat becomes stable.
 //  spinnaker.group "fiat"

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/Main.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/Main.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.orca.clouddriver.config.CloudDriverConfiguration
 import com.netflix.spinnaker.orca.config.JesqueConfiguration
 import com.netflix.spinnaker.orca.config.OrcaConfiguration
 import com.netflix.spinnaker.orca.config.OrcaPersistenceConfiguration
+import com.netflix.spinnaker.orca.config.PipelineTemplateConfiguration
 import com.netflix.spinnaker.orca.config.RedisConfiguration
 import com.netflix.spinnaker.orca.data.jackson.StageMixins
 import com.netflix.spinnaker.orca.echo.config.EchoConfiguration
@@ -77,6 +78,7 @@ import org.springframework.scheduling.annotation.EnableAsync
   ApplicationConfig,
   FiatAuthenticationConfig,
   StackdriverConfig,
+  PipelineTemplateConfiguration,
 ])
 @ComponentScan([
   "com.netflix.spinnaker.config"

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-include "orca-core",
+include "orca-extensionpoint",
+  "orca-core",
   "orca-retrofit",
   "orca-front50",
   "orca-bakery",
@@ -29,7 +30,8 @@ include "orca-core",
   "orca-web",
   "orca-smoke-test",
   "orca-applications",
-  "orca-spring-batch"
+  "orca-spring-batch",
+  "orca-pipelinetemplate"
 
 rootProject.name = "orca"
 


### PR DESCRIPTION
Adds an orca-extensionpoint module as a no-dependency API for adding extensions to orca core functionality.
Defines PipelinePreprocessor extension point and wires it into OperationsController /orchestrate endpoint to transform supplied JSON object.
Adds orca-pipelinetemplate module as placeholder to start work on declarative continuous delivery efforts, with initial (no-op) PipelinePreprocessor implementation (also not enabled by default without `pipelineTemplate.enabled=true`

Some build updates to get rid of all subprojects having groovy as a compile time dependency.

@spinnaker/netflix-reviewers PTAL - does adding a separate module for extension interfaces seem like a dumb idea? (orca-core is a pretty heavy dependency to bring in currently, was trying to avoid that...)