### PR TITLE
fix(pipelinetemplate): Resolve EL expressions in module param arguments

### DIFF
--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/ModuleTagSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/ModuleTagSpec.groovy
@@ -44,19 +44,20 @@ class ModuleTagSpec extends Specification {
           variables: [
             [name: 'myStringVar', defaultValue: 'hello'] as NamedHashMap,
             [name: 'myOtherVar'] as NamedHashMap,
-            [name: 'subject'] as NamedHashMap
+            [name: 'subject'] as NamedHashMap,
+            [name: 'job'] as NamedHashMap
           ],
-          definition: '{{myStringVar}} {{myOtherVar}}, {{subject}}')
+          definition: '{{myStringVar}} {{myOtherVar}}, {{subject}}. You triggered {{job}}')
       ]
     )
-    RenderContext context = new DefaultRenderContext('myApp', pipelineTemplate, [job: 'job', buildNumber: 1234])
+    RenderContext context = new DefaultRenderContext('myApp', pipelineTemplate, [job: 'myJob', buildNumber: 1234])
     context.variables.put("testerName", "Mr. Tester Testington")
 
     when:
-    def result = renderer.render('{% module myModule myOtherVar=world, subject=testerName %}', context)
+    def result = renderer.render('{% module myModule myOtherVar=world, subject=testerName, job=trigger.job %}', context)
 
     then:
     // The ModuleTag outputs JSON
-    result == '"hello world, Mr. Tester Testington"'
+    result == '"hello world, Mr. Tester Testington. You triggered myJob"'
   }
 }


### PR DESCRIPTION
The current implementation of module parameters is fairly naive of the handlebars context. This change will allow people to resolve nested values in the context and resolve other EL expressions.

@spinnaker/netflix-reviewers PTAL