### PR TITLE
chore(aws): remove no longer used amiId

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageFinder.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageFinder.java
@@ -127,7 +127,6 @@ public class AmazonImageFinder implements ImageFinder {
       put("imageId", imageId);
 
       put("ami", imageId);
-      put("amiId", imageId);
 
       put("region", region);
 


### PR DESCRIPTION
* remove no longer used `amiId` property from `deploymentDetails` map on
the stage context for AWS.  this is cleanup as a result of the
discussion in #1264.
