### PR TITLE
feat(pipelinetemplate): Basic template & config validation

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/InvalidPipelineTemplateException.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/InvalidPipelineTemplateException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.exceptions;
+
+import java.util.List;
+import java.util.Map;
+
+public class InvalidPipelineTemplateException extends RuntimeException {
+
+  private List<Map<String, Object>> errors;
+
+  public InvalidPipelineTemplateException(List<Map<String, Object>> errors) {
+    this.errors = errors;
+  }
+
+  public InvalidPipelineTemplateException(String message, List<Map<String, Object>> errors) {
+    super(message);
+    this.errors = errors;
+  }
+
+  public List<Map<String, Object>> getErrors() {
+    return errors;
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisitor;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.VersionedSchema;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -23,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class PipelineTemplate {
+public class PipelineTemplate implements VersionedSchema {
 
   private String schema;
   private String id;
@@ -110,6 +111,11 @@ public class PipelineTemplate {
     public void setNotifications(List<NamedHashMap> notifications) {
       this.notifications = notifications;
     }
+  }
+
+  @Override
+  public String getSchemaVersion() {
+    return schema;
   }
 
   public String getSchema() {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateConfiguration.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.VersionedSchema;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -22,7 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-public class TemplateConfiguration {
+public class TemplateConfiguration implements VersionedSchema {
 
   private String schema;
   private String id;
@@ -151,6 +153,11 @@ public class TemplateConfiguration {
     public void setDescription(String description) {
       this.description = description;
     }
+  }
+
+  @Override
+  public String getSchemaVersion() {
+    return schema;
   }
 
   public String getRuntimeId() {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1SchemaValidationHelper.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1SchemaValidationHelper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator;
+
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinition;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class V1SchemaValidationHelper {
+
+  static void validateStageDefinitions(List<StageDefinition> stageDefinitions, Errors errors, Function<String, String> locationFormatter) {
+    stageDefinitions.forEach(stageDefinition -> {
+      if (stageDefinition.getId() == null) {
+        errors.addError(Error.builder()
+          .withMessage("Stage ID is unset")
+          .withLocation(locationFormatter.apply("stages"))
+        );
+      }
+
+      if (stageDefinition.getType() == null) {
+        errors.addError(Error.builder()
+          .withMessage("Stage is missing type")
+          .withLocation(locationFormatter.apply("stages." + stageDefinition.getId()))
+        );
+      }
+
+      if (stageDefinition.getConfig() == null) {
+        errors.addError(Error.builder()
+          .withMessage("Stage configuration is unset")
+          .withLocation(locationFormatter.apply("stages." + stageDefinition.getId()))
+        );
+      }
+    });
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateConfigurationSchemaValidator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateConfigurationSchemaValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator;
+
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration.PipelineDefinition;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.SchemaValidator;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.VersionedSchema;
+
+public class V1TemplateConfigurationSchemaValidator implements SchemaValidator {
+
+  private static final String SUPPORTED_VERSION = "1";
+
+  @Override
+  public void validate(VersionedSchema configuration, Errors errors) {
+    if (!(configuration instanceof TemplateConfiguration)) {
+      throw new IllegalArgumentException("Expected TemplateConfiguration");
+    }
+    TemplateConfiguration config = (TemplateConfiguration) configuration;
+
+    if (!SUPPORTED_VERSION.equals(config.getSchemaVersion())) {
+      errors.addError(Error.builder()
+        .withMessage("config schema version is unsupported: expected '" + SUPPORTED_VERSION + "', got '" + config.getSchemaVersion() + "'"));
+    }
+
+    PipelineDefinition pipelineDefinition = config.getPipeline();
+    if (pipelineDefinition == null) {
+      errors.addError(Error.builder()
+        .withMessage("Missing pipeline configuration")
+        .withLocation(location("pipeline"))
+      );
+    } else {
+      if (pipelineDefinition.getApplication() == null) {
+        errors.addError(Error.builder()
+          .withMessage("Missing 'application' pipeline configuration")
+          .withLocation(location("pipeline.application"))
+        );
+      }
+    }
+
+    V1SchemaValidationHelper.validateStageDefinitions(config.getStages(), errors, V1TemplateConfigurationSchemaValidator::location);
+
+    // TODO rz - validate required variables are set and of the correct type
+  }
+
+  private static String location(String location) {
+    return "configuration:" + location;
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateSchemaValidator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateSchemaValidator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator;
+
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.SchemaValidator;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.VersionedSchema;
+
+public class V1TemplateSchemaValidator implements SchemaValidator {
+
+  private static final String SUPPORTED_VERSION = "1";
+
+  @Override
+  public void validate(VersionedSchema pipelineTemplate, Errors errors) {
+    if (!(pipelineTemplate instanceof PipelineTemplate)) {
+      throw new IllegalArgumentException("Expected PipelineTemplate");
+    }
+    PipelineTemplate template = (PipelineTemplate) pipelineTemplate;
+
+    if (!SUPPORTED_VERSION.equals(template.getSchemaVersion())) {
+      errors.addError(Error.builder()
+        .withMessage("template schema version is unsupported: expected '" + SUPPORTED_VERSION + "', got '" + template.getSchemaVersion() + "'"));
+    }
+
+    V1SchemaValidationHelper.validateStageDefinitions(template.getStages(), errors, V1TemplateSchemaValidator::location);
+
+    // TODO rz - validate variable type & defaultValue combinations
+  }
+
+  private static String location(String location) {
+    return "template:" + location;
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/validator/Errors.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/validator/Errors.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.validator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class Errors {
+  List<Error> errors = new ArrayList<>();
+
+  public Errors() {
+    // empty
+  }
+
+  public Errors addError(Error e) {
+    errors.add(e);
+    return this;
+  }
+
+  public boolean hasErrors(boolean includeWarn) {
+    if (!includeWarn) {
+      return errors.stream().filter(error -> error.severity != Severity.WARN).count() > 0;
+    }
+    return !errors.isEmpty();
+  }
+
+  public Map<String, Object> toResponse() {
+    HashMap<String, Object> m = new HashMap<>();
+    m.put("errors", errors
+      .stream()
+      .map(e -> {
+        HashMap<String, Object> err = new HashMap<>();
+        if (e.message != null) err.put("message", e.message);
+        if (e.location != null) err.put("location", e.location);
+        if (e.cause != null) err.put("cause", e.cause);
+        if (e.suggestion != null) err.put("suggestion", e.suggestion);
+        err.put("severity", e.severity);
+        return err;
+      })
+      .collect(Collectors.toList())
+    );
+    return m;
+  }
+
+  public enum Severity {
+    FATAL,
+
+    // Warn severity should be used when an error will not end fatally, but should still be addressed
+    // Things like best practice / deprecation notices would go here.
+    WARN
+  }
+
+  public static class Error {
+    Severity severity = Severity.FATAL;
+    String message;
+    String location;
+    String cause;
+    String suggestion;
+
+    public static Error builder() {
+      return new Error();
+    }
+
+    public Error withSeverity(Severity severity) {
+      this.severity = severity;
+      return this;
+    }
+
+    public Error withMessage(String message) {
+      this.message = message;
+      return this;
+    }
+
+    public Error withLocation(String location) {
+      this.location = location;
+      return this;
+    }
+
+    public Error withCause(String cause) {
+      this.cause = cause;
+      return this;
+    }
+
+    public Error withSuggestion(String remedy) {
+      this.suggestion = remedy;
+      return this;
+    }
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/validator/SchemaValidator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/validator/SchemaValidator.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.validator;
+
+public interface SchemaValidator {
+
+  void validate(VersionedSchema versionedSchema, Errors errors);
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/validator/VersionedSchema.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/validator/VersionedSchema.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.validator;
+
+public interface VersionedSchema {
+
+  String getSchemaVersion();
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -123,7 +123,7 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
     then:
     noExceptionThrown()
     result.errors != null
-    result.errors.containsKey("failed loading template")
+    result.errors*.message.contains("failed loading template")
   }
 
   def 'should not render unknown handlebars identifiers'() {
@@ -145,6 +145,7 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
         buildNumber: 1111
       ],
       config: [
+        schema: '1',
         id: 'myTemplate',
         pipeline: [
           application: 'myapp',

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1SchemaValidationHelperSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1SchemaValidationHelperSpec.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator
+
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinition
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class V1SchemaValidationHelperSpec extends Specification {
+
+  @Unroll
+  def "should validate stage definitions"() {
+    given:
+    Errors errors = new Errors()
+
+    when:
+    V1SchemaValidationHelper.validateStageDefinitions([stageDefinition], errors, { return "namespace:$it" as String })
+
+    then:
+    if (expectedError) {
+      errors.errors[0] == expectedError
+    } else {
+      !errors.hasErrors(true)
+    }
+
+    where:
+    stageDefinition << [
+      new StageDefinition(),
+      new StageDefinition(id: 'foo'),
+      new StageDefinition(id: 'foo', type: 'findImage'),
+      new StageDefinition(id: 'foo', type: 'findImage', config: [:])
+    ]
+    expectedError << [
+      new Errors.Error(message: 'Stage ID is unset', location: 'namespace:stages'),
+      new Errors.Error(message: 'Stage is missing type', location: 'namespace:stages.foo'),
+      new Errors.Error(message: 'Stage configuration is unset', location: 'namespace:stages.foo'),
+      false
+    ]
+  }
+
+  static String locationFormatter(String location) {
+    return "namespace:$location" as String
+  }
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateConfigurationSchemaValidatorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateConfigurationSchemaValidatorSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator
+
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration.PipelineDefinition
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors
+import spock.lang.Specification
+import spock.lang.Subject
+
+class V1TemplateConfigurationSchemaValidatorSpec extends Specification {
+
+  @Subject
+  V1TemplateConfigurationSchemaValidator subject = new V1TemplateConfigurationSchemaValidator()
+
+  def "should support version 1"() {
+    given:
+    def errors = new Errors()
+    def templateConfiguration = new TemplateConfiguration(schema: schema)
+
+    when:
+    subject.validate(templateConfiguration, errors)
+
+    then:
+    if (hasErrors) {
+      !errors.hasErrors(true)
+    } else {
+      errors.hasErrors(true)
+    }
+
+    where:
+    schema | hasErrors
+    null   | true
+    "1"    | false
+    "2"    | true
+  }
+
+  def "should require application name"() {
+    given:
+    def errors = new Errors()
+    def templateConfiguration = new TemplateConfiguration(schema: "1", pipeline: new PipelineDefinition(application: application))
+
+    when:
+    subject.validate(templateConfiguration, errors)
+
+    then:
+    if (hasErrors) {
+      errors.errors[0].message == "Missing 'application' pipeline configuration"
+      errors.errors[0].location == 'configuration:pipeline.application'
+    } else {
+      !errors.hasErrors(true)
+    }
+
+    where:
+    application | hasErrors
+    null        | true
+    'myapp'     | false
+  }
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateSchemaValidatorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateSchemaValidatorSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator
+
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors
+import spock.lang.Specification
+import spock.lang.Subject
+
+class V1TemplateSchemaValidatorSpec extends Specification {
+
+  @Subject
+  V1TemplateSchemaValidator subject = new V1TemplateSchemaValidator()
+
+  def "should support version 1"() {
+    given:
+    def errors = new Errors()
+    def template = new PipelineTemplate(schema: schema)
+
+    when:
+    subject.validate(template, errors)
+
+    then:
+    if (hasErrors) {
+      !errors.hasErrors(true)
+    } else {
+      errors.hasErrors(true)
+    }
+
+    where:
+    schema | hasErrors
+    null   | true
+    "1"    | false
+    "2"    | true
+  }
+}

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.controllers
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.igor.BuildArtifactFilter
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.InvalidPipelineTemplateException
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import org.apache.log4j.MDC
 import org.springframework.mock.env.MockEnvironment
@@ -488,7 +489,7 @@ class OperationsControllerSpec extends Specification {
     0 * pipelineStarter.start(_)
   }
 
-  def "should return 400 status code when planned pipeline config contains errors"() {
+  def "should throw validation exception when templated pipeline contains errors"() {
     given:
     def pipelineConfig = [
       plan: true,
@@ -502,7 +503,7 @@ class OperationsControllerSpec extends Specification {
     controller.orchestrate(pipelineConfig, response)
 
     then:
+    thrown(InvalidPipelineTemplateException)
     0 * pipelineStarter.start(_)
-    1 * response.setStatus(HttpServletResponse.SC_BAD_REQUEST)
   }
 }


### PR DESCRIPTION
Working in a better interface for performing validation of templates and configurations. This doesn't include working in any of the `orca-validation` module stuff. My goal here is to emit more user-friendly errors than stacktraces that are surfaced in the UI or Halyard.

@spinnaker/netflix-reviewers PTAL