### PR TITLE
feat(provider/kubernetes): Enable deployment of baked docker containers

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -118,11 +118,12 @@ class BakeStage implements BranchingStageDefinitionBuilder, RestartableStage {
           it.type == PIPELINE_CONFIG_TYPE && bakeInitializationStages*.id.contains(it.parentStageId) && (it.context.ami || it.context.imageId)
         }.collect { Stage bakeStage ->
           def deploymentDetails = [:]
-          ["ami", "imageId", "amiSuffix", "baseLabel", "baseOs", "storeType", "vmType", "region", "package", "cloudProviderType", "cloudProvider"].each {
+          ["ami", "imageId", "amiSuffix", "baseLabel", "baseOs", "refId", "storeType", "vmType", "region", "package", "cloudProviderType", "cloudProvider"].each {
             if (bakeStage.context.containsKey(it)) {
               deploymentDetails.put(it, bakeStage.context.get(it))
             }
           }
+
           return deploymentDetails
         }
       ]

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesContainerFinderSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesContainerFinderSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.kubernetes
+
+import spock.lang.Specification
+
+class KubernetesContainerFinderSpec extends Specification {
+
+  def 'Should successfully parse a fully qualified docker container name'() {
+    given:
+      def tag = "latest"
+      def repository = "myTeam/myImage"
+      def registry = "containers.docker.io"
+      def fullName = "${registry}/${repository}:${tag}"
+
+    when:
+      Map<String, String> nameParts = KubernetesContainerFinder.parseContainerPartsFrom(fullName)
+
+    then:
+      nameParts.repository == repository
+      nameParts.registry == registry
+      nameParts.tag == tag
+  }
+
+  def 'Should successfully parse a container with no tag'() {
+    given:
+      def tag = "latest"
+      def repository = "myTeam/myImage"
+      def registry = "containers.docker.io"
+      def fullName = "${registry}/${repository}"
+
+    when:
+      Map<String, String> nameParts = KubernetesContainerFinder.parseContainerPartsFrom(fullName)
+
+    then:
+      nameParts.repository == repository
+      nameParts.tag == tag
+      nameParts.registry == registry
+  }
+
+  def 'Should fail to parse a container with no registry'() {
+    given:
+      def tag = "latest"
+      def repository = "myTeam/myImage"
+      def fullName = "${repository}:${tag}"
+    when:
+      KubernetesContainerFinder.parseContainerPartsFrom(fullName)
+    then:
+      IllegalStateException ex = thrown()
+  }
+}


### PR DESCRIPTION
This aims to enable the deployment of baked docker containers by making two changes:
- The bake stages `refId` is added to the `deploymentDetails`
- The parsed docker image name is added to the `imageDetails`

This PR is a requirement for https://github.com/spinnaker/deck/pull/3588 to work and these two PRs should therefor be seen in unison. Like I mentioned in the Deck PR, I'm open to corrections on this approach, as I've merely made this work, and there might be a different preferred path. 