### PR TITLE
add details of running executions to execution tracker

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -300,10 +300,10 @@ class TaskController {
   }
 
   @RequestMapping(value = "/executions/activeByInstance", method = RequestMethod.GET)
-  Map<String, Integer> activeExecutionsByInstance() {
+  Map<String, ActiveExecutionTracker.OrcaInstance> activeExecutionsByInstance() {
     activeExecutionTracker
       .activeExecutionsByInstance()
-      .sort { a, b -> b.value <=> a.value }
+      .sort { a, b -> b.value.executions.size() <=> a.value.executions.size() }
   }
 
   private List<Pipeline> filterPipelinesByHistoryCutoff(List<Pipeline> pipelines) {


### PR DESCRIPTION
Also don't flush them when an instance goes stale so we can see zombie executions.
