### PR TITLE
Remove '-' before level in logback format to be like rest of Spinnaker

### DIFF
--- a/orca-web/src/main/resources/logback-defaults.xml
+++ b/orca-web/src/main/resources/logback-defaults.xml
@@ -19,7 +19,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(-%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} [%X{X-SPINNAKER-USER}] %m%n
+      <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} [%X{X-SPINNAKER-USER}] %m%n
       </pattern>
     </encoder>
   </appender>


### PR DESCRIPTION
@ttomsu 

You changed this here https://github.com/spinnaker/orca/commit/7514e2ad115798aa9b44c97c742ea8876f398928#diff-8af87d1b446779657d406343bfb9c928L20

I assume it was an accident.