### PR TITLE
feat(webhooks): allow custom headers on webhook call

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/WebhookService.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/WebhookService.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.orca.webhook
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -34,9 +35,11 @@ class WebhookService {
   @Autowired
   UserConfiguredUrlRestrictions userConfiguredUrlRestrictions
 
-  ResponseEntity<Object> exchange(HttpMethod httpMethod, String url, Object payload) {
+  ResponseEntity<Object> exchange(HttpMethod httpMethod, String url, Object payload, Object customHeaders) {
     URI validatedUri = userConfiguredUrlRestrictions.validateURI(url)
-    HttpEntity<Object> payloadEntity = new HttpEntity<>(payload)
+    HttpHeaders headers = new HttpHeaders()
+    customHeaders?.each{ key, value -> headers.add(key as String, value as String) }
+    HttpEntity<Object> payloadEntity = new HttpEntity<>(payload, headers)
     return restTemplate.exchange(validatedUri, httpMethod, payloadEntity, Object)
   }
 

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.webhook.WebhookService
-import groovy.transform.CompileStatic
 import org.apache.http.HttpHeaders
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpMethod
@@ -44,9 +43,10 @@ class CreateWebhookTask implements RetryableTask {
     String url = stage.context.url
     def method = stage.context.method ? HttpMethod.valueOf(stage.context.method.toString().toUpperCase()) : HttpMethod.POST
     def payload = stage.context.payload
+    def customHeaders = stage.context.customHeaders
     boolean waitForCompletion = (stage.context.waitForCompletion as String)?.toBoolean()
 
-    def response = webhookService.exchange(method, url, payload)
+    def response = webhookService.exchange(method, url, payload, customHeaders)
 
     def outputs = [:]
     outputs << [statusCode: response.statusCode]

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
@@ -40,14 +40,16 @@ class CreateWebhookTaskSpec extends Specification {
     def stage = new Stage(pipeline, "webhook", "My webhook", [
       url: "https://my-service.io/api/",
       method: "post",
-      payload: [payload1: "Hello Spinnaker!"]
+      payload: [payload1: "Hello Spinnaker!"],
+      customHeaders: [header1: "Header"]
     ])
 
     createWebhookTask.webhookService = Stub(WebhookService) {
       exchange(
         HttpMethod.POST,
         "https://my-service.io/api/",
-        [payload1: "Hello Spinnaker!"]
+        [payload1: "Hello Spinnaker!"],
+        [header1: "Header"]
       ) >> new ResponseEntity<Map>([:], HttpStatus.OK)
     }
 
@@ -69,6 +71,7 @@ class CreateWebhookTaskSpec extends Specification {
       exchange(
         HttpMethod.POST,
         "https://my-service.io/api/",
+        null,
         null
       ) >> new ResponseEntity<Map>([:], HttpStatus.OK)
     }
@@ -92,6 +95,7 @@ class CreateWebhookTaskSpec extends Specification {
       exchange(
         HttpMethod.GET,
         "https://my-service.io/api/",
+        null,
         null
       ) >> new ResponseEntity<Map>([:], HttpStatus.OK)
     }
@@ -108,13 +112,15 @@ class CreateWebhookTaskSpec extends Specification {
     def stage = new Stage(pipeline, "webhook", "My webhook", [
       url: "https://my-service.io/api/",
       method: "delete",
-      payload: [:]
+      payload: [:],
+      customHeaders: [:]
     ])
 
     createWebhookTask.webhookService = Stub(WebhookService) {
       exchange(
         HttpMethod.DELETE,
         "https://my-service.io/api/",
+        [:],
         [:]
       ) >> new ResponseEntity<Map>([error: "Oh noes, you can't do this"], HttpStatus.BAD_REQUEST)
     }
@@ -136,7 +142,7 @@ class CreateWebhookTaskSpec extends Specification {
     ])
 
     createWebhookTask.webhookService = Stub(WebhookService) {
-      exchange(HttpMethod.POST, "https://my-service.io/api/", null) >> new ResponseEntity<Map>([success: true], HttpStatus.CREATED)
+      exchange(HttpMethod.POST, "https://my-service.io/api/", null, null) >> new ResponseEntity<Map>([success: true], HttpStatus.CREATED)
     }
 
     when:
@@ -159,7 +165,7 @@ class CreateWebhookTaskSpec extends Specification {
     createWebhookTask.webhookService = Stub(WebhookService) {
       def headers = new HttpHeaders()
       headers.add(HttpHeaders.LOCATION, "https://my-service.io/api/status/123")
-      exchange(HttpMethod.POST, "https://my-service.io/api/", null) >> new ResponseEntity<Map>([success: true], headers, HttpStatus.CREATED)
+      exchange(HttpMethod.POST, "https://my-service.io/api/", null, null) >> new ResponseEntity<Map>([success: true], headers, HttpStatus.CREATED)
     }
 
     when:
@@ -183,7 +189,7 @@ class CreateWebhookTaskSpec extends Specification {
     def body = [success: true, location: "https://my-service.io/api/status/123"]
 
     createWebhookTask.webhookService = Stub(WebhookService) {
-      exchange(HttpMethod.POST, "https://my-service.io/api/", null) >> new ResponseEntity<Map>(body, HttpStatus.CREATED)
+      exchange(HttpMethod.POST, "https://my-service.io/api/", null, null) >> new ResponseEntity<Map>(body, HttpStatus.CREATED)
     }
 
     when:
@@ -213,7 +219,7 @@ class CreateWebhookTaskSpec extends Specification {
     ]
 
     createWebhookTask.webhookService = Stub(WebhookService) {
-      exchange(HttpMethod.POST, "https://my-service.io/api/", null) >> new ResponseEntity<Map>(body, HttpStatus.CREATED)
+      exchange(HttpMethod.POST, "https://my-service.io/api/", null, null) >> new ResponseEntity<Map>(body, HttpStatus.CREATED)
     }
 
     when:


### PR DESCRIPTION
This will add support for customizing request headers that will be sent to the service called by the webhook stage.

Depends on https://github.com/spinnaker/deck/pull/3589