### PR TITLE
fix(clouddriver): Add missing locations to failed find image error message

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -167,7 +167,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
     if (missingLocations) {
       Set<String> searchNames = extractBaseImageNames(imageNames)
       if (searchNames.size() != 1) {
-        throw new IllegalStateException("Request to resolve images for missing ${config.requiredLocations.first().pluralType()} requires exactly one image. (Found ${searchNames})")
+        throw new IllegalStateException("Request to resolve images for missing ${config.requiredLocations.first().pluralType()} requires exactly one image. (Found ${searchNames}, missing locations: ${missingLocations*.value.join(',')})")
       }
 
       def deploymentDetailTemplate = imageSummaries.find { k, v -> v != null }.value[0]


### PR DESCRIPTION
Adds some additional context to find image from cluster to include the missing locations to help users self-service find image issues.

@spinnaker/netflix-reviewers PTAL