### PR TITLE
fix(pipelinetemplate): Ensure plan flag doesnt get overwritten by preprocessors

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -64,6 +64,7 @@ class OperationsController {
     parsePipelineTrigger(executionRepository, buildService, pipeline)
     Map trigger = pipeline.trigger
 
+    boolean plan = pipeline.plan ?: false
     for (PipelinePreprocessor preprocessor : (pipelinePreprocessors ?: [])) {
       pipeline = preprocessor.process(pipeline)
     }
@@ -85,7 +86,7 @@ class OperationsController {
     def augmentedContext = [trigger: pipeline.trigger]
     def processedPipeline = ContextParameterProcessor.process(pipeline, augmentedContext, false)
 
-    if (pipeline.plan == true) {
+    if (plan) {
       log.info('not starting pipeline (plan: true): {}', pipeline.id)
       if (pipeline.errors != null) {
         throw new InvalidPipelineTemplateException("Pipeline template is invalid", pipeline.errors as List<Map<String, Object>>)


### PR DESCRIPTION
I was errantly relying on `pipeline.plan` existing after any PipelinePreprocessors run, which can mutate the pipeline object (and in this case, was removing the attribute before the time we actually needed to use it).

cc @danielpeach 