### PR TITLE
support pointing clouddriver reads at a readonly replica.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/CloudDriverCacheService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/CloudDriverCacheService.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver
+
+import retrofit.client.Response
+import retrofit.http.Body
+import retrofit.http.POST
+import retrofit.http.Path
+
+interface CloudDriverCacheService {
+
+  @POST("/cache/{cloudProvider}/{type}")
+  Response forceCacheUpdate(@Path("cloudProvider") String cloudProvider,
+                            @Path("type") String type,
+                            @Body Map<String, ? extends Object> data)
+
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/CloudDriverCacheStatusService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/CloudDriverCacheStatusService.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver
+
+import retrofit.http.GET
+import retrofit.http.Path
+
+interface CloudDriverCacheStatusService {
+  @GET("/cache/{cloudProvider}/{type}")
+  Collection<Map> pendingForceCacheUpdates(@Path("cloudProvider") String cloudProvider,
+                                           @Path("type") String type)
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestService.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver
 
 import com.netflix.spinnaker.orca.clouddriver.model.Task
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import retrofit.client.Response
 import retrofit.http.Body
 import retrofit.http.GET
 import retrofit.http.POST
@@ -46,5 +47,19 @@ interface KatoRestService {
 
   @GET("/task/{id}")
   Observable<Task> lookupTask(@Path("id") String id)
+
+  @POST("/applications/{app}/jobs/{account}/{region}/{id}")
+  Response collectJob(@Path("app") String app,
+                      @Path("account") String account,
+                      @Path("region") String region,
+                      @Path("id") String id,
+                      @Body String details)
+
+  @GET("/applications/{app}/jobs/{account}/{region}/{id}/{fileName}")
+  Map<String, Object> getFileContents(@Path("app") String app,
+                                      @Path("account") String account,
+                                      @Path("region") String region,
+                                      @Path("id") String id,
+                                      @Path("fileName") String fileName)
 
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
@@ -20,7 +20,6 @@ import com.netflix.spinnaker.orca.clouddriver.model.Task
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import retrofit.http.Body
 import rx.Observable
 
 @Component
@@ -34,7 +33,7 @@ class KatoService {
     katoRestService.requestOperations(clientRequestId, operations)
   }
 
-  Observable<TaskId> requestOperations(String cloudProvider, @Body Collection<? extends Map<String, Map>> operations) {
+  Observable<TaskId> requestOperations(String cloudProvider, Collection<? extends Map<String, Map>> operations) {
     String clientRequestId = UUID.randomUUID().toString()
     katoRestService.requestOperations(clientRequestId, cloudProvider, operations)
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/MortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/MortService.groovy
@@ -19,10 +19,7 @@ package com.netflix.spinnaker.orca.clouddriver
 
 import groovy.transform.Canonical
 import groovy.transform.EqualsAndHashCode
-import retrofit.client.Response
-import retrofit.http.Body
 import retrofit.http.GET
-import retrofit.http.POST
 import retrofit.http.Path
 import retrofit.http.Query
 
@@ -48,11 +45,6 @@ interface MortService {
   @GET("/search")
   List<SearchResult> getSearchResults(@Query("q") String searchTerm,
                                       @Query("type") String type)
-
-  @POST("/cache/{cloudProvider}/{type}")
-  Response forceCacheUpdate(@Path("cloudProvider") String cloudProvider,
-                            @Path("type") String type,
-                            @Body Map<String, ? extends Object> data)
 
   @GET("/credentials/{account}")
   Map getAccountDetails(@Path("account") String account)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -17,13 +17,8 @@
 
 package com.netflix.spinnaker.orca.clouddriver
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter
-import com.fasterxml.jackson.annotation.JsonAnySetter
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import retrofit.client.Response
-import retrofit.http.Body
 import retrofit.http.GET
-import retrofit.http.POST
 import retrofit.http.Path
 import retrofit.http.Query
 import retrofit.http.QueryMap
@@ -61,21 +56,6 @@ public interface OortService {
                                             @Path("summaryType") String summaryType,
                                             @Query("onlyEnabled") String onlyEnabled)
 
-  @POST("/applications/{app}/jobs/{account}/{region}/{id}")
-  Response collectJob(@Path("app") String app,
-                      @Path("account") String account,
-                      @Path("region") String region,
-                      @Path("id") String id,
-                      @Body String details)
-
-  @GET("/applications/{app}/jobs/{account}/{region}/{id}/{fileName}")
-  Map<String, Object> getFileContents(@Path("app") String app,
-                         @Path("account") String account,
-                         @Path("region") String region,
-                         @Path("id") String id,
-                         @Path("fileName") String fileName)
-
-
   @GET("/search")
   Response getSearchResults(@Query("q") String searchTerm,
                             @Query("type") String type,
@@ -94,15 +74,6 @@ public interface OortService {
                                    @Path("account") String account,
                                    @Path("region") String region,
                                    @Path("name") String name)
-
-  @POST("/cache/{cloudProvider}/{type}")
-  Response forceCacheUpdate(@Path("cloudProvider") String cloudProvider,
-                            @Path("type") String type,
-                            @Body Map<String, ? extends Object> data)
-
-  @GET("/cache/{cloudProvider}/{type}")
-  Collection<Map> pendingForceCacheUpdates(@Path("cloudProvider") String cloudProvider,
-                                           @Path("type") String type)
 
   @GET("/{type}/images/{account}/{region}/{imageId}")
   List<Map> getByAmiId(@Path("type") String type,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationProperties.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationProperties.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config
+
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@Canonical
+@ConfigurationProperties
+class CloudDriverConfigurationProperties {
+  @Canonical
+  static class BaseUrl {
+    String baseUrl
+  }
+
+  @Canonical
+  static class CloudDriver {
+    String baseUrl;
+    BaseUrl readonly;
+  }
+
+  BaseUrl mort
+  BaseUrl oort
+  BaseUrl kato
+  CloudDriver clouddriver
+
+  String getCloudDriverBaseUrl() {
+    clouddriver?.baseUrl ?: kato?.baseUrl ?: oort?.baseUrl ?: mort?.baseUrl
+  }
+
+  String getCloudDriverReadOnlyBaseUrl() {
+    clouddriver?.readonly?.baseUrl ?: getCloudDriverBaseUrl()
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/ImageForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/ImageForceCacheRefreshTask.java
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.orca.DefaultTaskResult;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.RetryableTask;
 import com.netflix.spinnaker.orca.TaskResult;
-import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +34,7 @@ public class ImageForceCacheRefreshTask extends AbstractCloudProviderAwareTask i
   static final String REFRESH_TYPE = "Image";
 
   @Autowired
-  OortService oort;
+  CloudDriverCacheService cacheService;
 
   @Autowired
   ObjectMapper objectMapper;
@@ -46,7 +46,7 @@ public class ImageForceCacheRefreshTask extends AbstractCloudProviderAwareTask i
 //    String cloudProvider = getCloudProvider(stage)
 //
 //    stage.context.targets.each { Map target ->
-//      oort.forceCacheUpdate(
+//      cacheService.forceCacheUpdate(
 //        cloudProvider, REFRESH_TYPE, [account: target.account, imageName: target.imageName, region: target.region]
 //      )
 //    }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/DestroyJobForceCacheRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/DestroyJobForceCacheRefreshTask.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
-import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,7 +31,7 @@ class DestroyJobForceCacheRefreshTask extends AbstractCloudProviderAwareTask imp
   static final String REFRESH_TYPE = "Job"
 
   @Autowired
-  OortService oort
+  CloudDriverCacheService cacheService
 
   @Override
   TaskResult execute(Stage stage) {
@@ -42,7 +42,7 @@ class DestroyJobForceCacheRefreshTask extends AbstractCloudProviderAwareTask imp
     String region = stage.context.region
 
     def model = [jobName: name, region: region, account: account, evict: true]
-    oort.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
+    cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
     new DefaultTaskResult(ExecutionStatus.SUCCEEDED)
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.KatoRestService
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
 import com.netflix.spinnaker.orca.pipeline.model.Stage
@@ -37,7 +38,7 @@ public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implemen
   long timeout = TimeUnit.DAYS.toMillis(1)
 
   @Autowired
-  OortService oortService
+  KatoRestService katoRestService
 
   @Autowired
   ObjectMapper objectMapper
@@ -72,7 +73,7 @@ public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implemen
       def name = names[0]
       def parsedName = Names.parseName(name)
 
-      Map job = objectMapper.readValue(oortService.collectJob(parsedName.app, account, location, name, "delete").body.in(), new TypeReference<Map>() {})
+      Map job = objectMapper.readValue(katoRestService.collectJob(parsedName.app, account, location, name, "delete").body.in(), new TypeReference<Map>() {})
       outputs.jobStatus = job
 
       switch ((String) job.jobState) {
@@ -82,7 +83,7 @@ public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implemen
 
           if (stage.context.propertyFile) {
             Map<String, Object> properties = [:]
-            properties = oortService.getFileContents(parsedName.app, account, location, name, stage.context.propertyFile)
+            properties = katoRestService.getFileContents(parsedName.app, account, location, name, stage.context.propertyFile)
             if (properties.size() == 0) {
               throw new IllegalStateException("expected properties file ${stage.context.propertyFile} but one was not found or was empty")
             }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerForceRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerForceRefreshTask.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
-import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,7 +31,7 @@ class DeleteLoadBalancerForceRefreshTask extends AbstractCloudProviderAwareTask 
   static final String REFRESH_TYPE = "LoadBalancer"
 
   @Autowired
-  OortService oort
+  CloudDriverCacheService cacheService
 
   @Override
   TaskResult execute(Stage stage) {
@@ -44,7 +44,7 @@ class DeleteLoadBalancerForceRefreshTask extends AbstractCloudProviderAwareTask 
 
     regions.each { region ->
       def model = [loadBalancerName: name, region: region, account: account, vpcId: vpcId, evict: true]
-      oort.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
+      cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
     }
     new DefaultTaskResult(ExecutionStatus.SUCCEEDED)
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTask.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
-import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,14 +31,14 @@ public class UpsertLoadBalancerForceRefreshTask extends AbstractCloudProviderAwa
   static final String REFRESH_TYPE = "LoadBalancer"
 
   @Autowired
-  OortService oort
+  CloudDriverCacheService cacheService
 
   @Override
   TaskResult execute(Stage stage) {
     String cloudProvider = getCloudProvider(stage)
     stage.context.targets.each { Map target ->
       target.availabilityZones.keySet().each { String region ->
-        oort.forceCacheUpdate(
+        cacheService.forceCacheUpdate(
           cloudProvider, REFRESH_TYPE, [loadBalancerName: target.name, region: region, account: target.credentials]
         )
       }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupForceRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupForceRefreshTask.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
-import com.netflix.spinnaker.orca.clouddriver.MortService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,7 +31,7 @@ class DeleteSecurityGroupForceRefreshTask extends AbstractCloudProviderAwareTask
   static final String REFRESH_TYPE = "SecurityGroup"
 
   @Autowired
-  MortService mort
+  CloudDriverCacheService cacheService
 
   @Override
   TaskResult execute(Stage stage) {
@@ -44,7 +44,7 @@ class DeleteSecurityGroupForceRefreshTask extends AbstractCloudProviderAwareTask
 
     regions.each { region ->
       def model = [securityGroupName: name, vpcId: vpcId, region: region, account: account, evict: true]
-      mort.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
+      cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
     }
     new DefaultTaskResult(ExecutionStatus.SUCCEEDED)
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/SecurityGroupForceCacheRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/SecurityGroupForceCacheRefreshTask.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
-import com.netflix.spinnaker.orca.clouddriver.MortService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,14 +31,14 @@ public class SecurityGroupForceCacheRefreshTask extends AbstractCloudProviderAwa
   static final String REFRESH_TYPE = "SecurityGroup"
 
   @Autowired
-  MortService mort
+  CloudDriverCacheService cacheService
 
   @Override
   TaskResult execute(Stage stage) {
     String cloudProvider = getCloudProvider(stage)
 
     stage.context.targets.each { Map target ->
-      mort.forceCacheUpdate(
+      cacheService.forceCacheUpdate(
         cloudProvider, REFRESH_TYPE, [account: target.accountName, securityGroupName: target.name, region: target.region]
       )
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
@@ -21,7 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
-import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheStatusService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
@@ -44,7 +45,10 @@ class ServerGroupCacheForceRefreshTask extends AbstractCloudProviderAwareTask im
   long autoSucceedAfterMs = TimeUnit.MINUTES.toMillis(12)
 
   @Autowired
-  OortService oort
+  CloudDriverCacheStatusService cacheStatusService
+
+  @Autowired
+  CloudDriverCacheService cacheService
 
   @Autowired
   ObjectMapper objectMapper
@@ -111,7 +115,7 @@ class ServerGroupCacheForceRefreshTask extends AbstractCloudProviderAwareTask im
     def status = RUNNING
     refreshableServerGroups.each { Map<String, String> model ->
       try {
-        def response = oort.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
+        def response = cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
         if (response.status == HttpURLConnection.HTTP_OK) {
           // cache update was applied immediately, no need to poll for completion
           status = SUCCEEDED
@@ -139,7 +143,7 @@ class ServerGroupCacheForceRefreshTask extends AbstractCloudProviderAwareTask im
                                                   String cloudProvider,
                                                   StageData stageData,
                                                   Long startTime) {
-    def pendingForceCacheUpdates = oort.pendingForceCacheUpdates(cloudProvider, REFRESH_TYPE)
+    def pendingForceCacheUpdates = cacheStatusService.pendingForceCacheUpdates(cloudProvider, REFRESH_TYPE)
 
     boolean finishedProcessing = true
     stageData.deployServerGroups.each { String region, Set<String> serverGroups ->

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver
 
 import com.netflix.spinnaker.orca.clouddriver.config.CloudDriverConfiguration
+import com.netflix.spinnaker.orca.clouddriver.config.CloudDriverConfigurationProperties
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.test.httpserver.HttpServerRule
 import org.junit.Rule
@@ -46,9 +47,14 @@ class KatoRestServiceSpec extends Specification {
   final taskId = "e1jbn3"
 
   def setup() {
-    service = new CloudDriverConfiguration(
-      retrofitClient: new OkClient(), retrofitLogLevel: FULL, spinnakerRequestInterceptor: noopInterceptor
-    ).katoDeployService(httpServer.baseURI, new OrcaObjectMapper())
+    def cfg = new CloudDriverConfiguration()
+    def builder = cfg.clouddriverRetrofitBuilder(
+        new OrcaObjectMapper(),
+        new OkClient(),
+        FULL,
+        noopInterceptor,
+        new CloudDriverConfigurationProperties(clouddriver: new CloudDriverConfigurationProperties.CloudDriver(baseUrl: httpServer.baseURI)))
+    service = cfg.katoDeployService(builder)
   }
 
   def "can interpret the response from an operation request"() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerForceRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerForceRefreshTaskSpec.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.loadbalancer
 
-import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import spock.lang.Specification
 import spock.lang.Subject
@@ -38,13 +38,13 @@ class DeleteLoadBalancerForceRefreshTaskSpec extends Specification {
 
   void "should force cache refresh server groups via oort when clusterName provided"() {
     setup:
-    task.oort = Mock(OortService)
+    task.cacheService = Mock(CloudDriverCacheService)
 
     when:
     task.execute(stage)
 
     then:
-    1 * task.oort.forceCacheUpdate(stage.context.cloudProvider, DeleteLoadBalancerForceRefreshTask.REFRESH_TYPE, _) >> {
+    1 * task.cacheService.forceCacheUpdate(stage.context.cloudProvider, DeleteLoadBalancerForceRefreshTask.REFRESH_TYPE, _) >> {
       String cloudProvider, String type, Map<String, ? extends Object> body ->
 
       assert body.loadBalancerName == config.loadBalancerName

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTaskSpec.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.loadbalancer
 
-import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import spock.lang.Specification
 import spock.lang.Subject
@@ -38,13 +38,13 @@ class UpsertLoadBalancerForceRefreshTaskSpec extends Specification {
 
   void "should force cache refresh server groups via oort when name provided"() {
     setup:
-    task.oort = Mock(OortService)
+    task.cacheService = Mock(CloudDriverCacheService)
 
     when:
     task.execute(stage)
 
     then:
-    1 * task.oort.forceCacheUpdate('aws', UpsertLoadBalancerForceRefreshTask.REFRESH_TYPE, _) >> { String cloudProvider, String type, Map<String, ? extends Object> body ->
+    1 * task.cacheService.forceCacheUpdate('aws', UpsertLoadBalancerForceRefreshTask.REFRESH_TYPE, _) >> { String cloudProvider, String type, Map<String, ? extends Object> body ->
       assert cloudProvider == "aws"
       assert body.loadBalancerName == "flapjack-frontend"
       assert body.account == "fzlem"

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupForceRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupForceRefreshTaskSpec.groovy
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.orca.clouddriver.tasks.securitygroup
 
-import com.netflix.spinnaker.orca.clouddriver.MortService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import spock.lang.Specification
 import spock.lang.Subject
@@ -38,13 +38,13 @@ class DeleteSecurityGroupForceRefreshTaskSpec extends Specification {
 
   void "should force cache refresh security group via mort"() {
     setup:
-    task.mort = Mock(MortService)
+    task.cacheService = Mock(CloudDriverCacheService)
 
     when:
     task.execute(stage)
 
     then:
-    1 * task.mort.forceCacheUpdate(stage.context.cloudProvider, DeleteSecurityGroupForceRefreshTask.REFRESH_TYPE, _) >> {
+    1 * task.cacheService.forceCacheUpdate(stage.context.cloudProvider, DeleteSecurityGroupForceRefreshTask.REFRESH_TYPE, _) >> {
       String cloudProvider, String type, Map<String, ? extends Object> body ->
 
       assert body.securityGroupName == config.securityGroupName

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/SecurityGroupForceCacheRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/SecurityGroupForceCacheRefreshTaskSpec.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.securitygroup
 
-import com.netflix.spinnaker.orca.clouddriver.MortService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import spock.lang.Specification
 import spock.lang.Subject
@@ -39,13 +39,13 @@ class SecurityGroupForceCacheRefreshTaskSpec extends Specification {
 
   void "should force cache refresh security groups via mort"() {
     setup:
-    task.mort = Mock(MortService)
+    task.cacheService = Mock(CloudDriverCacheService)
 
     when:
     task.execute(stage)
 
     then:
-    1 * task.mort.forceCacheUpdate('aws', SecurityGroupForceCacheRefreshTask.REFRESH_TYPE, _) >> {
+    1 * task.cacheService.forceCacheUpdate('aws', SecurityGroupForceCacheRefreshTask.REFRESH_TYPE, _) >> {
       String cloudProvider, String type, Map<String, ? extends Object> body ->
 
       assert body.securityGroupName == config.name

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/MigrateForceRefreshDependenciesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/MigrateForceRefreshDependenciesTaskSpec.groovy
@@ -16,8 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
-import com.netflix.spinnaker.orca.clouddriver.MortService
-import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
@@ -31,12 +30,10 @@ class MigrateForceRefreshDependenciesTaskSpec extends Specification {
   def stage = new PipelineStage(new Pipeline(), "refreshTask")
   def taskId = new TaskId(UUID.randomUUID().toString())
 
-  OortService oort = Mock(OortService)
-  MortService mort = Mock(MortService)
+  CloudDriverCacheService cacheService = Mock(CloudDriverCacheService)
 
   void setup() {
-    task.oort = oort
-    task.mort = mort
+    task.cacheService = cacheService
     stage.context = [
       cloudProvider: 'aws',
       target       : [
@@ -84,8 +81,8 @@ class MigrateForceRefreshDependenciesTaskSpec extends Specification {
     task.execute(stage)
 
     then:
-    1 * mort.forceCacheUpdate('aws', 'SecurityGroup', [securityGroupName: 'new-sg-1', region: 'us-east-1', account: 'test', vpcId: 'vpc-1'])
-    1 * mort.forceCacheUpdate('aws', 'SecurityGroup', [securityGroupName: 'new-sg-2', region: 'us-east-1', account: 'prod', vpcId: 'vpc-2'])
+    1 * cacheService.forceCacheUpdate('aws', 'SecurityGroup', [securityGroupName: 'new-sg-1', region: 'us-east-1', account: 'test', vpcId: 'vpc-1'])
+    1 * cacheService.forceCacheUpdate('aws', 'SecurityGroup', [securityGroupName: 'new-sg-2', region: 'us-east-1', account: 'prod', vpcId: 'vpc-2'])
     0 * _
   }
 
@@ -110,9 +107,9 @@ class MigrateForceRefreshDependenciesTaskSpec extends Specification {
     task.execute(stage)
 
     then:
-    1 * oort.forceCacheUpdate('aws', 'LoadBalancer', [loadBalancerName: 'newElb-vpc1', region: 'us-east-1', account: 'test'])
-    1 * mort.forceCacheUpdate('aws', 'SecurityGroup', [securityGroupName: 'new-sg-1', region: 'us-east-1', account: 'test', vpcId: 'vpc-1'])
-    1 * mort.forceCacheUpdate('aws', 'SecurityGroup', [securityGroupName: 'new-sg-2', region: 'us-east-1', account: 'prod', vpcId: 'vpc-2'])
+    1 * cacheService.forceCacheUpdate('aws', 'LoadBalancer', [loadBalancerName: 'newElb-vpc1', region: 'us-east-1', account: 'test'])
+    1 * cacheService.forceCacheUpdate('aws', 'SecurityGroup', [securityGroupName: 'new-sg-1', region: 'us-east-1', account: 'test', vpcId: 'vpc-1'])
+    1 * cacheService.forceCacheUpdate('aws', 'SecurityGroup', [securityGroupName: 'new-sg-2', region: 'us-east-1', account: 'prod', vpcId: 'vpc-2'])
     0 * _
   }
 }


### PR DESCRIPTION
This extracts the mutating bits out of `OortService` and `MortService` leaving those only performing `GET` operations against clouddriver. Adds a `ConfigurationProperties` object for clouddriver baseUrl configuration that supports providing `clouddriver.readonly.baseUrl` as a pointer to a clouddriver that should only receive read operations (this could be backed by a redis read replica).

Also prefers `clouddriver.baseUrl` as the configuration for the standard clouddriver endpoint but falls back to one of `kato.baseUrl`, `oort.baseUrl`, `mort.baseUrl` for backwards compatibility with existing configurations.

This moves:
* `forceCacheRefresh` from `MortService` and `OortService` into `CloudDriverCacheService` which will hit the writable clouddriver url
* `pendingForceCacheRefreshes` from `OortService` into `CloudDriverCacheStatusService` which will hit the readonly clouddriver url if available
* `collectJob` and `getFileContents` from `OortService` to `KatoRestService`

Nothing should change if clouddriver.readonly.baseUrl is not provided

@spinnaker/netflix-reviewers PTAL