### PR TITLE
fix(expressions) - restrict expressions

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/pipeline/DeploymentStrategiesExecutionSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/pipeline/DeploymentStrategiesExecutionSpec.groovy
@@ -40,6 +40,7 @@ import com.netflix.spinnaker.orca.pipeline.parallel.WaitForRequisiteCompletionSt
 import com.netflix.spinnaker.orca.pipeline.parallel.WaitForRequisiteCompletionTask
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.tasks.NoOpTask
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.test.batch.BatchTestConfiguration
 import groovy.transform.CompileStatic
@@ -258,6 +259,11 @@ abstract class DeploymentStrategiesExecutionSpec<R extends ExecutionRunner> exte
     @Bean
     FactoryBean<ExecutionRunnerSpec.TestTask> testTask() {
       new SpockMockFactoryBean(ExecutionRunnerSpec.TestTask)
+    }
+
+    @Bean
+    ContextParameterProcessor contextParameterProcessor() {
+      new ContextParameterProcessor()
     }
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -20,9 +20,13 @@ import com.netflix.spinnaker.orca.pipeline.PipelineStarterListener;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.orca.pipeline.persistence.PipelineStack;
 import com.netflix.spinnaker.orca.pipeline.persistence.memory.InMemoryPipelineStack;
+import com.netflix.spinnaker.orca.pipeline.util.ContextFunctionConfiguration;
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -45,7 +49,7 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
   "com.netflix.spinnaker.orca.restart",
   "com.netflix.spinnaker.orca.deprecation"
 })
