### PR TITLE
feat(pipelinetemplate): Metadata for UI; template protection

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
@@ -32,6 +32,7 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfig
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator.V1TemplateConfigurationSchemaValidator;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator.V1TemplateSchemaValidator;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator.V1TemplateSchemaValidator.SchemaValidatorContext;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -101,7 +102,7 @@ public class PipelineTemplatePipelinePreprocessor implements PipelinePreprocesso
     List<PipelineTemplate> templates = templateLoader.load(templateConfiguration.getPipeline().getTemplate());
     PipelineTemplate template = TemplateMerge.merge(templates);
 
-    new V1TemplateSchemaValidator().validate(template, validationErrors);
+    new V1TemplateSchemaValidator().validate(template, validationErrors, new SchemaValidatorContext(!templateConfiguration.getStages().isEmpty()));
     if (validationErrors.hasErrors(request.plan)) {
       return validationErrors.toResponse();
     }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplateMerge.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplateMerge.java
@@ -31,16 +31,22 @@ public class TemplateMerge {
     for (PipelineTemplate template : templates) {
       appendSource(result, template);
 
-      // TODO rz - should validate var types are the same here or elsewhere?
+      // If any of the templates are set as protected, configurations won't be allowed to alter stages.
+      if (template.getProtect()) {
+        result.setProtect(true);
+      }
+
       result.setVariables(mergeNamedContent(result.getVariables(), template.getVariables()));
 
       mergeConfiguration(result, template);
 
-      // TODO rz - might make sense that any child template must use inject syntax / modules.
       result.setStages(mergeIdentifiable(result.getStages(), template.getStages()));
-
       result.setModules(mergeIdentifiable(result.getModules(), template.getModules()));
     }
+
+    // Apply the last template's metadata to the final result
+    result.setMetadata(templates.get(templates.size() - 1).getMetadata());
+
     return result;
   }
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
@@ -29,10 +29,42 @@ public class PipelineTemplate implements VersionedSchema {
   private String schema;
   private String id;
   private String source;
+  private Metadata metadata = new Metadata();
+  private Boolean protect = false;
   private List<Variable> variables;
   private Configuration configuration;
   private List<StageDefinition> stages;
   private List<TemplateModule> modules;
+
+  public static class Metadata {
+    private String name;
+    private String description;
+    private String owner;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public void setDescription(String description) {
+      this.description = description;
+    }
+
+    public String getOwner() {
+      return owner;
+    }
+
+    public void setOwner(String owner) {
+      this.owner = owner;
+    }
+  }
 
   public static class Variable implements NamedContent {
     private String name;
@@ -144,6 +176,22 @@ public class PipelineTemplate implements VersionedSchema {
 
   public void setSource(String source) {
     this.source = source;
+  }
+
+  public Metadata getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(Metadata metadata) {
+    this.metadata = metadata;
+  }
+
+  public Boolean getProtect() {
+    return protect;
+  }
+
+  public void setProtect(Boolean protect) {
+    this.protect = protect;
   }
 
   public List<Variable> getVariables() {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateConfigurationSchemaValidator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateConfigurationSchemaValidator.java
@@ -17,18 +17,24 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator;
 
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration.PipelineDefinition;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.EmptyValidatorContext;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Severity;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.SchemaValidator;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.ValidatorContext;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.VersionedSchema;
 
 public class V1TemplateConfigurationSchemaValidator implements SchemaValidator {
 
   private static final String SUPPORTED_VERSION = "1";
 
-  @Override
   public void validate(VersionedSchema configuration, Errors errors) {
+    validate(configuration, errors, new EmptyValidatorContext());
+  }
+
+  @Override
+  public void validate(VersionedSchema configuration, Errors errors, ValidatorContext context) {
     if (!(configuration instanceof TemplateConfiguration)) {
       throw new IllegalArgumentException("Expected TemplateConfiguration");
     }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/validator/EmptyValidatorContext.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/validator/EmptyValidatorContext.java
@@ -15,7 +15,5 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.validator;
 
-public interface SchemaValidator<T extends ValidatorContext> {
-
-  void validate(VersionedSchema versionedSchema, Errors errors, T context);
+public class EmptyValidatorContext implements ValidatorContext {
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/validator/ValidatorContext.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/validator/ValidatorContext.java
@@ -15,7 +15,5 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.validator;
 
-public interface SchemaValidator<T extends ValidatorContext> {
-
-  void validate(VersionedSchema versionedSchema, Errors errors, T context);
+public interface ValidatorContext {
 }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplateMergeSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplateMergeSpec.groovy
@@ -29,6 +29,7 @@ class TemplateMergeSpec extends Specification {
     PipelineTemplate t1 = new PipelineTemplate().with {
       id = 't1'
       schema = '1'
+      protect = true
       variables = [
         new Variable(name: 'foo', description: 'foo description', type: 'string', defaultValue: 'foo value'),
         new Variable(name: 'bar', description: 'bar description', type: 'list', defaultValue: ['bar value'])
@@ -89,6 +90,7 @@ class TemplateMergeSpec extends Specification {
     result.id == 'mergedTemplate'
     result.schema == '1'
     result.source == 't1'
+    result.protect
     result.variables*.name == ['foo', 'bar']
     result.variables.find { it.name == 'foo' }.defaultValue == 'overridden value'
     result.configuration.triggers*.name == ['trigger1', 'trigger2']

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateSchemaValidatorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateSchemaValidatorSpec.groovy
@@ -16,9 +16,11 @@
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator
 
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator.V1TemplateSchemaValidator.SchemaValidatorContext
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
 
 class V1TemplateSchemaValidatorSpec extends Specification {
 
@@ -31,7 +33,7 @@ class V1TemplateSchemaValidatorSpec extends Specification {
     def template = new PipelineTemplate(schema: schema)
 
     when:
-    subject.validate(template, errors)
+    subject.validate(template, errors, new SchemaValidatorContext(false))
 
     then:
     if (hasErrors) {
@@ -45,5 +47,25 @@ class V1TemplateSchemaValidatorSpec extends Specification {
     null   | true
     "1"    | false
     "2"    | true
+  }
+
+  @Unroll
+  def "should error if configuration defines stages when template is protected"() {
+    given:
+    def errors = new Errors()
+    def template = new PipelineTemplate(schema: '1', protect: true)
+
+    when:
+    subject.validate(template, errors, new SchemaValidatorContext(hasStages))
+
+    then:
+    if (hasStages) {
+      errors.hasErrors(true)
+    } else {
+      !errors.hasErrors(true)
+    }
+
+    where:
+    hasStages << [true, false]
   }
 }


### PR DESCRIPTION
* Adds `protect` flag to templates, allowing template creators to prevent configuration-level modification of the stage graph. Going for the simplest level to start with, we can get more granular down the road if necessary.
* Adds new (optional) metadata block to templates containing `name`, `description` and `owner` so we can surface this in the UI for additional context.

@spinnaker/netflix-reviewers @spinnaker/google-reviewers PTAL