### PR TITLE
fix(pipelinetemplate): Handlebars rendering & variable inheritance issues

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/GraphMutator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/GraphMutator.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisi
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConditionalStanzaTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConfigModuleReplacementTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConfigStageInjectionTransform;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.DefaultVariableAssignmentTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.PipelineConfigInheritanceTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.RenderTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.StageInheritanceControlTransform;
@@ -36,6 +37,7 @@ public class GraphMutator {
   List<PipelineTemplateVisitor> visitors = new ArrayList<>();
 
   public GraphMutator(TemplateConfiguration configuration, Renderer renderer, Registry registry, Map<String, Object> trigger) {
+    visitors.add(new DefaultVariableAssignmentTransform(configuration));
     visitors.add(new ConditionalStanzaTransform(configuration, renderer, trigger));
     visitors.add(new ConfigModuleReplacementTransform(configuration));
     visitors.add(new PipelineConfigInheritanceTransform(configuration));

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConditionalStanzaTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConditionalStanzaTransform.java
@@ -44,13 +44,13 @@ public class ConditionalStanzaTransform implements PipelineTemplateVisitor {
     trimConditionals(templateConfiguration.getStages(), pipelineTemplate);
   }
 
-  private <T extends Conditional> void trimConditionals(List<T> list, PipelineTemplate template) {
-    if (list == null) {
+  private <T extends Conditional> void trimConditionals(List<T> stages, PipelineTemplate template) {
+    if (stages == null) {
       return;
     }
 
-    for (T el : list) {
-      if (el.getWhen() == null || el.getWhen().size() == 0) {
+    for (T el : stages) {
+      if (el.getWhen() == null || el.getWhen().isEmpty()) {
         continue;
       }
 
@@ -60,7 +60,7 @@ public class ConditionalStanzaTransform implements PipelineTemplateVisitor {
       for (String conditional : el.getWhen()) {
         String rendered = renderer.render(conditional, context);
         if (!Boolean.parseBoolean(rendered)) {
-          list.remove(el);
+          stages.remove(el);
           return;
         }
       }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/DefaultVariableAssignmentTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/DefaultVariableAssignmentTransform.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform;
+
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.IllegalTemplateConfigurationException;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisitor;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate.Variable;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class DefaultVariableAssignmentTransform implements PipelineTemplateVisitor {
+
+  TemplateConfiguration templateConfiguration;
+
+  public DefaultVariableAssignmentTransform(TemplateConfiguration templateConfiguration) {
+    this.templateConfiguration = templateConfiguration;
+  }
+
+  @Override
+  public void visitPipelineTemplate(PipelineTemplate pipelineTemplate) {
+    if (pipelineTemplate.getVariables() == null || pipelineTemplate.getVariables().isEmpty()) {
+      return;
+    }
+
+    Map<String, Object> configVars = templateConfiguration.getPipeline().getVariables();
+
+    // if the config is missing vars and the template defines a default value, assign those values from the config
+    pipelineTemplate.getVariables().stream()
+      .filter(templateVar -> !configVars.containsKey(templateVar.getName()) && templateVar.hasDefaultValue())
+      .forEach(templateVar -> configVars.put(templateVar.getName(), templateVar.getDefaultValue()));
+
+    List<String> missingVariables = pipelineTemplate.getVariables().stream()
+      .filter(templateVar -> !configVars.containsKey(templateVar.getName()))
+      .map(Variable::getName)
+      .collect(Collectors.toList());
+
+    if (!missingVariables.isEmpty()) {
+      throw new IllegalTemplateConfigurationException("Missing variable values for: " + StringUtils.join(missingVariables, ", "));
+    }
+
+    // TODO rz - validate variable values match the defined variable type
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
@@ -72,6 +72,10 @@ public class PipelineTemplate implements VersionedSchema {
     public void setDefaultValue(Object defaultValue) {
       this.defaultValue = defaultValue;
     }
+
+    public boolean hasDefaultValue() {
+      return defaultValue != null;
+    }
   }
 
   public static class Configuration {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/ModuleHelper.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/ModuleHelper.java
@@ -56,7 +56,7 @@ public class ModuleHelper implements Helper<Object> {
 
   @Override
   public String apply(Object context, Options options) throws IOException {
-    isTrue(context instanceof String, "found '%s', expected 'module id'", context);
+    isTrue(context instanceof String, "module: could not find module by given id '%s', or id type is invalid", context);
 
     PipelineTemplate template = options.get("pipelineTemplate");
     if (template == null) {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/WithMapKeyHelper.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/WithMapKeyHelper.java
@@ -28,10 +28,10 @@ public class WithMapKeyHelper implements Helper<Map<String, Object>> {
 
   @Override
   public Object apply(Map<String, Object> context, Options options) throws IOException {
-    notNull(context, "Map value must not be null");
+    notNull(context, "withMapKey: Map value must not be null");
 
     String key = options.param(0);
-    notNull(key, "A key is required");
+    notNull(key, "withMapKey: A key is required");
 
     if (!context.containsKey(key)) {
       throw new IllegalArgumentException("withObjectKey helper given key that does not exist (key: " + key + ")");

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer
 import org.unitils.reflectionassert.ReflectionComparatorMode
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
 
 import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals
 
@@ -169,7 +170,21 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
     result.stages[0].regions == '{{unknown_identifier}}'
   }
 
-  Map<String, Object> createTemplateRequest(String templatePath, Map<String, Object> variables = [:], List<Map<String, Object>> stages = [:], boolean plan = false) {
+  @Unroll
+  def 'should not render falsy conditional stages'() {
+    when:
+    def result = subject.process(createTemplateRequest('conditional-stages-001.yml', [includeWait: includeWait]))
+
+    then:
+    result.stages*.name == expectedStageNames
+
+    where:
+    includeWait || expectedStageNames
+    true        || ['wait', 'conditionalWait']
+    false       || ['wait']
+  }
+
+  Map<String, Object> createTemplateRequest(String templatePath, Map<String, Object> variables = [:], List<Map<String, Object>> stages = [], boolean plan = false) {
     return [
       type: 'templatedPipeline',
       trigger: [

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigStageInjectionTransformSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigStageInjectionTransformSpec.groovy
@@ -108,7 +108,7 @@ class ConfigStageInjectionTransformSpec extends Specification {
     def configBuilder = { injectRule ->
       new TemplateConfiguration(
         stages: [
-          new StageDefinition(id: 'injected', type: 'manualJudgement', inject: injectRule)
+          new StageDefinition(id: 'injected', type: 'manualJudgment', inject: injectRule)
         ]
       )
     }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/DefaultVariableAssignmentTransformSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/DefaultVariableAssignmentTransformSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform
+
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.IllegalTemplateConfigurationException
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate.Variable
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration.PipelineDefinition
+import spock.lang.Specification
+
+class DefaultVariableAssignmentTransformSpec extends Specification {
+
+  def 'should assign default variables if configuration defines none'() {
+    given:
+    def template = new PipelineTemplate(
+      variables: [
+        new Variable(name: 'foo', defaultValue: 'fooDefaultValue'),
+        new Variable(name: 'bar'),
+        new Variable(name: 'baz', defaultValue: 'bazDefaultValue')
+      ]
+    )
+
+    def configuration = new TemplateConfiguration(
+      pipeline: new PipelineDefinition(
+        variables: [
+          bar: 'barValue',
+          baz: 'bazValue'
+        ]
+      )
+    )
+
+    def subject = new DefaultVariableAssignmentTransform(configuration)
+
+    when:
+    subject.visitPipelineTemplate(template)
+
+    then:
+    configuration.pipeline.variables.with {
+      it['foo'] == 'fooDefaultValue'
+      it['bar'] == 'barValue'
+      it['baz'] == 'bazValue'
+    }
+  }
+
+  def 'should throw template configuration exception if required variable is undefined'() {
+    given:
+    def template = new PipelineTemplate(
+      variables: [
+        new Variable(name: 'bar')
+      ]
+    )
+
+    def configuration = new TemplateConfiguration(
+      pipeline: new PipelineDefinition(
+        variables: [:]
+      )
+    )
+
+    def subject = new DefaultVariableAssignmentTransform(configuration)
+
+    when:
+    subject.visitPipelineTemplate(template)
+
+    then:
+    thrown(IllegalTemplateConfigurationException)
+  }
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/RenderTransformSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/RenderTransformSpec.groovy
@@ -51,7 +51,8 @@ class RenderTransformSpec extends Specification {
       id: 'deployToPrestaging',
       schema: '1',
       variables: [
-        new Variable(name: 'regions', type: 'list')
+        new Variable(name: 'regions', type: 'list'),
+        new Variable(name: 'slackChannel', type: 'string', defaultValue: '#det')
       ],
       configuration: new Configuration(
         triggers: [
@@ -77,14 +78,14 @@ class RenderTransformSpec extends Specification {
           ]
         ),
         new StageDefinition(
-          id: 'manualJudgement',
-          type: 'manualJudgement',
+          id: 'manualjudgment',
+          type: 'manualjudgment',
           dependsOn: ['findImage'],
           config: [
             propagateAuthentication: true,
             notifications: [
               type: 'slack',
-              channel: '#det',
+              channel: '{{slackChannel}}',
               when: ['awaiting']
             ]
           ]
@@ -92,7 +93,7 @@ class RenderTransformSpec extends Specification {
         new StageDefinition(
           id: 'deploy',
           type: 'deploy',
-          dependsOn: ['manualJudgement'],
+          dependsOn: ['manualJudgment'],
           config: [
             clusters: '[{{#each regions}}{{module "deployCluster" region=this}}{{#unless @last}},{{/unless}}{{/each}}]'
           ]

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/HandlebarsRendererSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/HandlebarsRendererSpec.groovy
@@ -50,7 +50,8 @@ class HandlebarsRendererSpec extends Specification {
     '1.1'                 || Double         | 1.1
     'true'                || Boolean        | true
     '{{ stringVar }}'     || String         | 'myStringValue'
-    '''\
+    '''
+
 [
   {{#each regions}}
   "{{ this }}"{{#unless @last}},{{/unless}}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/ConditionHelperSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/helper/ConditionHelperSpec.groovy
@@ -70,8 +70,8 @@ class ConditionHelperSpec extends Specification {
     t.cause.getClass() == IllegalArgumentException
 
     where:
-    template                            | context
-    '{{contains value "something"}}'    | [value: 1]
+    template                             | context
+    '{{contains value "something"}}'     | [value: 1]
     '{{containsKey value "something"}}'  | [value: 1]
   }
 

--- a/orca-pipelinetemplate/src/test/resources/templates/conditional-stages-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/conditional-stages-001.yml
@@ -1,0 +1,18 @@
+schema: "1"
+id: simpleTemplate
+variables:
+- name: includeWait
+  type: boolean
+stages:
+- id: wait
+  type: wait
+  config:
+    waitTime: 5
+- id: conditionalWait
+  type: wait
+  dependsOn:
+  - wait
+  config:
+    waitTime: 5
+  when:
+  - '{{isEqual includeWait true}}'


### PR DESCRIPTION
Continuing to test more advanced templates. Apologize this PR is a bit over the place.

* Adding default variable assignment from templates into the configuration. This implementation was overlooked previously.
* Unmarshaling handlebars templates from JSON was failing if the rendered string had extraneous leading whitespace. I'm now trimming this before passing it off to the object mapper.
* A few minor quality of life changes on handlebars error handling. I'm very unsatisfied by the errors returned by the handlebars library, so I'll be putting together another PR to help address debuggability of incorrect templates.
* Most importantly, Terminator-ing the spelling of `judgment`.

@spinnaker/reviewers PTAL