### PR TITLE
provide better error message when canary baseline lookup fails

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
@@ -116,7 +116,13 @@ class DeployCanaryStage extends ParallelDeployStage implements CloudProviderAwar
     def findImageCtx = [application: stage.execution.application, account: stage.context.baseline.account, cluster: stage.context.baseline.cluster, regions: regions, cloudProvider: stage.context.baseline.cloudProvider ?: 'aws']
     Stage s = new OrchestrationStage(new Orchestration(), "findImage", findImageCtx)
     TaskResult result = findImage.execute(s)
-    return result.stageOutputs.amiDetails
+    try {
+      return result.stageOutputs.amiDetails
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not determine image for baseline deployment (account: ${findImageCtx.account}, " +
+        "cluster: ${findImageCtx.cluster}, regions: ${findImageCtx.regions}, " +
+        "cloudProvider: ${findImageCtx.cloudProvider})", e)
+    }
   }
 
   @CompileDynamic


### PR DESCRIPTION
The default error message is vague:
```
Deploy Canary failureRequest to resolve images for missing regions requires exactly one image. (Found [])
```
This just makes it more clear (IMO).