### PR TITLE
feat(pipelines): allow user-specified limit when fetching latest pipe…

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -151,10 +151,12 @@ class TaskController {
   @RequestMapping(value = "/pipelines", method = RequestMethod.GET)
   List<Pipeline> listLatestPipelines(
     @RequestParam(value = "pipelineConfigIds") String pipelineConfigIds,
+    @RequestParam(value = "limit", required = false) Integer limit,
     @RequestParam(value = "statuses", required = false) String statuses) {
     statuses = statuses ?: ExecutionStatus.values()*.toString().join(",")
+    limit = limit ?: 1
     def executionCriteria = new ExecutionRepository.ExecutionCriteria(
-      limit: 1,
+      limit: limit,
       statuses: (statuses.split(",") as Collection)
     )
 


### PR DESCRIPTION
…lines

Still defaulting to 1, but making it configurable so a user can get a list of recent pipeline runs for a particular pipeline config ID

@spinnaker/netflix-reviewers PTAL - part of some rework on the Fast Properties UI view