### PR TITLE
any execution that does not specify a version will run v2

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupLinearStageSupportSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupLinearStageSupportSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.pipeline.model.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner
 import spock.lang.Specification
 import spock.lang.Unroll
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.V1_EXECUTION_ENGINE
 
 class TargetServerGroupLinearStageSupportSpec extends Specification {
 
@@ -100,7 +101,7 @@ class TargetServerGroupLinearStageSupportSpec extends Specification {
   @Unroll
   def "#target should inject stages correctly before and after each location stage"() {
     given:
-    def stage = new PipelineStage(new Pipeline(), "test", [target: target, regions: ["us-east-1", "us-west-1"]])
+    def stage = new PipelineStage(new Pipeline(executionEngine: V1_EXECUTION_ENGINE), "test", [target: target, regions: ["us-east-1", "us-west-1"]])
     def arbitraryStageBuilder = new ResizeServerGroupStage()
     supportStage.preInjectables = [new TargetServerGroupLinearStageSupport.Injectable(
       name: "testPreInjectable",

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarterListener.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarterListener.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.V2_EXECUTION_ENGINE;
 
 /**
  * Reacts to pipelines finishing and schedules the next job waiting
@@ -78,7 +79,7 @@ public class PipelineStarterListener implements ExecutionListener {
           if (Objects.equals(id, nextPipelineId)) {
             Pipeline queuedExecution = executionRepository.retrievePipeline(id);
             log.info("starting pipeline {} due to {} ending", nextPipelineId, execution.getId());
-            if (Objects.equals(queuedExecution.getExecutionEngine(), "v2")) {
+            if (Objects.equals(queuedExecution.getExecutionEngine(), V2_EXECUTION_ENGINE)) {
               try {
                 getPipelineLauncher().start(queuedExecution);
               } catch (Exception e) {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.groovy
@@ -21,14 +21,13 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.security.User
 import groovy.transform.CompileStatic
-
 import static com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED
 
 @CompileStatic
 abstract class Execution<T extends Execution<T>> implements Serializable {
   public static final String V1_EXECUTION_ENGINE = "v1"
   public static final String V2_EXECUTION_ENGINE = "v2"
-  public static final String DEFAULT_EXECUTION_ENGINE = V1_EXECUTION_ENGINE
+  public static final String DEFAULT_EXECUTION_ENGINE = V2_EXECUTION_ENGINE
 
   String id
   String application

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/PipelineStarterListenerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/batch/pipeline/PipelineStarterListenerSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import spock.lang.Specification
 import spock.lang.Subject
 import static com.netflix.spinnaker.orca.ExecutionStatus.CANCELED
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.V1_EXECUTION_ENGINE
 
 class PipelineStarterListenerSpec extends Specification {
 
@@ -60,7 +61,7 @@ class PipelineStarterListenerSpec extends Specification {
     startTracker.getAllStartedExecutions() >> [completedId]
     startTracker.getQueuedPipelines(_) >> [nextId]
     executionRepository.retrievePipeline(_) >> { String id ->
-      new Pipeline(id: id, pipelineConfigId: pipelineConfigId, canceled: true, status: CANCELED)
+      new Pipeline(id: id, pipelineConfigId: pipelineConfigId, canceled: true, status: CANCELED, executionEngine: V1_EXECUTION_ENGINE)
     }
 
     when:

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoEventSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoEventSpec.groovy
@@ -17,12 +17,12 @@
 package com.netflix.spinnaker.orca.echo.spring
 
 import com.netflix.spinnaker.config.SpringBatchConfiguration
-import com.netflix.spinnaker.orca.batch.ExecutionListenerProvider
-import com.netflix.spinnaker.orca.batch.StageBuilderProvider
-import com.netflix.spinnaker.orca.batch.listeners.SpringBatchExecutionListenerProvider
 import com.netflix.spinnaker.orca.DefaultTaskResult
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.batch.ExecutionListenerProvider
+import com.netflix.spinnaker.orca.batch.StageBuilderProvider
+import com.netflix.spinnaker.orca.batch.listeners.SpringBatchExecutionListenerProvider
 import com.netflix.spinnaker.orca.batch.stages.LinearStageDefinitionBuilder
 import com.netflix.spinnaker.orca.batch.stages.SpringBatchStageBuilderProvider
 import com.netflix.spinnaker.orca.config.JesqueConfiguration
@@ -44,8 +44,8 @@ import org.springframework.test.context.ContextConfiguration
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.V1_EXECUTION_ENGINE
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD
-
 /**
  * Most of what the listener does can be tested at a unit level, this is just to
  * ensure that we're making the right assumptions about the statuses we'll get
@@ -90,9 +90,10 @@ class EchoEventSpec extends Specification {
 
   def setupSpec() {
     def config = [
-      application: "app",
-      name       : "my-pipeline",
-      stages     : [[type: "stage1"], [type: "stage2"]]
+      application    : "app",
+      name           : "my-pipeline",
+      stages         : [[type: "stage1"], [type: "stage2"]],
+      executionEngine: V1_EXECUTION_ENGINE
     ]
     json = new OrcaObjectMapper().writeValueAsString(config)
   }

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListenerSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListenerSpec.groovy
@@ -9,6 +9,7 @@ import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 import static com.netflix.spinnaker.orca.ExecutionStatus.*
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.V1_EXECUTION_ENGINE
 
 class EchoNotifyingStageListenerSpec extends Specification {
 
@@ -19,7 +20,7 @@ class EchoNotifyingStageListenerSpec extends Specification {
   def echoListener = new EchoNotifyingStageListener(echoService)
 
   @Shared
-  def pipelineStage = new PipelineStage(new Pipeline(), "test", "test", [:])
+  def pipelineStage = new PipelineStage(new Pipeline(executionEngine: V1_EXECUTION_ENGINE), "test", "test", [:])
 
   @Shared
   def orchestrationStage = new OrchestrationStage(new Orchestration(), "test")

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.security.AuthenticatedRequest
 import org.slf4j.MDC
 import spock.lang.Specification
 import spock.lang.Subject
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.V1_EXECUTION_ENGINE
 
 class DependentPipelineStarterSpec extends Specification {
 
@@ -36,9 +37,11 @@ class DependentPipelineStarterSpec extends Specification {
     setup:
     Map triggeredPipelineConfig = [name: "triggered", id: "triggered"]
     Execution parentPipeline = new Pipeline(
-        name: "parent",
-        authentication: new Execution.AuthenticationDetails(user: "parentUser",
-                                                            allowedAccounts: ["acct1,acct2"]))
+      name: "parent",
+      authentication: new Execution.AuthenticationDetails(user: "parentUser",
+        allowedAccounts: ["acct1,acct2"]),
+      executionEngine: V1_EXECUTION_ENGINE
+    )
     PipelineStarter pipelineStarter = Spy(PipelineStarter)
     Map mdc = [(AuthenticatedRequest.SPINNAKER_USER)    : "myMDCUser",
                (AuthenticatedRequest.SPINNAKER_ACCOUNTS): "acct3,acct4"]
@@ -68,9 +71,11 @@ class DependentPipelineStarterSpec extends Specification {
     setup:
     Map triggeredPipelineConfig = [name: "triggered", id: "triggered"]
     Execution parentPipeline = new Pipeline(
-        name: "parent",
-        authentication: new Execution.AuthenticationDetails(user: "parentUser",
-                                                            allowedAccounts: ["acct1,acct2"]))
+      name: "parent",
+      authentication: new Execution.AuthenticationDetails(user: "parentUser",
+        allowedAccounts: ["acct1,acct2"]),
+      executionEngine: V1_EXECUTION_ENGINE
+    )
     PipelineStarter pipelineStarter = Spy(PipelineStarter)
     dependentPipelineStarter = new DependentPipelineStarter(objectMapper: mapper,
                                                             pipelineStarter: pipelineStarter)


### PR DESCRIPTION
This will any "anonymous" pipelines submitted via the REST API will run on v2. That should mean everything is running v2.

We should ensure this is happy before merging #1214 