### PR TITLE
fix QUIP stage when build artifacts are missing

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/QuickPatchStage.groovy
@@ -58,7 +58,7 @@ class QuickPatchStage implements StageDefinitionBuilder {
 
   @Override
   def <T extends Execution<T>> void taskGraph(Stage<T> stage, TaskNode.Builder builder) {
-    builder.withTask("foo", ResolveQuipVersionTask)
+    builder.withTask("resolveQuipVersion", ResolveQuipVersionTask)
   }
 
   @Override

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/util/PackageInfoSpec.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.orca.batch.pipeline.util
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.util.PackageInfo
 import spock.lang.Specification
 import spock.lang.Subject
@@ -26,7 +26,8 @@ import spock.lang.Unroll
 class PackageInfoSpec extends Specification {
 
   @Subject
-  PackageInfo info = new PackageInfo(Mock(Stage), 'deb', '_', true, true, Mock(ObjectMapper))
+  def stage = new PipelineStage(context: [package: "package"])
+  PackageInfo info = new PackageInfo(stage, 'deb', '_', true, true, Mock(ObjectMapper))
 
   Map buildInfo = [
     artifacts: [


### PR DESCRIPTION
fixes the case were the build info/artifacts in the QUIP stage has been overwritten by a parallel or parent Jenkins stage.  the fix navigates the ancestors looking for the first match that contains the correct build info/artifacts based on the QUIP stage's properties.