### PR TITLE
Ensure target server group after stages are added correctly

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws
 
-import groovy.transform.CompileDynamic
-import groovy.transform.CompileStatic
 import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.RetryableTask
@@ -32,6 +30,8 @@ import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -40,11 +40,6 @@ import org.springframework.stereotype.Component
 class ModifyAwsScalingProcessStage extends TargetServerGroupLinearStageSupport {
   ModifyAwsScalingProcessStage() {
     name = "Modify Scaling Process"
-  }
-
-  @Override
-  def <T extends Execution> List<Stage<T>> aroundStages(Stage<T> parentStage) {
-    return composeTargets(parentStage);
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -36,8 +36,6 @@ class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport {
   @Override
   <T extends Execution<T>> void taskGraph(Stage<T> stage, TaskNode.Builder builder) {
     try {
-      composeTargets(stage)
-
       builder
         .withTask("disableServerGroup", DisableServerGroupTask)
         .withTask("monitorServerGroup", MonitorKatoTask)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupLinearStageSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupLinearStageSupport.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.kato.pipeline.Nameable
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.transform.Memoized
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import static com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.StageDefinitionBuilderSupport.newStage
@@ -39,10 +40,11 @@ abstract class TargetServerGroupLinearStageSupport implements StageDefinitionBui
   String name = this.type
 
   @Override
-  def <T extends Execution> List<Stage<T>> aroundStages(Stage<T> parentStage) {
+  def <T extends Execution<T>> List<Stage<T>> aroundStages(Stage<T> parentStage) {
     return composeTargets(parentStage)
   }
 
+  @Memoized
   List<Stage> composeTargets(Stage stage) {
     stage.resolveStrategyParams()
     def params = TargetServerGroup.Params.fromStage(stage)


### PR DESCRIPTION
Tactical fix for SPIN-2298

Because `aroundStages` is re-entrant but in the case of TargetServerGroupLinearStageSupport it also mutates the original stage context it was losing the additional regions. I would like to not have the method be re-entrant at all but this should fix things for now.