### PR TITLE
allow branch failure to fail pipeline even if other branches finish

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/ExecutionPropagationListener.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/ExecutionPropagationListener.groovy
@@ -16,10 +16,10 @@
 
 package com.netflix.spinnaker.orca.listeners
 
-import groovy.transform.CompileStatic
-import groovy.util.logging.Slf4j
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.pipeline.model.Execution
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 import static com.netflix.spinnaker.orca.ExecutionStatus.*
 
 @Slf4j
@@ -45,6 +45,11 @@ class ExecutionPropagationListener implements ExecutionListener {
     }
 
     if (!executionStatus) {
+      executionStatus = TERMINAL
+    }
+
+    def failedStages = execution.stages.findAll { it.status.complete && it.status != SUCCEEDED }
+    if (failedStages.any { it.context.completeOtherBranchesThenFail }) {
       executionStatus = TERMINAL
     }
 


### PR DESCRIPTION
Current options on stage failure are:

* fail branch and cancel other branches, pipeline = TERMINAL
* fail branch, finish other branches, pipeline = SUCCEEDED (unless other stuff fails)
* ignore failure (FAILED_CONTINUE status), pipeline = SUCCEEDED

This adds another option where the branch stops, other branches can complete but the pipeline itself will be TERMINAL at the end. This is for make benefit Cadmium folks.