### PR TITLE
Preliminary support for validating stages against json schemas

### DIFF
--- a/orca-validation/orca-validation.gradle
+++ b/orca-validation/orca-validation.gradle
@@ -1,0 +1,9 @@
+tasks.compileGroovy.enabled = false
+
+dependencies {
+  compile(group: "com.github.fge", name: "json-schema-validator", version: "2.2.6")
+
+  compile project(":orca-core")
+
+  spinnaker.group('jackson')
+}

--- a/orca-validation/src/main/java/com/netflix/spinnaker/config/ValidationConfiguration.java
+++ b/orca-validation/src/main/java/com/netflix/spinnaker/config/ValidationConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config;
+
+import com.netflix.spinnaker.orca.validation.ValidationModule;
+import org.springframework.context.annotation.ComponentScan;
+
+@ComponentScan(basePackageClasses = ValidationModule.class)
+public class ValidationConfiguration {
+}

--- a/orca-validation/src/main/java/com/netflix/spinnaker/orca/validation/StageValidator.java
+++ b/orca-validation/src/main/java/com/netflix/spinnaker/orca/validation/StageValidator.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.validation;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.main.JsonSchema;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.validation.exception.StageValidationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class StageValidator {
+  private static final Logger log = LoggerFactory.getLogger(StageValidator.class);
+
+  private final ObjectMapper objectMapper;
+  private final JsonSchemaFactory jsonSchemaFactory;
+
+  @Autowired
+  public StageValidator(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+    this.jsonSchemaFactory = JsonSchemaFactory.byDefault();
+  }
+
+  public boolean isValid(Stage stage) {
+    Optional<Schema> schema = loadSchema(stage);
+    if (!schema.isPresent()) {
+      return true;
+    }
+
+    JsonSchema jsonSchema = processSchema(schema.get());
+
+    try {
+      JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(stage.getContext()));
+      ProcessingReport processingReport = jsonSchema.validate(json);
+
+      if (!processingReport.isSuccess()) {
+        log.info(
+          "Failed to validate stage (executionId: {}, stageId: {}), reason: {}",
+          stage.getExecution().getId(),
+          stage.getId(),
+          processingReport
+        );
+      }
+
+      return processingReport.isSuccess();
+    } catch (ProcessingException | IOException e) {
+      throw new StageValidationException(e);
+    }
+  }
+
+  /**
+   * Load schema and exclude any conditional properties that are not enabled for the current stage's cloud provider.
+   */
+  private Optional<Schema> loadSchema(Stage stage) {
+    String stageType = stage.getType();
+    Optional<String> cloudProvider = getCloudProvider(stage);
+
+    try {
+      URL schemaUrl = StageValidator.class.getResource("/schemas/" + stageType + ".json");
+      if (schemaUrl == null) {
+        // schema does not exist
+        return Optional.empty();
+      }
+
+      Schema schema = objectMapper
+        .readerWithView(Views.Spinnaker.class)
+        .withType(Schema.class)
+        .readValue(new File(schemaUrl.toURI()));
+
+      schema.properties = schema.properties.entrySet().stream()
+        .filter(e -> {
+          // filter out any conditional property that does not support `cloudProvider`
+          Collection<String> cloudProviders = e.getValue().condition.cloudProviders;
+          return cloudProviders == null || cloudProviders.contains(cloudProvider.orElse(null));
+        })
+        .map(e -> {
+          // ensure that all schema properties support a 'string' value in order to support arbitrary SpEL expression use
+          Schema.Property property = e.getValue();
+          if (property.type != null && !property.type.equalsIgnoreCase("string")) {
+            property.anyOf = Arrays.asList(
+              Collections.singletonMap("type", property.type),
+              Collections.singletonMap("type", "string")
+            );
+            property.type = null;
+          }
+          return e;
+        })
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+      schema.required.addAll(
+        schema.properties.entrySet().stream()
+          .filter(e -> e.getValue().required)
+          .map(Map.Entry::getKey)
+          .collect(Collectors.toSet())
+      );
+
+      return Optional.of(schema);
+    } catch (Exception e) {
+      throw new StageValidationException(e);
+    }
+  }
+
+  private JsonSchema processSchema(Schema schema) {
+    try {
+      return jsonSchemaFactory.getJsonSchema(
+        objectMapper.readTree(
+          objectMapper.writerWithView(Views.Public.class).writeValueAsString(schema)
+        )
+      );
+    } catch (Exception e) {
+      throw new StageValidationException(e);
+    }
+  }
+
+  private static Optional<String> getCloudProvider(Stage stage) {
+    Map context = Optional.ofNullable(stage.getContext()).orElse(new HashMap<>());
+    if (context.containsKey("cloudProvider")) {
+      return Optional.of((String) context.get("cloudProvider"));
+    }
+
+    if (context.containsKey("cloudProviderType")) {
+      return Optional.of((String) context.get("cloudProviderType"));
+    }
+
+    return Optional.empty();
+  }
+
+  private static class Generic {
+    private final Map<String, Object> any = new HashMap<>();
+
+    @JsonAnyGetter
+    public Map<String, Object> any() {
+      return any;
+    }
+
+    @JsonAnySetter
+    public void setAny(String name, Object value) {
+      any.put(name, value);
+    }
+  }
+
+  private static class Schema extends Generic {
+    @JsonProperty
+    Map<String, Property> properties;
+
+    @JsonProperty
+    Set<String> required = new HashSet<>();
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    static class Property extends Generic {
+      @JsonProperty
+      String type;
+
+      @JsonProperty
+      List<Map> anyOf;
+
+      @JsonProperty
+      @JsonView(Views.Spinnaker.class)
+      boolean required;
+
+      @JsonProperty
+      @JsonView(Views.Spinnaker.class)
+      Condition condition = new Condition();
+
+      static class Condition extends Generic {
+        @JsonProperty
+        Set<String> cloudProviders;
+      }
+    }
+  }
+
+  private static class Views {
+    static class Public {
+    }
+
+    static class Spinnaker {
+    }
+  }
+}

