### PR TITLE
fix(azure): Set imageName on server groups

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureServerGroupCreator.groovy
@@ -45,6 +45,7 @@ class AzureServerGroupCreator implements ServerGroupCreator, DeploymentDetailsAw
       operation.image.isCustom = true
       operation.image.uri = bakeStage.context?.imageId
       operation.image.ostype = bakeStage.context?.osType
+      operation.image.imageName = bakeStage.context?.imageName
     }
 
     return [[(ServerGroupCreator.OPERATION): operation]]


### PR DESCRIPTION
This was displaying as an empty string in Deck