### PR TITLE
tag server groups with metadata if feature enabled

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/FeaturesRestService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/FeaturesRestService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver;
+
+import retrofit.http.GET;
+
+import java.util.List;
+
+public interface FeaturesRestService {
+
+  @GET("/features/stages")
+  List<AvailableStage> getStages();
+
+  public static class AvailableStage {
+    public String name;
+    public Boolean enabled;
+  }
+}
+

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/FeaturesService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/FeaturesService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FeaturesService {
+
+  @Autowired
+  private FeaturesRestService featuresRestService;
+
+  public boolean isStageAvailable(String stageType) {
+    return featuresRestService.getStages().stream().anyMatch(s -> s.enabled && stageType.equals(s.name));
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.clouddriver.FeaturesRestService
 import com.netflix.spinnaker.orca.clouddriver.KatoRestService
 import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.MortService
@@ -105,5 +106,19 @@ class CloudDriverConfiguration {
       .setConverter(new JacksonConverter(mapper))
       .build()
       .create(KatoRestService)
+  }
+
+  @Bean
+  FeaturesRestService featuresRestService(
+    @Value('${kato.baseUrl}') String katoBaseUrl, ObjectMapper mapper) {
+    new RestAdapter.Builder()
+      .setRequestInterceptor(spinnakerRequestInterceptor)
+      .setEndpoint(newFixedEndpoint(katoBaseUrl))
+      .setClient(retrofitClient)
+      .setLogLevel(retrofitLogLevel)
+      .setLog(new RetrofitSlf4jLog(KatoService))
+      .setConverter(new JacksonConverter(mapper))
+      .build()
+      .create(FeaturesRestService)
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
@@ -16,16 +16,17 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
-import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupMetadataTagTask
-import groovy.util.logging.Slf4j
+import com.netflix.spinnaker.orca.clouddriver.FeaturesService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage
-import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForUpInstancesTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CloneServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupMetadataTagTask
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Slf4j
@@ -33,6 +34,9 @@ import org.springframework.stereotype.Component
 class CloneServerGroupStage extends AbstractDeployStrategyStage {
 
   public static final String PIPELINE_CONFIG_TYPE = "cloneServerGroup"
+
+  @Autowired
+  private FeaturesService featuresService
 
   CloneServerGroupStage() {
     super(PIPELINE_CONFIG_TYPE)
@@ -44,7 +48,7 @@ class CloneServerGroupStage extends AbstractDeployStrategyStage {
 
   @Override
   protected List<TaskNode.TaskDefinition> basicTasks(Stage stage) {
-    def taggingEnabled = false // check clouddriver:/features/stages for upsertEntityTags
+    def taggingEnabled = featuresService.isStageAvailable("upsertEntityTags")
 
     def tasks = [
       new TaskNode.TaskDefinition("cloneServerGroup", CloneServerGroupTask),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
+import com.netflix.spinnaker.orca.clouddriver.FeaturesService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForUpInstancesTask
@@ -24,11 +25,15 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCache
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupMetadataTagTask
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
 class CreateServerGroupStage extends AbstractDeployStrategyStage {
   public static final String PIPELINE_CONFIG_TYPE = "createServerGroup"
+
+  @Autowired
+  private FeaturesService featuresService
 
   CreateServerGroupStage() {
     super(PIPELINE_CONFIG_TYPE)
@@ -36,7 +41,7 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage {
 
   @Override
   protected List<TaskNode.TaskDefinition> basicTasks(Stage stage) {
-    def taggingEnabled = false // check clouddriver:/features/stages for upsertEntityTags
+    def taggingEnabled = featuresService.isStageAvailable("upsertEntityTags")
 
     def tasks = [
       new TaskNode.TaskDefinition("createServerGroup", CreateServerGroupTask),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupMetadataTagTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupMetadataTagTask.groovy
@@ -31,7 +31,7 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeUnit
 
 @Component
 @Slf4j
@@ -45,16 +45,16 @@ class ServerGroupMetadataTagTask extends AbstractCloudProviderAwareTask implemen
   @Override
   TaskResult execute(Stage stage) {
     try {
-      TaskId taskId = kato.requestOperations(buildTagOperations(stage)).toBlocking().first();
+      TaskId taskId = kato.requestOperations(buildTagOperations(stage)).toBlocking().first()
       return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, new HashMap<String, Object>() {
         {
-          put("notification.type", "upsertentitytags");
-          put("kato.last.task.id", taskId);
+          put("notification.type", "upsertentitytags")
+          put("kato.last.task.id", taskId)
         }
-      });
+      })
     } catch (Exception e) {
       log.error("Failed to tag deployed server groups (stageId: ${stage.id}, executionId: ${stage.execution.id})", e)
-      return new DefaultTaskResult(ExecutionStatus.FAILED_CONTINUE);
+      return new DefaultTaskResult(ExecutionStatus.FAILED_CONTINUE)
     }
   }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupMetadataTagTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupMetadataTagTaskSpec.groovy
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import com.netflix.spinnaker.orca.pipeline.model.Orchestration
+import com.netflix.spinnaker.orca.pipeline.model.OrchestrationStage
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class ServerGroupMetadataTagTaskSpec extends Specification {
+
+  KatoService katoService = Mock(KatoService)
+
+  @Subject
+  ServerGroupMetadataTagTask task = new ServerGroupMetadataTagTask(kato: katoService)
+
+  List<Map> taggingOps = null
+
+  void "should return with failed/continue status if tagging operation fails"() {
+    when:
+    def stage = new PipelineStage(new Pipeline(), "whatever", [:])
+    def result = task.execute(stage)
+
+    then:
+    result.status == ExecutionStatus.FAILED_CONTINUE
+    1 * katoService.requestOperations(_) >> { throw new RuntimeException("something went wrong") }
+  }
+
+  void "sends tag with all relevant metadata for each server group"() {
+    given:
+    mockTaggingOperation()
+    List<Map> expectedTags = [
+      [
+        stageId: "x",
+        executionType: "pipeline",
+        pipelineConfigId: "config-id",
+        application: "foo",
+        executionId: "ex-id",
+        user: "chris"
+      ],
+      [
+        stageId: "x",
+        executionType: "pipeline",
+        pipelineConfigId: "config-id",
+        application: "foo",
+        executionId: "ex-id",
+        user: "chris"
+      ],
+      [
+        stageId: "x",
+        executionType: "pipeline",
+        pipelineConfigId: "config-id",
+        application: "foo",
+        executionId: "ex-id",
+        user: "chris"
+      ]
+    ]
+
+    when:
+    def pipeline = new Pipeline(pipelineConfigId: "config-id", application: "foo", id: "ex-id", authentication: [ user: "chris" ])
+    def stage = new PipelineStage(pipeline, "whatever", [
+      "deploy.server.groups": [
+        "us-east-1": ["foo-v001"],
+        "us-west-1": ["foo-v001", "foo-v002"]
+      ]
+    ])
+    stage.id = "x"
+    def result = task.execute(stage)
+
+    then:
+    result.status == ExecutionStatus.SUCCEEDED
+    taggingOps == expectedTags
+  }
+
+  void "omits user if authentication not found"() {
+    given:
+    mockTaggingOperation()
+
+    when:
+    def stage = new PipelineStage(new Pipeline(), "whatever", [
+      "deploy.server.groups": [
+        "us-east-1": ["foo-v001"],
+      ]
+    ])
+    def result = task.execute(stage)
+
+    then:
+    result.status == ExecutionStatus.SUCCEEDED
+    taggingOps[0].user == null
+  }
+
+  void "includes description on tasks"() {
+    given:
+    mockTaggingOperation()
+
+    when:
+    def orchestration = new Orchestration(description: "some description")
+    def stage = new OrchestrationStage(orchestration, "zzz", [
+      "deploy.server.groups": [
+        "us-east-1": ["foo-v001"],
+      ]
+    ])
+    task.execute(stage)
+
+    then:
+    taggingOps[0].description == "some description"
+  }
+
+  @Unroll
+  void "prefers comments to reason from context and applies as 'comments' field"() {
+    given:
+    mockTaggingOperation()
+
+    when:
+    def stage = new PipelineStage(new Pipeline(), "whatever", [
+      "deploy.server.groups": [
+        "us-east-1": ["foo-v001"],
+      ],
+      comments: comments,
+      reason: reason
+    ])
+    def result = task.execute(stage)
+
+    then:
+    result.status == ExecutionStatus.SUCCEEDED
+    taggingOps[0].comments == expected
+
+    where:
+    comments | reason || expected
+    null     | null   || null
+    null     | "r"    || "r"
+    "c"      | null   || "c"
+    "c"      | "r"    || "c"
+  }
+
+  private void mockTaggingOperation() {
+    1 * katoService.requestOperations({ ops ->
+      taggingOps = ops.collect { it.upsertEntityTags.tags[0].value }
+      true
+    }) >> rx.Observable.just(new TaskId("eh"))
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/pipeline/DeploymentStrategiesExecutionSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/pipeline/DeploymentStrategiesExecutionSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.batch.StageBuilderProvider
 import com.netflix.spinnaker.orca.batch.TaskTaskletAdapterImpl
 import com.netflix.spinnaker.orca.batch.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.batch.listeners.SpringBatchExecutionListenerProvider
+import com.netflix.spinnaker.orca.clouddriver.FeaturesService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.CreateServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.NoStrategy
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.Strategy
@@ -200,6 +201,11 @@ abstract class DeploymentStrategiesExecutionSpec<R extends ExecutionRunner> exte
 
   @CompileStatic
   static class Config {
+    @Bean
+    FactoryBean<FeaturesService> featuresService() {
+      new SpockMockFactoryBean(FeaturesService)
+    }
+
     @Bean
     FactoryBean<ExceptionHandler> exceptionHandler() {
       new SpockMockFactoryBean(ExceptionHandler)


### PR DESCRIPTION
* enables metadata tagging if `upsertEntityTags` is available from Clouddriver's features endpoint
* adds some tests

@spinnaker/reviewers PTAL - Deck changes to surface this metadata will follow...