### PR TITLE
(core) only render lastCapacityCheck on WaitForUpInstancesTask

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
-import com.netflix.spinnaker.orca.clouddriver.utils.HealthHelper
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler
@@ -125,8 +124,6 @@ abstract class AbstractInstancesCheckTask extends AbstractCloudProviderAwareTask
               newContext.zeroDesiredCapacityCount = 0
             }
           }
-          newContext.lastCapacityCheck =
-            HealthHelper.getHealthCountSnapshot(serverGroup.instances ?: [], interestingHealthProviderNames)
 
           return new DefaultTaskResult(ExecutionStatus.RUNNING, newContext)
         }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/HealthHelper.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/HealthHelper.groovy
@@ -82,7 +82,6 @@ class HealthHelper {
     } as Map
   }
 
-
   static boolean someAreDownAndNoneAreUp(Map instance, Collection<String> interestingHealthProviderNames) {
 
     List<Map> healths = filterHealths(instance, interestingHealthProviderNames)
@@ -110,29 +109,6 @@ class HealthHelper {
 
     boolean noneAreDown = !healths.any { Map health -> health.state == 'Down' }
     return someAreUp && noneAreDown
-  }
-
-  static HealthCountSnapshot getHealthCountSnapshot(List<Map> instances, Collection<String> interestingHealthProviderNames) {
-    HealthCountSnapshot snapshot = new HealthCountSnapshot()
-    instances.each { instance ->
-      List<Map> healths = filterHealths(instance, interestingHealthProviderNames)
-      if (areSomeUpConsideringPlatformHealth(healths, interestingHealthProviderNames, healths.any { Map health -> health.state == 'Up' } )) {
-        snapshot.up++
-      } else if (isDownConsideringPlatformHealth(healths) || healths.every { it.state == 'Down' } ) {
-        snapshot.down++
-      } else if (healths.any { it.state == 'OutOfService' } ) {
-        snapshot.outOfService++
-      } else if (healths.any { it.state == 'Starting' } ) {
-        snapshot.starting++
-      } else if (healths.every { it.state == 'Succeeded' } ) {
-        snapshot.succeeded++
-      } else if (healths.any { it.state == 'Failed' } ) {
-        snapshot.failed++
-      } else {
-        snapshot.unknown++
-      }
-    }
-    return snapshot
   }
 
   static class HealthCountSnapshot {


### PR DESCRIPTION
There is a fundamental problem with the way we are calculating the `lastCapacityCheck` value: it is not contextually sensitive to the task. 

The up/down counts need to be based on what the task itself is using to determine success. When waiting for up instances, the task is going to wait for all health checks to pass - but we're counting the instance as "up" if _any_ health checks pass.

The initial design of this was to make it generic, so we could show it across all the `AbstractInstancesCheckTask`s. It's a nice idea, but I don't think it's particularly useful. The problem we were originally trying to help with was Deploy stages, when instances aren't passing health checks. And, in the UI, we're _only_ surfacing this data on the Deploy stage. So let's make it work on Deploy stages, and consider abstracting it later if there's a use case.

@tomaslin PTAL (and thank you for calling this out)