### PR TITLE
fix(queue): limit re-deliveries of failed messages

### DIFF
--- a/orca-queue-redis/orca-queue-redis.gradle
+++ b/orca-queue-redis/orca-queue-redis.gradle
@@ -18,6 +18,8 @@ buildscript {
   // TODO: this stuff should go in spinnaker-dependencies module eventually
   ext.kotlinVersion = "1.1.0"
   ext.junitVersion = "1.0.0-M3"
+  ext.jupiterVersion = "5.0.0-M3"
+  ext.junitLegacyVersion = "4.12.0-M3"
   ext.spekVersion = "1.1.0"
 
   repositories {
@@ -48,7 +50,11 @@ dependencies {
   testCompile "org.jetbrains.spek:spek-api:$spekVersion"
   testCompile "com.nhaarman:mockito-kotlin:1.4.0"
   testCompile "com.natpryce:hamkrest:1.3.0.0"
+  testCompile "org.junit.jupiter:junit-jupiter-api:$jupiterVersion"
 
+  testRuntime "org.junit.platform:junit-platform-launcher:$junitVersion"
+  testRuntime "org.junit.jupiter:junit-jupiter-engine:$jupiterVersion"
+  testRuntime "org.junit.vintage:junit-vintage-engine:$junitLegacyVersion"
   testRuntime "org.jetbrains.spek:spek-junit-platform-engine:$spekVersion"
 }
 

--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.config
 
 import com.netflix.spinnaker.orca.q.Queue
+import com.netflix.spinnaker.orca.q.handler.DeadMessageHandler
 import com.netflix.spinnaker.orca.q.redis.RedisQueue
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
@@ -35,7 +36,15 @@ open class RedisQueueConfiguration {
     @Qualifier("jedisPool") redisPool: Pool<Jedis>,
     redisQueueProperties: RedisQueueProperties,
     clock: Clock,
-    currentInstanceId: String
-  ): Queue = RedisQueue(redisQueueProperties.queueName, redisPool, clock, currentInstanceId)
+    currentInstanceId: String,
+    deadMessageHandler: DeadMessageHandler
+  ): Queue =
+    RedisQueue(
+      redisQueueProperties.queueName,
+      redisPool,
+      clock,
+      currentInstanceId,
+      deadMessageHandler = deadMessageHandler::handle
+    )
 
 }

--- a/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueSpec.kt
+++ b/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueSpec.kt
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.orca.q.redis
 
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import com.netflix.spinnaker.orca.q.Message
+import com.netflix.spinnaker.orca.q.Queue
 import com.netflix.spinnaker.orca.q.QueueSpec
 import com.netflix.spinnaker.orca.q.QueueSpec.Companion.clock
 
