### PR TITLE
Adding inheritance control support for template stages

### DIFF
--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -6,6 +6,7 @@ dependencies {
   compile('com.github.jknack:handlebars:4.0.6')
   compile('com.github.jknack:handlebars-jackson2:1.0.0')
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${spinnaker.version('jackson')}"
+  compile('com.jayway.jsonpath:json-path:2.2.0')
 
   compile spinnaker.dependency("slf4jApi")
   compile spinnaker.dependency("bootAutoConfigure")

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/GraphMutator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/GraphMutator.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.Conf
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConfigStageInjectionTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.PipelineConfigInheritanceTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.RenderTransform;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.StageInheritanceControlTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
@@ -39,6 +40,7 @@ public class GraphMutator {
     visitors.add(new PipelineConfigInheritanceTransform(configuration));
     visitors.add(new ConfigStageInjectionTransform(configuration));
     visitors.add(new RenderTransform(configuration, renderer, registry));
+    visitors.add(new StageInheritanceControlTransform());
   }
 
   public void mutate(PipelineTemplate template) {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/StageInheritanceControlTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/StageInheritanceControlTransform.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.MapMerge;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisitor;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinition.InheritanceControl.Rule;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class StageInheritanceControlTransform implements PipelineTemplateVisitor {
+
+  @Override
+  public void visitPipelineTemplate(PipelineTemplate pipelineTemplate) {
+    pipelineTemplate.getStages()
+      .stream()
+      .filter(s -> s.getInheritanceControl() != null)
+      .forEach(s -> {
+        DocumentContext dc = JsonPath.parse(s.getConfig());
+        s.getInheritanceControl().getMerge().forEach(r -> merge(dc, r));
+        s.getInheritanceControl().getReplace().forEach(r -> replace(dc, r));
+        s.getInheritanceControl().getRemove().forEach(r -> dc.delete(r.getPath()));
+      });
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void merge(DocumentContext dc, Rule rule) {
+    Object oldValue = dc.read(rule.getPath());
+    if (oldValue instanceof Collection) {
+      if (!(rule.getValue() instanceof Collection)) {
+        throw new TemplateRenderException("cannot merge non-collection value into collection");
+      }
+      ((Collection) oldValue).addAll((Collection) rule.getValue());
+      dc.set(rule.getPath(), oldValue);
+    } else if (oldValue instanceof Map) {
+      if (!(rule.getValue() instanceof Map)) {
+        throw new TemplateRenderException("cannot merge non-map value into map");
+      }
+      Map<String, Object> merged = MapMerge.merge((Map<String, Object>) oldValue, (Map<String, Object>) rule.getValue());
+      dc.set(rule.getPath(), merged);
+    } else {
+      throw new TemplateRenderException("merge inheritance control must be given a list or map value: " + rule.getPath());
+    }
+  }
+
+  private static void replace(DocumentContext dc, Rule rule) {
+    Object oldValue = dc.read(rule.getPath());
+    if (oldValue instanceof Collection && !(rule.getValue() instanceof Collection)) {
+      throw new TemplateRenderException("cannot replace collection value with non-collection value");
+    } else if (oldValue instanceof Map && !(rule.getValue() instanceof Map)) {
+      throw new TemplateRenderException("cannot replace map value with non-map value");
+    }
+    dc.set(rule.getPath(), rule.getValue());
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
@@ -15,8 +15,11 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class StageDefinition implements Identifiable, Conditional {
 
@@ -29,6 +32,7 @@ public class StageDefinition implements Identifiable, Conditional {
   private List<Map<String, Object>> notifications;
   private String comments;
   private List<String> when;
+  private InheritanceControl inheritanceControl;
 
   public static class InjectionRule {
 
@@ -67,6 +71,58 @@ public class StageDefinition implements Identifiable, Conditional {
 
     public void setAfter(String after) {
       this.after = after;
+    }
+  }
+
+  public static class InheritanceControl {
+
+    private Collection<Rule> merge;
+    private Collection<Rule> replace;
+    private Collection<Rule> remove;
+
+    public static class Rule {
+      String path;
+      Object value;
+
+      public String getPath() {
+        return path;
+      }
+
+      public void setPath(String path) {
+        this.path = path;
+      }
+
+      public Object getValue() {
+        return value;
+      }
+
+      public void setValue(Object value) {
+        this.value = value;
+      }
+    }
+
+    public Collection<Rule> getMerge() {
+      return Optional.ofNullable(merge).orElse(new ArrayList<>());
+    }
+
+    public void setMerge(Collection<Rule> merge) {
+      this.merge = merge;
+    }
+
+    public Collection<Rule> getReplace() {
+      return Optional.ofNullable(replace).orElse(new ArrayList<>());
+    }
+
+    public void setReplace(Collection<Rule> replace) {
+      this.replace = replace;
+    }
+
+    public Collection<Rule> getRemove() {
+      return Optional.ofNullable(remove).orElse(new ArrayList<>());
+    }
+
+    public void setRemove(Collection<Rule> remove) {
+      this.remove = remove;
     }
   }
 
@@ -141,6 +197,14 @@ public class StageDefinition implements Identifiable, Conditional {
 
   public void setWhen(List<String> when) {
     this.when = when;
+  }
+
+  public InheritanceControl getInheritanceControl() {
+    return inheritanceControl;
+  }
+
+  public void setInheritanceControl(InheritanceControl inheritanceControl) {
+    this.inheritanceControl = inheritanceControl;
   }
 
   @Override

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/StageInheritanceControlTransformSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/StageInheritanceControlTransformSpec.groovy
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform
+
+import com.jayway.jsonpath.PathNotFoundException
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinition
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinition.InheritanceControl.Rule
+import spock.lang.Specification
+import spock.lang.Subject
+
+class StageInheritanceControlTransformSpec extends Specification {
+
+  @Subject StageInheritanceControlTransform subject = new StageInheritanceControlTransform()
+
+  def 'should merge like data structures'() {
+    given:
+    PipelineTemplate template = new PipelineTemplate(
+      stages: [
+        new StageDefinition(
+          id: 's1',
+          config: [
+            myList: [1, 2],
+            myMap: [
+              foo: 'bar'
+            ]
+          ],
+          inheritanceControl: [
+            merge: [
+              new Rule(path: '$.myList', value: [3]),
+              new Rule(path: '$.myMap', value: [baz: 'bang'])
+            ]
+          ]
+        )
+      ]
+    )
+
+    when:
+    subject.visitPipelineTemplate(template)
+
+    then:
+    noExceptionThrown()
+    template.stages[0].config.myList == [1, 2, 3]
+    template.stages[0].config.myMap == [foo: 'bar', baz: 'bang']
+  }
+
+  def 'should fail merging incompatible data structures'() {
+    given:
+    PipelineTemplate template = new PipelineTemplate(
+      stages: [
+        new StageDefinition(
+          id: 's1',
+          config: [
+            myList: [1, 2],
+            myMap: [
+              foo: 'bar'
+            ]
+          ],
+          inheritanceControl: [
+            merge: [
+              new Rule(path: path, value: value)
+            ]
+          ]
+        )
+      ]
+    )
+
+    when:
+    subject.visitPipelineTemplate(template)
+
+    then:
+    thrown(TemplateRenderException)
+
+    where:
+    path        | value
+    '$.myList'  | 1
+    '$.myList'  | [foo: 'bar']
+    '$.myMap'   | 1
+    '$.myMap'   | [1]
+  }
+
+  def 'should fail when path does not exist'() {
+    given:
+    PipelineTemplate template = new PipelineTemplate(
+      stages: [
+        new StageDefinition(
+          id: 's1',
+          config: [:],
+          inheritanceControl: [
+            merge: [
+              new Rule(path: '$.noExist', value: [4])
+            ]
+          ]
+        )
+      ]
+    )
+
+    when:
+    subject.visitPipelineTemplate(template)
+
+    then:
+    thrown(PathNotFoundException)
+  }
+
+  def 'should replace like data structures'() {
+    given:
+    PipelineTemplate template = new PipelineTemplate(
+      stages: [
+        new StageDefinition(
+          id: 's1',
+          config: [
+            myList: [1, 2],
+            myMap: [
+              foo: 'bar'
+            ]
+          ],
+          inheritanceControl: [
+            replace: [
+              new Rule(path: '$.myList', value: [3, 4]),
+              new Rule(path: '$.myMap', value: [baz: 'bang'])
+            ]
+          ]
+        )
+      ]
+    )
+
+    when:
+    subject.visitPipelineTemplate(template)
+
+    then:
+    noExceptionThrown()
+    template.stages[0].config.myList == [3, 4]
+    template.stages[0].config.myMap == [baz: 'bang']
+  }
+
+  def 'should fail replacing incompatible data structures'() {
+    given:
+    PipelineTemplate template = new PipelineTemplate(
+      stages: [
+        new StageDefinition(
+          id: 's1',
+          config: [
+            myList: [1, 2],
+            myMap: [
+              foo: 'bar'
+            ]
+          ],
+          inheritanceControl: [
+            replace: [
+              new Rule(path: path, value: value)
+            ]
+          ]
+        )
+      ]
+    )
+
+    when:
+    subject.visitPipelineTemplate(template)
+
+    then:
+    thrown(TemplateRenderException)
+
+    where:
+    path        | value
+    '$.myList'  | 1
+    '$.myList'  | [foo: 'bar']
+    '$.myMap'   | 1
+    '$.myMap'   | [1]
+  }
+
+  def 'should remove paths'() {
+    given:
+    PipelineTemplate template = new PipelineTemplate(
+      stages: [
+        new StageDefinition(
+          id: 's1',
+          config: [
+            myList: [1, 2],
+            myMap: [
+              foo: 'bar'
+            ],
+            subList: [3, 4],
+            subMap: [foo: 'bar', baz: 'bang']
+          ],
+          inheritanceControl: [
+            remove: [
+              new Rule(path: '$.myList'),
+              new Rule(path: '$.subList[0]'),
+              new Rule(path: '$.myMap'),
+              new Rule(path: '$.subMap.foo')
+            ]
+          ]
+        )
+      ]
+    )
+
+    when:
+    subject.visitPipelineTemplate(template)
+
+    then:
+    noExceptionThrown()
+    template.stages[0].config.myList == null
+    template.stages[0].config.myMap == null
+    template.stages[0].config.subList == [4]
+    template.stages[0].config.subMap == [baz: 'bang']
+  }
+}


### PR DESCRIPTION
Allows for finer-grained control over what gets inherited
or overridden by child templates or configurations in nested
data structures.

This is being run after the render stage, so inheritance controls
cannot use handlebar templates. We can change this later on, but
I wanted to limit the amount of side-effects as part of introducing
this level of modification.

Implements this guy: https://github.com/robzienert/dcd-spec#inheritance-control

@spinnaker/netflix-reviewers PTAL