-
+@EnableConfigurationProperties
 public class OrcaConfiguration {
   @Bean public Clock clock() {
     return Clock.systemDefaultZone();
@@ -96,6 +100,17 @@ public class OrcaConfiguration {
   @Bean
   public StageNavigator stageNavigator(ApplicationContext applicationContext) {
     return new StageNavigator(applicationContext);
+  }
+
+  @Bean
+  @ConfigurationProperties("expressions")
+  public ContextFunctionConfiguration contextFunctionConfiguration() {
+    return new ContextFunctionConfiguration();
+  }
+
+  @Bean
+  public ContextParameterProcessor contextParameterProcessor(ContextFunctionConfiguration contextFunctionConfiguration) {
+    return new ContextParameterProcessor(contextFunctionConfiguration);
   }
 
   // TODO: this is a weird place to have this, feels like it should be a bean configurer or something

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/tasks/ExpressionPreconditionTask.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/tasks/ExpressionPreconditionTask.groovy
@@ -21,18 +21,26 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
 class ExpressionPreconditionTask implements PreconditionTask {
   final String preconditionType = 'expression'
 
+  final ContextParameterProcessor contextParameterProcessor
+
+  @Autowired
+  ExpressionPreconditionTask(ContextParameterProcessor contextParameterProcessor) {
+    this.contextParameterProcessor = contextParameterProcessor
+  }
+
   @Override
   TaskResult execute(Stage stage) {
     def stageData = stage.mapTo("/context", StageData)
-    String expression = ContextParameterProcessor.process([
+    String expression = contextParameterProcessor.process([
         "expression": '${' + stageData.expression + '}'
-    ], ContextParameterProcessor.buildExecutionContext(stage, true), true).expression
+    ], contextParameterProcessor.buildExecutionContext(stage, true), true).expression
 
     def matcher = expression =~ /\$\{(.*)\}/
     if (matcher.matches()) {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupportSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupportSpec.groovy
@@ -18,10 +18,15 @@
 package com.netflix.spinnaker.orca.pipeline.model
 
 import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class OptionalStageSupportSpec extends Specification {
+
+  @Shared ContextParameterProcessor contextParameterProcessor = new ContextParameterProcessor()
+
   @Unroll
   def "should support expression-based optionality"() {
     given:
@@ -41,7 +46,7 @@ class OptionalStageSupportSpec extends Specification {
     ])
 
     expect:
-    OptionalStageSupport.isOptional(stage) == expectedOptionality
+    OptionalStageSupport.isOptional(stage, contextParameterProcessor) == expectedOptionality
 
     where:
     optionalConfig                                                                                                   || expectedOptionality
@@ -75,7 +80,7 @@ class OptionalStageSupportSpec extends Specification {
     pipeline.stages[1].parentStageId = pipeline.stages[0].id
 
     expect:
-    OptionalStageSupport.isOptional(pipeline.stages[1]) == expectedOptionality
+    OptionalStageSupport.isOptional(pipeline.stages[1], contextParameterProcessor) == expectedOptionality
 
     where:
     optionalConfig                                            || expectedOptionality

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/ExpressionPreconditionTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/ExpressionPreconditionTaskSpec.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.orca.pipeline.tasks
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -27,7 +28,7 @@ class ExpressionPreconditionTaskSpec extends Specification {
   @Unroll
   def "should evaluate expression precondition against stage context at execution time"() {
     given:
-    def task = new ExpressionPreconditionTask()
+    def task = new ExpressionPreconditionTask(new ContextParameterProcessor())
     def stage = new Stage<>(new Pipeline(), "Expression", [
       param1 : param1,
       context: [

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/restart/RollingRestartSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/restart/RollingRestartSpec.groovy
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.orca.pipeline.parallel.WaitForRequisiteCompletionSt
 import com.netflix.spinnaker.orca.pipeline.parallel.WaitForRequisiteCompletionTask
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.tasks.NoOpTask
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.test.JobCompletionListener
 import com.netflix.spinnaker.orca.test.batch.BatchTestConfiguration
@@ -168,6 +169,11 @@ class RollingRestartSpec extends Specification {
     @Bean
     ObjectMapper objectMapper() {
       OrcaObjectMapper.newInstance()
+    }
+
+    @Bean
+    ContextParameterProcessor contextParameterProcessor() {
+      new ContextParameterProcessor()
     }
   }
 }

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.echo.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import groovy.transform.CompileStatic
 import com.netflix.spinnaker.orca.echo.EchoService
 import com.netflix.spinnaker.orca.echo.spring.EchoNotifyingExecutionListener
@@ -74,7 +75,8 @@ class EchoConfiguration {
   @Bean
   EchoNotifyingExecutionListener echoNotifyingPipelineExecutionListener(EchoService echoService,
                                                                         Front50Service front50Service,
-                                                                        ObjectMapper objectMapper) {
-    new EchoNotifyingExecutionListener(echoService, front50Service, objectMapper)
+                                                                        ObjectMapper objectMapper,
+                                                                        ContextParameterProcessor contextParameterProcessor) {
+    new EchoNotifyingExecutionListener(echoService, front50Service, objectMapper, contextParameterProcessor)
   }
 }

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
@@ -24,10 +24,13 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
 
   private final ObjectMapper objectMapper
 
-  EchoNotifyingExecutionListener(EchoService echoService, Front50Service front50Service, ObjectMapper objectMapper) {
+  private final ContextParameterProcessor contextParameterProcessor
+
+  EchoNotifyingExecutionListener(EchoService echoService, Front50Service front50Service, ObjectMapper objectMapper, ContextParameterProcessor contextParameterProcessor) {
     this.echoService = echoService
     this.front50Service = front50Service
     this.objectMapper = objectMapper
+    this.contextParameterProcessor = contextParameterProcessor
   }
 
   @Override
@@ -96,7 +99,7 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
       notifications.getPipelineNotifications().each { appNotification ->
         Map executionMap = objectMapper.convertValue(pipeline, Map)
 
-        appNotification = ContextParameterProcessor.process(appNotification, executionMap, false)
+        appNotification = contextParameterProcessor.process(appNotification, executionMap, false)
 
         Map<String, Object> targetMatch = pipeline.notifications.find { pipelineNotification ->
           pipelineNotification.address == appNotification.address && pipelineNotification.type == appNotification.type

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoEventIntegrationSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoEventIntegrationSpec.groovy
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.orca.pipeline.parallel.WaitForRequisiteCompletionSt
 import com.netflix.spinnaker.orca.pipeline.parallel.WaitForRequisiteCompletionTask
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.tasks.NoOpTask
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.test.batch.BatchTestConfiguration
 import groovy.transform.CompileStatic
@@ -196,12 +197,17 @@ abstract class EchoEventIntegrationSpec<R extends ExecutionRunner> extends Speci
     }
 
     @Bean
-    EchoNotifyingExecutionListener echoNotifyingExecutionListener(EchoService echoService, Front50Service front50Service) {
-      new EchoNotifyingExecutionListener(echoService, front50Service, new ObjectMapper())
+    EchoNotifyingExecutionListener echoNotifyingExecutionListener(EchoService echoService, Front50Service front50Service, ContextParameterProcessor contextParameterProcessor) {
+      new EchoNotifyingExecutionListener(echoService, front50Service, new ObjectMapper(), contextParameterProcessor)
     }
 
     @Bean
     TestTask testTask() { mockFactory.Stub(TestTask) }
+
+    @Bean
+    ContextParameterProcessor contextParameterProcessor() {
+      new ContextParameterProcessor()
+    }
   }
 }
 

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListenerSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListenerSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.front50.model.ApplicationNotifications
 import com.netflix.spinnaker.orca.front50.model.ApplicationNotifications.Notification
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -33,8 +34,10 @@ class EchoNotifyingExecutionListenerSpec extends Specification {
   def front50Service = Mock(Front50Service)
   def objectMapper = new ObjectMapper()
 
+  @Shared ContextParameterProcessor contextParameterProcessor = new ContextParameterProcessor()
+
   @Subject
-  def echoListener = new EchoNotifyingExecutionListener(echoService, front50Service, objectMapper)
+  def echoListener = new EchoNotifyingExecutionListener(echoService, front50Service, objectMapper, contextParameterProcessor)
 
   @Shared
   ApplicationNotifications notifications = new ApplicationNotifications()

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -38,6 +38,9 @@ class DependentPipelineStarter implements ApplicationContextAware {
   @Autowired
   ObjectMapper objectMapper
 
+  @Autowired
+  ContextParameterProcessor contextParameterProcessor
+
   Pipeline trigger(Map pipelineConfig, String user, Execution parentPipeline, Map suppliedParameters, String parentPipelineStageId) {
     def json = objectMapper.writeValueAsString(pipelineConfig)
     log.info('triggering dependent pipeline {}:{}', pipelineConfig.id, json)
@@ -77,7 +80,7 @@ class DependentPipelineStarter implements ApplicationContextAware {
     }
 
     def augmentedContext = [trigger: pipelineConfig.trigger]
-    def processedPipeline = ContextParameterProcessor.process(pipelineConfig, augmentedContext, false)
+    def processedPipeline = contextParameterProcessor.process(pipelineConfig, augmentedContext, false)
 
     json = objectMapper.writeValueAsString(processedPipeline)
 

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.pipeline.PipelineLauncher
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import org.slf4j.MDC
 import org.springframework.context.support.StaticApplicationContext
@@ -59,7 +60,8 @@ class DependentPipelineStarterSpec extends Specification {
     ]
     dependentPipelineStarter = new DependentPipelineStarter(
       objectMapper: mapper,
-      applicationContext: applicationContext
+      applicationContext: applicationContext,
+      contextParameterProcessor: new ContextParameterProcessor()
     )
 
     when:
@@ -100,7 +102,8 @@ class DependentPipelineStarterSpec extends Specification {
     applicationContext.beanFactory.registerSingleton("pipelineLauncher", executionLauncher)
     dependentPipelineStarter = new DependentPipelineStarter(
       objectMapper: mapper,
-      applicationContext: applicationContext
+      applicationContext: applicationContext,
+      contextParameterProcessor: new ContextParameterProcessor()
     )
 
     when:

--- a/orca-spring-batch/src/main/groovy/com/netflix/spinnaker/config/SpringBatchConfiguration.java
+++ b/orca-spring-batch/src/main/groovy/com/netflix/spinnaker/config/SpringBatchConfiguration.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.orca.config.OrcaConfiguration;
 import com.netflix.spinnaker.orca.pipeline.ExecutionRunner;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator;
 import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.configuration.ListableJobLocator;
@@ -110,7 +111,8 @@ public class SpringBatchConfiguration {
   TaskTaskletAdapter taskTaskletAdapter(ExecutionRepository executionRepository,
                                         List<ExceptionHandler> exceptionHandlers,
                                         StageNavigator stageNavigator,
+                                        ContextParameterProcessor contextParameterProcessor,
                                         Registry registry) {
-    return new TaskTaskletAdapterImpl(executionRepository, exceptionHandlers, stageNavigator, registry);
+    return new TaskTaskletAdapterImpl(executionRepository, exceptionHandlers, stageNavigator, contextParameterProcessor, registry);
   }
 }

--- a/orca-spring-batch/src/main/groovy/com/netflix/spinnaker/orca/batch/RetryableTaskTasklet.groovy
+++ b/orca-spring-batch/src/main/groovy/com/netflix/spinnaker/orca/batch/RetryableTaskTasklet.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.orca.batch.retry.PollRequiresRetry
 import com.netflix.spinnaker.orca.pipeline.model.Execution.PausedDetails
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import groovy.transform.CompileStatic
 import org.joda.time.Duration
@@ -49,8 +50,9 @@ class RetryableTaskTasklet extends TaskTasklet {
                        List<ExceptionHandler> exceptionHandlers,
                        Registry registry,
                        StageNavigator stageNavigator,
+                       ContextParameterProcessor contextParameterProcessor,
                        Clock clock = Clock.systemUTC()) {
-    super(task, executionRepository, exceptionHandlers, registry, stageNavigator)
+    super(task, executionRepository, exceptionHandlers, registry, stageNavigator, contextParameterProcessor)
     this.clock = clock
     this.timeoutMs = task.timeout
   }

--- a/orca-spring-batch/src/test/groovy/com/netflix/spinnaker/orca/batch/ExecutionContextManagerSpec.groovy
+++ b/orca-spring-batch/src/test/groovy/com/netflix/spinnaker/orca/batch/ExecutionContextManagerSpec.groovy
@@ -18,12 +18,16 @@ package com.netflix.spinnaker.orca.batch
 
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import org.springframework.batch.core.scope.context.ChunkContext
 import org.springframework.batch.core.scope.context.StepContext
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class ExecutionContextManagerSpec extends Specification {
+
+  @Shared ContextParameterProcessor contextParameterProcessor = new ContextParameterProcessor()
 
   @Unroll
   def "should not overwrite a local value with a global value"() {
@@ -43,7 +47,7 @@ class ExecutionContextManagerSpec extends Specification {
     }
 
     when:
-    ExecutionContextManager.retrieve(stage, chunkContext)
+    ExecutionContextManager.retrieve(stage, chunkContext, contextParameterProcessor)
 
     then:
     stage.context.execution == pipeline
@@ -74,7 +78,7 @@ class ExecutionContextManagerSpec extends Specification {
     }
 
     when:
-    ExecutionContextManager.retrieve(stage, chunkContext)
+    ExecutionContextManager.retrieve(stage, chunkContext, contextParameterProcessor)
 
     then:
     stage.context.key == expectedValue
@@ -102,7 +106,7 @@ class ExecutionContextManagerSpec extends Specification {
     }
 
     when:
-    ExecutionContextManager.retrieve(stage, chunkContext)
+    ExecutionContextManager.retrieve(stage, chunkContext, contextParameterProcessor)
     def contextCopy = [:] + stage.context
 
     then:

--- a/orca-spring-batch/src/test/groovy/com/netflix/spinnaker/orca/batch/adapters/RetryableTaskTaskletSpec.groovy
+++ b/orca-spring-batch/src/test/groovy/com/netflix/spinnaker/orca/batch/adapters/RetryableTaskTaskletSpec.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.orca.batch.adapters
 
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
+
 import java.time.Clock
 import java.time.Instant
 import com.netflix.spectator.api.NoopRegistry
@@ -64,7 +66,7 @@ class RetryableTaskTaskletSpec extends Specification {
 
     and:
     def stage = new Stage<>(new Pipeline(), null, stageContext)
-    def tasklet = new RetryableTaskTasklet(task, null, null, new NoopRegistry(), stageNavigator, clock)
+    def tasklet = new RetryableTaskTasklet(task, null, null, new NoopRegistry(), stageNavigator, new ContextParameterProcessor(), clock)
     stage.execution.paused = new Execution.PausedDetails(pauseTime: 0)
 
     when:
@@ -104,7 +106,7 @@ class RetryableTaskTaskletSpec extends Specification {
     stage.tasks << new DefaultTask(status: SUCCEEDED)
     stage.tasks << new DefaultTask(status: RUNNING)
     stage.execution.status = PAUSED
-    def tasklet = new RetryableTaskTasklet(task, null, null, new NoopRegistry(), stageNavigator, clock)
+    def tasklet = new RetryableTaskTasklet(task, null, null, new NoopRegistry(), stageNavigator, new ContextParameterProcessor(), clock)
 
     when:
     def taskResult = tasklet.doExecuteTask(stage, chunkContext)

--- a/orca-test/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSpec.groovy
+++ b/orca-test/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSpec.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.orca.pipeline
 
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
+
 import java.util.function.BiFunction
 import java.util.function.Consumer
 import com.netflix.spinnaker.orca.Task
@@ -1109,6 +1111,11 @@ abstract class ExecutionRunnerSpec<R extends ExecutionRunner> extends Specificat
     @Qualifier("executionListener")
     FactoryBean<ExecutionListener> executionListener() {
       new SpockMockFactoryBean(ExecutionListener)
+    }
+
+    @Bean
+    ContextParameterProcessor contextParameterProcessor() {
+      new ContextParameterProcessor()
     }
   }
 

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -53,6 +53,9 @@ class OperationsController {
   @Autowired
   ExecutionRepository executionRepository
 
+  @Autowired
+  ContextParameterProcessor contextParameterProcessor
+
   @Autowired(required = false)
   BuildArtifactFilter buildArtifactFilter
 
@@ -84,7 +87,7 @@ class OperationsController {
     }
 
     def augmentedContext = [trigger: pipeline.trigger]
-    def processedPipeline = ContextParameterProcessor.process(pipeline, augmentedContext, false)
+    def processedPipeline = contextParameterProcessor.process(pipeline, augmentedContext, false)
 
     if (plan) {
       log.info('not starting pipeline (plan: true): {}', pipeline.id)

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.orca.controllers
 
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
+
 import javax.servlet.http.HttpServletResponse
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.igor.BuildArtifactFilter
@@ -56,7 +58,8 @@ class OperationsControllerSpec extends Specification {
       buildService: buildService,
       buildArtifactFilter: buildArtifactFilter,
       executionRepository: executionRepository,
-      pipelineLauncher: pipelineLauncher
+      pipelineLauncher: pipelineLauncher,
+      contextParameterProcessor: new ContextParameterProcessor()
     )
 
   @Unroll


### PR DESCRIPTION
- whitelist which classes and methods can be used in pipeline expressions
- inject configuration into ContextParameterProcessor to enable whitelisting allowed
  URLs in the fromUrl function
