### PR TITLE
Support tagging of server groups when created / cloned

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupMetadataTagTask
 import groovy.util.logging.Slf4j
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage
 import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
@@ -43,12 +44,25 @@ class CloneServerGroupStage extends AbstractDeployStrategyStage {
 
   @Override
   protected List<TaskNode.TaskDefinition> basicTasks(Stage stage) {
-    return [
+    def taggingEnabled = false // check clouddriver:/features/stages for upsertEntityTags
+
+    def tasks = [
       new TaskNode.TaskDefinition("cloneServerGroup", CloneServerGroupTask),
       new TaskNode.TaskDefinition("monitorDeploy", MonitorKatoTask),
-      new TaskNode.TaskDefinition("forceCacheRefresh", ServerGroupCacheForceRefreshTask),
+      new TaskNode.TaskDefinition("forceCacheRefresh", ServerGroupCacheForceRefreshTask)
+    ]
+
+    if (taggingEnabled) {
+      tasks += [
+        new TaskNode.TaskDefinition("tagServerGroup", ServerGroupMetadataTagTask)
+      ]
+    }
+
+    tasks += [
       new TaskNode.TaskDefinition("waitForUpInstances", WaitForUpInstancesTask),
       new TaskNode.TaskDefinition("forceCacheRefresh", ServerGroupCacheForceRefreshTask)
     ]
+
+    return tasks
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupMetadataTagTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupMetadataTagTask.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.netflix.spinnaker.orca.DefaultTaskResult
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.pipeline.model.Orchestration
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Slf4j
+class ServerGroupMetadataTagTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+  long backoffPeriod = TimeUnit.SECONDS.toMillis(5)
+  long timeout = TimeUnit.MINUTES.toMillis(5)
+
+  @Autowired
+  KatoService kato
+
+  @Override
+  TaskResult execute(Stage stage) {
+    try {
+      TaskId taskId = kato.requestOperations(buildTagOperations(stage)).toBlocking().first();
+      return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, new HashMap<String, Object>() {
+        {
+          put("notification.type", "upsertentitytags");
+          put("kato.last.task.id", taskId);
+        }
+      });
+    } catch (Exception e) {
+      log.error("Failed to tag deployed server groups (stageId: ${stage.id}, executionId: ${stage.execution.id})", e)
+      return new DefaultTaskResult(ExecutionStatus.FAILED_CONTINUE);
+    }
+  }
+
+  private List<Map> buildTagOperations(Stage stage) {
+    def tag = [
+      name : "spinnaker:metadata",
+      value: [
+        "stageId"      : stage.id,
+        "executionId"  : stage.execution.id,
+        "executionType": stage.execution.class.simpleName.toLowerCase(),
+        "application"  : stage.execution.application,
+        "user"         : stage.execution.authentication?.user
+      ]
+    ]
+
+    if (stage.execution instanceof Orchestration) {
+      tag.value.description = ((Orchestration) stage.execution).description
+    } else if (stage.execution instanceof Pipeline) {
+      tag.value.pipelineConfigId = ((Pipeline) stage.execution).pipelineConfigId
+    }
+
+    if (stage.context.reason || stage.context.comments) {
+      tag.value.comments = stage.context.comments ?: stage.context.reason
+    }
+
+    def operations = []
+    ((StageData) stage.mapTo(StageData)).deployServerGroups.each { String region, Set<String> serverGroups ->
+      serverGroups.each { String serverGroup ->
+        operations <<
+          [
+            "upsertEntityTags": [
+              tags     : [tag],
+              entityRef: [
+                entityType   : "servergroup",
+                entityId     : serverGroup,
+                account      : getCredentials(stage),
+                region       : region,
+                cloudProvider: getCloudProvider(stage)
+              ]
+            ]
+          ]
+      }
+    }
+
+    return operations
+  }
+
+  static class StageData {
+    @JsonProperty("deploy.server.groups")
+    Map<String, Set<String>> deployServerGroups = [:]
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
@@ -87,7 +87,7 @@ public class PipelineTemplatePipelinePreprocessor implements PipelinePreprocesso
     TemplateConfiguration config;
 
     public boolean isTemplatedPipelineRequest() {
-      return type.equals("templatedPipeline");
+      return type != null && type.equals("templatedPipeline");
     }
 
     public String getType() {


### PR DESCRIPTION
- requires that the 'upsertEntityTags' operation is available in clouddriver