@@ -28,9 +30,9 @@ class RedisQueueSpec : QueueSpec<RedisQueue>(
 
 private var redis: EmbeddedRedis? = null
 
-private fun createQueue(): RedisQueue {
+private fun createQueue(deadLetterCallback: (Queue, Message) -> Unit): RedisQueue {
   redis = EmbeddedRedis.embed()
-  return RedisQueue("test", redis!!.pool, clock, "i-1234")
+  return RedisQueue("test", redis!!.pool, clock, "i-1234", deadMessageHandler = deadLetterCallback)
 }
 
 private fun shutdownCallback() {

--- a/orca-queue-sqs/src/main/kotlin/com/netflix/spinnaker/orca/q/amazon/SqsQueue.kt
+++ b/orca-queue-sqs/src/main/kotlin/com/netflix/spinnaker/orca/q/amazon/SqsQueue.kt
@@ -31,7 +31,8 @@ import java.time.temporal.TemporalAmount
 class SqsQueue(
   private val amazonSqs: AmazonSQS,
   sqsProperties: SqsProperties,
-  override val ackTimeout: Duration = Duration.ofMinutes(1)
+  override val ackTimeout: Duration = Duration.ofMinutes(1),
+  override val deadMessageHandler: (Queue, Message) -> Unit
 ) : Queue {
 
   private val objectMapper = ObjectMapper().apply {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.config
 import com.netflix.spinnaker.orca.q.BlackholeExecutionLogRepository
 import com.netflix.spinnaker.orca.q.ExecutionLogRepository
 import com.netflix.spinnaker.orca.q.Queue
+import com.netflix.spinnaker.orca.q.handler.DeadMessageHandler
 import com.netflix.spinnaker.orca.q.memory.InMemoryQueue
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
@@ -38,7 +39,8 @@ open class QueueConfiguration {
   open fun systemClock(): Clock = Clock.systemDefaultZone()
 
   @Bean(name = arrayOf("queueImpl")) @ConditionalOnMissingBean(Queue::class)
-  open fun inMemoryQueue(clock: Clock): Queue = InMemoryQueue(clock)
+  open fun inMemoryQueue(clock: Clock, deadMessageHandler: DeadMessageHandler): Queue =
+    InMemoryQueue(clock, deadMessageHandler = deadMessageHandler::handle)
 
   @Bean @ConditionalOnMissingBean(ExecutionLogRepository::class)
   open fun executionLogRepository(): ExecutionLogRepository = BlackholeExecutionLogRepository()

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Queue.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Queue.kt
@@ -53,6 +53,20 @@ interface Queue {
    * The expired time after which un-acknowledged messages will be re-delivered.
    */
   val ackTimeout: TemporalAmount
+
+  /**
+   * A handler for messages that have failed to ackowledge delivery more than
+   * [Queue.ackTimeout] times.
+   */
+  val deadMessageHandler: (Queue, Message) -> Unit
+
+  companion object {
+    /**
+     * The maximum number of times an un-acknowledged message will be re-delivered
+     * before failing permanently.
+     */
+    val maxRedeliveries: Int = 10
+  }
 }
 
 /**

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/TrafficShapingQueue.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/TrafficShapingQueue.kt
@@ -39,6 +39,7 @@ import java.time.temporal.TemporalAmount
   private val log: Logger = LoggerFactory.getLogger(javaClass)
 
   override val ackTimeout = queueImpl.ackTimeout
+  override val deadMessageHandler: (Queue, Message) -> Unit = queueImpl.deadMessageHandler
 
   val pollInterceptors = interceptors.filter { it.supports(InterceptorType.POLL) }
   val messageInterceptors = interceptors.filter { it.supports(InterceptorType.MESSAGE) }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandler.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.q.handler
+
+import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
+import com.netflix.spinnaker.orca.q.*
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component open class DeadMessageHandler {
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  fun handle(queue: Queue, message: Message) {
+    log.error("Dead message: $message")
+    when (message) {
+      is TaskLevel -> queue.push(CompleteTask(message, TERMINAL))
+      is StageLevel -> queue.push(CompleteStage(message, TERMINAL))
+      is ExecutionLevel -> queue.push(CompleteExecution(message, TERMINAL))
+      else -> log.error("Unhandled message type ${message.javaClass}")
+    }
+  }
+}

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandlerSpec.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.q.handler
+
+import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.q.*
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.reset
+import com.nhaarman.mockito_kotlin.verify
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+
+class DeadMessageHandlerSpec : Spek({
+
+  val queue: Queue = mock()
+  val handler = DeadMessageHandler()
+
+  fun resetMocks() = reset(queue)
+
+  describe("handling an execution level message") {
+    val message = StartExecution(Pipeline::class.java, "1", "spinnaker")
+
+    afterGroup(::resetMocks)
+
+    action("the handler receives a message") {
+      handler.handle(queue, message)
+    }
+
+    it("terminates the execution") {
+      verify(queue).push(CompleteExecution(message, TERMINAL))
+    }
+  }
+
+  describe("handling a stage level message") {
+    val message = StartStage(Pipeline::class.java, "1", "spinnaker", "1")
+
+    afterGroup(::resetMocks)
+
+    action("the handler receives a message") {
+      handler.handle(queue, message)
+    }
+
+    it("terminates the stage") {
+      verify(queue).push(CompleteStage(message, TERMINAL))
+    }
+  }
+
+  describe("handling a task level message") {
+    val message = RunTask(Pipeline::class.java, "1", "spinnaker", "1", "1", DummyTask::class.java)
+
+    afterGroup(::resetMocks)
+
+    action("the handler receives a message") {
+      handler.handle(queue, message)
+    }
+
+    it("terminates the task") {
+      verify(queue).push(CompleteTask(message, TERMINAL))
+    }
+  }
+})

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/memory/InMemoryQueueSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/memory/InMemoryQueueSpec.kt
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.orca.q.memory
 
+import com.netflix.spinnaker.orca.q.Message
+import com.netflix.spinnaker.orca.q.Queue
 import com.netflix.spinnaker.orca.q.QueueSpec
 import com.netflix.spinnaker.orca.q.QueueSpec.Companion.clock
 
@@ -24,4 +26,5 @@ class InMemoryQueueSpec : QueueSpec<InMemoryQueue>(
   InMemoryQueue::redeliver
 )
 
-private fun createQueue() = InMemoryQueue(clock)
+private fun createQueue(deadLetterCallback: (Queue, Message) -> Unit) =
+  InMemoryQueue(clock, deadMessageHandler = deadLetterCallback)


### PR DESCRIPTION
Once a failed message has been tried 10 times it gets passed to a handler that will terminate the associated pipeline