### PR TITLE
initial cut at cluster guards

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -23,20 +23,20 @@ import retrofit.http.Path
 import retrofit.http.Query
 import retrofit.http.QueryMap
 
-public interface OortService {
-  @GET("/applications/{app}/clusters/{account}/{cluster}/{type}")
+interface OortService {
+  @GET("/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}")
   Response getCluster(@Path("app") String app,
                       @Path("account") String account,
                       @Path("cluster") String cluster,
-                      @Path("type") String type)
+                      @Path("cloudProvider") String cloudProvider)
 
-  @GET("/applications/{app}/clusters/{account}/{cluster}/{type}/serverGroups/{serverGroup}")
+  @GET("/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/serverGroups/{serverGroup}")
   Response getServerGroup(@Path("app") String app,
                           @Path("account") String account,
                           @Path("cluster") String cluster,
                           @Path("serverGroup") String serverGroup,
                           @Query("region") String region,
-                          @Path("type") String type)
+                          @Path("cloudProvider") String cloudProvider)
 
   @GET("/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/{scope}/serverGroups/target/{target}")
   Response getTargetServerGroup(@Path("app") String app,
@@ -59,7 +59,7 @@ public interface OortService {
   @GET("/search")
   Response getSearchResults(@Query("q") String searchTerm,
                             @Query("type") String type,
-                            @Query("platform") String platform)
+                            @Query("cloudProvider") String cloudProvider)
 
   @GET("/applications/{app}")
   Response getApplication(@Path("app") String app)
@@ -81,10 +81,17 @@ public interface OortService {
                        @Path("region") String region,
                        @Path("imageId") imageId)
 
-  @GET("/{type}/images/find")
-  List<Map> findImage(@Path("type") String type,
+  @GET("/{cloudProvider}/images/find")
+  List<Map> findImage(@Path("cloudProvider") String cloudProvider,
                       @Query("q") String query,
                       @Query("account") String account,
                       @Query("region") String region,
                       @QueryMap Map additionalFilters)
+
+  @GET("/tags")
+  List<Map> getEntityTags(@Query("cloudProvider") String cloudProvider,
+                          @Query("entityType") String entityType,
+                          @Query("entityId") String entityId,
+                          @Query("account") String account,
+                          @Query("region") String region)
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -51,6 +51,27 @@ class TargetServerGroup {
     return Support.locationFromServerGroup(serverGroup, exactLocationType)
   }
 
+  /**
+   * Used in TrafficGuard, which is Java, which doesn't play nice with @Delegate
+   */
+  String getName() {
+    return serverGroup.name
+  }
+
+  /**
+   * Used in TrafficGuard, which is Java, which doesn't play nice with @Delegate
+   */
+  Boolean isDisabled() {
+    return serverGroup.isDisabled
+  }
+
+  /**
+   * Used in TrafficGuard, which is Java, which doesn't play nice with @Delegate
+   */
+  List<Map> getInstances() {
+    return (serverGroup.instances ?: []) as List<Map>
+  }
+
   Map toClouddriverOperationPayload(String account) {
     //TODO(cfieber) - add an endpoint on Clouddriver to do provider appropriate conversion of a TargetServerGroup
     def op = [

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTask.groovy
@@ -17,9 +17,22 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DestroyServerGroupStage
+import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
 class DestroyServerGroupTask extends AbstractServerGroupTask {
   String serverGroupAction = DestroyServerGroupStage.PIPELINE_CONFIG_TYPE
+
+  @Autowired
+  TrafficGuard trafficGuard
+
+  @Override
+  void validateClusterStatus(Map operation) {
+    trafficGuard.verifyTrafficRemoval(operation.serverGroupName as String,
+      getCredentials(operation),
+      getLocation(operation),
+      getCloudProvider(operation), "Destroying")
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DisableServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DisableServerGroupTask.groovy
@@ -17,13 +17,27 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DisableServerGroupStage
+import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
 class DisableServerGroupTask extends AbstractServerGroupTask {
+
+  @Autowired
+  TrafficGuard trafficGuard
+
   @Override
   protected boolean isAddTargetOpOutputs() {
     true
   }
   String serverGroupAction = DisableServerGroupStage.PIPELINE_CONFIG_TYPE
+
+  @Override
+  void validateClusterStatus(Map operation) {
+    trafficGuard.verifyTrafficRemoval(operation.serverGroupName as String,
+      getCredentials(operation),
+      getLocation(operation),
+      getCloudProvider(operation), "Disabling")
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/OortHelper.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/OortHelper.groovy
@@ -51,8 +51,8 @@ class OortHelper {
     }
   }
 
-  Optional<Map> getCluster(String application, String account, String cluster, String type) {
-    return convertedResponse(Map) { oortService.getCluster(application, account, cluster, type) }
+  Optional<Map> getCluster(String application, String account, String cluster, String cloudProvider) {
+    return convertedResponse(Map) { oortService.getCluster(application, account, cluster, cloudProvider) }
   }
 
   Optional<TargetServerGroup> getTargetServerGroup(String account,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.utils;
+
+import com.netflix.frigga.Names;
+import com.netflix.spinnaker.orca.clouddriver.FeaturesService;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.front50.model.Application;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class TrafficGuard {
+
+  private final OortHelper oortHelper;
+
+  private final Front50Service front50Service;
+
+  @Autowired
+  public TrafficGuard(OortHelper oortHelper, Front50Service front50Service) {
+    this.oortHelper = oortHelper;
+    this.front50Service = front50Service;
+  }
+
+  public void verifyTrafficRemoval(String serverGroupName, String account, Location location, String cloudProvider, String operationDescriptor) {
+    Names names = Names.parseName(serverGroupName);
+
+    if (!hasDisableLock(names.getCluster(), account, location)) {
+      return;
+    }
+
+    Optional<Map> cluster = oortHelper.getCluster(names.getApp(), account, names.getCluster(), cloudProvider);
+
+    if (!cluster.isPresent()) {
+      throw new IllegalStateException("Could not find traffic-protected cluster.");
+    }
+
+    List<TargetServerGroup> targetServerGroups = ((List<Map<String, Object>>) cluster.get().get("serverGroups"))
+      .stream()
+      .map(TargetServerGroup::new)
+      .filter(tsg -> location.equals(tsg.getLocation()))
+      .collect(Collectors.toList());
+
+    boolean otherEnabledServerGroupFound = targetServerGroups.stream().anyMatch(tsg ->
+      !serverGroupName.equals(tsg.getName()) &&
+        !Boolean.TRUE.equals(tsg.isDisabled()) &&
+        (tsg.getInstances()).size() > 0
+    );
+    if (!otherEnabledServerGroupFound) {
+      throw new IllegalStateException(String.format("This cluster has traffic protection enabled. " +
+        "%s %s would leave the cluster with no instances taking traffic.", operationDescriptor, serverGroupName));
+    }
+  }
+
+  public boolean hasDisableLock(String cluster, String account, Location location) {
+    Names names = Names.parseName(cluster);
+    Application application = front50Service.get(names.getApp());
+    if (application == null || !application.details().containsKey("trafficGuards")) {
+      return false;
+    }
+    List<Map<String, String>> trafficGuards = (List<Map<String, String>>) application.details().get("trafficGuards");
+    return trafficGuards.stream().anyMatch(guard ->
+      ("*".equals(guard.get("account")) || account.equals(guard.get("account"))) &&
+        ("*".equals(guard.get("location")) || location.getValue().equals(guard.get("location"))) &&
+          ("*".equals(guard.get("stack")) || StringUtils.equals(names.getStack(), guard.get("stack"))) &&
+            ("*".equals(guard.get("detail")) || StringUtils.equals(names.getDetail(), guard.get("detail")))
+    );
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTaskSpec.groovy
@@ -21,14 +21,16 @@ import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver
+import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import spock.lang.Specification
 import spock.lang.Subject
 
 class DestroyServerGroupTaskSpec extends Specification {
+  def trafficGuard = Stub(TrafficGuard)
   @Subject
-    task = new DestroyServerGroupTask()
+    task = new DestroyServerGroupTask(trafficGuard: trafficGuard)
   def stage = new PipelineStage(new Pipeline(), "whatever")
   def taskId = new TaskId(UUID.randomUUID().toString())
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.utils
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location.Type
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.model.Application
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class TrafficGuardSpec extends Specification {
+
+  OortHelper oortHelper = Mock(OortHelper)
+
+  Front50Service front50Service = Mock(Front50Service)
+
+  Application application = Stub(Application) {
+    details() >> applicationDetails
+  }
+
+  Map otherServerGroup
+  Map targetServerGroup
+  Location location
+
+  @Shared
+  Map<String, Object> applicationDetails = [:]
+
+  @Subject
+  TrafficGuard trafficGuard = new TrafficGuard(oortHelper, front50Service)
+
+  void setup() {
+    targetServerGroup = [
+      account: "test",
+      region : "us-east-1",
+      name   : "app-foo-v001"
+    ]
+    otherServerGroup = [
+      account   : "test",
+      region    : "us-east-1",
+      name      : "app-foo-v000",
+      isDisabled: true
+    ]
+    location = new Location(Type.REGION, "us-east-1")
+    applicationDetails.clear()
+  }
+
+  void "should throw exception when target server group is the only one enabled in cluster"() {
+    given:
+    addGuard([account: "test", location: "us-east-1", stack: "foo"])
+
+    when:
+    trafficGuard.verifyTrafficRemoval("app-foo-v001", "test", location, "aws", "x")
+
+    then:
+    thrown(IllegalStateException)
+    1 * front50Service.get("app") >> application
+    1 * oortHelper.getCluster("app", "test", "app-foo", "aws") >> [
+      serverGroups: [targetServerGroup, otherServerGroup]
+    ]
+  }
+
+  void "should throw exception when target server group is the only one in cluster"() {
+    given:
+    addGuard([account: "test", location: "us-east-1", stack: "foo"])
+
+    when:
+    trafficGuard.verifyTrafficRemoval("app-foo-v001", "test", location, "aws", "x")
+
+    then:
+    thrown(IllegalStateException)
+    1 * front50Service.get("app") >> application
+    1 * oortHelper.getCluster("app", "test", "app-foo", "aws") >> [
+      serverGroups: [targetServerGroup]
+    ]
+  }
+
+  void "should validate location when looking for other enabled server groups in cluster"() {
+    given:
+    addGuard([account: "test", location: "us-east-1", stack: "foo"])
+    otherServerGroup.isDisabled = false
+    otherServerGroup.region = "us-west-1"
+
+    when:
+    trafficGuard.verifyTrafficRemoval("app-foo-v001", "test", location, "aws", "x")
+
+    then:
+    thrown(IllegalStateException)
+    1 * front50Service.get("app") >> application
+    1 * oortHelper.getCluster("app", "test", "app-foo", "aws") >> [
+      serverGroups: [targetServerGroup, otherServerGroup]
+    ]
+  }
+
+  void "should validate existence of cluster"() {
+    given:
+    addGuard([account: "test", location: "us-east-1", stack: "foo"])
+
+    when:
+    trafficGuard.verifyTrafficRemoval("app-foo-v001", "test", location, "aws", "x")
+
+    then:
+    thrown(IllegalStateException)
+    1 * front50Service.get("app") >> application
+    1 * oortHelper.getCluster("app", "test", "app-foo", "aws") >> Optional.empty()
+  }
+
+  void "should not throw if another server group is enabled and has instances"() {
+    given:
+    addGuard([account: "test", location: "us-east-1", stack: "foo"])
+    otherServerGroup.isDisabled = false
+    otherServerGroup.instances = [[id: 'a']]
+
+    when:
+    trafficGuard.verifyTrafficRemoval("app-foo-v001", "test", location, "aws", "x")
+
+    then:
+    notThrown(IllegalStateException)
+    1 * front50Service.get("app") >> application
+    1 * oortHelper.getCluster("app", "test", "app-foo", "aws") >> [
+      serverGroups: [targetServerGroup, otherServerGroup]
+    ]
+  }
+
+  @Unroll
+  void "hasDisableLock should match on wildcards in stack, detail, account, location"() {
+    given:
+    addGuard([account: guardAccount, stack: guardStack, detail: guardDetail, location: guardLocation])
+
+    when:
+    boolean result = trafficGuard.hasDisableLock(cluster, account, location)
+
+    then:
+    result == expected
+    1 * front50Service.get("app") >> application
+
+    where:
+    cluster | account | guardStack | guardDetail | guardAccount | guardLocation || expected
+    "app"   | "test"  | null       | null        | "test"       | "us-east-1"   || true // exact match
+    "app"   | "test"  | "*"        | null        | "test"       | "us-east-1"   || true
+    "app"   | "test"  | null       | "*"         | "test"       | "us-east-1"   || true
+    "app"   | "test"  | null       | null        | "*"          | "us-east-1"   || true
+    "app"   | "test"  | null       | null        | "test"       | "*"           || true
+    "app"   | "test"  | "*"        | "*"         | "*"          | "*"           || true
+    "app"   | "test"  | null       | null        | "prod"       | "us-east-1"   || false // different account
+    "app"   | "test"  | null       | null        | "test"       | "eu-west-1"   || false // different location
+    "app"   | "test"  | "foo"      | null        | "test"       | "us-east-1"   || false // different stack
+    "app"   | "test"  | null       | "zz"        | "test"       | "us-east-1"   || false // different detail
+  }
+
+  void "hasDisableLock returns false on missing applications"() {
+    when:
+    boolean result = trafficGuard.hasDisableLock("app", "test", location)
+
+    then:
+    result == false
+    1 * front50Service.get("app") >> null
+  }
+
+  void "hasDisableLock returns false on applications with no guards configured"() {
+    when:
+    boolean result = trafficGuard.hasDisableLock("app", "test", location)
+
+    then:
+    !applicationDetails.containsKey("trafficGuards")
+    result == false
+    1 * front50Service.get("app") >> application
+  }
+
+  void "hasDisableLock returns false on applications with empty guards configured"() {
+    when:
+    applicationDetails.put("trafficGuards", [])
+    boolean result = trafficGuard.hasDisableLock("app", "test", location)
+
+    then:
+    result == false
+    1 * front50Service.get("app") >> application
+  }
+
+  private void addGuard(Map guard) {
+    applicationDetails.putIfAbsent("trafficGuards", [])
+    applicationDetails.get("trafficGuards") << guard
+  }
+
+}


### PR DESCRIPTION
Rough cut of a proposed guarding mechanism to prevent disable/destroy operations from leaving a cluster in a state where it has no instances taking traffic.

Requires the entity tags feature to be enabled.

@spinnaker/netflix-reviewers PTAL - if this seems like a good approach, I'll start working on the UI