### PR TITLE
fix(Jenkins): Ensuring there is a buildNumber present in the context before proceeding

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
@@ -54,6 +54,12 @@ class MonitorJenkinsJobTask implements RetryableTask {
   TaskResult execute(Stage stage) {
     String master = stage.context.master
     String job = stage.context.job
+
+    if (!stage.context.buildNumber) {
+      log.error("failed to get build number for job ${job} from master ${master}")
+      return new DefaultTaskResult(ExecutionStatus.TERMINAL)
+    }
+
     def buildNumber = (int) stage.context.buildNumber
     try {
       Map<String, Object> build = buildService.getBuild(buildNumber, master, job)


### PR DESCRIPTION
- Added a guard to return with a TERMINAL status when we dont have a buildNumber