### PR TITLE
Add optional force flag to the cancel pipeline endpoint

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/zombie/ZombiePipelineCleanupAgent.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/zombie/ZombiePipelineCleanupAgent.java
@@ -113,11 +113,11 @@ public class ZombiePipelineCleanupAgent {
       );
   }
 
-  public void slayIfZombie(Pipeline pipeline) {
+  public void slayIfZombie(Pipeline pipeline, boolean force) {
     just(pipeline)
       .filter(this::isV2)
       .filter(this::isIncomplete)
-      .filter(this::hasZombieTask)
+      .filter(p -> hasZombieTask(p, force))
       .subscribe(this::slayZombie);
   }
 
@@ -161,11 +161,15 @@ public class ZombiePipelineCleanupAgent {
   }
 
   private boolean hasZombieTask(Pipeline pipeline) {
+    return hasZombieTask(pipeline, false);
+  }
+
+  private boolean hasZombieTask(Pipeline pipeline, boolean force) {
     return just(pipeline)
       .flatMapIterable(Pipeline::getStages)
       .flatMapIterable(Stage::getTasks)
       .filter(this::isIncomplete)
-      .exists((task) -> isZombie(pipeline, task))
+      .exists((task) -> force || isZombie(pipeline, task))
       .toBlocking()
       .first();
   }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -188,9 +188,10 @@ class TaskController {
   @PreAuthorize("hasPermission(this.getPipeline(#id)?.application, 'APPLICATION', 'WRITE')")
   @RequestMapping(value = "/pipelines/{id}/cancel", method = RequestMethod.PUT)
   @ResponseStatus(HttpStatus.ACCEPTED)
-  void cancel(@PathVariable String id, @RequestParam(required = false) String reason) {
+  void cancel(@PathVariable String id, @RequestParam(required = false) String reason,
+              @RequestParam(defaultValue = "false") boolean force) {
     executionRepository.cancel(id, AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"), reason)
-    zombiePipelineCleanupAgent.ifPresent({ it.slayIfZombie(executionRepository.retrievePipeline(id)) })
+    zombiePipelineCleanupAgent.ifPresent({ it.slayIfZombie(executionRepository.retrievePipeline(id), force) })
   }
 
   @PreAuthorize("hasPermission(this.getPipeline(#id)?.application, 'APPLICATION', 'WRITE')")


### PR DESCRIPTION
This option will make it possible to force cancel a pipeline (kill a Zombie process) before the default timeout has passed.

The intent is to make a feature in Deck that lets a user force cancel a zombie process before the default timeout interval of the pipeline has elapsed.