### PR TITLE
feat(webhooks): Support preconfigured webhook stages

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSupport.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionRunnerSupport.java
@@ -16,13 +16,6 @@
 
 package com.netflix.spinnaker.orca.pipeline;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 import com.netflix.spinnaker.orca.pipeline.TaskNode.TaskDefinition;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
@@ -30,6 +23,15 @@ import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner;
 import com.netflix.spinnaker.orca.pipeline.model.Task;
 import com.netflix.spinnaker.orca.pipeline.tasks.NoOpTask;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
 import static com.google.common.collect.Lists.reverse;
 import static com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED;
 import static com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.StageDefinitionBuilderSupport.newStage;
@@ -258,9 +260,9 @@ public abstract class ExecutionRunnerSupport implements ExecutionRunner {
   }
 
   private <T extends Execution<T>> StageDefinitionBuilder findBuilderForStage(Stage<T> stage) {
-    return stageDefinitionBuilders
-      .stream()
-      .filter(builder -> builder.getType().equals(stage.getType()))
+    return stageDefinitionBuilders.stream()
+      .filter(builder -> builder.getType().equals(stage.getType())
+        || (stage.getContext() != null && stage.getContext().get("alias") != null && builder.getType().equals(stage.getContext().get("alias"))))
       .findFirst()
       .orElseThrow(() -> new NoSuchStageDefinitionBuilder(stage.getType()));
   }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StageBuilderAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StageBuilderAware.kt
@@ -25,6 +25,6 @@ interface StageBuilderAware {
   val stageDefinitionBuilders: Collection<StageDefinitionBuilder>
 
   fun Stage<*>.builder(): StageDefinitionBuilder =
-    stageDefinitionBuilders.find { it.type == getType() }
+    stageDefinitionBuilders.find { it.type == getType() || getContext().get("alias") == it.type }
       ?: throw NoSuchStageDefinitionBuilder(getType())
 }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
@@ -141,3 +141,10 @@ val rollingPushStage = object : StageDefinitionBuilder {
       .withTask("afterLoop", DummyTask::class.java)
   }
 }
+
+val webhookStage = object : StageDefinitionBuilder {
+  override fun getType() = "webhook"
+  override fun <T : Execution<T>> taskGraph(stage: Stage<T>, builder: Builder) {
+    builder.withTask("createWebhook", DummyTask::class.java)
+  }
+}

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -38,3 +38,37 @@ tasks:
 logging:
   config: classpath:logback-defaults.xml
 
