### PR TITLE
fix(pipelinetemplate): Correctly handle template inheritance with injection

### DIFF
--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigStageInjectionTransformSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigStageInjectionTransformSpec.groovy
@@ -157,6 +157,22 @@ class ConfigStageInjectionTransformSpec extends Specification {
     requisiteStageIds('injected', template.stages) == ['s2']
   }
 
+  def 'should de-dupe template-injected stages'() {
+    given:
+    PipelineTemplate template = new PipelineTemplate(
+      stages: [
+        new StageDefinition(id: 's2', type: 'deploy'),
+        new StageDefinition(id: 's1', inject: [first: true], type: 'findImageFromTags'),
+      ]
+    )
+
+    when:
+    new ConfigStageInjectionTransform(new TemplateConfiguration()).visitPipelineTemplate(template)
+
+    then:
+    template.stages*.id == ['s1', 's2']
+  }
+
   static StageDefinition getStageById(String id, List<StageDefinition> allStages) {
     return allStages.find { it.id == id }
   }


### PR DESCRIPTION
In the case of multiple template inheritance, templates are first merged together by `TemplateMerge`, which doesn't have knowledge of injection rules. Once getting to the stage injection mutations, the stages with injection rules will re-insert themselves, creating duplicates. This caused incorrect graphs, as well as concurrent modification exceptions to be raised while using the streaming API.

@spinnaker/netflix-reviewers @jeyrschabu PTAL