### PR TITLE
fix(queue): don't just assume task ids are valid

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
@@ -81,13 +81,6 @@ fun Stage<out Execution<*>>.nextTask(task: Task) =
   }
 
 /**
- * @return the task with the specified id.
- * @throws IllegalArgumentException if there is no such task.
- */
-fun Stage<out Execution<*>>.task(taskId: String) =
-  getTasks().find { it.id == taskId } ?: throw IllegalArgumentException("No such task")
-
-/**
  * @return the stage with the specified [refId].
  * @throws IllegalArgumentException if there is no such stage.
  */

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
@@ -252,6 +252,20 @@ data class InvalidStageId(
 }
 
 /**
+ * Task id was not found in the stage.
+ */
+data class InvalidTaskId(
+  override val executionType: Class<out Execution<*>>,
+  override val executionId: String,
+  override val application: String,
+  override val stageId: String,
+  override val taskId: String
+) : ConfigurationError(), TaskLevel {
+  constructor(source: TaskLevel) :
+    this(source.executionType, source.executionId, source.application, source.stageId, source.taskId)
+}
+
+/**
  * No such [Task] class.
  */
 data class InvalidTaskType(

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
@@ -36,8 +36,7 @@ open class CompleteTaskHandler
 ) : MessageHandler<CompleteTask> {
 
   override fun handle(message: CompleteTask) {
-    message.withStage { stage ->
-      val task = stage.task(message.taskId)
+    message.withTask { stage, task ->
       task.status = message.status
       task.endTime = clock.millis()
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/PauseTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/PauseTaskHandler.kt
@@ -18,7 +18,10 @@ package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.ExecutionStatus.PAUSED
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
-import com.netflix.spinnaker.orca.q.*
+import com.netflix.spinnaker.orca.q.MessageHandler
+import com.netflix.spinnaker.orca.q.PauseStage
+import com.netflix.spinnaker.orca.q.PauseTask
+import com.netflix.spinnaker.orca.q.Queue
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -32,12 +35,10 @@ open class PauseTaskHandler
   override val messageType = PauseTask::class.java
 
   override fun handle(message: PauseTask) {
-    message.withStage { stage ->
-      stage.task(message.taskId).apply {
-        status = PAUSED
-        repository.storeStage(stage)
-        queue.push(PauseStage(message))
-      }
+    message.withTask { stage, task ->
+      task.status = PAUSED
+      repository.storeStage(stage)
+      queue.push(PauseStage(message))
     }
   }
 }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerSpec.kt
@@ -52,10 +52,10 @@ class RunTaskHandlerSpec : Spek({
       val pipeline = pipeline {
         stage {
           type = "whatever"
+          startTime = clock.instant().toEpochMilli()
           task {
             id = "1"
             implementingClass = DummyTask::class.qualifiedName
-            startTime = clock.instant().toEpochMilli()
           }
         }
       }
@@ -88,10 +88,10 @@ class RunTaskHandlerSpec : Spek({
       val pipeline = pipeline {
         stage {
           type = "whatever"
+          startTime = clock.instant().toEpochMilli()
           task {
             id = "1"
             implementingClass = DummyTask::class.qualifiedName
-            startTime = clock.instant().toEpochMilli()
           }
         }
       }
@@ -120,10 +120,10 @@ class RunTaskHandlerSpec : Spek({
       val pipeline = pipeline {
         stage {
           type = "whatever"
+          startTime = clock.instant().toEpochMilli()
           task {
             id = "1"
             implementingClass = DummyTask::class.qualifiedName
-            startTime = clock.instant().toEpochMilli()
           }
         }
       }
@@ -198,10 +198,10 @@ class RunTaskHandlerSpec : Spek({
       val pipeline = pipeline {
         stage {
           type = "whatever"
+          startTime = clock.instant().toEpochMilli()
           task {
             id = "1"
             implementingClass = DummyTask::class.qualifiedName
-            startTime = clock.instant().toEpochMilli()
           }
         }
       }
@@ -391,11 +391,11 @@ class RunTaskHandlerSpec : Spek({
         val pipeline = pipeline {
           stage {
             type = "whatever"
+            startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
             task {
               id = "1"
               implementingClass = DummyTask::class.qualifiedName
               status = RUNNING
-              startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
             }
           }
         }
@@ -430,11 +430,11 @@ class RunTaskHandlerSpec : Spek({
           }
           stage {
             type = "whatever"
+            startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
             task {
               id = "1"
               implementingClass = DummyTask::class.qualifiedName
               status = RUNNING
-              startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
             }
           }
         }
@@ -465,11 +465,11 @@ class RunTaskHandlerSpec : Spek({
           }
           stage {
             type = "whatever"
+            startTime = clock.instant().minusMillis(timeout.plusMinutes(1).toMillis() + 1).toEpochMilli()
             task {
               id = "1"
               implementingClass = DummyTask::class.qualifiedName
               status = RUNNING
-              startTime = clock.instant().minusMillis(timeout.plusMinutes(1).toMillis() + 1).toEpochMilli()
             }
           }
         }
@@ -502,12 +502,12 @@ class RunTaskHandlerSpec : Spek({
         context["override"] = "global"
         stage {
           type = "whatever"
+          startTime = clock.instant().toEpochMilli()
           context["stage"] = "foo"
           context["override"] = "stage"
           task {
             id = "1"
             implementingClass = DummyTask::class.qualifiedName
-            startTime = clock.instant().toEpochMilli()
           }
         }
       }
@@ -541,6 +541,10 @@ class RunTaskHandlerSpec : Spek({
     val pipeline = pipeline {
       stage {
         type = "whatever"
+        task {
+          id = "1"
+          implementingClass = InvalidTask::class.qualifiedName
+        }
       }
     }
     val message = RunTask(Pipeline::class.java, pipeline.id, "foo", pipeline.stages.first().id, "1", InvalidTask::class.java)


### PR DESCRIPTION
Because of concurrency issues in `JedisExecutionRepository` it's pretty easy to end up with invalid task ids. Obviously, that needs fixing but it did expose that they weren't getting handled well.