### PR TITLE
feat(nuorca): Add get execution logs endpoint

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -37,6 +37,7 @@ dependencies {
   compile spinnaker.dependency('spectatorApi')
   compile spinnaker.dependency('kork')
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${spinnaker.version('jackson')}"
+  compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${spinnaker.version('jackson')}"
 
   compile "org.springframework.security:spring-security-web:3.2.9.RELEASE"
 

--- a/orca-loadtest/src/main/resources/request-bodies/wait.json
+++ b/orca-loadtest/src/main/resources/request-bodies/wait.json
@@ -12,5 +12,6 @@
   ],
   "limitConcurrent": true,
   "parallel": true,
-  "appConfig": {}
+  "appConfig": {},
+  "executionEngine": "v3"
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/ExecutionLogListener.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/ExecutionLogListener.kt
@@ -19,7 +19,6 @@ import com.netflix.spinnaker.orca.events.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationListener
 import org.springframework.stereotype.Component
-import java.io.Serializable
 
 @Component
 open class ExecutionLogListener
@@ -42,7 +41,7 @@ open class ExecutionLogListener
     })
   }
 
-  private fun toLogEntry(event: ExecutionEvent, details: Map<String, Serializable>): ExecutionLogEntry = event.run {
+  private fun toLogEntry(event: ExecutionEvent, details: Map<String, String>): ExecutionLogEntry = event.run {
     ExecutionLogEntry(
       executionId,
       timestamp(),

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/ExecutionLogRepository.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/ExecutionLogRepository.kt
@@ -15,19 +15,19 @@
  */
 package com.netflix.spinnaker.orca.q
 
-import java.io.Serializable
 import java.time.Instant
 
 data class ExecutionLogEntry(
   val executionId: String,
   val timestamp: Instant,
   val eventType: String,
-  val details: Map<String, Serializable>,
+  val details: Map<String, String>,
   var currentInstanceId: String
 )
 
 interface ExecutionLogRepository {
   fun save(entry: ExecutionLogEntry)
+  fun getAllByExecutionId(executionId: String): List<ExecutionLogEntry>
 }
 
 /**
@@ -35,4 +35,5 @@ interface ExecutionLogRepository {
  */
 class BlackholeExecutionLogRepository : ExecutionLogRepository {
   override fun save(entry: ExecutionLogEntry) {}
+  override fun getAllByExecutionId(executionId: String): List<ExecutionLogEntry> = listOf()
 }


### PR DESCRIPTION
Returns fun payloads like so:

```json
[
  {
    "executionId": "003d47e0-b079-445a-bcce-8fb42c6886f7",
    "timestamp": "2017-04-27T23:16:05.571Z",
    "eventType": "ExecutionStarted",
    "details": {},
    "currentInstanceId": "nfml-rzienert"
  },
  {
    "executionId": "003d47e0-b079-445a-bcce-8fb42c6886f7",
    "timestamp": "2017-04-27T23:16:05.621Z",
    "eventType": "StageStarted",
    "details": {},
    "currentInstanceId": "nfml-rzienert"
  },
  {
    "executionId": "003d47e0-b079-445a-bcce-8fb42c6886f7",
    "timestamp": "2017-04-27T23:16:05.655Z",
    "eventType": "TaskStarted",
    "details": {},
    "currentInstanceId": "nfml-rzienert"
  },
  {
    "executionId": "003d47e0-b079-445a-bcce-8fb42c6886f7",
    "timestamp": "2017-04-27T23:16:20.775Z",
    "eventType": "TaskComplete",
    "details": {
      "status": "SUCCEEDED"
    },
    "currentInstanceId": "nfml-rzienert"
  },
  {
    "executionId": "003d47e0-b079-445a-bcce-8fb42c6886f7",
    "timestamp": "2017-04-27T23:16:20.805Z",
    "eventType": "StageComplete",
    "details": {
      "status": "SUCCEEDED"
    },
    "currentInstanceId": "nfml-rzienert"
  },
  {
    "executionId": "003d47e0-b079-445a-bcce-8fb42c6886f7",
    "timestamp": "2017-04-27T23:16:20.835Z",
    "eventType": "ExecutionComplete",
    "details": {
      "status": "SUCCEEDED"
    },
    "currentInstanceId": "nfml-rzienert"
  }
]
```

@robfletcher PTAL