### PR TITLE
Pin `min` capacity to `desired` capacity when rolling back

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/CaptureSourceServerGroupCapacityStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/CaptureSourceServerGroupCapacityStage.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws
+
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.pipeline.TaskNode
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.stereotype.Component
+
+@Component
+class CaptureSourceServerGroupCapacityStage implements StageDefinitionBuilder {
+  @Override
+  <T extends Execution<T>> void taskGraph(Stage<T> stage, TaskNode.Builder builder) {
+    builder
+      .withTask("snapshotSourceServerGroup", CaptureSourceServerGroupCapacityTask)
+  }
+}
+

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/RollbackServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/RollbackServerGroupStage.groovy
@@ -18,6 +18,8 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ApplySourceServerGroupCapacityStage
+import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.CaptureSourceServerGroupCapacityStage
 import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.model.Execution
@@ -81,6 +83,14 @@ class RollbackServerGroupStage implements StageDefinitionBuilder {
     @JsonIgnore
     ResizeServerGroupStage resizeServerGroupStage
 
+    @Autowired
+    @JsonIgnore
+    CaptureSourceServerGroupCapacityStage captureSourceServerGroupCapacityStage
+
+    @Autowired
+    @JsonIgnore
+    ApplySourceServerGroupCapacityStage applySourceServerGroupCapacityStage
+
     @JsonIgnore
     def <T extends Execution<T>> List<Stage<T>> buildStages(Stage<T> parentStage) {
       def stages = []
@@ -91,14 +101,17 @@ class RollbackServerGroupStage implements StageDefinitionBuilder {
         parentStage.execution, enableServerGroupStage.type, "enable", enableServerGroupContext, parentStage, SyntheticStageOwner.STAGE_AFTER
       )
 
+      stages << buildCaptureSourceServerGroupCapacityStage(parentStage, parentStage.mapTo(ResizeStrategy.Source))
+
       Map resizeServerGroupContext = new HashMap(parentStage.context) + [
-        action : ResizeStrategy.ResizeAction.scale_to_server_group.toString(),
-        source : {
+        action            : ResizeStrategy.ResizeAction.scale_to_server_group.toString(),
+        source            : {
           def source = parentStage.mapTo(ResizeStrategy.Source)
           source.serverGroupName = rollbackServerGroupName
           return source
         }.call(),
-        asgName: restoreServerGroupName
+        asgName           : restoreServerGroupName,
+        pinMinimumCapacity: true
       ]
       stages << StageDefinitionBuilder.StageDefinitionBuilderSupport.newStage(
         parentStage.execution, resizeServerGroupStage.type, "resize", resizeServerGroupContext, parentStage, SyntheticStageOwner.STAGE_AFTER
@@ -110,7 +123,53 @@ class RollbackServerGroupStage implements StageDefinitionBuilder {
         parentStage.execution, disableServerGroupStage.type, "disable", disableServerGroupContext, parentStage, SyntheticStageOwner.STAGE_AFTER
       )
 
+      stages << buildApplySourceServerGroupCapacityStage(parentStage, parentStage.mapTo(ResizeStrategy.Source))
       return stages
     }
+
+    Stage buildCaptureSourceServerGroupCapacityStage(Stage parentStage,
+                                                     ResizeStrategy.Source source) {
+      Map captureSourceServerGroupCapacityContext = [
+        useSourceCapacity: true,
+        source           : [
+          asgName        : rollbackServerGroupName,
+          serverGroupName: rollbackServerGroupName,
+          region         : source.region,
+          account        : source.credentials,
+          cloudProvider  : source.cloudProvider
+        ]
+      ]
+      return StageDefinitionBuilder.StageDefinitionBuilderSupport.newStage(
+        parentStage.execution,
+        captureSourceServerGroupCapacityStage.type,
+        "snapshot",
+        captureSourceServerGroupCapacityContext,
+        parentStage,
+        SyntheticStageOwner.STAGE_AFTER
+      )
+    }
+
+    Stage buildApplySourceServerGroupCapacityStage(Stage parentStage,
+                                                   ResizeStrategy.Source source) {
+      Map applySourceServerGroupCapacityContext = [
+        credentials: source.credentials,
+        target     : [
+          asgName        : restoreServerGroupName,
+          serverGroupName: restoreServerGroupName,
+          region         : source.region,
+          account        : source.credentials,
+          cloudProvider  : source.cloudProvider
+        ]
+      ]
+      return StageDefinitionBuilder.StageDefinitionBuilderSupport.newStage(
+        parentStage.execution,
+        applySourceServerGroupCapacityStage.type,
+        "apply",
+        applySourceServerGroupCapacityContext,
+        parentStage,
+        SyntheticStageOwner.STAGE_AFTER
+      )
+    }
   }
+
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToServerGroupResizeStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToServerGroupResizeStrategySpec.groovy
@@ -68,13 +68,17 @@ class ScaleToServerGroupResizeStrategySpec extends Specification {
     thrown(IllegalStateException)
   }
 
-  def "should return source server group's capacity"() {
+  @Unroll
+  def "should return source server group capacity"() {
     given:
-    stage.context.source = [
-      credentials    : "test",
-      serverGroupName: "s-v001",
-      region         : "us-west-1",
-      cloudProvider  : "aws"
+    stage.context = [
+      source            : [
+        credentials    : "test",
+        serverGroupName: "s-v001",
+        region         : "us-west-1",
+        cloudProvider  : "aws"
+      ],
+      pinMinimumCapacity: pinMinimumCapacity
     ]
 
     when:
@@ -85,15 +89,21 @@ class ScaleToServerGroupResizeStrategySpec extends Specification {
       return Optional.of(new TargetServerGroup(
         capacity: [
           min    : 1,
-          max    : 2,
+          max    : 3,
           desired: 3
         ]
       ))
     }
 
-    capacity.min == 1
-    capacity.max == 2
+    capacity.min == expectedMinimumCapacity
+    capacity.max == 3
     capacity.desired == 3
+
+    where:
+    pinMinimumCapacity || expectedMinimumCapacity
+    null               || 1
+    false              || 1
+    true               || 3
   }
 
   @Unroll

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -197,7 +197,7 @@ public class Stage<T extends Execution<T>> implements Serializable {
    * Maps the stage's context to a typed object at a provided pointer. Uses
    * <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer</a> notation for determining the pointer's position
    */
-  <O> O mapTo(String pointer, Class<O> type) {
+  public <O> O mapTo(String pointer, Class<O> type) {
     try {
       return objectMapper.readValue(new TreeTraversingParser(getPointer(pointer != null ? pointer : "", contextToNode()), objectMapper), type);
     } catch (IOException e) {


### PR DESCRIPTION
This prevents the target server group from unnecessarily scaling down
and causing the rollback to timeout / take far longer than expected.

`min` capacity is restored when the rollback is complete.