### PR TITLE
core/notifications: add notifications from Front50 to pipeline notifications

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.echo.config
 
+import com.netflix.spinnaker.orca.front50.Front50Service
 import groovy.transform.CompileStatic
 import com.netflix.spinnaker.orca.echo.EchoService
 import com.netflix.spinnaker.orca.echo.spring.EchoNotifyingExecutionListener
@@ -69,7 +70,8 @@ class EchoConfiguration {
   }
 
   @Bean
-  EchoNotifyingExecutionListener echoNotifyingPipelineExecutionListener(EchoService echoService) {
-    new EchoNotifyingExecutionListener(echoService)
+  EchoNotifyingExecutionListener echoNotifyingPipelineExecutionListener(EchoService echoService,
+                                                                        Front50Service front50Service) {
+    new EchoNotifyingExecutionListener(echoService, front50Service)
   }
 }

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoEventIntegrationSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoEventIntegrationSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.orca.batch.TaskTaskletAdapterImpl
 import com.netflix.spinnaker.orca.batch.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.batch.listeners.SpringBatchExecutionListenerProvider
 import com.netflix.spinnaker.orca.echo.EchoService
+import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.pipeline.ExecutionRunner
 import com.netflix.spinnaker.orca.pipeline.ExecutionRunnerSpec.TestTask
 import com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWindow
@@ -185,13 +186,18 @@ abstract class EchoEventIntegrationSpec<R extends ExecutionRunner> extends Speci
     }
 
     @Bean
+    Front50Service front50Service() {
+      mockFactory.Mock(Front50Service)
+    }
+
+    @Bean
     EchoNotifyingStageListener echoNotifyingStageListener(EchoService echoService) {
       new EchoNotifyingStageListener(echoService)
     }
 
     @Bean
