### PR TITLE
feat(webhooks): allow custom headers on monitor task of webhook stage

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/WebhookService.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/WebhookService.groovy
@@ -37,14 +37,21 @@ class WebhookService {
 
   ResponseEntity<Object> exchange(HttpMethod httpMethod, String url, Object payload, Object customHeaders) {
     URI validatedUri = userConfiguredUrlRestrictions.validateURI(url)
-    HttpHeaders headers = new HttpHeaders()
-    customHeaders?.each{ key, value -> headers.add(key as String, value as String) }
+    HttpHeaders headers = buildHttpHeaders(customHeaders)
     HttpEntity<Object> payloadEntity = new HttpEntity<>(payload, headers)
     return restTemplate.exchange(validatedUri, httpMethod, payloadEntity, Object)
   }
 
-  ResponseEntity<Object> getStatus(String url) {
+  ResponseEntity<Object> getStatus(String url, Object customHeaders) {
     URI validatedUri = userConfiguredUrlRestrictions.validateURI(url)
-    return restTemplate.getForEntity(validatedUri, Object)
+    HttpHeaders headers = buildHttpHeaders(customHeaders)
+    HttpEntity<Object> httpEntity = new HttpEntity<>(headers)
+    return restTemplate.exchange(validatedUri, HttpMethod.GET, httpEntity, Object)
+  }
+
+  private static HttpHeaders buildHttpHeaders(Object customHeaders) {
+    HttpHeaders headers = new HttpHeaders()
+    customHeaders?.each { key, value -> headers.add(key as String, value as String) }
+    return headers
   }
 }

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.webhook.WebhookService
-import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -49,8 +48,9 @@ class MonitorWebhookTask implements Task {
     String successStatuses = stage.context.successStatuses
     String canceledStatuses = stage.context.canceledStatuses
     String terminalStatuses = stage.context.terminalStatuses
+    def customHeaders = stage.context.customHeaders
 
-    def response = webhookService.getStatus(statusEndpoint)
+    def response = webhookService.getStatus(statusEndpoint, customHeaders)
     def result
     try {
       result = JsonPath.read(response.body, statusJsonPath)

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTaskSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTaskSpec.groovy
@@ -73,7 +73,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "should do a get request to the defined statusEndpoint"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123") >> new ResponseEntity<Map>([status:"RUNNING"], HttpStatus.OK)
+      1 * getStatus("https://my-service.io/api/status/123", [Authorization: "Basic password"]) >> new ResponseEntity<Map>([status:"RUNNING"], HttpStatus.OK)
     }
     def stage = new Stage(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',
@@ -81,6 +81,7 @@ class MonitorWebhookTaskSpec extends Specification {
       successStatuses: 'SUCCESS',
       canceledStatuses: 'CANCELED',
       terminalStatuses: 'TERMINAL',
+      customHeaders: [Authorization: "Basic password"],
       someVariableWeDontCareAbout: 'Hello!'
     ])
 
@@ -95,7 +96,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "should find correct element using statusJsonPath parameter"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123") >> new ResponseEntity<Map>([status:"TERMINAL"], HttpStatus.OK)
+      1 * getStatus("https://my-service.io/api/status/123", null) >> new ResponseEntity<Map>([status:"TERMINAL"], HttpStatus.OK)
     }
     def stage = new Stage(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',
@@ -117,7 +118,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "should return percentComplete if supported by endpoint"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123") >> new ResponseEntity<Map>([status:42], HttpStatus.OK)
+      1 * getStatus("https://my-service.io/api/status/123", [:]) >> new ResponseEntity<Map>([status:42], HttpStatus.OK)
     }
     def stage = new Stage(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',
@@ -125,7 +126,8 @@ class MonitorWebhookTaskSpec extends Specification {
       successStatuses: 'SUCCESS',
       canceledStatuses: 'CANCELED',
       terminalStatuses: 'TERMINAL',
-      someVariableWeDontCareAbout: 'Hello!'
+      someVariableWeDontCareAbout: 'Hello!',
+      customHeaders: [:]
     ])
 
     when:
@@ -139,7 +141,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "100 percent complete should result in SUCCEEDED status"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123") >> new ResponseEntity<Map>([status:100], HttpStatus.OK)
+      1 * getStatus("https://my-service.io/api/status/123", null) >> new ResponseEntity<Map>([status:100], HttpStatus.OK)
     }
     def stage = new Stage(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',
@@ -161,7 +163,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "should return TERMINAL status if jsonPath can not be found"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123") >> new ResponseEntity<Map>([status:"SUCCESS"], HttpStatus.OK)
+      1 * getStatus("https://my-service.io/api/status/123", null) >> new ResponseEntity<Map>([status:"SUCCESS"], HttpStatus.OK)
     }
     def stage = new Stage(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',
@@ -180,7 +182,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "should return TERMINAL status if jsonPath isn't evaluated to single value"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123") >> new ResponseEntity<Map>([status:["some", "complex", "list"]], HttpStatus.OK)
+      1 * getStatus("https://my-service.io/api/status/123", null) >> new ResponseEntity<Map>([status:["some", "complex", "list"]], HttpStatus.OK)
     }
     def stage = new Stage(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',


### PR DESCRIPTION
Add custom header support to monitor (getStatus) task  of webhook stage.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](http://www.spinnaker.io/docs/contributing-to-spinnaker).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
