### PR TITLE
feat(pipelinetemplate): Adding a Jinja template renderer alternative

### DIFF
--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -5,6 +5,9 @@ dependencies {
 
   compile('com.github.jknack:handlebars:4.0.6')
   compile('com.github.jknack:handlebars-jackson2:1.0.0')
+
+  compile('com.hubspot.jinjava:jinjava:2.1.14')
+
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${spinnaker.version('jackson')}"
   compile('com.jayway.jsonpath:json-path:2.2.0')
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
@@ -21,7 +21,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.netflix.spinnaker.orca.pipelinetemplate.PipelineTemplateModule;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.HandlebarsRenderer;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JsonRenderedValueConverter;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderedValueConverter;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -38,7 +42,19 @@ public class PipelineTemplateConfiguration {
   }
 
   @Bean
-  Renderer renderer(ObjectMapper pipelineTemplateObjectMapper) {
-    return new HandlebarsRenderer(pipelineTemplateObjectMapper);
+  RenderedValueConverter jsonRenderedValueConverter(ObjectMapper pipelineTemplateObjectMapper) {
+    return new JsonRenderedValueConverter(pipelineTemplateObjectMapper);
+  }
+
+  @Bean
+  @ConditionalOnExpression("!${pipelineTemplate.jinja.enabled}")
+  Renderer handlebarsRenderer(RenderedValueConverter renderedValueConverter, ObjectMapper pipelineTemplateObjectMapper) {
+    return new HandlebarsRenderer(renderedValueConverter, pipelineTemplateObjectMapper);
+  }
+
+  @Bean
+  @ConditionalOnExpression("${pipelineTemplate.jinja.enabled}")
+  Renderer jinjaRenderer(RenderedValueConverter renderedValueConverter, ObjectMapper pipelineTemplateObjectMapper) {
+    return new JinjaRenderer(renderedValueConverter, pipelineTemplateObjectMapper);
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.loader.ResourceLocator;
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.tags.ModuleTag;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+public class JinjaRenderer implements Renderer {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private Jinjava jinja;
+
+  private RenderedValueConverter renderedValueConverter;
+
+  public JinjaRenderer(ObjectMapper pipelineTemplateObjectMapper) {
+    this(new JsonRenderedValueConverter(pipelineTemplateObjectMapper), pipelineTemplateObjectMapper);
+  }
+
+  public JinjaRenderer(RenderedValueConverter renderedValueConverter, ObjectMapper pipelineTemplateObjectMapper) {
+    this.renderedValueConverter = renderedValueConverter;
+
+    JinjavaConfig config = new JinjavaConfig();
+    jinja = new Jinjava(config);
+    jinja.setResourceLocator(new NoopResourceLocator());
+    jinja.getGlobalContext().registerTag(new ModuleTag(this, pipelineTemplateObjectMapper));
+
+    log.info("PipelineTemplates: Using JinjaRenderer");
+  }
+
+  @Override
+  public String render(String template, RenderContext context) {
+    String rendered;
+    try {
+      rendered = jinja.render(template, context.getVariables());
+    } catch (InterpretException e) {
+      log.error("Failed rendering jinja template", e);
+      throw new TemplateRenderException(new Error()
+        .withMessage("failed rendering jinja template")
+        .withCause(e.getMessage())
+        .withLocation(context.getLocation())
+      );
+    }
+
+    rendered = rendered.trim().replaceAll("\n", "");
+
+    if (!template.equals(rendered)) {
+      log.debug("rendered '" + template + "' -> '" + rendered + "'");
+    }
+
+    return rendered;
+  }
+
+  @Override
+  public Object renderGraph(String template, RenderContext context) {
+    return renderedValueConverter.convertRenderedValue(render(template, context));
+  }
+
+  private static class NoopResourceLocator implements ResourceLocator {
+    @Override
+    public String getString(String fullName, Charset encoding, JinjavaInterpreter interpreter) throws IOException {
+      return null;
+    }
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JsonRenderedValueConverter.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JsonRenderedValueConverter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
+import org.apache.commons.lang3.math.NumberUtils;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+
+public class JsonRenderedValueConverter implements RenderedValueConverter {
+
+  private ObjectMapper pipelineTemplateObjectMapper;
+
+  public JsonRenderedValueConverter(ObjectMapper pipelineTemplateObjectMapper) {
+    this.pipelineTemplateObjectMapper = pipelineTemplateObjectMapper;
+  }
+
+  @Override
+  public Object convertRenderedValue(String rendered) {
+    if (NumberUtils.isNumber(rendered)) {
+      if (rendered.contains(".")) {
+        return NumberUtils.createDouble(rendered);
+      }
+      try {
+        return NumberUtils.createInteger(rendered);
+      } catch (NumberFormatException ignored) {
+        return NumberUtils.createLong(rendered);
+      }
+    } else if (rendered.equals("true") || rendered.equals("false")) {
+      return Boolean.parseBoolean(rendered);
+    } else if (rendered.startsWith("{{") || (!rendered.startsWith("{") && !rendered.startsWith("["))) {
+      return rendered;
+    }
+
+    JsonNode node;
+    try {
+      node = pipelineTemplateObjectMapper.readTree(rendered);
+    } catch (IOException e) {
+      throw new TemplateRenderException("template produced invalid json", e);
+    }
+
+    try {
+      if (node.isArray()) {
+        return pipelineTemplateObjectMapper.readValue(rendered, Collection.class);
+      }
+      if (node.isObject()) {
+        return pipelineTemplateObjectMapper.readValue(rendered, HashMap.class);
+      }
+      if (node.isBoolean()) {
+        return Boolean.parseBoolean(node.asText());
+      }
+      if (node.isDouble()) {
+        return node.doubleValue();
+      }
+      if (node.canConvertToInt()) {
+        return node.intValue();
+      }
+      if (node.canConvertToLong()) {
+        return node.longValue();
+      }
+      if (node.isTextual()) {
+        return node.textValue();
+      }
+      if (node.isNull()) {
+        return null;
+      }
+    } catch (IOException e) {
+      throw new TemplateRenderException("template produced invalid json", e);
+    }
+
+    throw new TemplateRenderException("unknown rendered object type");
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/RenderedValueConverter.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/RenderedValueConverter.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render;
+
+public interface RenderedValueConverter {
+
+  Object convertRenderedValue(String renderedValue);
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/ModuleTag.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/ModuleTag.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.tags;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.lib.tag.Tag;
+import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.util.HelperStringTokenizer;
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.NamedHashMap;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateModule;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.DefaultRenderContext;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderContext;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderUtil;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ModuleTag implements Tag {
+
+  private Renderer renderer;
+
+  private ObjectMapper objectMapper;
+
+  public ModuleTag(Renderer renderer, ObjectMapper pipelineTemplateObjectMapper) {
+    this.renderer = renderer;
+    this.objectMapper = pipelineTemplateObjectMapper;
+  }
+
+  @Override
+  public String getName() {
+    return "module";
+  }
+
+  @Override
+  public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+    List<String> helper = new HelperStringTokenizer(tagNode.getHelpers()).splitComma(true).allTokens();
+    if (helper.isEmpty()) {
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'module' expects ID as first parameter: " + helper, tagNode.getLineNumber());
+    }
+
+    Context context = interpreter.getContext();
+    String moduleId = helper.get(0);
+
+    PipelineTemplate template = (PipelineTemplate) context.get("pipelineTemplate");
+    if (template == null) {
+      throw new TemplateRenderException(new Error()
+        .withMessage("Pipeline template missing from jinja context")
+        .withCause("Internal error")
+        .withLocation(String.format("module:%s", moduleId))
+      );
+    }
+
+    TemplateModule module = template.getModules().stream()
+      .filter(m -> m.getId().equals(moduleId))
+      .findFirst()
+      .orElseThrow((Supplier<RuntimeException>) () -> new TemplateRenderException(String.format("Module does not exist by ID: %s", moduleId)));
+
+    RenderContext moduleContext = new DefaultRenderContext(
+      (String) context.get("application"),
+      template,
+      (Map<String, Object>) context.get("trigger")
+    );
+    moduleContext.setLocation("module:" + moduleId);
+
+    // Assign parameters into the context
+    Map<String, Object> paramPairs = new HashMap<>();
+    helper.subList(1, helper.size()).forEach(p -> {
+      String[] parts = p.split("=");
+      if (parts.length != 2) {
+        throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'module' expects parameters to be in a 'key=value' format: " + helper, tagNode.getLineNumber());
+      }
+      paramPairs.put(parts[0], parts[1]);
+    });
+
+    List<String> missing = new ArrayList<>();
+    for (NamedHashMap var : module.getVariables()) {
+      // First try to assign the variable from the context directly
+      Object val = context.get(var.getName());
+      if (val == null) {
+        // Try to assign from a parameter (using the param value as a context key first, then as a literal)
+        if (paramPairs.containsKey(var.getName())) {
+          val = context.get(paramPairs.get(var.getName()), paramPairs.get(var.getName()));
+        }
+
+        // If the val is still null, try to assign from a default value
+        if (val == null && var.containsKey("defaultValue")) {
+          val = var.get("defaultValue");
+        }
+
+        if (val == null) {
+          missing.add(var.getName());
+          continue;
+        }
+      }
+      moduleContext.getVariables().put(var.getName(), val);
+    }
+
+    if (missing.size() > 0) {
+      throw new TemplateRenderException(new Error()
+        .withMessage("Missing required variables in module")
+        .withCause("'" + StringUtils.join(missing, "', '") + "' must be defined")
+        .withLocation(moduleContext.getLocation())
+      );
+    }
+
+    Object rendered = RenderUtil.deepRender(renderer, module.getDefinition(), moduleContext);
+
+    try {
+      return new String(objectMapper.writeValueAsBytes(rendered));
+    } catch (JsonProcessingException e) {
+      throw new TemplateRenderException(new Error()
+        .withMessage("Failed rendering module as JSON")
+        .withCause(e.getMessage())
+        .withLocation(moduleContext.getLocation())
+      );
+    }
+  }
+
+  @Override
+  public String getEndTagName() {
+    return null;
+  }
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -22,7 +22,7 @@ import com.netflix.spectator.api.Timer
 import com.netflix.spinnaker.orca.extensionpoint.pipeline.PipelinePreprocessor
 import com.netflix.spinnaker.orca.pipelinetemplate.loader.FileTemplateSchemeLoader
 import com.netflix.spinnaker.orca.pipelinetemplate.loader.TemplateLoader
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.HandlebarsRenderer
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer
 import org.unitils.reflectionassert.ReflectionComparatorMode
 import spock.lang.Specification
@@ -37,7 +37,7 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
 
   TemplateLoader templateLoader = new TemplateLoader([new FileTemplateSchemeLoader(objectMapper)])
 
-  Renderer renderer = new HandlebarsRenderer(objectMapper)
+  Renderer renderer = new JinjaRenderer(objectMapper)
 
   Registry registry = Mock() {
     clock() >> Mock(Clock) {
@@ -159,15 +159,6 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
     noExceptionThrown()
     result.errors != null
     result.errors*.message.contains("failed loading template")
-  }
-
-  def 'should not render unknown handlebars identifiers'() {
-    when:
-    def result = subject.process(createTemplateRequest('invalid-handlebars-001.yml', [:], [], true))
-
-    then:
-    noExceptionThrown()
-    result.stages[0].regions == '{{unknown_identifier}}'
   }
 
   @Unroll

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class JinjaRendererSpec extends Specification {
+
+  ObjectMapper objectMapper = new ObjectMapper()
+
+  @Subject
+  Renderer subject = new JinjaRenderer(objectMapper)
+
+  @Unroll
+  def 'should render and return correct java type'() {
+    given:
+    RenderContext context = new DefaultRenderContext('myApp', new PipelineTemplate(), [job: 'job', buildNumber: 1234]).with {
+      variables.put('stringVar', 'myStringValue')
+      variables.put('regions', ['us-east-1', 'us-west-2'])
+      variables.put('objectVar', [key1: 'value1', key2: 'value2'])
+      it
+    }
+
+    when:
+    def result = subject.renderGraph(template, context)
+
+    then:
+    expectedType.isAssignableFrom(result.getClass())
+    result == expectedResult
+
+    where:
+    template          || expectedType | expectedResult
+    '1'               || Integer      | 1
+    '1.1'             || Double       | 1.1
+    'true'            || Boolean      | true
+    '{{ stringVar }}' || String       | 'myStringValue'
+    '''
+
+[
+  {% for region in regions %}
+    "{{ region }}"{% if not loop.last %},{% endif %}
+  {% endfor %}
+]
+'''                   || List         | ['us-east-1', 'us-west-2']
+    '''\
+[
+{% for key, value in objectVar.items() %}
+  "{{ key }}:{{ value }}"{% if not loop.last %},{% endif %}
+{% endfor %}
+]
+'''                   || List         | ['key1:value1', 'key2:value2']
+  }
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/ModuleTagSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/ModuleTagSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.tags
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.NamedHashMap
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateModule
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.DefaultRenderContext
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderContext
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer
+import spock.lang.Specification
+import spock.lang.Subject
+
+class ModuleTagSpec extends Specification {
+
+  ObjectMapper objectMapper = new ObjectMapper()
+
+  Renderer renderer = new JinjaRenderer(objectMapper)
+
+  @Subject
+  ModuleTag subject = new ModuleTag(renderer, objectMapper)
+
+  def 'should render module'() {
+    given:
+    PipelineTemplate pipelineTemplate = new PipelineTemplate(
+      modules: [
+        new TemplateModule(
+          id: 'myModule',
+          variables: [
+            [name: 'myStringVar', defaultValue: 'hello'] as NamedHashMap,
+            [name: 'myOtherVar'] as NamedHashMap,
+            [name: 'subject'] as NamedHashMap
+          ],
+          definition: '{{myStringVar}} {{myOtherVar}}, {{subject}}')
+      ]
+    )
+    RenderContext context = new DefaultRenderContext('myApp', pipelineTemplate, [job: 'job', buildNumber: 1234])
+    context.variables.put("testerName", "Mr. Tester Testington")
+
+    when:
+    def result = renderer.render('{% module myModule myOtherVar=world, subject=testerName %}', context)
+
+    then:
+    // The ModuleTag outputs JSON
+    result == '"hello world, Mr. Tester Testington"'
+  }
+}

--- a/orca-pipelinetemplate/src/test/resources/templates/conditional-stages-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/conditional-stages-001.yml
@@ -15,4 +15,5 @@ stages:
   config:
     waitTime: 5
   when:
-  - '{{isEqual includeWait true}}'
+  # This could also just be '{{ includeWait }}', but examples.
+  - '{{ includeWait == true }}'

--- a/orca-pipelinetemplate/src/test/resources/templates/invalid-handlebars-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/invalid-handlebars-001.yml
@@ -1,8 +1,0 @@
-schema: "1"
-id: invalidHandlebarsTemplate
-stages:
-- id: bake
-  type: bake
-  name: Bake
-  config:
-    regions: "{{unknown_identifier}}"

--- a/orca-pipelinetemplate/src/test/resources/templates/simple-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/simple-001.yml
@@ -17,9 +17,9 @@ stages:
   config:
     regions: |
       [
-      {{#each regions}}
-      "{{ this }}"{{#unless @last}},{{/unless}}
-      {{/each}}
+      {% for region in regions %}
+      "{{ region }}"{% if not loop.last %},{% endif %}
+      {% endfor %}
       ]
     package: "{{ application }}-package"
     baseOs: trusty


### PR DESCRIPTION
Refactoring pipeline templates codebase to use a Jinja rendering engine over Handlebars.

While converting our internal pipelines to use templates, I found that I was spending a lot of time fighting against Handlebars. Jinja is a lot more expressive, so it's easier to work with (especially around maps and mutating objects). As a bonus, the standard Jinja tags, filters and expression are fairly well-featured, which should allow us to maintain a smaller codebase (whereas Handlebars, I was already having to build a number of helpers for simple quality of life). I opted for doing this work now, rather than later so we don't need to support a migration effort.

I'm leaving the handlebars code in place (and also the default) for the time being while I convert our already existing pipelines over to Jinja, as the formats are incompatible. A separate PR will rip it out.

Lastly, there's another (lower priority quality of life) task of switching the rendered output from JSON to YAML, which will make templates less verbose - so I created an interface to support that in `RenderedValueConverter`.

@spinnaker/netflix-reviewers PTAL
