### PR TITLE
Fast Property multiple apps in scope

### DIFF
--- a/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
+++ b/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
@@ -85,7 +85,7 @@ class CreatePropertiesTask implements Task {
 
   List assemblePersistedPropertyListFromContext(Map<String, Object> context, List propertyList) {
     Map scope = context.scope
-    scope.appId = scope.appIdList.first()
+    scope.appId = scope.appIdList.join(',')
     String email = context.email
     String cmcTicket = context.cmcTicket
 

--- a/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTaskSpec.groovy
+++ b/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTaskSpec.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import retrofit.client.Response
 import retrofit.mime.TypedByteArray
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /*
  * Copyright 2016 Netflix, Inc.
@@ -82,6 +83,32 @@ class CreatePropertiesTaskSpec extends Specification {
         appId == scope.appIdList.first()
       }
     }
+  }
+
+  @Unroll("appIdList to appId:  #appIdList -> #expectedAppId")
+  def "assemblePersistedPropertyListFromContext with one application in scope list"() {
+    given:
+    def pipeline = new Pipeline(application: 'foo')
+    def scope = createScope()
+    def property = createProperty()
+    scope.appIdList = appIdList
+
+    def stage = createPropertiesStage(pipeline, scope, property, [])
+
+    when:
+    List properties = task.assemblePersistedPropertyListFromContext(stage.context, stage.context.persistedProperties)
+
+    then:
+    properties.size() == 1
+    properties[0].property.appId == expectedAppId
+
+    where:
+
+    appIdList                | expectedAppId
+    []                       | ""
+    ["deck"]                 | "deck"
+    ["deck", "mahe"]         | "deck,mahe"
+    ["deck", "mahe", "orca"] | "deck,mahe,orca"
   }
 
   def "assemble the changed property list if list is null for a new property"() {


### PR DESCRIPTION
Allows multiple application names to be added to a scope for a fast property.
Previously only the first one in the appIdList was used.