### PR TITLE
if a pipeline fails during the initial startup phase, put it in a TERMINAL state with a cancellation reason

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineLauncher.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineLauncher.java
@@ -85,4 +85,16 @@ public class PipelineLauncher extends ExecutionLauncher<Pipeline> {
         tracker.addToStarted(execution.getPipelineConfigId(), execution.getId());
       });
   }
+
+  @Override
+  protected Pipeline handleStartupFailure(Pipeline execution, Throwable failure) {
+    Pipeline failed = super.handleStartupFailure(execution, failure);
+    startTracker.ifPresent(tracker -> {
+      if (execution.getPipelineConfigId() != null) {
+        tracker.removeFromQueue(execution.getPipelineConfigId(), execution.getId());
+      }
+      tracker.markAsFinished(execution.getPipelineConfigId(), execution.getId());
+    });
+    return failed;
+  }
 }


### PR DESCRIPTION
@anotherchrisberry this is what I was mentioning to you.

I can trigger this behavior by running a pipeline like:

````json
{
  "keepWaitingPipelines": false,
  "limitConcurrent": true,
  "parallel": true,
  "lastModifiedBy": "user@host.net",
  "stages": [
    {
      "refId": "1",
      "requisiteStageRefIds": [],
      "type": "destroyServerGroup",
      "name": "Destroy Server Group",
      "cloudProviderType": "aws",
      "regions": [
        "us-east-1"
      ],
      "cloudProvider": "aws",
      "target": "ancestor_asg",
      "credentials": "test",
      "cluster": "spintest"
    }
  ],
  "triggers": [],
  "executionEngine": "v2",
  "updateTs": "1486499714000"
}
````

@robfletcher PTAL