### PR TITLE
feat(pipelinetemplate): Support YAML output from templates

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
@@ -20,11 +20,16 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.netflix.spinnaker.orca.pipelinetemplate.PipelineTemplateModule;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.*;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.HandlebarsRenderer;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderedValueConverter;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.YamlRenderedValueConverter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.yaml.snakeyaml.Yaml;
 
 @ConditionalOnProperty("pipelineTemplate.enabled")
 @ComponentScan(basePackageClasses = PipelineTemplateModule.class)
@@ -38,8 +43,8 @@ public class PipelineTemplateConfiguration {
   }
 
   @Bean
-  RenderedValueConverter jsonRenderedValueConverter(ObjectMapper pipelineTemplateObjectMapper) {
-    return new JsonRenderedValueConverter(pipelineTemplateObjectMapper);
+  RenderedValueConverter yamlRenderedValueConverter() {
+    return new YamlRenderedValueConverter(new Yaml());
   }
 
   @Bean

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
@@ -67,7 +67,7 @@ public class JinjaRenderer implements Renderer {
       );
     }
 
-    rendered = rendered.trim().replaceAll("\n", "");
+    rendered = rendered.trim();
 
     if (!template.equals(rendered)) {
       log.debug("rendered '" + template + "' -> '" + rendered + "'");

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/YamlRenderedValueConverter.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/YamlRenderedValueConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render;
+
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.composer.ComposerException;
+
+public class YamlRenderedValueConverter implements RenderedValueConverter {
+
+  private Yaml yaml;
+
+  public YamlRenderedValueConverter(Yaml yaml) {
+    this.yaml = yaml;
+  }
+
+  @Override
+  public Object convertRenderedValue(String renderedValue) {
+    try {
+      return yaml.load(renderedValue);
+    } catch (ComposerException e) {
+      throw new TemplateRenderException("template produced invalid yaml", e);
+    }
+  }
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import org.yaml.snakeyaml.Yaml
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -25,8 +26,10 @@ class JinjaRendererSpec extends Specification {
 
   ObjectMapper objectMapper = new ObjectMapper()
 
+  RenderedValueConverter renderedValueConverter = new YamlRenderedValueConverter(new Yaml())
+
   @Subject
-  Renderer subject = new JinjaRenderer(objectMapper)
+  Renderer subject = new JinjaRenderer(renderedValueConverter, objectMapper)
 
   @Unroll
   def 'should render and return correct java type'() {
@@ -66,5 +69,12 @@ class JinjaRendererSpec extends Specification {
 {% endfor %}
 ]
 '''                   || List         | ['key1:value1', 'key2:value2']
+    '''
+{% for region in regions %}
+- {{ region }}
+{% endfor %}
+'''                   || List         | ['us-east-1', 'us-west-2']
   }
+
+
 }


### PR DESCRIPTION
Big quality of life improvement for pipeline templating. Makes templates like these:

```yaml
- id: bake
  type: bake
  config:
    regions: |-
      [
        {% for region in bakeRegions %}
          "{{ region }}"{% if not loop.last %},{% endif %}
        {% endfor %}
      ]
```

Easier to read and write, like so:

```yaml
- id: bake
  type: bake
  config:
    regions: |
      {% for region in bakeRegions %}
      - {{ region }}
      {% endfor %}
```

Still supports JSON, of course, so there's no incompatibility with existing templates.

@spinnaker/reviewers PTAL