### PR TITLE
Task.implementing class becomes a String to avoid CNFE when deserializing

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSupport.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSupport.java
@@ -244,7 +244,7 @@ public abstract class ExecutionRunnerSupport implements ExecutionRunner {
     task.setId(taskId);
     task.setName(taskDef.getName());
     task.setStatus(NOT_STARTED);
-    task.setImplementingClass(taskDef.getImplementingClass());
+    task.setImplementingClass(taskDef.getImplementingClass().getName());
     if (isEnd) {
       switch (type) {
         case FULL:

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Task.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Task.java
@@ -26,7 +26,7 @@ import static com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED;
 @Data
 public class Task {
   String id;
-  Class<? extends com.netflix.spinnaker.orca.Task> implementingClass;
+  String implementingClass;
   String name;
   Long startTime;
   Long endTime;

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/restart/PipelineRestartingSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/restart/PipelineRestartingSpec.groovy
@@ -69,10 +69,10 @@ class PipelineRestartingSpec extends Specification {
     pipeline.stages[0].tasks << new TaskModel(
       id: 1, name: "task1", status: SUCCEEDED,
       startTime: currentTimeMillis(),
-      endTime: currentTimeMillis(), implementingClass: Task1)
+      endTime: currentTimeMillis(), implementingClass: Task1.name)
     pipeline.stages[0].tasks << new TaskModel(
       id: 2, name: "task2", status: RUNNING,
-      startTime: currentTimeMillis(), implementingClass: Task2)
+      startTime: currentTimeMillis(), implementingClass: Task2.name)
     repository.store(pipeline)
 
     when:

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/restart/RollingRestartSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/restart/RollingRestartSpec.groovy
@@ -77,7 +77,7 @@ class RollingRestartSpec extends Specification {
         startTime: currentTimeMillis(),
         endTime: currentTimeMillis(),
         loopStart: true,
-        implementingClass: StartTask)
+        implementingClass: StartTask.name)
       tasks << new TaskModel(
         id: 2,
         name: "end",
@@ -85,13 +85,13 @@ class RollingRestartSpec extends Specification {
         startTime: currentTimeMillis(),
         endTime: currentTimeMillis(),
         loopEnd: true,
-        implementingClass: EndTask)
+        implementingClass: EndTask.name)
       tasks << new TaskModel(
         id: 3,
         name: "final",
         status: NOT_STARTED,
         startTime: currentTimeMillis(),
-        implementingClass: FinalTask)
+        implementingClass: FinalTask.name)
     }
     repository.retrievePipeline(pipeline.id) >> pipeline
 


### PR DESCRIPTION
Previously deserializing old executions could blow up if someone renamed a Task implementation class. Now at least it will only prevent running a new execution. Still not ideal but having a bean name reference or whatever is just as prone to breakage and this solution doesn't require any data migration.