### PR TITLE
refactor(applications): remove accounts field from create/update…

### DIFF
--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTask.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTask.groovy
@@ -24,24 +24,21 @@ import retrofit.RetrofitError
 @Component
 class DeleteApplicationTask extends AbstractFront50Task {
   @Override
-  Map<String, Object> performRequest(String account, Application application) {
+  Map<String, Object> performRequest(Application application) {
     Map<String, Object> outputs = [:]
-
-    boolean deletePermission
 
     try {
       def existingApplication = front50Service.get(application.name)
       if (existingApplication) {
         outputs.previousState = existingApplication
-
-        existingApplication.updateAccounts(existingApplication.listAccounts() - account)
-        if (existingApplication.listAccounts()) {
-          // application still exists in at least one other account, do not delete.
-          front50Service.update(application.name, existingApplication)
-        } else {
-          // application is not associated with any accounts, delete.
-          front50Service.delete(application.name)
-          deletePermission = true
+        front50Service.delete(application.name)
+        try {
+          front50Service.deletePermission(application.name)
+        } catch (RetrofitError re) {
+          if (re.response.status == 404) {
+            return [:]
+          }
+          throw re
         }
       }
     } catch (RetrofitError e) {
@@ -50,18 +47,6 @@ class DeleteApplicationTask extends AbstractFront50Task {
       }
       throw e
     }
-
-    if (deletePermission) {
-      try {
-        front50Service.deletePermission(application.name)
-      } catch (RetrofitError re) {
-        if (re.response.status == 404) {
-          return [:]
-        }
-        throw re
-      }
-    }
-
     return outputs
   }
 

--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/UpsertApplicationTask.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/UpsertApplicationTask.groovy
@@ -28,7 +28,7 @@ import retrofit.RetrofitError
 @CompileStatic
 class UpsertApplicationTask extends AbstractFront50Task {
   @Override
-  Map<String, Object> performRequest(String account, Application application) {
+  Map<String, Object> performRequest(Application application) {
     Map<String, Object> outputs = [:]
     outputs.previousState = [:]
 
@@ -39,16 +39,9 @@ class UpsertApplicationTask extends AbstractFront50Task {
     def existingApplication = fetchApplication(application.name)
     if (existingApplication) {
       outputs.previousState = existingApplication
-
-      if (!application.accounts) {
-        application.updateAccounts((existingApplication.listAccounts() << account) as Set)
-      }
-
       log.info("Updating application (name: ${application.name})")
       front50Service.update(application.name, application)
     } else {
-      application.updateAccounts((application.listAccounts() << account) as Set)
-
       log.info("Creating application (name: ${application.name})")
       front50Service.create(application)
     }

--- a/orca-applications/src/test/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTaskSpec.groovy
+++ b/orca-applications/src/test/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTaskSpec.groovy
@@ -40,7 +40,7 @@ class DeleteApplicationTaskSpec extends Specification {
   void "should delete global application if it was only associated with a single account"() {
     given:
     task.front50Service = Mock(Front50Service) {
-      1 * get(config.application.name) >> new Application(accounts: "test")
+      1 * get(config.application.name) >> new Application()
       1 * delete(config.application.name)
       1 * deletePermission(config.application.name)
       0 * _._
@@ -53,24 +53,9 @@ class DeleteApplicationTaskSpec extends Specification {
     taskResult.status == ExecutionStatus.SUCCEEDED
   }
 
-  void "should de-associate global application if it was associated with multiple accounts"() {
-    given:
-    task.front50Service = Mock(Front50Service) {
-      1 * get(config.application.name) >> new Application(name: "application", accounts: "prod,test")
-      1 * update("application", { it.accounts == "prod" })
-      0 * _._
-    }
-
-    when:
-    def taskResult = task.execute(new Stage<>(new Pipeline(), "DeleteApplication", config))
-
-    then:
-    taskResult.status == ExecutionStatus.SUCCEEDED
-  }
-
   void "should keep track of previous state"() {
     given:
-    Application application = new Application(accounts: "test")
+    Application application = new Application()
     task.front50Service = Mock(Front50Service) {
       1 * get(config.application.name) >> application
       1 * delete(config.application.name)

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/model/Application.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/model/Application.groovy
@@ -27,11 +27,10 @@ import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 
 @Canonical
-public class Application {
+class Application {
   public String name
   public String description
   public String email
-  public String accounts
   public String updateTs
   public String createTs
   public Boolean platformHealthOnly
@@ -62,19 +61,6 @@ public class Application {
   @JsonAnySetter
   public void set(String name, Object value) {
     details.put(name, value)
-  }
-
-  @JsonIgnore
-  Set<String> listAccounts() {
-    if (!accounts?.trim()) {
-      return []
-    }
-    return accounts.split(",").collect { it.toLowerCase() } as Set<String>
-  }
-
-  @JsonIgnore
-  void updateAccounts(Set<String> accounts) {
-    this.accounts = accounts ? accounts.collect { it.trim().toLowerCase() }.join(",") : null
   }
 
   @JsonIgnore

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/AbstractFront50Task.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/AbstractFront50Task.groovy
@@ -34,7 +34,7 @@ abstract class AbstractFront50Task implements Task {
   @Autowired
   ObjectMapper mapper
 
-  abstract  Map<String, Object>  performRequest(String account, Application application)
+  abstract  Map<String, Object> performRequest(Application application)
   abstract String getNotificationType()
 
   @Override
@@ -47,12 +47,7 @@ abstract class AbstractFront50Task implements Task {
     if (stage.context.user){
       application.user = stage.context.user
     }
-    def account = (stage.context.account as String)?.toLowerCase()
-
     def missingInputs = []
-    if (!account) {
-      missingInputs << 'account'
-    }
 
     if (!application.name) {
       missingInputs << 'application.name'
@@ -65,12 +60,11 @@ abstract class AbstractFront50Task implements Task {
 
     def outputs = [
       "notification.type": getNotificationType(),
-      "application.name": application.name,
-      "account": account
+      "application.name": application.name
     ]
     def executionStatus = ExecutionStatus.SUCCEEDED
 
-    Map<String, Object> results = performRequest(account, application)
+    Map<String, Object> results = performRequest(application)
     return new TaskResult(executionStatus, outputs + (results ?: [:]))
   }
 

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/model/ApplicationSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/model/ApplicationSpec.groovy
@@ -24,38 +24,7 @@ import spock.lang.Unroll
 
 class ApplicationSpec extends Specification {
   @Subject
-  def application = new Application(accounts: "prod,test")
-
-  @Unroll
-  void "'#accounts' should expand to #expected"() {
-    setup:
-    application.accounts = accounts
-
-    expect:
-    application.listAccounts() == expected
-
-    where:
-    accounts    | expected
-    "prod,test" | ["prod", "test"] as Set
-    ""          | [] as Set
-    null        | [] as Set
-  }
-
-  @Unroll
-  void "#accounts should reduce to '#expected'"() {
-    setup:
-    application.updateAccounts(accounts as Set)
-
-    expect:
-    application.accounts == expected
-
-    where:
-    accounts                  | expected
-    ["prod", "test", "extra"] | "prod,test,extra"
-    ["prod"]                  | "prod"
-    []                        | null
-    null                      | null
-  }
+  def application = new Application()
 
   void 'dynamic properties should be marshalled at root of application'() {
     setup:
@@ -63,7 +32,6 @@ class ApplicationSpec extends Specification {
     application.someBoolean = true
     application.someMap = [ a: 'some string', b: 4 ]
     def expected = [
-        accounts: "prod,test",
         requiredGroupMembership: [],
         someBoolean: true,
         someMap: [a: 'some string', b: 4]


### PR DESCRIPTION
… application tasks

The `accounts` field on an application in Front50 has existed for legacy reasons but is no longer really useful, as far as we can tell. Gate will supply a valid list of accounts into which an application is deployed, which is a much more reliable indicator of which accounts an application exists.

If the field is still truly required for some other services, `accounts` can be supplied as a normal attribute to the application - just needs to be a comma-separated string. I would hope nobody is relying on that field.

(depends on a separate PR in Front50 and another in Deck)
