### PR TITLE
fix(jobs): add output from jobs to global context for downstream jobs

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -99,6 +99,6 @@ public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implemen
       }
     }
 
-    new DefaultTaskResult(status, outputs)
+    new DefaultTaskResult(status, outputs, outputs)
   }
 }


### PR DESCRIPTION
In order for properties to be lookup enabled, need to add the values generated by the monitor jobs task to the global context