### PR TITLE
fix(compiler): fix compilation issues with stage.mapTo

### DIFF
--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/pipelines/DeleteProjectStage.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/pipelines/DeleteProjectStage.groovy
@@ -30,7 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-@CompileStatic
 class DeleteProjectStage implements StageDefinitionBuilder {
   @Override
   <T extends Execution<T>> void taskGraph(Stage<T> stage, TaskNode.Builder builder) {

--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/pipelines/UpsertProjectStage.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/pipelines/UpsertProjectStage.groovy
@@ -32,7 +32,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-@CompileStatic
 class UpsertProjectStage implements StageDefinitionBuilder {
   @Override
   <T extends Execution<T>> void taskGraph(Stage<T> stage, TaskNode.Builder builder) {


### PR DESCRIPTION
Probably fixes a subtle bug due to the way Groovy static/abstract classes are compiled statically?

The bug surfaces with the following exception:
```
java.lang.IllegalAccessError: 
tried to access method com.netflix.spinnaker.orca.pipeline.model.Stage.mapTo
(Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object; from class 
com.netflix.spinnaker.orca.applications.pipelines.UpsertProjectStage$UpsertProjectTask
```

I did not test this beyond trusting IntelliJ's compiler, which seems happy with the `@CompileStatic`s removed.

@robfletcher PTAL