### PR TITLE
fix(expressions) - test case highlighting why classes should be explicitly whitelisted

### DIFF
--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
@@ -157,6 +157,21 @@ class ContextParameterProcessorSpec extends Specification {
 
   }
 
+  def "should not allow subtypes in expression allowed types"() {
+    given:
+    def source = ["test": sourceValue]
+    def context = [:]
+
+    when:
+    def result = contextParameterProcessor.process(source, context, true)
+
+    then:
+    result.test == sourceValue
+
+    where:
+    sourceValue = '${new rx.internal.util.RxThreadFactory("").newThread(null).getContextClassLoader().toString()}'
+  }
+
   def "should replace the keys in a map"() {
     given:
     def source = ['${replaceMe}': 'somevalue', '${replaceMe}again': ['cats': 'dogs']]


### PR DESCRIPTION
Adds a test case for the fix in efbc839ad4e48e3d6ad5325f22e0a8981d04f213 that highlights the danger of allowing unknown subtypes to be instantiated (rx.internal.util.RxThreadFactory extends AtomicLong extends Number)
