### PR TITLE
feat(pipelinetemplates): Adding withMapKey handlebars helper

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/HandlebarsRenderer.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/HandlebarsRenderer.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.helper.Condit
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.helper.JsonHelper;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.helper.ModuleHelper;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.helper.UnknownIdentifierHelper;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.helper.WithMapKeyHelper;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +56,7 @@ public class HandlebarsRenderer implements Renderer {
       .registerHelperMissing(new UnknownIdentifierHelper())
       .registerHelper("json", new JsonHelper(pipelineTemplateObjectMapper))
       .registerHelper("module", new ModuleHelper(this, pipelineTemplateObjectMapper))
+      .registerHelper("withMapKey", new WithMapKeyHelper())
     ;
     ConditionHelper.register(handlebars);
   }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/WithMapKeyHelper.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/WithMapKeyHelper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.helper;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.Options.Buffer;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+public class WithMapKeyHelper implements Helper<Map<String, Object>> {
+
+  @Override
+  public Object apply(Map<String, Object> context, Options options) throws IOException {
+    notNull(context, "Map value must not be null");
+
+    String key = options.param(0);
+    notNull(key, "A key is required");
+
+    if (!context.containsKey(key)) {
+      throw new IllegalArgumentException("withObjectKey helper given key that does not exist (key: " + key + ")");
+    }
+
+    Object val = context.get(key);
+
+    Buffer buffer = options.buffer();
+    if (options.isFalsy(val)) {
+      buffer.append(options.inverse(val));
+    } else {
+      buffer.append(options.fn(val));
+    }
+    return buffer;
+  }
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/WithMapKeyHelperSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/WithMapKeyHelperSpec.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.helper
+
+import com.github.jknack.handlebars.EscapingStrategy
+import com.github.jknack.handlebars.Handlebars
+import com.github.jknack.handlebars.Template
+import spock.lang.Specification
+
+class WithMapKeyHelperSpec extends Specification {
+
+  Handlebars handlebars = new Handlebars()
+    .with(EscapingStrategy.NOOP)
+
+  def setup() {
+    handlebars.registerHelper("withMapKey", new WithMapKeyHelper())
+  }
+
+  def 'should render nested map'() {
+    given:
+    Map context = [
+      'stringVar': 'key1',
+      'mapVar': [key1: 'value1', key2: 'value2']
+    ]
+
+    and:
+    def template = '{{#withMapKey mapVar stringVar}}{{this}}{{/withMapKey}}'
+
+    expect:
+    compile(template, context) == 'value1'
+  }
+
+  String compile(String template, Object context) {
+    Template t = handlebars.compileInline(template)
+    return t.apply(context)
+  }
+
+}


### PR DESCRIPTION
I'm converting some spindemo pipelines into solidified examples to verify we've got all the helpers we need to get things done without the deployment model work.

Handlebars' compatibility with maps is quite unpleasant, so this PR adds a new block helper that allows template owners to dynamically register variables using a specific map's key without iterating over the whole map.

Example: The deploy stage targeting AWS takes a list of clusters which is pretty easily iterable, but needs to be given both a region, as well as availability zones within that region.

```yaml
variables:
- name: regions
  description: A list of regions to bake in
  type: list
  defaultValue:
  - us-east-1
  - us-west-2
- name: regionAvailabilityZones
  description: A map of regions to availability zones to deploy into
  type: object
  defaultValue:
    us-east-1:
    - us-east-1c
    - us-east-1d
    - us-east-1e
    us-west-2:
    - us-west-2a
    - us-west-2c

stages:
- id: deploy
  dependsOn: bake
  type: deploy
  name: Deploy
  config:
    # ...
    clusters: |
      {{#each regions}}
        {{! Technically this assign block isn't needed, but I wanted to be explicit: }}
        {{#assign "region"}} {{this}} {{/assign}}
        {{#withMapKey regionAvailabilityZones region}}
          {{module deployCluster region=region availabilityZones=this}}
        {{/withMapKey}}
      {{/each}}

modules:
- id: deployCluster
  variables:
  - name: region
  - name: availabilityZones
  definition:
    # ...
    # Note on syntax below: Handlebars renders directly to JSON
    availabilityZones: |
      {
        "{{ region }}": [
        {{#each availabilityZones}}
          "{{ this }}"{{#unless @last}},{{/unless}}
        {{/each}}
        ]
      }
```

@spinnaker/netflix-reviewers PTAL