### PR TITLE
feat(pipelinetemplate): Support spinnaker-baked pipeline templates

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
-
-
 package com.netflix.spinnaker.orca.front50
 
 import com.netflix.spinnaker.orca.front50.model.Application
@@ -61,6 +57,18 @@ interface Front50Service {
 
   @GET("/pipelines?restricted=false")
   List<Map<String, Object>> getAllPipelines()
+
+  @GET("/pipelineTemplates")
+  List<Map<String, Object>> getPipelineTemplates(@Query("scopes") List<String> scopes)
+
+  @POST("/pipelineTemplates")
+  Response savePipelineTemplate(@Body Map pipelineTemplate)
+
+  @GET("/pipelineTemplates/{pipelineTemplateId}")
+  Map<String, Object> getPipelineTemplate(@Path("pipelineTemplateId") String pipelineTemplateId)
+
+  @PUT("/pipelineTemplates/{pipelineTemplateId}")
+  Response updatePipelineTemplate(@Path("pipelineTemplateId") String pipelieneTemplateId, @Body Map pipelineTemplate)
 
   @GET("/strategies")
   List<Map<String, Object>> getAllStrategies()

--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -2,6 +2,8 @@ tasks.compileGroovy.enabled = false
 
 dependencies {
   compile project(":orca-extensionpoint")
+  compile project(":orca-core")
+  compile project(":orca-front50")
 
   compile('com.hubspot.jinjava:jinjava:2.1.14')
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
@@ -30,7 +30,10 @@ import org.springframework.context.annotation.ComponentScan;
 import org.yaml.snakeyaml.Yaml;
 
 @ConditionalOnProperty("pipelineTemplate.enabled")
-@ComponentScan(basePackageClasses = PipelineTemplateModule.class)
+@ComponentScan(
+  basePackageClasses = PipelineTemplateModule.class,
+  basePackages = {"com.netflix.spinnaker.orca.pipelinetemplate.tasks", "com.netflix.spinnaker.orca.pipelinetemplate.pipeline"}
+)
 public class PipelineTemplateConfiguration {
 
   @Bean

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/Front50SchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/Front50SchemeLoader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.loader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.Map;
+
+@Component
+public class Front50SchemeLoader implements TemplateSchemeLoader {
+  private final Front50Service front50Service;
+
+  private final ObjectMapper objectMapper;
+
+  @Autowired
+  public Front50SchemeLoader(Front50Service front50Service, ObjectMapper pipelineTemplateObjectMapper) {
+    this.front50Service = front50Service;
+    this.objectMapper = pipelineTemplateObjectMapper;
+  }
+
+  @Override
+  public boolean supports(URI uri) {
+    String scheme = uri.getScheme();
+    return scheme.equalsIgnoreCase("spinnaker");
+  }
+
+  @Override
+  public PipelineTemplate load(URI uri) {
+    String id = uri.getHost();
+    try {
+      Map<String, Object> pipelineTemplate = front50Service.getPipelineTemplate(id);
+      return objectMapper.convertValue(pipelineTemplate, PipelineTemplate.class);
+    } catch (Exception e) {
+      throw new TemplateLoaderException(e);
+    }
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/CreatePipelineTemplateStage.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/CreatePipelineTemplateStage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.pipeline;
+
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode.Builder;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipelinetemplate.tasks.CreatePipelineTemplateTask;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CreatePipelineTemplateStage implements StageDefinitionBuilder {
+
+  @Override
+  public <T extends Execution<T>> void taskGraph(Stage<T> stage, Builder builder) {
+    builder
+      .withTask("createPipelineTemplate", CreatePipelineTemplateTask.class);
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/UpdatePipelineTemplateStage.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/UpdatePipelineTemplateStage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.pipeline;
+
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode.Builder;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipelinetemplate.tasks.UpdatePipelineTemplateTask;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpdatePipelineTemplateStage implements StageDefinitionBuilder {
+
+  @Override
+  public <T extends Execution<T>> void taskGraph(Stage<T> stage, Builder builder) {
+    builder
+      .withTask("updatePipelineTemplate", UpdatePipelineTemplateTask.class);
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/CreatePipelineTemplateTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/CreatePipelineTemplateTask.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class CreatePipelineTemplateTask implements RetryableTask {
+
+  @Autowired(required = false)
+  private Front50Service front50Service;
+
+  @Autowired
+  private ObjectMapper pipelineTemplateObjectMapper;
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public TaskResult execute(Stage stage) {
+    if (front50Service == null) {
+      throw new UnsupportedOperationException("Front50 is not enabled, no way to fetch pager duty. Fix this by setting front50.enabled: true");
+    }
+
+    if (!stage.getContext().containsKey("pipelineTemplate")) {
+      throw new IllegalArgumentException("Missing required task parameter (pipelineTemplate)");
+    }
+
+    PipelineTemplate pipelineTemplate;
+    try {
+      pipelineTemplate = pipelineTemplateObjectMapper.convertValue(stage.getContext().get("pipelineTemplate"), PipelineTemplate.class);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Pipeline template task parameter is not valid", e);
+    }
+
+    Response response = front50Service.savePipelineTemplate((Map<String, Object>) stage.getContext().get("pipelineTemplate"));
+
+    // TODO rz - app & account context?
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put("notification.type", "createpipelinetemplate");
+    outputs.put("pipelineTemplate.id", pipelineTemplate.getId());
+
+    if (response.getStatus() == HttpStatus.OK.value()) {
+      return new TaskResult(ExecutionStatus.SUCCEEDED, outputs);
+    }
+
+    return new TaskResult(ExecutionStatus.TERMINAL, outputs);
+  }
+
+  @Override
+  public long getBackoffPeriod() {
+    return 15000;
+  }
+
+  @Override
+  public long getTimeout() {
+    return TimeUnit.MINUTES.toMillis(1);
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/UpdatePipelineTemplateTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/UpdatePipelineTemplateTask.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import retrofit.client.Response;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class UpdatePipelineTemplateTask implements RetryableTask {
+
+  @Autowired(required = false)
+  private Front50Service front50Service;
+
+  @Autowired
+  private ObjectMapper pipelineTemplateObjectMapper;
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public TaskResult execute(Stage stage) {
+    if (front50Service == null) {
+      throw new UnsupportedOperationException("Front50 is not enabled, no way to fetch pager duty. Fix this by setting front50.enabled: true");
+    }
+
+    List<String> missingParams = new ArrayList<>();
+    if (!stage.getContext().containsKey("id")) {
+      missingParams.add("id");
+    }
+
+    if (!stage.getContext().containsKey("pipelineTemplate")) {
+      missingParams.add("pipelineTemplate");
+    }
+
+    if (!missingParams.isEmpty()) {
+      throw new IllegalArgumentException("Missing required task parameter (" +
+        StringUtils.arrayToCommaDelimitedString(missingParams.toArray()) +
+        ")");
+    }
+
+    PipelineTemplate pipelineTemplate;
+    try {
+      pipelineTemplate = pipelineTemplateObjectMapper.convertValue(stage.getContext().get("pipelineTemplate"), PipelineTemplate.class);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Pipeline template task parameter is not valid", e);
+    }
+
+    Response response = front50Service.updatePipelineTemplate(
+      (String) stage.getContext().get("id"),
+      (Map<String, Object>) stage.getContext().get("pipelineTemplate")
+    );
+
+    // TODO rz - app & account context?
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put("notification.type", "updatepipelinetemplate");
+    outputs.put("pipelineTemplate.id", pipelineTemplate.getId());
+
+    if (response.getStatus() == HttpStatus.OK.value()) {
+      return new TaskResult(ExecutionStatus.SUCCEEDED, outputs);
+    }
+
+    return new TaskResult(ExecutionStatus.TERMINAL, outputs);
+  }
+
+  @Override
+  public long getBackoffPeriod() {
+    return 15000;
+  }
+
+  @Override
+  public long getTimeout() {
+    return TimeUnit.MINUTES.toMillis(1);
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisitor;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.VersionedSchema;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -40,6 +41,7 @@ public class PipelineTemplate implements VersionedSchema {
     private String name;
     private String description;
     private String owner;
+    private List<String> scopes = new ArrayList<>();
 
     public String getName() {
       return name;
@@ -63,6 +65,14 @@ public class PipelineTemplate implements VersionedSchema {
 
     public void setOwner(String owner) {
       this.owner = owner;
+    }
+
+    public List<String> getScopes() {
+      return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+      this.scopes = scopes;
     }
   }
 

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/loader/Front50SchemeLoaderSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/loader/Front50SchemeLoaderSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.loader
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException
+import retrofit.RetrofitError
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class Front50SchemeLoaderSpec extends Specification {
+
+  Front50Service front50Service = Mock()
+
+  @Subject
+  def schemeLoader = new Front50SchemeLoader(front50Service, new ObjectMapper())
+
+  @Unroll
+  void 'should support spinnaker scheme'() {
+    expect:
+    schemeLoader.supports(new URI(uri)) == shouldSupport
+
+    where:
+    uri || shouldSupport
+    "spinnaker://myTemplateId" || true
+    "http://myTemplateId"      || false
+  }
+
+  void 'should raise exception when uri does not exist'() {
+    when:
+    schemeLoader.load(new URI('spinnaker://myTemplateId'))
+
+    then:
+    front50Service.getPipelineTemplate("myTemplateId") >> {
+      throw RetrofitError.networkError("http://front50/no-exist", new IOException("resource not found"))
+    }
+    def e = thrown(TemplateLoaderException)
+    e.cause instanceof RetrofitError
+  }
+
+  void 'should load simple pipeline template'() {
+    given:
+    Map<String, Object> template = [
+      schema: '1',
+      id: 'myTemplateId',
+      metadata: [
+        name: 'My Template'
+      ]
+    ]
+
+    when:
+    def result = schemeLoader.load(new URI('spinnaker://myTemplateId'))
+
+    then:
+    front50Service.getPipelineTemplate('myTemplateId') >> { return template }
+    result.schema == template.schema
+    result.id == template.id
+    result.metadata.name == template.metadata.name
+  }
+}


### PR DESCRIPTION
Adds: 

* Added `spinnaker://myPipelineId` template loader
* Added create & update tasks for write operations into front50
* Added `scope` stanza list for templates, this will be used via the UI to filter what templates are available for people to create templates from. Will add enhancement in a followup PR to enforce within orca as well.

@spinnaker/netflix-reviewers PTAL for initial feedback