### PR TITLE
fix(core): Don't apply traffic checks w/o front50

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Locat
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.front50.model.Application;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 
 @Component
+@Slf4j
 public class TrafficGuard {
 
   private final OortHelper oortHelper;
@@ -113,7 +115,8 @@ public class TrafficGuard {
 
   public boolean hasDisableLock(String cluster, String account, Location location) {
     if (front50Service == null) {
-      throw new UnsupportedOperationException("Front50 has not been configured, no way to check disable lock. Fix this by setting front50.enabled: true");
+      log.warn("Front50 has not been configured, no way to check disable lock. Fix this by setting front50.enabled: true");
+      return false;
     }
     Names names = Names.parseName(cluster);
     Application application;


### PR DESCRIPTION
Crashing the pipeline when front50 is disabled causes problems when running pipelines against a minimal (clouddriver + orca) Spinnaker
