### PR TITLE
When restarting pipelines/stages, restart any actively running stages

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
@@ -16,11 +16,26 @@
 
 package com.netflix.spinnaker.orca.pipeline;
 
-import java.util.*;
 import com.netflix.spinnaker.orca.ExecutionStatus;
-import com.netflix.spinnaker.orca.pipeline.model.*;
+import com.netflix.spinnaker.orca.pipeline.model.AbstractStage;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Orchestration;
+import com.netflix.spinnaker.orca.pipeline.model.OrchestrationStage;
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline;
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner;
+import com.netflix.spinnaker.orca.pipeline.model.Task;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import static com.netflix.spinnaker.orca.pipeline.TaskNode.Builder;
 import static com.netflix.spinnaker.orca.pipeline.TaskNode.GraphType.FULL;
 import static java.util.Collections.emptyList;
@@ -103,8 +118,9 @@ public interface StageDefinitionBuilder {
             requisiteStageRefIds.addAll((Collection<String>) it.getContext().get("requisiteIds"));
           }
 
-          // only want to consider completed child stages
-          return it.getStatus().isComplete() && requisiteStageRefIds.contains(stage.getRefId());
+          // only want to consider completed or running child stages
+          return (it.getStatus().isComplete() || it.getStatus() == ExecutionStatus.RUNNING)
+            && requisiteStageRefIds.contains(stage.getRefId());
         })
         .collect(toList());
 


### PR DESCRIPTION
Given a pipeline execution:

```
TYPE      Jenkins1        -> Manual Judgement -> Jenkins2
STATUS    FAILED_CONTINUE    RUNNING             NOT_STARTED
CONDITION                    jenkins1.status != 'FAILED_CONTINUE'
```

Restarting the Jenkins1 stage will cause Manual Judgement to continue to run, but the condition expression will resolve to `true`, causing Jenkins2 to start.

This PR will now have the stage definition builder restart running tasks as well.

@spinnaker/reviewers PTAL