### PR TITLE
feature(netflix): simplify zombie pipeline cleanup

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ActiveExecutionTracker.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ActiveExecutionTracker.java
@@ -25,6 +25,7 @@ import static java.lang.String.format;
 
 public interface ActiveExecutionTracker {
   Map<String, OrcaInstance> activeExecutionsByInstance();
+  boolean isActiveInstance(String instance);
 
   @Value class OrcaInstance {
     boolean overdue;

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -303,7 +303,9 @@ class TaskController {
   Map<String, ActiveExecutionTracker.OrcaInstance> activeExecutionsByInstance() {
     activeExecutionTracker
       .activeExecutionsByInstance()
-      .sort { a, b -> b.value.executions.size() <=> a.value.executions.size() }
+      .sort { a, b ->
+        b.value.overdue <=> a.value.overdue || b.value.count <=> a.value.count
+      }
   }
 
   private List<Pipeline> filterPipelinesByHistoryCutoff(List<Pipeline> pipelines) {


### PR DESCRIPTION
Instead of using a heuristic to determine if a pipeline is in a zombie state we now just look at the reported state of the instance running the pipeline.