### PR TITLE
orca-clouddriver: Make backoff and timeout configurable for WaitForUpsertedImageTagsTask

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/WaitForUpsertedImageTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/WaitForUpsertedImageTagsTask.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -34,6 +35,12 @@ import java.util.concurrent.TimeUnit;
 public class WaitForUpsertedImageTagsTask implements RetryableTask, CloudProviderAware {
   @Autowired
   List<ImageTagger> imageTaggers;
+
+  @Value("${tasks.waitForImageTags.backoffSeconds:30}")
+  int backoffSeconds;
+
+  @Value("${tasks.waitForImageTags.timeoutMinutes:10}")
+  int timeoutMinutes;
 
   @Override
   public TaskResult execute(Stage stage) {
@@ -52,12 +59,12 @@ public class WaitForUpsertedImageTagsTask implements RetryableTask, CloudProvide
 
   @Override
   public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(30);
+    return TimeUnit.SECONDS.toMillis(backoffSeconds);
   }
 
   @Override
   public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(10);
+    return TimeUnit.MINUTES.toMillis(timeoutMinutes);
   }
 
   static class StageData {


### PR DESCRIPTION
Since some providers often take >10min to tag an image.