### PR TITLE
feat(trafficguards): check on terminate/disable instances

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/TerminateInstanceAndDecrementServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/TerminateInstanceAndDecrementServerGroupTask.groovy
@@ -23,7 +23,9 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.instance.TerminatingInstance
 import com.netflix.spinnaker.orca.clouddriver.pipeline.instance.TerminatingInstanceSupport
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -38,12 +40,22 @@ class TerminateInstanceAndDecrementServerGroupTask extends AbstractCloudProvider
   @Autowired
   TerminatingInstanceSupport instanceSupport
 
+  @Autowired
+  TrafficGuard trafficGuard
+
   @Override
   TaskResult execute(Stage stage) {
     String cloudProvider = getCloudProvider(stage)
     String account = getCredentials(stage)
 
     List<TerminatingInstance> remainingInstances = instanceSupport.remainingInstances(stage)
+
+    trafficGuard.verifyInstanceTermination(
+      [stage.context.instance] as List<String>,
+      account,
+      Location.region(stage.context.region as String),
+      cloudProvider,
+      "Terminating the requested instance in ")
 
     def taskId = kato.requestOperations(cloudProvider, [[(CLOUD_OPERATION_TYPE): stage.context]])
         .toBlocking()

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
@@ -26,10 +26,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import retrofit.RetrofitError;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
+
+import static java.lang.String.format;
 
 @Component
 public class TrafficGuard {
@@ -44,6 +44,40 @@ public class TrafficGuard {
     this.front50Service = front50Service.orElse(null);
   }
 
+  public void verifyInstanceTermination(List<String> instanceIds, String account, Location location, String cloudProvider, String operationDescriptor) {
+    Map<String, List<String>> instancesPerServerGroup = new HashMap<>();
+    instanceIds.forEach(instanceId -> {
+
+      Optional<String> resolvedServerGroupName = resolveServerGroupNameForInstance(instanceId, account, location.getValue(), cloudProvider);
+      resolvedServerGroupName.ifPresent(name -> instancesPerServerGroup.computeIfAbsent(name, serverGroup -> new ArrayList<>()).add(instanceId));
+    });
+
+    instancesPerServerGroup.entrySet().forEach(entry -> {
+      String serverGroupName = entry.getKey();
+      Names names = Names.parseName(serverGroupName);
+      if (hasDisableLock(names.getCluster(), account, location)) {
+        Optional<TargetServerGroup> targetServerGroup = oortHelper.getTargetServerGroup(account, serverGroupName, location.getValue(), cloudProvider);
+
+        targetServerGroup.ifPresent(serverGroup -> {
+          Optional<Map> thisInstance = serverGroup.getInstances().stream().filter(i -> "Up".equals(i.get("healthState"))).findFirst();
+          if (thisInstance.isPresent() && "Up".equals(thisInstance.get().get("healthState"))) {
+            long otherActiveInstances = serverGroup.getInstances().stream().filter(i -> "Up".equals(i.get("healthState")) && !entry.getValue().contains(i.get("name"))).count();
+            if (otherActiveInstances == 0) {
+              verifyOtherServerGroupsAreTakingTraffic(serverGroupName, location, account, cloudProvider, operationDescriptor);
+            }
+          }
+        });
+      }
+    });
+  }
+
+  private Optional<String> resolveServerGroupNameForInstance(String instanceId, String account, String region, String cloudProvider) {
+    List<Map> searchResults = (List<Map>) oortHelper.getSearchResults(instanceId, "instances", cloudProvider).get(0).getOrDefault("results", new ArrayList<>());
+    Optional<Map> instance = searchResults.stream().filter(r -> account.equals(r.get("account")) && region.equals(r.get("region"))).findFirst();
+    // instance not found, assume it's already terminated, what could go wrong
+    return Optional.ofNullable((String) instance.orElse(new HashMap<>()).get("serverGroup"));
+  }
+
   public void verifyTrafficRemoval(String serverGroupName, String account, Location location, String cloudProvider, String operationDescriptor) {
     Names names = Names.parseName(serverGroupName);
 
@@ -51,12 +85,16 @@ public class TrafficGuard {
       return;
     }
 
+    verifyOtherServerGroupsAreTakingTraffic(serverGroupName, location, account, cloudProvider, operationDescriptor);
+  }
+
+  private void verifyOtherServerGroupsAreTakingTraffic(String serverGroupName, Location location, String account, String cloudProvider, String operationDescriptor) {
+    Names names = Names.parseName(serverGroupName);
     Optional<Map> cluster = oortHelper.getCluster(names.getApp(), account, names.getCluster(), cloudProvider);
 
     if (!cluster.isPresent()) {
-      throw new IllegalStateException("Could not find traffic-protected cluster.");
+      throw new IllegalStateException(format("Could not find cluster '%s' in %s/%s with traffic guard configured.", names.getCluster(), account, location.getValue()));
     }
-
     List<TargetServerGroup> targetServerGroups = ((List<Map<String, Object>>) cluster.get().get("serverGroups"))
       .stream()
       .map(TargetServerGroup::new)
@@ -65,12 +103,11 @@ public class TrafficGuard {
 
     boolean otherEnabledServerGroupFound = targetServerGroups.stream().anyMatch(tsg ->
       !serverGroupName.equals(tsg.getName()) &&
-        !Boolean.TRUE.equals(tsg.isDisabled()) &&
-        (tsg.getInstances()).size() > 0
+        (tsg.getInstances().stream().filter(i -> "Up".equals(i.get("healthState"))).count()) > 0
     );
     if (!otherEnabledServerGroupFound) {
-      throw new IllegalStateException(String.format("This cluster has traffic protection enabled. " +
-        "%s %s would leave the cluster with no instances taking traffic.", operationDescriptor, serverGroupName));
+      throw new IllegalStateException(format("This cluster ('%s' in %s/%s) has traffic guards enabled. " +
+        "%s %s would leave the cluster with no instances taking traffic.", names.getCluster(), account, location.getValue(), operationDescriptor, serverGroupName));
     }
   }
 


### PR DESCRIPTION
Traffic guards are pretty limited right now, and don't verify remaining instances are "Up" - only that the other server groups in the cluster have some instances and that the other server group is not disabled.

This checks for actual "Up" instances, and adds guards on terminate/disable (and terminate and shrink) instance operations.

This is going to add a fair amount of overhead to instance-level operations, so I'd like some feedback on performance concerns.

Also clarifying exception ("traffic protection" is now "traffic guards") message to be more consistent with other references.

@spinnaker/netflix-reviewers PTAL