+# This configuration lets you configure Webhook stages that will appear as native stages in the Deck UI.
+# Properties that are set here will not be displayed in the GUI
+#webhook:
+#  preconfigured:
+#    - label: Some Webhook
+#      description: This is a webhook stage, but it appears as a native stage in Spinnaker
+#      type: customWebhook # Should be unique
+#      # The following properties are all optional:
+#      enabled: true # default true
+#      url: https://my.webhook.com/event
+#      headers:
+#        Accept:
+#          - application/json
+#        AnotherHeader:
+#          - valueOne
+#          - valueTwo
+#      method: POST
+#      payload: |
+#        {
+#          "text": "Version ${trigger.buildInfo.artifacts[0].version} deployed"
+#        }
+#      waitForCompletion: true
+#      # The rest of the properties are only used if waitForCompletion == true
+#      statusUrlResolution: webhookResponse # getMethod, locationHeader, webhookResponse
+#      statusUrlJsonPath: $.statusUrl # Only used if statusUrlResolution == webhookResponse
+#      statusJsonPath: $.status
+#      progressJsonPath: $.progress
+#      successStatuses: SUCCESS,COMPLETED
+#      canceledStatuses: CANCELED
+#      terminalStatuses: TERMINATED
+#    - label: Another Webhook
+#      description: This is also a webhook stage, but it has no properties set
+#      type: anotherCustomWebhook
+#      enabled: false

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookProperties.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookProperties.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.webhook.config
+
+import groovy.transform.ToString
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.http.HttpMethod
+
+@ConfigurationProperties("webhook")
+@ToString
+class PreconfiguredWebhookProperties {
+
+  public static List<String> ALL_FIELDS = PreconfiguredWebhook.declaredFields.findAll {
+    !it.synthetic && !['props', 'enabled', 'label', 'description', 'type'].contains(it.name)
+  }.collect { it.name }
+
+  List<PreconfiguredWebhook> preconfigured = []
+
+  @ToString(includeNames = true, includePackage = false)
+  static class PreconfiguredWebhook {
+    boolean enabled = true
+    String label
+    String description
+    String type
+
+    // Stage configuration fields (all optional):
+    String url
+    Map<String, List<String>> headers
+    HttpMethod method
+    String payload
+    Boolean waitForCompletion
+    StatusUrlResolution statusUrlResolution
+    String statusUrlJsonPath // if webhookResponse above
+    String statusJsonPath
+    String progressJsonPath
+    String successStatuses
+    String canceledStatuses
+    String terminalStatuses
+
+    List<String> getPreconfiguredProperties() {
+      return ALL_FIELDS.findAll { this[it] != null }
+    }
+
+    boolean noUserConfigurableFields() {
+      if (waitForCompletion == null) {
+        return false
+      } else if (waitForCompletion) {
+        return getPreconfiguredProperties().size() >= ALL_FIELDS.size() - (statusUrlResolution == StatusUrlResolution.webhookResponse ? 0 : 1)
+      } else {
+        return ["url", "headers", "method", "payload"].every { this[it] != null }
+      }
+    }
+  }
+
+  static enum StatusUrlResolution {
+    getMethod, locationHeader, webhookResponse
+  }
+
+}

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.groovy
@@ -17,9 +17,10 @@
 
 package com.netflix.spinnaker.orca.webhook.config
 
-import com.netflix.spinnaker.orca.webhook.WebhookService
+import com.netflix.spinnaker.orca.webhook.service.WebhookService
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
@@ -28,6 +29,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 @ConditionalOnProperty(prefix = "webhook.stage", value = "enabled", matchIfMissing = true)
 @ComponentScan(basePackageClasses = WebhookService)
