### PR TITLE
feat(pipelinetemplates): Adding basic plan capability

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
@@ -62,8 +62,8 @@ public class V1SchemaExecutionGenerator implements ExecutionGenerator {
         stage.put("refId", s.getId());
         stage.put("type", s.getType());
         stage.put("name", s.getName());
-        stage.put("context", s.getConfig());
         stage.put("requisiteStageRefIds", getStageRequisiteIds(s, template.getStages()));
+        stage.putAll(s.getConfig());
         return stage;
       })
       .collect(Collectors.toList()));

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
@@ -145,6 +145,9 @@ public class PipelineTemplate {
   }
 
   public Configuration getConfiguration() {
+    if (configuration == null) {
+      configuration = new Configuration();
+    }
     return configuration;
   }
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
@@ -138,7 +138,7 @@ public class StageDefinition implements Identifiable, Conditional {
   }
 
   public String getName() {
-    return name;
+    return Optional.ofNullable(name).orElse(id);
   }
 
   public void setName(String name) {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/UnknownIdentifierHelper.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/UnknownIdentifierHelper.java
@@ -13,11 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.orca.pipelinetemplate.exceptions;
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.helper;
 
-public class IllegalTemplateConfigurationException extends IllegalStateException {
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
 
-  public IllegalTemplateConfigurationException(String message) {
-    super(message);
+import java.io.IOException;
+
+public class UnknownIdentifierHelper implements Helper<Object> {
+  @Override
+  public Object apply(Object context, Options options) throws IOException {
+    return options.fn.text();
   }
 }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGeneratorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGeneratorSpec.groovy
@@ -91,5 +91,6 @@ class V1SchemaExecutionGeneratorSpec extends Specification {
     result.keepWaitingPipelines == false
     result.stages*.type == ['bake', 'tagImage']
     result.stages*.requisiteStageRefIds == [[], ['bake']]
+    result.stages.find { it.type == 'bake' }.baseOs == 'trusty'
   }
 }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/HandlebarsRendererSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/HandlebarsRendererSpec.groovy
@@ -59,5 +59,6 @@ class HandlebarsRendererSpec extends Specification {
 '''                       || List           | ['us-east-1', 'us-west-2']
     '{{json objectVar}}'  || Map            | [key1: 'value1', key2: 'value2']
     '{{json trigger}}'    || Map            | [job: 'job', buildNumber: 1234]
+    '{{unknownVar}}'      || String         | '{{unknownVar}}'
   }
 }

--- a/orca-pipelinetemplate/src/test/resources/templates/invalid-handlebars-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/invalid-handlebars-001.yml
@@ -1,0 +1,8 @@
+schema: "1"
+id: invalidHandlebarsTemplate
+stages:
+- id: bake
+  type: bake
+  name: Bake
+  config:
+    regions: "{{unknown_identifier}}"

--- a/orca-pipelinetemplate/src/test/resources/templates/invalid-template-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/invalid-template-001.yml
@@ -1,0 +1,8 @@
+# "stage" is not a valid field on a pipeline template
+schema: "1"
+id: invalidTemplate
+stage:
+- id: bake
+  type: bake
+  config:
+    some: value


### PR DESCRIPTION
A very rudimentary plan capability for pipeline templates. I have some ideas on how to improve (and increase) debug output if people get to using this and need more output. I'd prefer to see how people start to use this feature before diving deep into enhanced output.

Should we want more details, I think I'll do some refactoring to allow us to collect consumer-friendly errors and debug output as we compile the execution. Before tackling this, I'd like to see what the UI might want to display so we're providing the right context.

@spinnaker/reviewers PTAL