### PR TITLE
Fix Fast Property Rollback

### DIFF
--- a/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
+++ b/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
@@ -52,10 +52,9 @@ class CreatePropertiesTask implements Task {
       if (stage.context.delete) {
         log.info("Deleting Property: ${prop.property.propertyId} on execution ${stage.execution.id}")
         response = maheService.deleteProperty(prop.property.propertyId, 'delete', prop.property.env)
-        propertyIdList << prop.property.propertyId
         propertyAction = PropertyAction.DELETE
       } else {
-        log.info("Upserting Property: ${prop}")
+        log.info("Upserting Property: ${prop} on execution ${stage.execution.id}")
         response = maheService.upsertProperty(prop)
         propertyAction = prop.property.propertyId ? PropertyAction.UPDATE : PropertyAction.CREATE
       }
@@ -78,12 +77,8 @@ class CreatePropertiesTask implements Task {
       propertyAction: propertyAction,
     ]
 
+    return new DefaultTaskResult(SUCCEEDED, outputs, outputs)
 
-    if (rollback) {
-      return new DefaultTaskResult(SUCCEEDED, outputs, outputs)
-    } else {
-      return new DefaultTaskResult(SUCCEEDED, outputs)
-    }
   }
 
 
@@ -95,11 +90,13 @@ class CreatePropertiesTask implements Task {
     String cmcTicket = context.cmcTicket
 
     return propertyList.collect { Map prop ->
-      prop << scope
-      prop.email = email
-      prop.sourceOfUpdate = 'spinnaker'
-      prop.cmcTicket = cmcTicket
-      [property: prop]
+      if(prop) {
+        prop << scope
+        prop.email = email
+        prop.sourceOfUpdate = 'spinnaker'
+        prop.cmcTicket = cmcTicket
+        [property: prop]
+      }
     }
   }
 

--- a/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTaskSpec.groovy
+++ b/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTaskSpec.groovy
@@ -84,6 +84,24 @@ class CreatePropertiesTaskSpec extends Specification {
     }
   }
 
+  def "assemble the changed property list if list is null for a new property"() {
+    given:
+    def pipeline = new Pipeline(application: 'foo')
+    def scope = createScope()
+    def property = createProperty()
+    def originalProperty = []
+
+    def stage = createPropertiesStage(pipeline, scope, property, originalProperty )
+
+    when:
+    List properties = task.assemblePersistedPropertyListFromContext(stage.context, stage.context.persistedProperties)
+    List originalProperties = task.assemblePersistedPropertyListFromContext(stage.context, stage.context.originalProperties)
+
+    then: "this is what the property payload the is sent to MAHE needs to look like"
+    properties.size() == 1
+    originalProperties.size() == 0
+  }
+
   def "create a single new persistent property"() {
     given:
     def pipeline = new Pipeline(application: 'foo')
@@ -131,7 +149,7 @@ class CreatePropertiesTaskSpec extends Specification {
 
     then: "deleting a fast property does not return a property ID"
     with(results.stageOutputs) {
-      propertyIdList.size() == 1
+      propertyIdList.size() == 0
     }
 
   }


### PR DESCRIPTION
This should fix the fast property rollback on pipeline TERMINAL and CANCEL status

There was also a bug introduce that caused the monitoring of FP Deletes to fail with a NPE that this addresses.