### PR TITLE
super rough first pass at layering configs for deployment model

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/DeploymentModel.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/DeploymentModel.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
+
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.MapMerge;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+//wire model
+public class DeploymentModel {
+  Map<String, ExtensibleNamedHashMap> clusters = new HashMap<>();
+  Map<String, ExtensibleNamedHashMap> loadBalancers = new HashMap<>();
+  Map<String, ExtensibleNamedHashMap> accounts = new HashMap<>();
+  Map<String, ExtensibleNamedHashMap> environments = new HashMap<>();
+
+  public Map<String, ExtensibleNamedHashMap> getClusters() {
+    return clusters;
+  }
+
+  public Map<String, ExtensibleNamedHashMap> getLoadBalancers() {
+    return loadBalancers;
+  }
+
+  public Map<String, ExtensibleNamedHashMap> getAccounts() {
+    return accounts;
+  }
+
+  public Map<String, ExtensibleNamedHashMap> getEnvironments() {
+    return environments;
+  }
+}
+
+
+class Ingress {
+
+}
+
+class ClusterRequirements {
+  static class Resources {
+    String cpu;
+    String ram;
+    String disk;
+    String network;
+
+    public String getCpu() {
+      return cpu;
+    }
+
+    public void setCpu(String cpu) {
+      this.cpu = cpu;
+    }
+
+    public String getRam() {
+      return ram;
+    }
+
+    public void setRam(String ram) {
+      this.ram = ram;
+    }
+
+    public String getDisk() {
+      return disk;
+    }
+
+    public void setDisk(String disk) {
+      this.disk = disk;
+    }
+
+    public String getNetwork() {
+      return network;
+    }
+
+    public void setNetwork(String network) {
+      this.network = network;
+    }
+  }
+
+  Resources resources;
+  List<String> membership;
+
+  Ingress ingress;
+
+  public Resources getResources() {
+    return resources;
+  }
+
+  public void setResources(Resources resources) {
+    this.resources = resources;
+  }
+
+  public List<String> getMembership() {
+    return membership;
+  }
+
+  public void setMembership(List<String> membership) {
+    this.membership = membership;
+  }
+
+  public Ingress getIngress() {
+    return ingress;
+  }
+
+  public void setIngress(Ingress ingress) {
+    this.ingress = ingress;
+  }
+}
+
+class Region {
+  String name;
+  List<String> zones;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<String> getZones() {
+    return zones;
+  }
+
+  public void setZones(List<String> zones) {
+    this.zones = zones;
+  }
+}
+class Account {
+  String name;
+  String cloudProvider;
+  Map<String, Region> regions;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getCloudProvider() {
+    return cloudProvider;
+  }
+
+  public void setCloudProvider(String cloudProvider) {
+    this.cloudProvider = cloudProvider;
+  }
+
+  public Map<String, Region> getRegions() {
+    return regions;
+  }
+
+  public void setRegions(Map<String, Region> regions) {
+    this.regions = regions;
+  }
+}
+
+class Environment {
+  Account account;
+  String stack;
+  String detail;
+  Map<String, Region> regions;
+
+  public Account getAccount() {
+    return account;
+  }
+
+  public void setAccount(Account account) {
+    this.account = account;
+  }
+
+  public String getStack() {
+    return stack;
+  }
+
+  public void setStack(String stack) {
+    this.stack = stack;
+  }
+
+  public String getDetail() {
+    return detail;
+  }
+
+  public void setDetail(String detail) {
+    this.detail = detail;
+  }
+
+  public Map<String, Region> getRegions() {
+    return regions;
+  }
+
+  public void setRegions(Map<String, Region> regions) {
+    this.regions = regions;
+  }
+}
+
+class LoadBalancer {
+  String name;
+  String type;
+  Ingress ingress;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public Ingress getIngress() {
+    return ingress;
+  }
+
+  public void setIngress(Ingress ingress) {
+    this.ingress = ingress;
+  }
+}
+
+// enhm -> clustermodel -> cluster
+class Cluster {
+  String name;
+  String application;
+  Environment environment;
+  ClusterRequirements requires;
+  List<LoadBalancer> loadBalancers;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getApplication() {
+    return application;
+  }
+
+  public void setApplication(String application) {
+    this.application = application;
+  }
+
+  public Environment getEnvironment() {
+    return environment;
+  }
+
+  public void setEnvironment(Environment environment) {
+    this.environment = environment;
+  }
+
+  public ClusterRequirements getRequires() {
+    return requires;
+  }
+
+  public void setRequires(ClusterRequirements requires) {
+    this.requires = requires;
+  }
+
+  public List<LoadBalancer> getLoadBalancers() {
+    return loadBalancers;
+  }
+
+  public void setLoadBalancers(List<LoadBalancer> loadBalancers) {
+    this.loadBalancers = loadBalancers;
+  }
+}
+
+
+class DeploymentModelResolver {
+  private ExtensibleContentResolver<DeploymentModel> resolver;
+  private final ObjectMapper mapper = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+  public DeploymentModelResolver(List<DeploymentModel> sources) {
+    this.resolver = new ExtensibleContentResolver<>(sources);
+  }
+
+  public Cluster getCluster(String name) {
+    ExtensibleNamedHashMap clusterContent = getResolved(name, DeploymentModel::getClusters);
+    clusterContent.computeIfPresent("environment", (k, environment) -> getEnvironment(environment));
+    clusterContent.computeIfPresent("loadBalancers", (k, loadBalancers) -> {
+      if (loadBalancers instanceof Collection) {
+        return ((Collection<Object>) loadBalancers).stream().map(this::getLoadBalancer).collect(Collectors.toList());
+      } else {
+        throw new IllegalStateException("expected collection");
+      }
+    });
+
+    return mapper.convertValue(clusterContent, Cluster.class);
+  }
+
+  public Environment getEnvironment(Object nameOrPayload) {
+    ExtensibleNamedHashMap environmentContent = getResolved(nameOrPayload, DeploymentModel::getEnvironments);
+    environmentContent.computeIfPresent("account", (k, accountPayload) -> getAccount(accountPayload));
+    return mapper.convertValue(environmentContent, Environment.class);
+  }
+
+  public Account getAccount(Object nameOrPayload) {
+    ExtensibleNamedHashMap accountContent = getResolved(nameOrPayload, DeploymentModel::getAccounts);
+    return mapper.convertValue(accountContent, Account.class);
+  }
+
+  public LoadBalancer getLoadBalancer(Object nameOrPayload) {
+    ExtensibleNamedHashMap loadBalancerContent = getResolved(nameOrPayload, DeploymentModel::getLoadBalancers);
+    return mapper.convertValue(loadBalancerContent, LoadBalancer.class);
+  }
+
+  private ExtensibleNamedHashMap getResolved(Object nameOrPayload, Function<DeploymentModel, Map<String, ExtensibleNamedHashMap>> type) {
+    if (nameOrPayload instanceof String) {
+      String name = nameOrPayload.toString();
+      ExtensibleNamedHashMap resolved = resolver.resolve(name, type).orElseThrow(NoSuchElementException::new);
+      if (!name.equals(resolved.getName())) {
+        resolved.put("name", name);
+      }
+      return resolved;
+    } else if (nameOrPayload instanceof Map) {
+      ExtensibleNamedHashMap content = new ExtensibleNamedHashMap((Map<String, Object>) nameOrPayload);
+      String name = content.getName();
+      if (name == null) {
+        name = "inlineOverride";
+        content.put("name", name);
+      }
+      DeploymentModel dm = new DeploymentModel();
+      type.apply(dm).put(name, content);
+      return new ExtensibleContentResolver<>(resolver, Arrays.asList(dm)).resolve(name, type).orElseThrow(NoSuchElementException::new);
+    } else {
+      throw new IllegalStateException("invalid content supplied: " + nameOrPayload.getClass().getSimpleName());
+    }
+  }
+}
+class ExtensibleContentResolver<T> {
+  private final Optional<ExtensibleContentResolver<T>> chain;
+  private final List<T> sources;
+
+  public ExtensibleContentResolver(List<T> sources) {
+    this(null, sources);
+  }
+
+  public ExtensibleContentResolver(ExtensibleContentResolver<T> chain, List<T> sources) {
+    this.chain = Optional.ofNullable(chain);
+    this.sources = sources;
+  }
+
+  public Optional<ExtensibleNamedHashMap> resolve(String name, Function<T, Map<String, ExtensibleNamedHashMap>> type) {
+    if (name == null || name.isEmpty()) {
+      return Optional.empty();
+    }
+    Optional<ExtensibleNamedHashMap> base = sources.stream().map(type).filter(enhm -> enhm.containsKey(name)).findFirst().map(enhm -> enhm.get(name));
+    ExtensibleNamedHashMap baseContent = base.orElseGet(() -> {
+        ExtensibleNamedHashMap chainContent = chain.flatMap((p) -> p.resolve(name, type)).orElse(null);
+        return chainContent;
+    });
+
+    return Optional.ofNullable(baseContent).map(enhm -> {
+      if (enhm.getExtends() != null && !enhm.isEmpty()) {
+        ExtensibleNamedHashMap parent = resolve(enhm.getExtends(), type).orElseThrow(NoSuchElementException::new);
+        ExtensibleNamedHashMap result = new ExtensibleNamedHashMap();
+        result.putAll(MapMerge.merge(parent, enhm));
+        return result;
+      } else {
+        return enhm;
+      }
+    });
+  }
+}
+
+interface ExtensibleContent {
+  default String getExtends() { return null; }
+}
+
+class ExtensibleNamedHashMap extends NamedHashMap implements ExtensibleContent {
+  public ExtensibleNamedHashMap() {
+    super();
+  }
+
+  public ExtensibleNamedHashMap(Map<String, Object> content) {
+    super(content);
+  }
+
+  @Override
+  public String getExtends() {
+    Object ext = get("extends");
+    if (ext == null) {
+      return null;
+    }
+    return ext.toString();
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/NamedHashMap.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/NamedHashMap.java
@@ -16,8 +16,17 @@
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class NamedHashMap extends HashMap<String, Object> implements NamedContent {
+
+  public NamedHashMap() {
+    super();
+  }
+
+  public NamedHashMap(Map<String, Object> content) {
+    super(content);
+  }
 
   public String getName() {
     return String.valueOf(get("name"));

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/DeploymentModelSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/DeploymentModelSpec.groovy
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model
+
+import com.fasterxml.jackson.annotation.JsonBackReference
+import com.fasterxml.jackson.annotation.JsonManagedReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import groovy.transform.Canonical
+import org.yaml.snakeyaml.Yaml
+import spock.lang.Specification
+
+/**
+ * DeploymentModelSpec.
+ */
+class DeploymentModelSpec extends Specification {
+/* jackson foo:
+  @Canonical
+  static class Child {
+    @JsonBackReference
+    Parent p
+    int age
+
+    String getName() {
+      return p.children.entrySet().findResult { e -> if (e.value.is(this)) return e.key else return null }
+    }
+  }
+
+  @Canonical
+  static class Parent {
+    @JsonManagedReference
+    Map<String, Child> children = [:]
+  }
+
+  def "it should serialize"() {
+    given:
+    def p = new Parent()
+    p.children.jimmy = new Child(p: p, age: 3)
+    p.children.billy = new Child(p: p, age: 5)
+
+    when:
+    def result = new ObjectMapper().writeValueAsString(p)
+
+    then:
+    result != null
+    println result
+  }
+
+  def "it should deserialize"() {
+    given:
+    def json = '{"children":{"jimmy":{"age":3},"billy":{"age":5}}}'
+
+    when:
+    Parent p = new ObjectMapper().readValue(json, Parent)
+
+    then:
+    p.children.size() == 2
+    p.children.jimmy.name == 'jimmy'
+  }
+*/
+
+  def "should layer content"() {
+    given:
+    def models = [
+        new DeploymentModel(clusters: [leaf: enhm([extends: 'extendo', someOtherAttribute: 'mustard', someExtendAttribute: 'bologna'])]), //highest precidence
+        new DeploymentModel(clusters: [extendo: enhm([extends: 'base', someExtendAttribute: 'ham'])]),
+        new DeploymentModel(clusters: [base: enhm([regions: ['us-east-1', 'us-west-2'], someBaseAttribute: 'bacon'])]), //lowest precidence
+    ]
+
+    def resolver = new ExtensibleContentResolver<DeploymentModel>(models)
+
+    expect:
+    resolver.resolve('leaf', {DeploymentModel dm -> dm.clusters }).get() == enhm([
+        regions: ['us-east-1', 'us-west-2'],
+        someBaseAttribute: 'bacon',
+        someExtendAttribute: 'bologna',
+        someOtherAttribute: 'mustard',
+        extends: 'extendo'
+    ])
+  }
+
+  def "should override lower layer content"() {
+    given:
+    def models = [
+        new DeploymentModel(clusters: [leaf: enhm([extends: 'extendo', someOtherAttribute: 'mustard', someExtendAttribute: 'bologna']), base: enhm([regions: ['eu-west-1']])]), //highest precidence
+        new DeploymentModel(clusters: [extendo: enhm([extends: 'base', someExtendAttribute: 'ham'])]),
+        new DeploymentModel(clusters: [base: enhm([regions: ['us-east-1', 'us-west-2'], someBaseAttribute: 'bacon'])]), //lowest precidence
+    ]
+
+    def resolver = new ExtensibleContentResolver<DeploymentModel>(models)
+
+    expect:
+    resolver.resolve('leaf', {DeploymentModel dm -> dm.clusters }).get() == enhm([
+        regions: ['eu-west-1'],
+        someExtendAttribute: 'bologna',
+        someOtherAttribute: 'mustard',
+        extends: 'extendo'
+    ])
+  }
+
+  def "should resolve a cluster"() {
+    given:
+    def models = [
+        new DeploymentModel(clusters: [spinBase: enhm([requires: [resources: [cpu: "1", ram: "4gb", disk: "20gb"]]])])
+    ]
+
+    def dmResolver = new DeploymentModelResolver(models)
+
+    when:
+    def cluster = dmResolver.getCluster("spinBase")
+
+    then:
+    cluster != null
+    cluster.requires.resources.cpu == "1"
+  }
+
+  def "should resolve a cluster with environment with account"() {
+    given:
+    def models = [
+        new DeploymentModel(accounts: [test: enhm(
+            name: "test",
+            cloudProvider: "aws",
+            regions: ["us-east-1": [
+                name: "us-east-1",
+                zones: ["us-east-1c", "us-east-1d"]
+            ]]
+        )]),
+        new DeploymentModel(environments: [staging: enhm(account: "test", stack: "staging")]),
+        new DeploymentModel(clusters: [spinBase: enhm([environment: "staging", requires: [resources: [cpu: "1", ram: "4gb", disk: "20gb"]]])])
+    ]
+
+    def dmResolver = new DeploymentModelResolver(models)
+
+    when:
+    def cluster = dmResolver.getCluster("spinBase")
+
+    then:
+    cluster != null
+    cluster.requires.resources.cpu == "1"
+    cluster.environment.stack == "staging"
+    cluster.environment.account.cloudProvider == "aws"
+  }
+
+  def "should allow inline extension"() {
+    def models = [
+        new DeploymentModel(accounts: [test: enhm(
+            name: "test",
+            cloudProvider: "aws",
+            regions: ["us-east-1": [
+                name: "us-east-1",
+                zones: ["us-east-1c", "us-east-1d"]
+            ]]
+        )]),
+        new DeploymentModel(environments: [staging: enhm(account: "test", stack: "staging")]),
+        new DeploymentModel(clusters: [spinBase: enhm([
+            environment: [extends: "staging", "detail": "canary"],
+            requires: [
+                resources: [
+                    cpu: "1",
+                    ram: "4gb",
+                    disk: "20gb"]]])])
+    ]
+
+    def dmResolver = new DeploymentModelResolver(models)
+
+    when:
+    def cluster = dmResolver.getCluster("spinBase")
+
+    then:
+    cluster != null
+    cluster.requires.resources.cpu == "1"
+    cluster.environment.stack == "staging"
+    cluster.environment.account.cloudProvider == "aws"
+    cluster.environment.detail == "canary"
+  }
+
+  def "should fail on unknown extends at resolve time"() {
+    given:
+    def models = [
+        new DeploymentModel(clusters: [spinBase: enhm([ extends: 'unknown' ])])
+    ]
+    def dmResolver = new DeploymentModelResolver(models)
+
+    when:
+    dmResolver.getCluster("spinBase")
+
+    then:
+    thrown(NoSuchElementException)
+  }
+
+  def "should read yaml filearooni"() {
+
+    given:
+    def mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
+    def models = new Yaml().loadAll(getClass().getResourceAsStream("/gate.yml")).collect {
+      mapper.convertValue(it, DeploymentModel)
+    }
+    def resolver = new DeploymentModelResolver(models)
+
+    when:
+    def cluster = resolver.getCluster("gateMain")
+    println mapper.writeValueAsString(cluster)
+    cluster = resolver.getCluster("gateFailover")
+    println mapper.writeValueAsString(cluster)
+
+    then:
+    true
+  }
+
+  private ExtensibleNamedHashMap enhm(Map<String, Object> content) {
+    return new ExtensibleNamedHashMap(content)
+  }
+}

--- a/orca-pipelinetemplate/src/test/resources/gate.yml
+++ b/orca-pipelinetemplate/src/test/resources/gate.yml
@@ -1,0 +1,150 @@
+#document netflix-conventions
+clusters:
+  netflix-conventions:
+    requires:
+      membership:
+        - nf-datacenter
+        - nf-infrastructure
+
+accounts:
+  awsdefault:
+    cloudProvider: aws
+    regions:
+      us-east-1:
+        name: us-east-1 #baerf
+        zones:
+          - us-east-1c
+          - us-east-1d
+          - us-east-1e
+      us-west-2:
+        name: us-west-2  #backrefs?
+        zones:
+          - us-west-2a
+          - us-west-2b
+          - us-west-2c
+
+  mgmttest:
+    extends: awsdefault
+    accountId: 123456789012
+
+  mgmt:
+    extends: awsdefault
+    accountId: 234567890123
+
+
+---
+
+#document spinnaker-conventions
+
+environments:
+  spinBase:
+    regions:
+      us-west-2: {}
+
+  test:
+    extends: spinBase
+    account: mgmttest
+    stack: test
+
+  spinProd:
+    extends: spinBase
+    account: mgmt
+
+  prestaging:
+    extends: spinProd
+    stack: prestaging
+
+  main:
+    extends: spinProd
+    stack: main
+
+  failover:
+    extends: main
+    regions:
+      us-west-2: null
+      us-east-1: {}
+
+loadBalancers:
+  spinnaker-elb:
+    type: internal
+#  listeners:
+#    - port: 80
+#      instancePort: 7001
+#      externalProtocol: HTTP
+#    - port: 443
+#      instancePort: 7002
+#      externalProtocol: TCP
+#  health:
+#    - instancePort: 7001
+#    - type: HTTP #implied
+#  ingress:
+#    - type: security-group #or CIDR or self
+#      from: spinnaker-internal-service
+#      ports:
+#        - 443
+
+clusters:
+  spinnaker-service:
+    extends: netflix-conventions
+    requires:
+      membership: #this doesn't merge it overwrites..
+                  # could also make it name: {} but bleh
+        - spinnaker-internal-service
+
+---
+
+loadBalancers:
+  gate-elb:
+    extends: spinnaker-elb
+#  listeners:
+#    - port: 7103
+#      instancePort: 7103
+#      externalProtocol: TCP
+
+clusters:
+  gateBase:
+    extends: spinnaker-service
+    application: gate
+    requires:
+      resources:
+        disk: 20gb
+        network: 1mbit
+        cpu: 2
+        ram: 4gb
+
+  gatePrestaging:
+    extends: gateBase
+    environment: prestaging
+    loadBalancers:
+      - extends: gate-elb
+        name: gate-prestaging-frontend
+
+  gateMain:
+    extends: gateBase
+    environment: main
+    requires:
+      resources:
+        network: 10mbit
+        ram: 16gb
+    loadBalancers:
+      - extends: gate-elb
+        name: gate-main-internal
+      - extends: gate-elb
+        type: external
+        name: gate-main-external
+
+  gateFailover:
+    extends: gateMain
+    environment: failover
+
+#---
+#
+#wat: >
+#  given serverGroup gate-main we can produce:
+#    upsertSecurityGroup operations: gate and gate-elb with appropriate ingress on gate for gate-elb
+#      - convention creates an application (stack?) specific security group, and for each ELB sets up ingress perms for
+#        all listeners instancePort settings
+#      - for elb adds ingress perms from config
+#    upsertLoadBalancer operations: gate-main-frontend and gate-main-external
+#    createServerGroup operation: gate-main in aws mgmt us-west-2
+#


### PR DESCRIPTION
just looking for some feedback on the approach, the code is an inlined pile of garbage currently.

generally:
* a DeploymentModel represents a single yaml document, containing clusters, loadBalancers, accounts, environments (potentially more in the future) all keyed on name/id pointing to an object
* object can extend another object with `extends: name`
* a resolver takes an ordered list of documents (priority order). when looking up an object by name (for retrieval or extension) the first object found by name wins.
* resolving an object by name follows the `extends` and keeps layering on the configuration via MapMerge
* resolving to a typed object (`Cluster` from `Map`) resolves the object to its fully merged format, as well resolving its relationships to other configurable types. (e.g Cluster has an Environment has an Account, so cluster Map is formed, and cluster.get("environment") is used to resolve Environment which causes environment Map to merge and environment.get("account") to be resolved.

end state it is intended that a pipeline template should be able to take a variable of type `cluster` (or `environment` or `account`) and the resolver will supply a resolved strongly typed object for that variable. I also intend to build a transformer that knows how to take the current model (Cluster to start) which (while incomplete) is intended not to be cloud provider specific, and produce the proper payload for a cloud provider deploy.

feels like there is some overlap with the existing pipeline template composition bit (and I'm I think a bit out of date with that). I was going to circle back to that at some point.

I think this does a good job of addressing the inheritance selector issues with the one exception of lists not being treated well (they are just replaced as opposed to merged - both of those choices have bad tradeoffs).

Probably the most interesting thing to look at would be `gate.yml` which produces the following once loaded, and the gateMain cluster is mapped to the strongly typed cluster object, then serialized back out (DeploymentModelSpec does that):
````json
{
  "name" : "gateMain",
  "application" : "gate",
  "environment" : {
    "account" : {
      "name" : "mgmt",
      "cloudProvider" : "aws",
      "regions" : {
        "us-east-1" : {
          "name" : "us-east-1",
          "zones" : [ "us-east-1c", "us-east-1d", "us-east-1e" ]
        },
        "us-west-2" : {
          "name" : "us-west-2",
          "zones" : [ "us-west-2a", "us-west-2b", "us-west-2c" ]
        }
      }
    },
    "stack" : "main",
    "detail" : null,
    "regions" : {
      "us-west-2" : {
        "name" : null,
        "zones" : null
      }
    }
  },
  "requires" : {
    "resources" : {
      "cpu" : "2",
      "ram" : "16gb",
      "disk" : "20gb",
      "network" : "10mbit"
    },
    "membership" : [ "spinnaker-internal-service" ],
    "ingress" : null
  },
  "loadBalancers" : [ {
    "name" : "gate-main-internal",
    "type" : "internal",
    "ingress" : null
  }, {
    "name" : "gate-main-external",
    "type" : "external",
    "ingress" : null
  } ]
}
````
