### PR TITLE
feat(web): Adding resolve pipeline template endpoint

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate;
+
+import com.netflix.spinnaker.orca.pipelinetemplate.loader.TemplateLoader;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.TemplateMerge;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration.TemplateSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class PipelineTemplateService {
+
+  private final TemplateLoader templateLoader;
+
+  @Autowired
+  public PipelineTemplateService(TemplateLoader templateLoader) {
+    this.templateLoader = templateLoader;
+  }
+
+  public PipelineTemplate resolveTemplate(TemplateSource templateSource) {
+    List<PipelineTemplate> templates = templateLoader.load(templateSource);
+    return TemplateMerge.merge(templates);
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
@@ -70,7 +70,7 @@ public class PipelineTemplate implements VersionedSchema {
     private String name;
     private String group = "Ungrouped";
     private String description;
-    private String type;
+    private String type = "string";
     private Object defaultValue;
     private String example;
 

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/PipelineTemplateController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/PipelineTemplateController.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.controllers
+
+import com.netflix.spinnaker.orca.pipelinetemplate.PipelineTemplateService
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration.TemplateSource
+import groovy.transform.InheritConstructors
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@ConditionalOnProperty("pipelineTemplate.enabled")
+@RestController
+@Slf4j
+class PipelineTemplateController {
+
+  @Autowired
+  PipelineTemplateService pipelineTemplateService
+
+  @RequestMapping(value = "/pipelineTemplate", method = RequestMethod.GET)
+  PipelineTemplate getPipelineTemplate(@RequestParam("source") String source) {
+    if (source == null || source?.empty) {
+      throw new InvalidTemplateSourceException("template source must not be empty")
+    }
+
+    pipelineTemplateService.resolveTemplate(new TemplateSource(source: source))
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(InvalidTemplateSourceException)
+  Map invalidTemplateSourceHandler(InvalidTemplateSourceException e) {
+    return [message: e.message, status: HttpStatus.BAD_REQUEST]
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(TemplateLoaderException)
+  Map templateLoadingErrorHandler(TemplateLoaderException e) {
+    return [message: e.message, status: HttpStatus.BAD_REQUEST]
+  }
+
+  @InheritConstructors
+  static class InvalidTemplateSourceException extends RuntimeException {}
+}


### PR DESCRIPTION
Endpoint resolves & merges a template inheritance tree by source. This will be used to help Deck render variable bindings while configuring a pipeline template.

@spinnaker/reviewers PTAL