### PR TITLE
chore(changelog): Extend changelog commit keywords.

### DIFF
--- a/.clog.toml
+++ b/.clog.toml
@@ -1,0 +1,4 @@
+[clog]
+
+[sections]
+"Configuration Changes" = ["config", "conf"]


### PR DESCRIPTION
Adds a few new changelog keywords: `config` or `conf` for configuration changes. @tomaslin FYI.