### PR TITLE
Fixes NPE when deleting a Fast Property.

### DIFF
--- a/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
+++ b/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
@@ -49,8 +49,11 @@ class CreatePropertiesTask implements Task {
         log.info("Upserting Property: ${prop}")
         response = maheService.upsertProperty(prop)
       }
-      if (response.status == 200 && response.body.mimeType().startsWith('application/')) {
-        propertyIdList << mapper.readValue(response.body.in().text, Map)
+
+      if (response.status == 200) {
+        if (response.body?.mimeType()?.startsWith('application/')) {
+          propertyIdList << mapper.readValue(response.body.in().text, Map)
+        }
       } else {
         throw new IllegalStateException("Unable to handle $response for property $prop")
       }


### PR DESCRIPTION
The call to delete a Fast Property does not return a body, only a status code
This was causing a NPE when calling the mimeTime() method on the body.

@robfletcher @ajordens PTAL
