### PR TITLE
make sure synthetic stages don't get re-generated on restart

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSupport.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSupport.java
@@ -175,10 +175,12 @@ public abstract class ExecutionRunnerSupport implements ExecutionRunner {
     SyntheticStageOwner type
   ) {
     List<Stage<T>> stages = parent.getExecution().getStages();
-    int index = stages.indexOf(parent);
-    int offset = type == STAGE_BEFORE ? 0 : 1;
-    stages.add(index + offset, stage);
-    stage.setParentStageId(parent.getId());
+    if (stages.stream().filter(it -> it.getId().equals(stage.getId())).count() == 0) {
+      int index = stages.indexOf(parent);
+      int offset = type == STAGE_BEFORE ? 0 : 1;
+      stages.add(index + offset, stage);
+      stage.setParentStageId(parent.getId());
+    }
   }
 
   // TODO: change callback type to Consumer<TaskDefinition>

--- a/orca-spring-batch/src/main/groovy/com/netflix/spinnaker/orca/batch/SpringBatchExecutionRunner.java
+++ b/orca-spring-batch/src/main/groovy/com/netflix/spinnaker/orca/batch/SpringBatchExecutionRunner.java
@@ -284,9 +284,9 @@ public class SpringBatchExecutionRunner extends ExecutionRunnerSupport {
   }
 
   private <E extends Execution<E>> void buildStepsForFlow(Stage<E> stage, Map<Serializable, AtomicInteger> taskIdGenerators, FlowBuilder<Flow> flow) {
-    planBeforeOrAfterStages(stage, STAGE_BEFORE, (preStage) -> {
-      buildStepsForFlow(preStage, taskIdGenerators, flow);
-    });
+    planBeforeOrAfterStages(stage, STAGE_BEFORE, (preStage) ->
+      buildStepsForFlow(preStage, taskIdGenerators, flow)
+    );
     planStage(
       stage,
       (stages, taskGraph) -> {


### PR DESCRIPTION
This was partly masked by the fact that restarting on the same orca instance would use the same Spring Batch job so nothing got rebuilt at all. However, restarting on a new instance would duplicate all the synthetic and parallel stages.

 SPIN-2505
