### PR TITLE
fix(pipelinetemplate): Bubbling up root cause errors

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/IllegalTemplateConfigurationException.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/IllegalTemplateConfigurationException.java
@@ -26,6 +26,7 @@ public class IllegalTemplateConfigurationException extends IllegalStateException
   }
 
   public IllegalTemplateConfigurationException(Error error) {
+    this(error.getMessage());
     this.error = error;
   }
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/InvalidPipelineTemplateException.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/InvalidPipelineTemplateException.java
@@ -22,10 +22,6 @@ public class InvalidPipelineTemplateException extends RuntimeException {
 
   private List<Map<String, Object>> errors;
 
-  public InvalidPipelineTemplateException(List<Map<String, Object>> errors) {
-    this.errors = errors;
-  }
-
   public InvalidPipelineTemplateException(String message, List<Map<String, Object>> errors) {
     super(message);
     this.errors = errors;

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/TemplateRenderException.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/TemplateRenderException.java
@@ -15,14 +15,42 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.exceptions;
 
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
 
 public class TemplateRenderException extends RuntimeException {
 
-  private Error error;
+  public static TemplateRenderException fromError(Error error) {
+    return new TemplateRenderException(error.getMessage(), null, error);
+  }
+
+  public static TemplateRenderException fromError(Error error, Throwable cause) {
+    TemplateRenderException e = new TemplateRenderException(error.getMessage(), cause, error);
+
+    if (cause instanceof TemplateRenderException) {
+      error.withNested(((TemplateRenderException) cause).getErrors());
+    } else if (error.getCause() == null) {
+      error.withCause(cause.getMessage());
+    }
+
+    return e;
+  }
+
+  private Errors errors = new Errors();
+
+  public TemplateRenderException(String message, Throwable cause, Errors errors) {
+    this(message, cause);
+    this.errors = errors;
+  }
+
+  private TemplateRenderException(String message, Throwable cause, Error error) {
+    this(message, cause);
+    this.errors.add(error);
+  }
 
   public TemplateRenderException(Error error) {
-    this.error = error;
+    this(error.getMessage());
+    this.errors.add(error);
   }
 
   public TemplateRenderException(String message) {
@@ -33,7 +61,7 @@ public class TemplateRenderException extends RuntimeException {
     super(message, cause);
   }
 
-  public Error getError() {
-    return error;
+  public Errors getErrors() {
+    return errors;
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/StageInheritanceControlTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/StageInheritanceControlTransform.java
@@ -17,7 +17,7 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform;
 
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
-import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.IllegalTemplateConfigurationException;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.MapMerge;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisitor;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
@@ -46,27 +46,27 @@ public class StageInheritanceControlTransform implements PipelineTemplateVisitor
     Object oldValue = dc.read(rule.getPath());
     if (oldValue instanceof Collection) {
       if (!(rule.getValue() instanceof Collection)) {
-        throw new TemplateRenderException("cannot merge non-collection value into collection");
+        throw new IllegalTemplateConfigurationException("cannot merge non-collection value into collection");
       }
       ((Collection) oldValue).addAll((Collection) rule.getValue());
       dc.set(rule.getPath(), oldValue);
     } else if (oldValue instanceof Map) {
       if (!(rule.getValue() instanceof Map)) {
-        throw new TemplateRenderException("cannot merge non-map value into map");
+        throw new IllegalTemplateConfigurationException("cannot merge non-map value into map");
       }
       Map<String, Object> merged = MapMerge.merge((Map<String, Object>) oldValue, (Map<String, Object>) rule.getValue());
       dc.set(rule.getPath(), merged);
     } else {
-      throw new TemplateRenderException("merge inheritance control must be given a list or map value: " + rule.getPath());
+      throw new IllegalTemplateConfigurationException("merge inheritance control must be given a list or map value: " + rule.getPath());
     }
   }
 
   private static void replace(DocumentContext dc, Rule rule) {
     Object oldValue = dc.read(rule.getPath());
     if (oldValue instanceof Collection && !(rule.getValue() instanceof Collection)) {
-      throw new TemplateRenderException("cannot replace collection value with non-collection value");
+      throw new IllegalTemplateConfigurationException("cannot replace collection value with non-collection value");
     } else if (oldValue instanceof Map && !(rule.getValue() instanceof Map)) {
-      throw new TemplateRenderException("cannot replace map value with non-map value");
+      throw new IllegalTemplateConfigurationException("cannot replace map value with non-map value");
     }
     dc.set(rule.getPath(), rule.getValue());
   }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
@@ -18,15 +18,24 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateError;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
+import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
 import com.hubspot.jinjava.loader.ResourceLocator;
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.filters.FriggaFilter;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.tags.ModuleTag;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Severity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.parser.ParserException;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -60,12 +69,18 @@ public class JinjaRenderer implements Renderer {
     String rendered;
     try {
       rendered = jinja.render(template, context.getVariables());
+    } catch (FatalTemplateErrorsException fte) {
+      log.error("Failed rendering jinja template", fte);
+      throw new TemplateRenderException("failed rendering jinja template", fte, unwrapJinjaTemplateErrorException(fte, context.getLocation()));
     } catch (InterpretException e) {
+      log.warn("Caught supertype InterpretException instead of " + e.getClass().getSimpleName());
       log.error("Failed rendering jinja template", e);
-      throw new TemplateRenderException(new Error()
-        .withMessage("failed rendering jinja template")
-        .withCause(e.getMessage())
-        .withLocation(context.getLocation())
+
+      throw TemplateRenderException.fromError(
+        new Error()
+          .withMessage("failed rendering jinja template")
+          .withLocation(context.getLocation()),
+        e
       );
     }
 
@@ -80,11 +95,19 @@ public class JinjaRenderer implements Renderer {
 
   @Override
   public Object renderGraph(String template, RenderContext context) {
-    // TODO rz - Need to catch exceptions out of this value converter & give more detailed information if it's a nested
-    // value. For example, if iterating over module output, the line number reported by yamlsnake will be for the final
-    // template, not the input, so it's difficult to correlate what actually is broken.
     String renderedValue = render(template, context);
-    return renderedValueConverter.convertRenderedValue(renderedValue);
+    try {
+      return renderedValueConverter.convertRenderedValue(renderedValue);
+    } catch (ParserException e) {
+      throw TemplateRenderException.fromError(
+        new Error()
+          .withMessage("Failed converting rendered value to YAML")
+          .withLocation(context.getLocation())
+          .withDetail("source", template)
+          .withCause(e.getMessage()),
+        e
+      );
+    }
   }
 
   private static class NoopResourceLocator implements ResourceLocator {
@@ -93,4 +116,46 @@ public class JinjaRenderer implements Renderer {
       return null;
     }
   }
+
+  private static Errors unwrapJinjaTemplateErrorException(FatalTemplateErrorsException e, String location) {
+    Errors errors = new Errors();
+    for (TemplateError templateError : e.getErrors()) {
+      if (templateError.getException() instanceof TemplateRenderException) {
+        TemplateRenderException tre = (TemplateRenderException) templateError.getException();
+        errors.addAll(tre.getErrors());
+        continue;
+      }
+
+      Error error = new Error()
+        .withMessage(templateError.getMessage())
+        .withSeverity(templateError.getSeverity().equals(ErrorType.FATAL) ? Severity.FATAL : Severity.WARN)
+        .withLocation(location);
+      errors.add(error);
+
+      if (templateError.getReason() != ErrorReason.OTHER) {
+        error.withDetail("reason", templateError.getReason().name());
+      }
+      if (templateError.getItem() != ErrorItem.OTHER) {
+        error.withDetail("item", templateError.getItem().name());
+      }
+      if (templateError.getFieldName() != null) {
+        error.withDetail("fieldName", templateError.getFieldName());
+      }
+      if (templateError.getLineno() > 0) {
+        error.withDetail("lineno", Integer.toString(templateError.getLineno()));
+      }
+      if (templateError.getCategory() != BasicTemplateErrorCategory.UNKNOWN) {
+        error.withDetail("category", templateError.getCategory().toString());
+        templateError.getCategoryErrors().forEach((s, s2) -> error.withDetail("categoryError:" + s, s2));
+      }
+
+      // This gross little bit is necessary for bubbling up any errors that
+      // might've occurred while rendering a nested module.
+      if (templateError.getException() != null && templateError.getException().getCause() instanceof TemplateRenderException) {
+        error.withNested(((TemplateRenderException) templateError.getException().getCause()).getErrors());
+      }
+    }
+    return errors;
+  }
+
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/RenderUtil.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/RenderUtil.java
@@ -16,7 +16,7 @@
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render;
 
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
-import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,10 +36,11 @@ public class RenderUtil {
   @SuppressWarnings("unchecked")
   private static Object deepRender(Renderer renderer, Object obj, RenderContext context, int depth) {
     if (depth >= MAX_RENDER_DEPTH) {
-      throw new TemplateRenderException(new Errors.Error()
-        .withMessage(String.format("Cannot exceed %d levels of depth in handlebars rendering", MAX_RENDER_DEPTH))
-        .withSuggestion("Try breaking up your templates into smaller, more reusable chunks via modules")
-        .withLocation(context.getLocation())
+      throw TemplateRenderException.fromError(
+        new Error()
+          .withMessage(String.format("Cannot exceed %d levels of depth in handlebars rendering", MAX_RENDER_DEPTH))
+          .withSuggestion("Try breaking up your templates into smaller, more reusable chunks via modules")
+          .withLocation(context.getLocation())
       );
     }
 
@@ -73,11 +74,12 @@ public class RenderUtil {
       return objMap;
     }
 
-    throw new TemplateRenderException(new Errors.Error()
-      .withMessage("Unknown rendered type, cannot continue render of template")
-      .withCause("Unhandled type: " + obj.getClass().getSimpleName())
-      .withSuggestion("Expected types: primitives, collections and maps")
-      .withLocation(context.getLocation())
+    throw TemplateRenderException.fromError(
+      new Error()
+        .withMessage("Unknown rendered type, cannot continue")
+        .withCause("Unhandled type: " + obj.getClass().getSimpleName())
+        .withSuggestion("Expected types: primitives, collections and maps")
+        .withLocation(context.getLocation())
     );
   }
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1SchemaValidationHelper.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1SchemaValidationHelper.java
@@ -27,21 +27,21 @@ public class V1SchemaValidationHelper {
   static void validateStageDefinitions(List<StageDefinition> stageDefinitions, Errors errors, Function<String, String> locationFormatter) {
     stageDefinitions.forEach(stageDefinition -> {
       if (stageDefinition.getId() == null) {
-        errors.addError(new Error()
+        errors.add(new Error()
           .withMessage("Stage ID is unset")
           .withLocation(locationFormatter.apply("stages"))
         );
       }
 
       if (stageDefinition.getType() == null) {
-        errors.addError(new Error()
+        errors.add(new Error()
           .withMessage("Stage is missing type")
           .withLocation(locationFormatter.apply("stages." + stageDefinition.getId()))
         );
       }
 
       if (stageDefinition.getConfig() == null) {
-        errors.addError(new Error()
+        errors.add(new Error()
           .withMessage("Stage configuration is unset")
           .withLocation(locationFormatter.apply("stages." + stageDefinition.getId()))
         );
@@ -49,14 +49,14 @@ public class V1SchemaValidationHelper {
 
       if (stageDefinition.getDependsOn() != null && !stageDefinition.getDependsOn().isEmpty() &&
         stageDefinition.getInject() != null && stageDefinition.getInject().hasAny()) {
-        errors.addError(new Error()
+        errors.add(new Error()
           .withMessage("A stage cannot have both dependsOn and an inject rule defined simultaneously")
           .withLocation(locationFormatter.apply("stages." + stageDefinition.getId()))
         );
       }
 
       if (stageDefinition.getInject() != null && stageDefinition.getInject().hasMany()) {
-        errors.addError(new Error()
+        errors.add(new Error()
           .withMessage("A stage cannot have multiple inject rules defined")
           .withLocation(locationFormatter.apply("stages." + stageDefinition.getId()))
         );

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateConfigurationSchemaValidator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateConfigurationSchemaValidator.java
@@ -41,19 +41,19 @@ public class V1TemplateConfigurationSchemaValidator implements SchemaValidator {
     TemplateConfiguration config = (TemplateConfiguration) configuration;
 
     if (!SUPPORTED_VERSION.equals(config.getSchemaVersion())) {
-      errors.addError(new Error()
+      errors.add(new Error()
         .withMessage("config schema version is unsupported: expected '" + SUPPORTED_VERSION + "', got '" + config.getSchemaVersion() + "'"));
     }
 
     PipelineDefinition pipelineDefinition = config.getPipeline();
     if (pipelineDefinition == null) {
-      errors.addError(new Error()
+      errors.add(new Error()
         .withMessage("Missing pipeline configuration")
         .withLocation(location("pipeline"))
       );
     } else {
       if (pipelineDefinition.getApplication() == null) {
-        errors.addError(new Error()
+        errors.add(new Error()
           .withMessage("Missing 'application' pipeline configuration")
           .withLocation(location("pipeline.application"))
         );
@@ -64,7 +64,7 @@ public class V1TemplateConfigurationSchemaValidator implements SchemaValidator {
 
     config.getStages().forEach(s -> {
       if ((s.getDependsOn() == null || s.getDependsOn().isEmpty()) && (s.getInject() == null || !s.getInject().hasAny())) {
-        errors.addError(new Error()
+        errors.add(new Error()
           .withMessage("A configuration-defined stage should have either dependsOn or an inject rule defined")
           .withLocation(location(String.format("stages.%s", s.getId())))
           .withSeverity(Severity.WARN));

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateSchemaValidator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateSchemaValidator.java
@@ -35,12 +35,12 @@ public class V1TemplateSchemaValidator<T extends SchemaValidatorContext> impleme
     PipelineTemplate template = (PipelineTemplate) pipelineTemplate;
 
     if (!SUPPORTED_VERSION.equals(template.getSchemaVersion())) {
-      errors.addError(new Error()
+      errors.add(new Error()
         .withMessage("template schema version is unsupported: expected '" + SUPPORTED_VERSION + "', got '" + template.getSchemaVersion() + "'"));
     }
 
     if (template.getProtect() && context.configHasStages) {
-      errors.addError(new Error()
+      errors.add(new Error()
         .withMessage("Modification of the stage graph (adding, removing, editing) is disallowed")
         .withCause("The template being used has marked itself as protected")
       );

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/StageInheritanceControlTransformSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/StageInheritanceControlTransformSpec.groovy
@@ -16,7 +16,7 @@
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform
 
 import com.jayway.jsonpath.PathNotFoundException
-import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.IllegalTemplateConfigurationException
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinition
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinition.InheritanceControl.Rule
@@ -83,7 +83,7 @@ class StageInheritanceControlTransformSpec extends Specification {
     subject.visitPipelineTemplate(template)
 
     then:
-    thrown(TemplateRenderException)
+    thrown(IllegalTemplateConfigurationException)
 
     where:
     path        | value
@@ -172,7 +172,7 @@ class StageInheritanceControlTransformSpec extends Specification {
     subject.visitPipelineTemplate(template)
 
     then:
-    thrown(TemplateRenderException)
+    thrown(IllegalTemplateConfigurationException)
 
     where:
     path        | value


### PR DESCRIPTION
Refactoring error handling in pipeline templates to correctly propagate causes.
In some cases, especially around modules, context was not being provided for
what the actual error was:

```json
{
  "message": "Pipeline template is invalid",
  "status": "BAD_REQUEST",
  "errors": [
    {
      "severity": "FATAL",
      "location": "template:stages.wait",
      "message": "Failed rendering stage"
    }
  ]
}
```

With these changes, errors now include details as well as nested errors, which 
gives a clearer picture of what the problem is:

```json
{
  "message": "Pipeline template is invalid",
  "status": "BAD_REQUEST",
  "errors": [
    {
      "severity": "FATAL",
      "location": "template:stages.wait",
      "message": "Failed rendering stage",
      "nestedErrors": [
        {
          "severity": "FATAL",
          "location": "template:stages.wait",
          "details": {
            "reason": "SYNTAX_ERROR",
            "lineno": "1"
          },
          "message": "InterpretException: Error rendering tag",
          "nestedErrors": [
            {
              "severity": "FATAL",
              "cause": "while parsing a flow mapping\n in 'string', line 1, column 2:\n    {{ foo\n     ^\nexpected ',' or '}', but got StreamEnd\n in 'string', line 1, column 7:\n    {{ foo\n          ^\n",
              "location": "module:myModule",
              "details": {
                "source": "{{ foo"
              },
              "message": "Failed converting rendered value to YAML"
            }
          ]
        }
      ]
    }
  ]
}
```

This specific example was created with the following invalid template: 

```yaml
schema: "1"
id: brokenModule
variables: []
stages:
- id: wait
  type: wait
  config:
    blah: "{% module myModule %}"

modules:
- id: myModule
  variables: []
  definition: |
    waitTime: "{{ foo"
```

I've also updated quite a few exceptions to use the `Errors` class to provide
better context in various error conditions.
