### PR TITLE
feat(pipelinetemplate): Frigga jinja filter

### DIFF
--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -16,6 +16,7 @@ dependencies {
   compile spinnaker.dependency("springContext")
   compile spinnaker.dependency("jacksonDatabind")
   compile spinnaker.dependency("spectatorApi")
+  compile spinnaker.dependency("frigga")
 
   testCompile spinnaker.dependency("slf4jSimple")
   testCompile 'org.spockframework:spock-unitils:1.1-groovy-2.4-rc-2'

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
@@ -22,6 +22,7 @@ import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.loader.ResourceLocator;
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.filters.FriggaFilter;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.tags.ModuleTag;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
 import org.slf4j.Logger;
@@ -49,6 +50,7 @@ public class JinjaRenderer implements Renderer {
     jinja = new Jinjava(config);
     jinja.setResourceLocator(new NoopResourceLocator());
     jinja.getGlobalContext().registerTag(new ModuleTag(this, pipelineTemplateObjectMapper));
+    jinja.getGlobalContext().registerFilter(new FriggaFilter());
 
     log.info("PipelineTemplates: Using JinjaRenderer");
   }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/filters/FriggaFilter.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/filters/FriggaFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.filters;
+
+import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.filter.Filter;
+import com.netflix.frigga.Names;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class FriggaFilter implements Filter {
+
+  @Override
+  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    String input = (String) var;
+    if (args.length != 1) {
+      throw new InterpretException("frigga filter requires 1 arg (the name of the frigga part to return)");
+    }
+
+    String methodName = "get" + args[0].substring(0, 1).toUpperCase() + args[0].substring(1);
+
+    Method accessor;
+    try {
+      accessor = Names.class.getMethod(methodName);
+    } catch (NoSuchMethodException e) {
+      throw new InterpretException("frigga filter cannot find Frigga method: " + methodName, e);
+    }
+
+    Names names = Names.parseName(input);
+    try {
+      return accessor.invoke(names);
+    } catch (IllegalAccessException e) {
+      throw new InterpretException("frigga filter provided invalid name (illegal access)");
+    } catch (InvocationTargetException e) {
+      throw new InterpretException("frigga filter provided failed to execute successfully", e);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "frigga";
+  }
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/filters/FriggaFilterSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/filters/FriggaFilterSpec.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.filters
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.DefaultRenderContext
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderContext
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.tags.ModuleTag
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class FriggaFilterSpec extends Specification {
+
+  ObjectMapper objectMapper = new ObjectMapper()
+
+  Renderer renderer = new JinjaRenderer(objectMapper)
+
+  @Subject
+  ModuleTag subject = new ModuleTag(renderer, objectMapper)
+
+  @Unroll
+  def "should filter frigga names"() {
+    given:
+    RenderContext context = new DefaultRenderContext("myapp", Mock(PipelineTemplate), [:])
+    context.variables.put("myVar", input)
+
+    when:
+    def result = renderer.render("{{ myVar|frigga('$name') }}", context)
+
+    then:
+    result == expectedResult
+
+    where:
+    input           | name      || expectedResult
+    'foo-test-v000' | 'app'     || 'foo'
+    'foo-test-v000' | 'cluster' || 'foo-test'
+    'foo-test-v000' | 'stack'   || 'test'
+  }
+}


### PR DESCRIPTION
A common thing in many stages is working with cluster names (or parts of them). Quality of life filter that should cut down the number of variables required in some templates.

```yaml
variables:
- name: clusterName
  defaultValue: myapp-test-dcd
stages:
# ...
- type: deploy
  config:
    clusters:
    - account: test
      application: "{{ application }}" # var comes for free, but could also do `clusterName|frigga('app')`
      freeFormDetails: "{{ clusterName|frigga('detail') }}" # dcd
      stack: "{{ clusterName|frigga('stack') }}" # test
      # ...
```

@spinnaker/netflix-reviewers @spinnaker/google-reviewers PTAL