--- a/orca-validation/src/main/java/com/netflix/spinnaker/orca/validation/ValidationModule.java
+++ b/orca-validation/src/main/java/com/netflix/spinnaker/orca/validation/ValidationModule.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.validation;
+
+public class ValidationModule {
+}

--- a/orca-validation/src/main/java/com/netflix/spinnaker/orca/validation/exception/StageValidationException.java
+++ b/orca-validation/src/main/java/com/netflix/spinnaker/orca/validation/exception/StageValidationException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.validation.exception;
+
+public class StageValidationException extends RuntimeException {
+  public StageValidationException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/orca-validation/src/main/resources/schemas/aws.json
+++ b/orca-validation/src/main/resources/schemas/aws.json
@@ -1,0 +1,23 @@
+{
+  "title": "Example AWS-only schema",
+  "type": "object",
+  "properties": {
+    "field1": {
+      "type": "string",
+      "condition": {
+        "cloudProviders": [
+          "aws"
+        ]
+      },
+      "required": true
+    },
+    "field2": {
+      "type": "boolean",
+      "condition": {
+        "cloudProviders": [
+          "aws"
+        ]
+      }
+    }
+  }
+}

--- a/orca-validation/src/main/resources/schemas/bake.json
+++ b/orca-validation/src/main/resources/schemas/bake.json
@@ -1,0 +1,51 @@
+{
+  "title": "Bake Stage Schema",
+  "type": "object",
+  "properties": {
+    "cloudProviderType": {
+      "type": "string",
+      "required": true
+    },
+    "baseOs": {
+      "type": "string",
+      "required": true
+    },
+    "storeType": {
+      "type": "string"
+    },
+    "package": {
+      "type": "string",
+      "required": true
+    },
+    "regions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "condition": {
+        "cloudProviders": [
+          "aws"
+        ]
+      },
+      "required": true
+    },
+    "enhancedNetworking": {
+      "type": "boolean",
+      "condition": {
+        "cloudProviders": [
+          "aws"
+        ]
+      },
+      "required": true
+    },
+    "vmType": {
+      "type": "string",
+      "condition": {
+        "cloudProviders": [
+          "aws"
+        ]
+      },
+      "required": true
+    }
+  }
+}