+@EnableConfigurationProperties(PreconfiguredWebhookProperties)
 class WebhookConfiguration {
 
   @Bean

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/exception/PreconfiguredWebhookNotFoundException.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/exception/PreconfiguredWebhookNotFoundException.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.webhook.exception
+
+class PreconfiguredWebhookNotFoundException extends RuntimeException {
+  PreconfiguredWebhookNotFoundException(String webhookKey) {
+    super("Could not find a stage named '$webhookKey'")
+  }
+}

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStage.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStage.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.webhook.pipeline
+
+import com.netflix.spinnaker.orca.pipeline.TaskNode
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.webhook.config.PreconfiguredWebhookProperties.PreconfiguredWebhook
+import com.netflix.spinnaker.orca.webhook.exception.PreconfiguredWebhookNotFoundException
+import com.netflix.spinnaker.orca.webhook.service.WebhookService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class PreconfiguredWebhookStage extends WebhookStage {
+
+  @Autowired
+  private WebhookService webhookService
+
+  def fields = PreconfiguredWebhook.declaredFields.findAll {
+    !it.synthetic && !['props', 'enabled', 'label', 'description', 'type'].contains(it.name)
+  }.collect { it.name }
+
+  @Override
+  <T extends Execution<T>> void taskGraph(Stage<T> stage, TaskNode.Builder builder) {
+    def preconfiguredWebhook = webhookService.getPreconfiguredWebhooks().find { stage.type == it.type }
+
+    if (!preconfiguredWebhook) {
+      throw new PreconfiguredWebhookNotFoundException((String) stage.type)
+    }
+
+    stage.setContext(overrideIfNotSetInContext(stage.context, preconfiguredWebhook))
+    super.taskGraph(stage, builder)
+  }
+
+  private Map<String, Object> overrideIfNotSetInContext(Map<String, Object> context, PreconfiguredWebhook preconfiguredWebhook) {
+    fields.each {
+      if (context[it] == null) {
+        context[it] = preconfiguredWebhook[it]
+      }
+    }
+    return context
+  }
+}

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStage.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStage.groovy
@@ -23,10 +23,8 @@ import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-
 import com.netflix.spinnaker.orca.webhook.tasks.CreateWebhookTask
 import com.netflix.spinnaker.orca.webhook.tasks.MonitorWebhookTask
-import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.webhook.WebhookService
+import com.netflix.spinnaker.orca.webhook.service.WebhookService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookSpec.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.webhook.config
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static com.netflix.spinnaker.orca.webhook.config.PreconfiguredWebhookProperties.StatusUrlResolution.*
+
+class PreconfiguredWebhookSpec extends Specification {
+
+  def "getPreconfiguredFields should return all fields if all stage configuration fields are populated"() {
+    setup:
+    def preconfiguredWebhook = createPreconfiguredWebhook()
+
+    when:
+    def fields = preconfiguredWebhook.preconfiguredProperties
+
+    then:
+    fields == ["url", "headers", "method", "payload", "waitForCompletion", "statusUrlResolution", "statusUrlJsonPath",
+      "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses"]
+  }
+
+  def "getPreconfiguredFields should return empty list if no stage configuration fields are populated"() {
+    setup:
+    def preconfiguredWebhook = new PreconfiguredWebhookProperties.PreconfiguredWebhook()
+
+    when:
+    def fields = preconfiguredWebhook.preconfiguredProperties
+
+    then:
+    fields == []
+  }
+
+  @Unroll
+  def "noUserConfigurableFields should be correct based on the configuration values"() {
+    when:
+    def preconfiguredWebhook = createPreconfiguredWebhook()
+    preconfiguredWebhook.with {
+      url = _url
+      waitForCompletion = _waitForCompletion
+      statusUrlResolution = _statusUrlResolution
+      statusJsonPath = _statusJsonPath
+    }
+
+    then:
+    preconfiguredWebhook.noUserConfigurableFields() == expected
+
+    where:
+    _url   | _waitForCompletion  | _statusUrlResolution | _statusJsonPath || expected
+    null   | null                | null                 | null            || false
+    null   | false               | null                 | null            || false
+    "foo"  | null                | null                 | null            || false
+    "foo"  | false               | null                 | null            || true
+    null   | true                | null                 | null            || false
+    "foo"  | true                | locationHeader       | null            || true
+    "foo"  | true                | getMethod            | null            || true
+    "foo"  | true                | getMethod            | "bar"           || true
+    "foo"  | true                | webhookResponse      | null            || false
+    "foo"  | true                | webhookResponse      | "bar"           || true
+  }
+
+  static PreconfiguredWebhookProperties.PreconfiguredWebhook createPreconfiguredWebhook() {
+    def headers = new HttpHeaders()
+    headers.put("header", ["value1", "value2"])
+    return new PreconfiguredWebhookProperties.PreconfiguredWebhook(
+      url: "url", headers: headers, method: HttpMethod.POST, payload: "payload",
+      waitForCompletion: true, statusUrlResolution: webhookResponse,
+      statusUrlJsonPath: "statusUrlJsonPath", statusJsonPath: "statusJsonPath", progressJsonPath: "progressJsonPath",
+      successStatuses: "successStatuses", canceledStatuses: "canceledStatuses", terminalStatuses: "terminalStatuses"
+    )
+  }
+}

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.webhook.pipeline
+
+import com.netflix.spinnaker.orca.pipeline.TaskNode
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.webhook.config.PreconfiguredWebhookProperties
+import com.netflix.spinnaker.orca.webhook.service.WebhookService
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import spock.lang.Specification
+import spock.lang.Subject
+
+class PreconfiguredWebhookStageSpec extends Specification {
+
+  def webhookService = Mock(WebhookService)
+  def builder = new TaskNode.Builder()
+
+  @Subject
+  preconfiguredWebhookStage = new PreconfiguredWebhookStage(webhookService: webhookService)
+
+  def "Context should be taken from PreconfiguredWebhookProperties"() {
+    given:
+    def stage = new Stage<Pipeline>(new Pipeline(), "webhook_1", [:])
+
+    when:
+    preconfiguredWebhookStage.taskGraph(stage, builder)
+
+    then:
+    1 * webhookService.preconfiguredWebhooks >> [createPreconfiguredWebhook("Webhook #1", "Description #1", "webhook_1")]
+    stage.context == [
+      url: "a",
+      headers: ["header": ["value1"]],
+      method: HttpMethod.POST,
+      payload: "b",
+      waitForCompletion: true,
+      statusUrlResolution: PreconfiguredWebhookProperties.StatusUrlResolution.webhookResponse,
+      statusUrlJsonPath: "c",
+      statusJsonPath: "d",
+      progressJsonPath: "e",
+      successStatuses: "f",
+      canceledStatuses: "g",
+      terminalStatuses: "h"
+    ]
+  }
+
+  def "Existing context should be preserved"() {
+    given:
+    def stage = new Stage<Pipeline>(new Pipeline(), "webhook_1", [
+      url: "a",
+      headers: ["header": ["value1"]],
+      method: HttpMethod.POST,
+      payload: "b",
+      waitForCompletion: true,
+      statusUrlResolution: PreconfiguredWebhookProperties.StatusUrlResolution.webhookResponse,
+      statusUrlJsonPath: "c",
+      statusJsonPath: "d",
+      progressJsonPath: "e",
+      successStatuses: "f",
+      canceledStatuses: "g",
+      terminalStatuses: "h"
+    ])
+
+    when:
+    preconfiguredWebhookStage.taskGraph(stage, builder)
+
+    then:
+    1 * webhookService.preconfiguredWebhooks >> [new PreconfiguredWebhookProperties.PreconfiguredWebhook(label: "Webhook #1", description: "Description #1", type: "webhook_1")]
+    stage.context == [
+      url: "a",
+      headers: ["header": ["value1"]],
+      method: HttpMethod.POST,
+      payload: "b",
+      waitForCompletion: true,
+      statusUrlResolution: PreconfiguredWebhookProperties.StatusUrlResolution.webhookResponse,
+      statusUrlJsonPath: "c",
+      statusJsonPath: "d",
+      progressJsonPath: "e",
+      successStatuses: "f",
+      canceledStatuses: "g",
+      terminalStatuses: "h"
+    ]
+  }
+
+  def "Should prioritize user context to preconfigured context to allow overriding values in advanced use cases"() {
+    given:
+    def stage = new Stage<Pipeline>(new Pipeline(), "webhook_1", [
+      url: "fromContext",
+      headers: ["fromContext": ["fromContext"]],
+      method: HttpMethod.POST,
+      waitForCompletion: false,
+      statusUrlResolution: PreconfiguredWebhookProperties.StatusUrlResolution.locationHeader,
+      statusUrlJsonPath: "fromContext",
+      statusJsonPath: "fromContext",
+      progressJsonPath: "fromContext",
+      successStatuses: "fromContext",
+      canceledStatuses: "fromContext",
+      terminalStatuses: "fromContext"
+    ])
+
+    when:
+    preconfiguredWebhookStage.taskGraph(stage, builder)
+
+    then:
+    1 * webhookService.preconfiguredWebhooks >> [createPreconfiguredWebhook("Webhook #1", "Description #1", "webhook_1")]
+    stage.context == [
+      url: "fromContext",
+      headers: ["fromContext": ["fromContext"]],
+      method: HttpMethod.POST,
+      payload: "b",
+      waitForCompletion: false,
+      statusUrlResolution: PreconfiguredWebhookProperties.StatusUrlResolution.locationHeader,
+      statusUrlJsonPath: "fromContext",
+      statusJsonPath: "fromContext",
+      progressJsonPath: "fromContext",
+      successStatuses: "fromContext",
+      canceledStatuses: "fromContext",
+      terminalStatuses: "fromContext"
+    ]
+  }
+
+  static PreconfiguredWebhookProperties.PreconfiguredWebhook createPreconfiguredWebhook(def label, def description, def type) {
+    def headers = new HttpHeaders()
+    headers.add("header", "value1")
+    return new PreconfiguredWebhookProperties.PreconfiguredWebhook(
+      label: label, description: description, type: type, url: "a", headers: headers, method: HttpMethod.POST, payload: "b",
+      waitForCompletion: true, statusUrlResolution: PreconfiguredWebhookProperties.StatusUrlResolution.webhookResponse,
+      statusUrlJsonPath: "c", statusJsonPath: "d", progressJsonPath: "e", successStatuses: "f", canceledStatuses: "g", terminalStatuses: "h"
+    )
+  }
+}

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
@@ -20,7 +20,7 @@ package com.netflix.spinnaker.orca.webhook.tasks
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.webhook.WebhookService
+import com.netflix.spinnaker.orca.webhook.service.WebhookService
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -130,7 +130,7 @@ class CreateWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.TERMINAL
-    result.stageOutputs as Map == [statusCode: HttpStatus.BAD_REQUEST, buildInfo: [error: "Oh noes, you can't do this"], error: "The request did not return a 2xx status"]
+    result.stageOutputs as Map == [statusCode: HttpStatus.BAD_REQUEST, buildInfo: [error: "Oh noes, you can't do this"], error: "The request did not return a 2xx/3xx status"]
   }
 
   def "if statusUrlResolution is getMethod, should return SUCCEEDED status"() {

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTaskSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTaskSpec.groovy
@@ -20,7 +20,7 @@ package com.netflix.spinnaker.orca.webhook.tasks
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.webhook.WebhookService
+import com.netflix.spinnaker.orca.webhook.service.WebhookService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import spock.lang.Specification


### PR DESCRIPTION
Adds support for preconfigured webhook stages that appears as native stages in Deck. Please have a look, I'm sure there's a lot of room for improvement here 😃

Screenshots from Deck:
<img width="895" alt="skjermbilde 2017-05-09 kl 15 08 39" src="https://cloud.githubusercontent.com/assets/155558/25852386/77b9a0ba-34c9-11e7-9859-8ac38f0b40b1.png">
<img width="858" alt="skjermbilde 2017-05-09 kl 15 09 55" src="https://cloud.githubusercontent.com/assets/155558/25852440/a04a9d18-34c9-11e7-926b-c4394783eb6f.png">

Example configuration in `orca.yml`:

```yaml
webhook:
  preconfigured:
    - label: Some Webhook
      description: This is a webhook stage, but it appears as a native stage in Spinnaker
      type: customWebhook # Should be unique
      # The following properties are all optional:
      enabled: true # default true
      url: https://my.webhook.com/event
      headers:
        Accept:
          - application/json
        AnotherHeader:
          - valueOne
          - valueTwo
      method: POST
      payload: |
        {
          "text": "Version ${trigger.buildInfo.artifacts[0].version} deployed"
        }
      waitForCompletion: true
      # The rest of the properties are only used if waitForCompletion == true
      statusUrlResolution: webhookResponse # getMethod, locationHeader, webhookResponse
      statusUrlJsonPath: $.statusUrl # Only used if statusUrlResolution == webhookResponse
      statusJsonPath: $.status
      progressJsonPath: $.progress
      successStatuses: SUCCESS,COMPLETED
      canceledStatuses: CANCELED
      terminalStatuses: TERMINATED
    - label: Another Webhook
      description: This is also a webhook stage, but it has no properties set
      type: anotherCustomWebhook
      enabled: false
```

The properties that are defined in Orca are not surfaced to Deck in the configuration stage, however, all properties are visible in the execution context, so there should be no secrets in the configuration for now. I'm considering a way to mitigate this.

This PR adds a new endpoint that is queried from Deck that just pass the relevant parts of the configuration to the frontend, and a new `PreconfiguredWebhookStage` that extends `WebhookStage`. This new stage just merge the configuration in the stage context with the preconfigured values.

Corresponds with PR https://github.com/spinnaker/gate/pull/389 and https://github.com/spinnaker/deck/pull/3655.
See issue https://github.com/spinnaker/spinnaker/issues/1512.