-    EchoNotifyingExecutionListener echoNotifyingExecutionListener(EchoService echoService) {
-      new EchoNotifyingExecutionListener(echoService)
+    EchoNotifyingExecutionListener echoNotifyingExecutionListener(EchoService echoService, Front50Service front50Service) {
+      new EchoNotifyingExecutionListener(echoService, front50Service)
     }
 
     @Bean

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoEventSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoEventSpec.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.orca.batch.stages.SpringBatchStageBuilderProvider
 import com.netflix.spinnaker.orca.config.JesqueConfiguration
 import com.netflix.spinnaker.orca.config.OrcaConfiguration
 import com.netflix.spinnaker.orca.echo.EchoService
+import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.PipelineJobBuilder
 import com.netflix.spinnaker.orca.pipeline.PipelineStarter
@@ -66,6 +67,7 @@ class EchoEventSpec extends Specification {
   public static final taskMustRepeat = new DefaultTaskResult(ExecutionStatus.RUNNING)
 
   def echoService = Mock(EchoService)
+  def front50Service = Mock(Front50Service)
 
   @Autowired
   AbstractApplicationContext applicationContext
@@ -114,7 +116,7 @@ class EchoEventSpec extends Specification {
       autowireBean pipelineJobBuilder
     }
 
-    ((SpringBatchExecutionListenerProvider) executionListenerProvider).executionListeners.add(0, new EchoNotifyingExecutionListener(echoService))
+    ((SpringBatchExecutionListenerProvider) executionListenerProvider).executionListeners.add(0, new EchoNotifyingExecutionListener(echoService, front50Service))
     ((SpringBatchExecutionListenerProvider) executionListenerProvider).stageListeners.add(0, new EchoNotifyingStageListener(echoService))
     ((SpringBatchStageBuilderProvider) stageBuilderProvider).stageBuilders.addAll(stageBuilders)
 

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListenerSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListenerSpec.groovy
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.echo.spring
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.echo.EchoService
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.model.ApplicationNotifications
+import com.netflix.spinnaker.orca.front50.model.ApplicationNotifications.Notification
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+class EchoNotifyingExecutionListenerSpec extends Specification {
+
+  def echoService = Mock(EchoService)
+  def front50Service = Mock(Front50Service)
+
+  @Subject
+  def echoListener = new EchoNotifyingExecutionListener(echoService, front50Service)
+
+  @Shared
+  ApplicationNotifications notifications = new ApplicationNotifications()
+
+  @Shared
+  Notification slackPipes
+
+  @Shared
+  Notification slackTasks
+
+  @Shared
+  Notification emailTasks
+
+  void setup() {
+    slackPipes = new Notification([
+      when   : ["pipeline.started", "pipeline.failed"],
+      type   : "slack",
+      address: "spinnaker"
+    ])
+    slackTasks = new Notification([
+      when   : ["task.completed"],
+      type   : "slack",
+      address: "spinnaker-tasks"
+    ])
+    emailTasks = new Notification([
+      when: ["task.started"],
+      type: "email"
+    ])
+
+    notifications.set("slack", [slackPipes, slackTasks])
+    notifications.set("email", [emailTasks])
+  }
+
+  void "adds notifications to pipeline on beforeExecution"() {
+    given:
+    Pipeline pipeline = new Pipeline(application: "myapp")
+
+    when:
+    echoListener.beforeExecution(null, pipeline)
+
+    then:
+    pipeline.notifications == [slackPipes]
+    1 * front50Service.getApplicationNotifications("myapp") >> notifications
+    1 * echoService.recordEvent(_)
+    0 * _
+  }
+
+  void "adds notifications to pipeline on afterExecution"() {
+    given:
+    Pipeline pipeline = new Pipeline(application: "myapp")
+
+    when:
+    echoListener.afterExecution(null, pipeline, ExecutionStatus.TERMINAL, false)
+
+    then:
+    pipeline.notifications == [slackPipes]
+    1 * front50Service.getApplicationNotifications("myapp") >> notifications
+    1 * echoService.recordEvent(_)
+    0 * _
+  }
+
+  void "dedupes notifications"() {
+    given:
+    Pipeline pipeline = new Pipeline(application: "myapp")
+    def pipelineConfiguredNotification = [
+      when   : ["pipeline.started", "pipeline.completed"],
+      type   : "slack",
+      address: "spinnaker",
+      extraField: "extra"
+    ]
+    pipeline.notifications.add(pipelineConfiguredNotification)
+
+    when:
+    echoListener.beforeExecution(null, pipeline)
+
+    then:
+    pipeline.notifications.size() == 2
+    pipeline.notifications.when == [["pipeline.started", "pipeline.completed"], ["pipeline.failed"]]
+    pipeline.notifications.extraField == ["extra", null]
+    1 * front50Service.getApplicationNotifications("myapp") >> notifications
+    1 * echoService.recordEvent(_)
+    0 * _
+  }
+
+  void "handles case where no notifications are present"() {
+    given:
+    Pipeline pipeline = new Pipeline(application: "myapp")
+
+    when:
+    echoListener.beforeExecution(null, pipeline)
+
+    then:
+    pipeline.notifications == []
+    1 * front50Service.getApplicationNotifications("myapp") >> null
+    1 * echoService.recordEvent(_)
+    0 * _
+  }
+
+  void "handles case where no application notifications are present"() {
+    given:
+    Pipeline pipeline = new Pipeline(application: "myapp")
+    def pipelineConfiguredNotification = [
+      when   : ["pipeline.started", "pipeline.completed"],
+      type   : "slack",
+      address: "spinnaker"
+    ]
+    pipeline.notifications.add(pipelineConfiguredNotification)
+
+    when:
+    echoListener.beforeExecution(null, pipeline)
+
+    then:
+    pipeline.notifications.size() == 1
+    pipeline.notifications[0].when == ["pipeline.started", "pipeline.completed"]
+    1 * front50Service.getApplicationNotifications("myapp") >> null
+    1 * echoService.recordEvent(_)
+    0 * _
+  }
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -20,6 +20,7 @@
 package com.netflix.spinnaker.orca.front50
 
 import com.netflix.spinnaker.orca.front50.model.Application
+import com.netflix.spinnaker.orca.front50.model.ApplicationNotifications
 import com.netflix.spinnaker.orca.front50.model.Front50Credential
 import retrofit.client.Response
 import retrofit.http.*
@@ -43,20 +44,20 @@ interface Front50Service {
   @PATCH("/v2/applications/{applicationName}")
   Response update(@Path("applicationName") String applicationName, @Body Application application)
 
-  @DELETE("/permissions/applications/{name}")
-  Response deletePermission(@Path("name") String name)
+  @DELETE("/permissions/applications/{applicationName}")
+  Response deletePermission(@Path("applicationName") String applicationName)
 
-  @PUT("/permissions/applications/{name}")
-  Response updatePermission(@Path("name") String name, @Body Application.Permission permission)
+  @PUT("/permissions/applications/{applicationName}")
+  Response updatePermission(@Path("applicationName") String applicationName, @Body Application.Permission permission)
 
-  @GET("/pipelines/{application}")
-  List<Map<String, Object>> getPipelines(@Path("application") String application)
+  @GET("/pipelines/{applicationName}")
+  List<Map<String, Object>> getPipelines(@Path("applicationName") String applicationName)
 
   @POST("/pipelines")
   Response savePipeline(@Body Map pipeline)
 
-  @GET("/strategies/{application}")
-  List<Map<String, Object>> getStrategies(@Path("application") String application)
+  @GET("/strategies/{applicationName}")
+  List<Map<String, Object>> getStrategies(@Path("applicationName") String applicationName)
 
   @GET("/pipelines?restricted=false")
   List<Map<String, Object>> getAllPipelines()
@@ -75,6 +76,9 @@ interface Front50Service {
 
   @DELETE("/v2/projects/{projectId}")
   Response deleteProject(@Path("projectId") String projectId)
+
+  @GET("/notifications/application/{applicationName}")
+  ApplicationNotifications getApplicationNotifications(@Path("applicationName") String applicationName)
 
   static class Project {
     String id

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/model/ApplicationNotifications.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/model/ApplicationNotifications.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.front50.model
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+
+class ApplicationNotifications {
+  String application
+  String lastModifiedBy
+  Long lastModified
+
+  private Map<String, Collection<Notification>> notificationsByType = new HashMap<String, Collection<Notification>>()
+
+  @JsonAnyGetter
+  Map<String, Collection<Notification>> details() {
+    return notificationsByType
+  }
+
+  @JsonAnySetter
+  void set(String name, Collection<Notification> value) {
+    notificationsByType.put(name, value)
+  }
+
+  List<Map<String, Object>> getPipelineNotifications() {
+    notificationsByType.values().flatten()
+      .findAll { it.getWhen().any { it.startsWith("pipeline") }}
+      .findResults { notification ->
+        notification.when = notification.getWhen().findAll { it.startsWith("pipeline") }
+        notification
+      }
+  }
+
+  static class Notification extends HashMap<String, Object> {
+    Notification() {}
+    Notification(Map<String, Object> config) {
+      super(config)
+    }
+    List<String> getWhen() {
+      (List<String>) super.get("when") ?: []
+    }
+    String getType() {
+      (String) super.get("type")
+    }
+  }
+}

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/model/ApplicationNotificationsSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/model/ApplicationNotificationsSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.front50.model
+
+import com.netflix.spinnaker.orca.front50.model.ApplicationNotifications.Notification
+import spock.lang.Specification
+
+class ApplicationNotificationsSpec extends Specification {
+
+  void "getPipelineNotifications extracts only pipeline notifications"() {
+    given:
+    def slackPipes = new Notification([
+      when   : ["pipeline.started", "pipeline.failed"],
+      type   : "slack",
+      address: "spinnaker"
+    ])
+    def slackTasks = new Notification([
+      when   : ["task.completed"],
+      type   : "slack",
+      address: "spinnaker-tasks"
+    ])
+    def emailTasks = new Notification([
+      when: ["task.started"],
+      type: "email"
+    ])
+
+    ApplicationNotifications applicationNotification = new ApplicationNotifications()
+    applicationNotification.set("slack", [slackPipes, slackTasks])
+    applicationNotification.set("email", [emailTasks])
+    applicationNotification.set("somethingEmpty", [])
+
+    when:
+    def pipelineNotifications = applicationNotification.getPipelineNotifications()
+
+    then:
+    pipelineNotifications == [slackPipes]
+  }
+}


### PR DESCRIPTION
We currently rely on Echo to determine any application-configured pipeline notifications and send them out on pipeline events.

In the following unlikely scenario (because who would do something like this):
 * a full Spinnaker is running (spinnaker-a)
 * a separate Spinnaker stack (spinnaker-b) is running, but sends its notifications via Echo on spinnaker-a
spinnaker-a's Echo will only know about spinnaker-a, so when it fetches application-level notifications for a pipeline sent from spinnaker-b, it won't get them, or it will get the wrong notifications if there's an application with the same name in spinnaker-a.

To get around this, we can read from Front50 when starting a pipeline, and adding any pipeline-level notifications to the pipeline config.

The `ApplicationNotifications` class is here because Front50's notifications endpoint returns a data structure that's, um, challenging to work with.

I'm assuming Echo is smart enough to dedupe notifications (it seems to be based on my manual testing).

I didn't write tests but am happy to do so, just wanted to get some agreement on the approach. I did test this manually with the following scenarios:
 * a pipeline with its own notifications, but none in the application in Front50
 * a pipeline with its own notifications, and also some in the application in Front50
 * a pipeline without any notifications, but some in the application in Front50
 * a pipeline without any notifications, and also without any in Front50
 * a pipeline with notifications, but no application record in Front50
 * a pipeline without notifications and without an application record in Front50

@cfieber or @robfletcher or @tomaslin PTAL