### PR TITLE
fix(canary): add cloud provider to canary operations

### DIFF
--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorCanaryTaskSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorCanaryTaskSpec.groovy
@@ -132,11 +132,11 @@ class MonitorCanaryTaskSpec extends Specification {
 
     then:
     1 * mineService.getCanary(stage.context.canary.id) >> canaryConf
-    1 * katoService.requestOperations({ ops ->
+    1 * katoService.requestOperations('aws', { ops ->
       ops.size() == 2 &&
-      ops.find { it.resizeAsgDescription.asgName == 'foo--cfieber-canary-v000' } &&
-      ops.find { it.resizeAsgDescription.asgName == 'foo--cfieber-baseline-v000' } &&
-      ops.every { it.resizeAsgDescription.capacity == [min:3, max: 3, desired: 3]}
+      ops.find { it.resizeServerGroup.asgName == 'foo--cfieber-canary-v000' } &&
+      ops.find { it.resizeServerGroup.asgName == 'foo--cfieber-baseline-v000' } &&
+      ops.every { it.resizeServerGroup.capacity == [min:3, max: 3, desired: 3]}
       }) >> rx.Observable.just(new TaskId('blah'))
   }
 
@@ -196,10 +196,10 @@ class MonitorCanaryTaskSpec extends Specification {
 
     then:
     1 * mineService.getCanary(canaryConf.id) >> canaryConf
-    1 * katoService.requestOperations({ ops ->
+    1 * katoService.requestOperations('aws', { ops ->
       ops.size() == 2 &&
-      ops.find { it.disableAsgDescription.asgName == 'foo--cfieber-canary-v000' }
-      ops.find { it.disableAsgDescription.asgName == 'foo--cfieber-baseline-v000' } }) >> rx.Observable.just(new TaskId('blah'))
+      ops.find { it.disableServerGroup.asgName == 'foo--cfieber-canary-v000' }
+      ops.find { it.disableServerGroup.asgName == 'foo--cfieber-baseline-v000' } }) >> rx.Observable.just(new TaskId('blah'))
   }
 
 }


### PR DESCRIPTION
passes cloud provider to canary cleanup operations and uses new operation names