--- a/orca-validation/src/test/groovy/com/netflix/spinnaker/orca/validation/StageValidatorSpec.groovy
+++ b/orca-validation/src/test/groovy/com/netflix/spinnaker/orca/validation/StageValidatorSpec.groovy
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.validation
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.pipeline.model.Orchestration
+import com.netflix.spinnaker.orca.pipeline.model.OrchestrationStage
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll;
+
+class StageValidatorSpec extends Specification {
+  def objectMapper = new ObjectMapper()
+
+  @Subject
+  def stageValidator = new StageValidator(objectMapper)
+
+  void "should not raise an exception if schema does not exist"() {
+    expect:
+    stageValidator.loadSchema(new OrchestrationStage(new Orchestration(), type, [:])).isPresent() == expectedIsPresent
+
+    where:
+    type             || expectedIsPresent
+    "bake"           || true
+    "does-not-exist" || false
+  }
+
+  void "should apply cloudProvider-specific processing to schema"() {
+    when:
+    def awsSchema = stageValidator.loadSchema(
+      new OrchestrationStage(new Orchestration(), "aws", [cloudProvider: "aws"])
+    ).get()
+
+    def awsSchemaMap = objectMapper.readValue(
+      objectMapper
+        .writerWithView(StageValidator.Views.Public.class)
+        .writeValueAsString(awsSchema),
+      Map
+    )
+
+    then:
+    awsSchema.@properties.keySet().sort() == ["field1", "field2"].sort()
+    awsSchema.required.sort() == ["field1"].sort()
+
+    // verify type has been expanded to include 'string' as well as the explicitly specified value
+    awsSchemaMap.properties["field1"] == [
+      type: "string"
+    ]
+    awsSchemaMap.properties["field2"] == [
+      anyOf: [
+        [type: "boolean"],
+        [type: "string"]
+      ]
+    ]
+
+    when:
+    def nonAwsSchema = stageValidator.loadSchema(
+      new OrchestrationStage(new Orchestration(), "aws", [cloudProvider: "nonAws"])
+    ).get()
+
+    then: "all fields should have been filtered out as cloudProvider != 'aws'"
+    nonAwsSchema.@properties.isEmpty()
+    nonAwsSchema.required.isEmpty()
+  }
+
+  void "should validate bake request against schema"() {
+    expect:
+    stageValidator.isValid(new OrchestrationStage(new Orchestration(), "bake", [
+      package           : "mypackage",
+      cloudProviderType : "aws",
+      baseOs            : "ubuntu",
+      enhancedNetworking: '${spelExpressionThatEvaluatesToTrue()}',
+      vmType            : "pv",
+      regions           : ["us-west-1"]
+    ]))
+
+    stageValidator.isValid(new OrchestrationStage(new Orchestration(), "bake", [
+      package          : "mypackage",
+      cloudProviderType: "notAws",
+      baseOs           : "ubuntu",
+      regions          : ["us-west-1"]
+    ]))
+  }
+
+  @Unroll
+  void "should determine cloud provider for Stage"() {
+    given:
+    def stage = new OrchestrationStage(new Orchestration(), "bake", context)
+
+    expect:
+    stageValidator.getCloudProvider(stage).orElse(null) == expectedCloudProvider
+
+    where:
+    context                    || expectedCloudProvider
+    [:]                        || null
+    null                       || null
+    [cloudProvider: "aws"]     || "aws"
+    [cloudProviderType: "aws"] || "aws"
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,8 @@ include "orca-extensionpoint",
   "orca-smoke-test",
   "orca-applications",
   "orca-spring-batch",
-  "orca-pipelinetemplate"
+  "orca-pipelinetemplate",
+  "orca-validation"
 
 rootProject.name = "orca"
 


### PR DESCRIPTION
Ideally we have a single json schema document per stage type describing
relevant properties with some additional metadata linking the property
to 0..* cloud providers.

`orca` will process these schema documents and generate a valid json
schema containing only the properties supported by the current cloud
provider.