### PR TITLE
fix(aws/cloneServerGroup): prefer region when configuring allowLaunch…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CloneServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CloneServerGroupTask.groovy
@@ -86,11 +86,13 @@ class CloneServerGroupTask extends AbstractCloudProviderAwareTask implements Tas
 
     List<Map<String, Object>> descriptions = []
     // NFLX bakes images in their test account. This rigmarole is to allow the prod account access to that image.
+    Collection<String> targetRegions = operation.region ? [operation.region] :
+      operation.availabilityZones ? operation.availabilityZones.keySet() : []
     if (getCloudProvider(operation) == "aws" && // the operation is a clone of stage.context.
         operation.credentials != defaultBakeAccount &&
-        operation.availabilityZones &&
+        targetRegions &&
         operation.amiName) {
-      def allowLaunchDescriptions = operation.availabilityZones.collect { String region, List<String> azs ->
+      def allowLaunchDescriptions = targetRegions.collect { String region ->
         [
           allowLaunchDescription: [
             account    : operation.credentials,

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CloneServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CloneServerGroupTaskSpec.groovy
@@ -226,4 +226,26 @@ class CloneServerGroupTaskSpec extends Specification {
     where:
     contextAmi = "ami-ctx"
   }
+
+  def "favors 'region' to 'availabilityZones' when adding allowLaunch"() {
+    given:
+    stage.context.amiName = "ami-123"
+    stage.context.region = "eu-west-1"
+
+    def operations
+    task.kato = Mock(KatoService) {
+      1 * requestOperations(_, _) >> {
+        operations = it[1]
+        Observable.from(taskId)
+      }
+    }
+
+    when:
+    task.execute(stage)
+
+    then:
+    operations.size() == 2
+    operations[0].allowLaunchDescription.region == "eu-west-1"
+
+  }
 }


### PR DESCRIPTION
… in clone stage

The pipeline CloneServerGroup stage does not supply regions in an `availabilityZones` map - it just supplies a `region` field, which means the current code does not perform any `allowLaunch`es.

@spinnaker/netflix-reviewers PTAL