### PR TITLE
Support sourcing of pipeline templates from `file`, `http` and `https…

### DIFF
--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -5,6 +5,7 @@ dependencies {
 
   compile('com.github.jknack:handlebars:4.0.6')
   compile('com.github.jknack:handlebars-jackson2:1.0.0')
+  compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${spinnaker.version('jackson')}"
 
   compile spinnaker.dependency("slf4jApi")
   compile spinnaker.dependency("bootAutoConfigure")

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/TemplateLoaderException.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/TemplateLoaderException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipelinetemplate.exceptions;
+
+public class TemplateLoaderException extends RuntimeException {
+  public TemplateLoaderException(String message) {
+    super(message);
+  }
+
+  public TemplateLoaderException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public TemplateLoaderException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/FileTemplateSchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/FileTemplateSchemeLoader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipelinetemplate.loader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+
+import static java.lang.String.format;
+
+@Component
+public class FileTemplateSchemeLoader implements TemplateSchemeLoader {
+  private final ObjectMapper jsonObjectMapper;
+  private final ObjectMapper yamlObjectMapper;
+
+  @Autowired
+  public FileTemplateSchemeLoader(ObjectMapper pipelineTemplateObjectMapper) {
+    this.jsonObjectMapper = pipelineTemplateObjectMapper;
+
+    this.yamlObjectMapper = new ObjectMapper(new YAMLFactory())
+      .setConfig(jsonObjectMapper.getSerializationConfig())
+      .setConfig(jsonObjectMapper.getDeserializationConfig());
+  }
+
+  @Override
+  public boolean supports(URI uri) {
+    String scheme = uri.getScheme();
+    return scheme.equalsIgnoreCase("file") && (isJson(uri) || isYaml(uri));
+  }
+
+  @Override
+  public PipelineTemplate load(URI uri) {
+    File templateFile = new File(uri);
+
+    if (!templateFile.exists()) {
+      throw new TemplateLoaderException(new FileNotFoundException(uri.toString()));
+    }
+
+    try {
+      ObjectMapper objectMapper = isJson(uri) ? jsonObjectMapper : yamlObjectMapper;
+      return objectMapper.readValue(templateFile, PipelineTemplate.class);
+    } catch (IOException e) {
+      throw new TemplateLoaderException(e);
+    }
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/HttpTemplateSchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/HttpTemplateSchemeLoader.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipelinetemplate.loader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+public class HttpTemplateSchemeLoader implements TemplateSchemeLoader {
+  private final ObjectMapper jsonObjectMapper;
+  private final ObjectMapper yamlObjectMapper;
+
+  @Autowired
+  public HttpTemplateSchemeLoader(ObjectMapper pipelineTemplateObjectMapper) {
+    this.jsonObjectMapper = pipelineTemplateObjectMapper;
+
+    this.yamlObjectMapper = new ObjectMapper(new YAMLFactory())
+      .setConfig(jsonObjectMapper.getSerializationConfig())
+      .setConfig(jsonObjectMapper.getDeserializationConfig());
+  }
+
+  @Override
+  public boolean supports(URI uri) {
+    String scheme = uri.getScheme();
+    return scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https");
+  }
+
+  @Override
+  public PipelineTemplate load(URI uri) {
+    try (InputStream is = uri.toURL().openConnection().getInputStream();
+         BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+         Stream<String> stream = reader.lines()) {
+      ObjectMapper objectMapper = isJson(uri) ? jsonObjectMapper : yamlObjectMapper;
+      return objectMapper.readValue(stream.collect(Collectors.joining("\n")), PipelineTemplate.class);
+    } catch (Exception e) {
+      throw new TemplateLoaderException(e);
+    }
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateLoader.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipelinetemplate.loader;
+
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static java.lang.String.format;
+
+@Component
+public class TemplateLoader {
+  private Collection<TemplateSchemeLoader> schemeLoaders;
+
+  @Autowired
+  public TemplateLoader(Collection<TemplateSchemeLoader> schemeLoaders) {
+    this.schemeLoaders = schemeLoaders;
+  }
+
+  /**
+   * @return a LIFO list of pipeline templates
+   */
+  public List<PipelineTemplate> load(TemplateConfiguration.TemplateSource template) {
+    URI uri;
+    try {
+      uri = new URI(template.getSource());
+    } catch (URISyntaxException e) {
+      throw new TemplateLoaderException(format("Unable to load template from URI '%s'", template.getSource()), e);
+    }
+
+    TemplateSchemeLoader schemeLoader = schemeLoaders.stream()
+      .filter(l -> l.supports(uri))
+      .findFirst()
+      .orElseThrow(() -> new TemplateLoaderException(format("No TemplateSchemeLoader found for '%s'", uri.getScheme())));
+
+    // TODO-AJ If loaded `PipelineTemplate` has a source, we should be loading it as well ... all the way up!
+    return Collections.singletonList(schemeLoader.load(uri));
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateSchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateSchemeLoader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipelinetemplate.loader;
+
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+
+import java.io.File;
+import java.net.URI;
+
+public interface TemplateSchemeLoader {
+  boolean supports(URI uri);
+  PipelineTemplate load(URI uri);
+
+  default boolean isJson(URI uri) {
+    String uriName = uri.toString().toLowerCase();
+    return uriName.endsWith(".json");
+  }
+
+  default boolean isYaml(URI uri) {
+    String uriName = uri.toString().toLowerCase();
+    return uriName.endsWith(".yaml") || uriName.endsWith(".yml");
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/GraphMutator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/GraphMutator.java
@@ -32,12 +32,10 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 
-@Component
 public class GraphMutator {
 
   List<PipelineTemplateVisitor> visitors = new ArrayList<>();
 
-  @Autowired
   public GraphMutator(TemplateConfiguration configuration, Renderer renderer, Registry registry) {
     visitors.add(new ConditionalStanzaTransform(configuration, renderer));
     visitors.add(new ConfigModuleReplacementTransform(configuration));

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
@@ -17,8 +17,10 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisitor;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class PipelineTemplate {
 
@@ -150,7 +152,7 @@ public class PipelineTemplate {
   }
 
   public List<StageDefinition> getStages() {
-    return stages;
+    return Optional.ofNullable(stages).orElse(Collections.emptyList());
   }
 
   public void setStages(List<StageDefinition> stages) {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
@@ -17,10 +17,12 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class StageDefinition implements NamedContent, Conditional {
 
   private String id;
+  private String name;
   private InjectionRule inject;
   private String dependsOn; // TODO rz - comma-delimited for now
   private String type;
@@ -31,7 +33,7 @@ public class StageDefinition implements NamedContent, Conditional {
 
   @Override
   public String getName() {
-    return id;
+    return Optional.ofNullable(name).orElse(id);
   }
 
   public static class InjectionRule {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateConfiguration.java
@@ -15,8 +15,11 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 public class TemplateConfiguration {
@@ -24,7 +27,7 @@ public class TemplateConfiguration {
   private String schema;
   private String id;
   private PipelineDefinition pipeline;
-  private PipelineConfiguration configuration;
+  private PipelineConfiguration configuration = new PipelineConfiguration();
   private List<StageDefinition> stages;
   private List<TemplateModule> modules;
 
@@ -35,7 +38,7 @@ public class TemplateConfiguration {
     private String application;
     private String name;
     private TemplateSource template;
-    private Map<String, Object> variables;
+    private Map<String, Object> variables = new HashMap<>();
 
     public String getApplication() {
       return application;
@@ -93,7 +96,7 @@ public class TemplateConfiguration {
     private String description;
 
     public List<String> getInherit() {
-      return inherit;
+      return Optional.ofNullable(inherit).orElse(Collections.emptyList());
     }
 
     public void setInherit(List<String> inherit) {
@@ -178,7 +181,7 @@ public class TemplateConfiguration {
   }
 
   public List<StageDefinition> getStages() {
-    return stages;
+    return Optional.ofNullable(stages).orElse(Collections.emptyList());
   }
 
   public void setStages(List<StageDefinition> stages) {

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/loader/FileTemplateSchemeLoaderSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/loader/FileTemplateSchemeLoaderSpec.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipelinetemplate.loader
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException
+import spock.lang.Specification
+import spock.lang.Unroll;
+
+class FileTemplateSchemeLoaderSpec extends Specification {
+  def schemeLoader = new FileTemplateSchemeLoader(new ObjectMapper())
+
+  @Unroll
+  void "should support json/yaml/yml extensions"() {
+    expect:
+    schemeLoader.supports(new URI(uri)) == shouldSupport
+
+    where:
+    uri                                || shouldSupport
+    "file:///tmp/foobar.json"          || true
+    "file:///tmp/foobar.yaml"          || true
+    "file:///tmp/foobar.yml"           || true
+    "file:///tmp/foobar.txt"           || false
+    "http://www.google.com/foobar.yml" || false
+  }
+
+  void "should raise exception when uri does not exist"() {
+    when:
+    schemeLoader.load(new URI("file:///tmp/does-not-exist.yml"))
+
+    then:
+    def e = thrown(TemplateLoaderException)
+    e.cause instanceof FileNotFoundException
+  }
+
+  void "should load simple pipeline template"() {
+    given:
+    def uri = getClass().getResource("/templates/simple-001.yml").toURI()
+
+    when:
+    def pipelineTemplate = schemeLoader.load(uri)
+
+    then:
+    pipelineTemplate.id == "simpleTemplate"
+  }
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/loader/HttpTemplateSchemeLoaderSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/loader/HttpTemplateSchemeLoaderSpec.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipelinetemplate.loader
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject;
+
+class HttpTemplateSchemeLoaderSpec extends Specification {
+  @Subject
+  def schemeLoader = new HttpTemplateSchemeLoader(new ObjectMapper())
+
+  @Shared
+  def httpServer
+
+  @Shared
+  def httpServerPort
+
+  void setupSpec() {
+    httpServer = HttpServer.create(new InetSocketAddress(0), 0)
+    httpServer.createContext("/", { HttpExchange exchange ->
+      try {
+        exchange.responseHeaders.set("Content-Type", "application/yml")
+        def resource = HttpTemplateSchemeLoaderSpec.class.getResource(exchange.requestURI.path)
+        if (resource) {
+          exchange.sendResponseHeaders(200, 0)
+        } else {
+          exchange.sendResponseHeaders(404, 0)
+          exchange.responseBody.close()
+          return
+        }
+
+        new File(resource.toURI()).withInputStream {
+          exchange.responseBody << it
+        }
+        exchange.responseBody.close()
+
+      } catch (ignored) {
+        exchange.sendResponseHeaders(500, 0)
+        exchange.responseBody.close()
+      }
+    } as HttpHandler)
+
+    httpServer.start()
+    httpServerPort = httpServer.address.port
+  }
+
+  void cleanupSpec() {
+    httpServer.stop(0);
+  }
+
+  void "should fetch http uri"() {
+    given:
+    def uri = new URI("http://localhost:${httpServerPort}/templates/simple-001.yml")
+
+    when:
+    def pipelineTemplate = schemeLoader.load(uri)
+
+    then:
+    pipelineTemplate.id == "simpleTemplate"
+  }
+
+  void "should raise exception when uri does not exist"() {
+    given:
+    def uri = new URI("http://localhost:${httpServerPort}/templates/does-not-exist.yml")
+
+    when:
+    schemeLoader.load(uri)
+
+    then:
+    def e = thrown(TemplateLoaderException)
+    e.cause instanceof FileNotFoundException
+  }
+}

--- a/orca-pipelinetemplate/src/test/resources/templates/simple-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/simple-001.yml
@@ -1,0 +1,30 @@
+schema: "1"
+id: simpleTemplate
+variables:
+- name: application
+  description: The application name
+- name: regions
+  description: A list of regions to bake in
+  type: list
+configuration:
+  triggers:
+  - type: jenkins
+    master: spinnaker
+    job: SPINNAKER-package-{{ var.application }}
+    enabled: true
+stages:
+- id: bake
+  name: Bake
+  config:
+    regions: "{{ var.regions }}"
+    package: "{{ var.application }}-package"
+    baseOs: trusty
+    vmType: hvm
+    storeType: ebs
+    baseLabel: release
+- id: tagImage
+  name: Tag Image
+  dependsOn: bake
+  config:
+    tags:
+      stack: test


### PR DESCRIPTION
…` URIs

Currently only the first parent source is fetched (_limitation_)

```
curl -X "POST" "https://localhost:8083/orchestrate" \
     -H "Content-Type: application/context+json" \
     -d $'{
  "type": "templatedPipeline",
  "config": {
    "pipeline": {
		"template": {
			"source": "https://gist.githubusercontent.com/ajordens/8a227811ad994434927c4f410f8252d1/raw/3e2f67c106bcf4bb636946bce8e4a172ea5762b7/simple-v001.yml"
	    }
	}
  }
}'
```