### PR TITLE
Fixing module & stage merge functionality

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplateMerge.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplateMerge.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema;
 
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.Identifiable;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.NamedContent;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 
@@ -36,9 +37,9 @@ public class TemplateMerge {
       mergeConfiguration(result, template);
 
       // TODO rz - might make sense that any child template must use inject syntax / modules.
-      result.setStages(mergeNamedContent(result.getStages(), template.getStages()));
+      result.setStages(mergeIdentifiable(result.getStages(), template.getStages()));
 
-      result.setModules(mergeNamedContent(result.getModules(), template.getModules()));
+      result.setModules(mergeIdentifiable(result.getModules(), template.getModules()));
     }
     return result;
   }
@@ -94,4 +95,34 @@ public class TemplateMerge {
 
     return merged;
   }
+
+  public static <T extends Identifiable> List<T> mergeIdentifiable(List<T> a, List<T> b) {
+    if (a == null || a.size() == 0) {
+      return b;
+    }
+
+    if (b == null || b.size() == 0) {
+      return a;
+    }
+
+    List<T> merged = new ArrayList<>();
+    merged.addAll(a);
+    for (T bNode : b) {
+      boolean updated = false;
+      for (int i = 0; i < merged.size(); i++) {
+        if (merged.get(i).getId().equals(bNode.getId())) {
+          merged.set(i, bNode);
+          updated = true;
+          break;
+        }
+      }
+
+      if (!updated) {
+        merged.add(bNode);
+      }
+    }
+
+    return merged;
+  }
+
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigModuleReplacementTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigModuleReplacementTransform.java
@@ -30,6 +30,6 @@ public class ConfigModuleReplacementTransform implements PipelineTemplateVisitor
 
   @Override
   public void visitPipelineTemplate(PipelineTemplate pipelineTemplate) {
-    pipelineTemplate.setModules(TemplateMerge.mergeNamedContent(pipelineTemplate.getModules(), templateConfiguration.getModules()));
+    pipelineTemplate.setModules(TemplateMerge.mergeIdentifiable(pipelineTemplate.getModules(), templateConfiguration.getModules()));
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/Identifiable.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/Identifiable.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
+
+public interface Identifiable {
+
+  String getId();
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
@@ -17,9 +17,8 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-public class StageDefinition implements NamedContent, Conditional {
+public class StageDefinition implements Identifiable, Conditional {
 
   private String id;
   private String name;
@@ -30,11 +29,6 @@ public class StageDefinition implements NamedContent, Conditional {
   private List<Map<String, Object>> notifications;
   private String comments;
   private String when;
-
-  @Override
-  public String getName() {
-    return Optional.ofNullable(name).orElse(id);
-  }
 
   public static class InjectionRule {
 
@@ -76,12 +70,21 @@ public class StageDefinition implements NamedContent, Conditional {
     }
   }
 
+  @Override
   public String getId() {
     return id;
   }
 
   public void setId(String id) {
     this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
   }
 
   public InjectionRule getInject() {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateModule.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateModule.java
@@ -17,7 +17,7 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
 import java.util.List;
 
-public class TemplateModule implements NamedContent {
+public class TemplateModule implements Identifiable {
 
   private String id;
   private String usage;
@@ -25,10 +25,6 @@ public class TemplateModule implements NamedContent {
   private Object definition;
 
   @Override
-  public String getName() {
-    return id;
-  }
-
   public String getId() {
     return id;
   }


### PR DESCRIPTION
Small change to get stages & templates merging using their ids, rather than names. I know @cfieber is messing around with TemplateMerge, so I didn't want to do a whole ton of stuff.

@cfieber PTAL