### PR TITLE
Ensuring interesting health provider names are preserved for rolling …

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.orca.DefaultTaskResult;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.RetryableTask;
 import com.netflix.spinnaker.orca.TaskResult;
-import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.InterestingHealthProviderNamesSupplier;
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCreator;
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
 import com.netflix.spinnaker.orca.front50.Front50Service;
@@ -34,10 +33,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -47,14 +43,10 @@ public class DetermineHealthProvidersTask implements RetryableTask, CloudProvide
 
   private final Front50Service front50Service;
   private final Map<String, String> healthProviderNamesByPlatform;
-  private final Collection<InterestingHealthProviderNamesSupplier> interestingHealthProviderNamesSuppliers;
 
   @Autowired
-  public DetermineHealthProvidersTask(Front50Service front50Service,
-                                      Collection<InterestingHealthProviderNamesSupplier> interestingHealthProviderNamesSuppliers,
-                                      Collection<ServerGroupCreator> serverGroupCreators) {
+  public DetermineHealthProvidersTask(Front50Service front50Service, Collection<ServerGroupCreator> serverGroupCreators) {
     this.front50Service = front50Service;
-    this.interestingHealthProviderNamesSuppliers = interestingHealthProviderNamesSuppliers;
     this.healthProviderNamesByPlatform = serverGroupCreators
       .stream()
       .filter(serverGroupCreator ->  serverGroupCreator.getHealthProviderName().isPresent())
@@ -68,22 +60,6 @@ public class DetermineHealthProvidersTask implements RetryableTask, CloudProvide
 
   @Override
   public TaskResult execute(Stage stage) {
-    Optional<InterestingHealthProviderNamesSupplier> healthProviderNamesSupplierOptional = interestingHealthProviderNamesSuppliers
-      .stream()
-      .filter(supplier -> supplier.supports(getCloudProvider(stage), stage))
-      .findFirst();
-
-    if (healthProviderNamesSupplierOptional.isPresent()) {
-      List<String> interestingHealthProviderNames = healthProviderNamesSupplierOptional.get().process(getCloudProvider(stage), stage);
-      Map<String, List<String>> results = new HashMap<>();
-
-      if (interestingHealthProviderNames != null) {
-        // avoid a `null` value that may cause problems with ImmutableMap usage downstream
-        results.put("interestingHealthProviderNames", interestingHealthProviderNames);
-      }
-
-      return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, results);
-    }
 
     if (stage.getContext().containsKey("interestingHealthProviderNames")) {
       // should not override any stage-specified health providers

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/EnsureInterestingHealthProviderNamesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/EnsureInterestingHealthProviderNamesTask.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
+
+import com.netflix.spinnaker.orca.DefaultTaskResult;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class EnsureInterestingHealthProviderNamesTask implements Task, CloudProviderAware {
+  private Collection<InterestingHealthProviderNamesSupplier> interestingHealthProviderNamesSuppliers;
+
+  @Autowired
+  public EnsureInterestingHealthProviderNamesTask(Collection<InterestingHealthProviderNamesSupplier> interestingHealthProviderNamesSuppliers) {
+    this.interestingHealthProviderNamesSuppliers = interestingHealthProviderNamesSuppliers;
+  }
+
+  @Override
+  public TaskResult execute(Stage stage) {
+    String cloudProvider = getCloudProvider(stage);
+    Optional<InterestingHealthProviderNamesSupplier> healthProviderNamesSupplierOptional = interestingHealthProviderNamesSuppliers
+      .stream()
+      .filter(supplier -> supplier.supports(cloudProvider, stage))
+      .findFirst();
+
+    if (healthProviderNamesSupplierOptional.isPresent()) {
+      List<String> interestingHealthProviderNames = healthProviderNamesSupplierOptional.get().process(cloudProvider, stage);
+      Map<String, List<String>> results = new HashMap<>();
+
+      if (interestingHealthProviderNames != null) {
+        // avoid a `null` value that may cause problems with ImmutableMap usage downstream
+        results.put("interestingHealthProviderNames", interestingHealthProviderNames);
+      }
+
+      return new DefaultTaskResult(ExecutionStatus.SUCCEEDED, results);
+    }
+
+    return new DefaultTaskResult(ExecutionStatus.SUCCEEDED);
+
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/TitusInterestingHealthProviderNamesSupplier.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/TitusInterestingHealthProviderNamesSupplier.java
@@ -35,7 +35,7 @@ public class TitusInterestingHealthProviderNamesSupplier implements InterestingH
   private static final String TITUS = "titus";
   private static final String INTERESTING_HEALTH_PROVIDER_NAMES = "interestingHealthProviderNames";
   private static final String ROLLING_PUSH = "rollingpush";
-  private static final List<String> SUPPORTED_STAGES = Arrays.asList("enableServerGroup", "cloneServerGroup", "rollingPush");
+  private static final String SUPPORTED_STAGE = "rollingPush";
 
   private final OortService oortService;
   private final ObjectMapper objectMapper;
@@ -57,7 +57,7 @@ public class TitusInterestingHealthProviderNamesSupplier implements InterestingH
     }
 
     String strategy = (String) stage.getContext().get("strategy");
-    return SUPPORTED_STAGES.contains(stage.getType()) && ROLLING_PUSH.equals(strategy);
+    return SUPPORTED_STAGE.equals(stage.getType()) && ROLLING_PUSH.equals(strategy);
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/RollingPushStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/RollingPushStage.java
@@ -11,6 +11,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForUpInstanceHe
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask;
 import com.netflix.spinnaker.orca.kato.tasks.DisableInstancesTask;
 import com.netflix.spinnaker.orca.kato.tasks.rollingpush.CheckForRemainingTerminationsTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.EnsureInterestingHealthProviderNamesTask;
 import com.netflix.spinnaker.orca.kato.tasks.rollingpush.DetermineTerminationCandidatesTask;
 import com.netflix.spinnaker.orca.kato.tasks.rollingpush.DetermineTerminationPhaseInstancesTask;
 import com.netflix.spinnaker.orca.kato.tasks.rollingpush.WaitForNewInstanceLaunchTask;
@@ -32,6 +33,7 @@ public class RollingPushStage implements StageDefinitionBuilder {
   @Override
   public <T extends Execution<T>> void taskGraph(Stage<T> stage, TaskNode.Builder builder) {
     builder
+      .withTask("ensureInterestingHealthProviderNames", EnsureInterestingHealthProviderNamesTask.class)
       .withTask("determineTerminationCandidates", DetermineTerminationCandidatesTask.class)
       .withLoop(subGraph -> {
           subGraph

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTaskSpec.groovy
@@ -36,7 +36,6 @@ class DetermineHealthProvidersTaskSpec extends Specification {
   @Subject
   def task = new DetermineHealthProvidersTask(
     front50Service,
-    [],
     [new KubernetesServerGroupCreator(), new AmazonServerGroupCreator(), new GoogleServerGroupCreator(), new TitusServerGroupCreator()]
   )
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/EnsureInterestingHealthProviderNamesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/EnsureInterestingHealthProviderNamesTaskSpec.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class EnsureInterestingHealthProviderNamesTaskSpec extends Specification {
+  def interestingHealthProviderNamesSuppliers = Mock(TitusInterestingHealthProviderNamesSupplier)
+
+  @Subject
+  def task = new EnsureInterestingHealthProviderNamesTask([interestingHealthProviderNamesSuppliers])
+
+  @Unroll
+  def "should ensure interesting health provider names"() {
+    given:
+    def stage = new PipelineStage(new Pipeline(), "", [:])
+
+    and:
+    interestingHealthProviderNamesSuppliers.supports(_,_ as Stage) >> supports
+    interestingHealthProviderNamesSuppliers.process(_,_ as Stage) >> interestingHealthProviderNames
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    taskResult.status == ExecutionStatus.SUCCEEDED
+    (taskResult.getStageOutputs() as Map) == expectedStageOutputs
+
+    where:
+    supports            | interestingHealthProviderNames || expectedStageOutputs
+    false               | ['Titus']                      || [:]
+    true                | ['Titus']                      || [interestingHealthProviderNames: ["Titus"]]
+    true                | null                           || [:]
+    true                | []                             || [interestingHealthProviderNames: []]
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/TitusInterestingHealthProviderNamesSupplierSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/TitusInterestingHealthProviderNamesSupplierSpec.groovy
@@ -35,7 +35,7 @@ class TitusInterestingHealthProviderNamesSupplierSpec extends Specification {
   def titusInterestingHealthProviderNamesSupplier = new TitusInterestingHealthProviderNamesSupplier(oortService, new SourceResolver(), mapper)
 
   @Unroll
-  def "should only support if cloudProvider is titus and stage type in (enableServerGroup, rollingPush, cloneServerGroup)"() {
+  def "should only support if cloudProvider is titus and stage type in (rollingPush)"() {
     given:
     def stage = new PipelineStage(new Pipeline(), stageType, stageContext)
 
@@ -45,8 +45,8 @@ class TitusInterestingHealthProviderNamesSupplierSpec extends Specification {
     where:
     cloudProvider | stageType           | stageContext                || supports
     "titus"       | "createServerGroup" | [strategy: "rollingpush"]   || false
-    "titus"       | "enableServerGroup" | [strategy: "rollingpush"]   || true
-    "titus"       | "cloneServerGroup"  | [strategy: "rollingpush"]   || true
+    "titus"       | "enableServerGroup" | [strategy: "rollingpush"]   || false
+    "titus"       | "cloneServerGroup"  | [strategy: "rollingpush"]   || false
     "titus"       | "rollingPush"       | [strategy: "rollingpush"]   || true
     "titus"       | "createServerGroup" | [strategy: "custom"]        || false
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/RollingPushStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/RollingPushStageSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.kato.pipeline
 
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.EnsureInterestingHealthProviderNamesTask
 import groovy.transform.CompileStatic
 import com.netflix.spinnaker.config.SpringBatchConfiguration
 import com.netflix.spinnaker.orca.DefaultTaskResult
@@ -71,6 +72,7 @@ class RollingPushStageSpec extends Specification {
    * Task that runs before the loop
    */
   @Autowired @Qualifier("preLoop") Task preLoopTask
+  @Autowired @Qualifier("anotherPreLoop") Task anotherPreLoop
 
   /**
    * Task that is the start of the loop
@@ -103,6 +105,7 @@ class RollingPushStageSpec extends Specification {
   def "rolling push loops until completion"() {
     given: "everything in the rolling push loop will succeed"
     preLoopTask.execute(_) >> SUCCESS
+    anotherPreLoop.execute(_) >> SUCCESS
     startOfLoopTask.execute(_) >> SUCCESS
     loopTasks.each { task ->
       task.execute(_) >> SUCCESS
@@ -145,6 +148,12 @@ class RollingPushStageSpec extends Specification {
     @Qualifier("preLoop")
     FactoryBean<DetermineTerminationCandidatesTask> determineTerminationCandidatesTask() {
       new SpockMockFactoryBean<>(DetermineTerminationCandidatesTask)
+    }
+
+    @Bean
+    @Qualifier("anotherPreLoop")
+    FactoryBean<EnsureInterestingHealthProviderNamesTask> ensureInterestingHealthProviderNamesTask() {
+      new SpockMockFactoryBean<>(EnsureInterestingHealthProviderNamesTask)
     }
 
     @Bean


### PR DESCRIPTION
…push

The Titus migration uses a clone/create server group with a Rolling Push strategy. 
Additionally, the strategy creates two stages, a modify launch config stage and an actual rolling push stage.

Previously, ```interestingHealthProviderNames``` was set at the clone/create server group stage. However this was isolated to the said stage and not available in the rolling push stage context. 
As a consequence, the titus migration would get stuck waiting for up instances because ```interestingHealthProviderNames``` would default to ```["Load Balancer, Discovery"]```

This was never caught because of a false positive, the image used during testing was "discoverable", thus concealing the ugly behavior.

Now, this change revisits the implementation & ensures ```interestingHealthProviderNames``` are present (resolved through a titus job label) :

- Moved logic to determine interesting health provider names in rolling push to a task
- Updated RollingPush to ensure interesting health names before executing tasks