### PR TITLE
fix(pipelinetemplate): Allow associating to an existing pipelineConfigId

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
@@ -37,8 +37,10 @@ public class V1SchemaExecutionGenerator implements ExecutionGenerator {
     pipeline.put("id", configuration.getRuntimeId());
     pipeline.put("application", configuration.getPipeline().getApplication());
     pipeline.put("name", Optional.ofNullable(configuration.getPipeline().getName()).orElse("Unnamed Execution"));
-    // TODO Doesn't look like we even use this anywhere in the codebase.
-//    pipeline.put("appConfig", "unsupported");
+
+    if (configuration.getPipeline().getPipelineConfigId() != null) {
+      pipeline.put("pipelineConfigId", configuration.getPipeline().getPipelineConfigId());
+    }
 
     // TODO rz - Ehhhh
     Configuration c = template.getConfiguration();

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateConfiguration.java
@@ -36,6 +36,7 @@ public class TemplateConfiguration {
   public static class PipelineDefinition {
 
     private String application;
+    private String pipelineConfigId;
     private String name;
     private TemplateSource template;
     private Map<String, Object> variables = new HashMap<>();
@@ -46,6 +47,14 @@ public class TemplateConfiguration {
 
     public void setApplication(String application) {
       this.application = application;
+    }
+
+    public String getPipelineConfigId() {
+      return pipelineConfigId;
+    }
+
+    public void setPipelineConfigId(String pipelineConfigId) {
+      this.pipelineConfigId = pipelineConfigId;
     }
 
     public String getName() {


### PR DESCRIPTION
Pipeline templates will eventually have an associated pipeline config in front50 when the UI side of things are developed, just like any other pipeline. Until then, adding a config option to allow people to manually specify the pipelineConfigId that an execution should be associated with.
