### PR TITLE
handle completion of executions correctly

### DIFF
--- a/gradle/spek.gradle
+++ b/gradle/spek.gradle
@@ -26,7 +26,7 @@ dependencies {
   testCompile "org.jetbrains.spek:spek-api:$spekVersion"
   testCompile "org.jetbrains.spek:spek-subject-extension:$spekVersion"
   testCompile "com.nhaarman:mockito-kotlin:1.4.0"
-  testCompile "com.natpryce:hamkrest:1.3.0.0"
+  testCompile "com.natpryce:hamkrest:1.4.0.0"
   testCompile "org.junit.jupiter:junit-jupiter-api:$jupiterVersion"
 
   testRuntime "org.junit.platform:junit-platform-launcher:$junitVersion"

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
@@ -188,6 +188,9 @@ data class CancelStage(
 ) : Message(), StageLevel {
   constructor(source: StageLevel) :
     this(source.executionType, source.executionId, source.application, source.stageId)
+
+  constructor(stage: Stage<*>) :
+    this(stage.getExecution().javaClass, stage.getExecution().getId(), stage.getExecution().getApplication(), stage.getId())
 }
 
 data class StartExecution(
@@ -202,14 +205,13 @@ data class StartExecution(
 data class CompleteExecution(
   override val executionType: Class<out Execution<*>>,
   override val executionId: String,
-  override val application: String,
-  val status: ExecutionStatus
+  override val application: String
 ) : Message(), ExecutionLevel {
-  constructor(source: ExecutionLevel, status: ExecutionStatus) :
-    this(source.executionType, source.executionId, source.application, status)
+  constructor(source: ExecutionLevel) :
+    this(source.executionType, source.executionId, source.application)
 
-  constructor(source: Execution<*>, status: ExecutionStatus) :
-    this(source.javaClass, source.getId(), source.getApplication(), status)
+  constructor(source: Execution<*>) :
+    this(source.javaClass, source.getId(), source.getApplication())
 }
 
 data class ResumeExecution(

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -48,7 +48,7 @@ open class CompleteStageHandler
       } else {
         queue.push(CancelStage(message))
         if (stage.getSyntheticStageOwner() == null) {
-          queue.push(CompleteExecution(message, message.status))
+          queue.push(CompleteExecution(message))
         } else {
           queue.push(message.copy(stageId = stage.getParentStageId()))
         }
@@ -68,6 +68,7 @@ open class CompleteStageHandler
           queue.push(StartStage(it))
         }
       } else if (getSyntheticStageOwner() == STAGE_BEFORE) {
+        // TODO: I'm not convinced this is a good approach, we should probably signal completion of the branch and have downstream handler no-op if other branches are incomplete
         parent().let { parent ->
           if (parent.allBeforeStagesComplete()) {
             if (parent.getTasks().isNotEmpty()) {
@@ -86,7 +87,7 @@ open class CompleteStageHandler
           queue.push(CompleteStage(parent, SUCCEEDED))
         }
       } else {
-        queue.push(CompleteExecution(execution, SUCCEEDED))
+        queue.push(CompleteExecution(execution))
       }
     }
   }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandler.kt
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca.q.handler
 
-import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.CompleteExecution
 import com.netflix.spinnaker.orca.q.ConfigurationError
@@ -35,6 +34,6 @@ open class ConfigurationErrorHandler
   override val messageType = ConfigurationError::class.java
 
   override fun handle(message: ConfigurationError) {
-    queue.push(CompleteExecution(message, TERMINAL))
+    queue.push(CompleteExecution(message))
   }
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandler.kt
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component
     when (message) {
       is TaskLevel -> queue.push(CompleteTask(message, TERMINAL))
       is StageLevel -> queue.push(CompleteStage(message, TERMINAL))
-      is ExecutionLevel -> queue.push(CompleteExecution(message, TERMINAL))
+      is ExecutionLevel -> queue.push(CompleteExecution(message))
       else -> log.error("Unhandled message type ${message.javaClass}")
     }
   }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/discovery/DiscoveryActivatedSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/discovery/DiscoveryActivatedSpec.kt
@@ -35,7 +35,7 @@ object DiscoveryActivatedSpec : Spek({
 
   describe("a discovery-activated poller") {
 
-    val target: Function0<Unit> = mock()
+    val target: () -> Unit = mock()
     val subject = object : DiscoveryActivated {
       override val log = LoggerFactory.getLogger(this::class.java)
       override val enabled = AtomicBoolean(false)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/MessageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/MessageHandlerSpec.kt
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.q
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.throws
-import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.nhaarman.mockito_kotlin.mock
@@ -54,7 +53,7 @@ object MessageHandlerSpec : SubjectSpek<MessageHandler<*>>({
   fun resetMocks() = reset(queue, handleCallback)
 
   describe("when the handler is passed the wrong type of message") {
-    val message = CompleteExecution(Pipeline::class.java, "1", "foo", SUCCEEDED)
+    val message = CompleteExecution(Pipeline::class.java, "1", "foo")
 
     afterGroup(::resetMocks)
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueProcessorSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueProcessorSpec.kt
@@ -58,7 +58,7 @@ object QueueProcessorSpec : SubjectSpek<QueueProcessor>({
     }
 
     describe("when disabled in discovery") {
-      beforeGroup {
+      beforeEachTest {
         subject.onApplicationEvent(RemoteStatusChangedEvent(StatusChangeEvent(UP, OUT_OF_SERVICE)))
       }
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerSpec.kt
@@ -24,20 +24,22 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
 import com.netflix.spinnaker.orca.time.fixedClock
 import com.nhaarman.mockito_kotlin.*
-import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
 import org.springframework.context.ApplicationEventPublisher
 
-object CompleteStageHandlerSpec : Spek({
+object CompleteStageHandlerSpec : SubjectSpek<CompleteStageHandler>({
 
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
   val publisher: ApplicationEventPublisher = mock()
   val clock = fixedClock()
 
-  val handler = CompleteStageHandler(queue, repository, publisher, clock)
+  subject {
+    CompleteStageHandler(queue, repository, publisher, clock)
+  }
 
   fun resetMocks() = reset(queue, repository, publisher)
 
@@ -59,7 +61,7 @@ object CompleteStageHandlerSpec : Spek({
         afterGroup(::resetMocks)
 
         action("the handler receives a message") {
-          handler.handle(message)
+          subject.handle(message)
         }
 
         it("updates the stage state") {
@@ -114,7 +116,7 @@ object CompleteStageHandlerSpec : Spek({
         afterGroup(::resetMocks)
 
         action("the handler receives a message") {
-          handler.handle(message)
+          subject.handle(message)
         }
 
         it("updates the stage state") {
@@ -165,7 +167,7 @@ object CompleteStageHandlerSpec : Spek({
         afterGroup(::resetMocks)
 
         action("the handler receives a message") {
-          handler.handle(message)
+          subject.handle(message)
         }
 
         it("runs the next stages") {
@@ -201,7 +203,7 @@ object CompleteStageHandlerSpec : Spek({
       afterGroup(::resetMocks)
 
       action("the handler receives a message") {
-        handler.handle(message)
+        subject.handle(message)
       }
 
       it("updates the stage state") {
@@ -261,7 +263,7 @@ object CompleteStageHandlerSpec : Spek({
             afterGroup(::resetMocks)
 
             action("the handler receives a message") {
-              handler.handle(message)
+              subject.handle(message)
             }
 
             it("runs the next synthetic stage") {
@@ -283,7 +285,7 @@ object CompleteStageHandlerSpec : Spek({
             afterGroup(::resetMocks)
 
             action("the handler receives a message") {
-              handler.handle(message)
+              subject.handle(message)
             }
 
             it("runs the next synthetic stage") {
@@ -318,7 +320,7 @@ object CompleteStageHandlerSpec : Spek({
             afterGroup(::resetMocks)
 
             action("the handler receives a message") {
-              handler.handle(message)
+              subject.handle(message)
             }
 
             it("completes the stage") {
@@ -353,7 +355,7 @@ object CompleteStageHandlerSpec : Spek({
             afterGroup(::resetMocks)
 
             action("the handler receives a message") {
-              handler.handle(message)
+              subject.handle(message)
             }
 
             it("starts the first after stage") {
@@ -387,7 +389,7 @@ object CompleteStageHandlerSpec : Spek({
           afterGroup(::resetMocks)
 
           action("the handler receives a message") {
-            handler.handle(message)
+            subject.handle(message)
           }
 
           it("runs the next synthetic stage") {
@@ -409,7 +411,7 @@ object CompleteStageHandlerSpec : Spek({
           afterGroup(::resetMocks)
 
           action("the handler receives a message") {
-            handler.handle(message)
+            subject.handle(message)
           }
 
           it("signals the completion of the parent stage") {
@@ -442,7 +444,7 @@ object CompleteStageHandlerSpec : Spek({
         }
 
         action("the handler receives a message") {
-          handler.handle(message)
+          subject.handle(message)
         }
 
         afterGroup(::resetMocks)
@@ -479,7 +481,7 @@ object CompleteStageHandlerSpec : Spek({
       afterGroup(::resetMocks)
 
       action("the handler receives a message") {
-        handler.handle(message)
+        subject.handle(message)
       }
 
       it("waits for other branches to finish") {
@@ -513,7 +515,7 @@ object CompleteStageHandlerSpec : Spek({
       afterGroup(::resetMocks)
 
       action("the handler receives a message") {
-        handler.handle(message)
+        subject.handle(message)
       }
 
       it("runs any post-branch tasks") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerSpec.kt
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Task
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
 import com.netflix.spinnaker.orca.time.fixedClock
+import com.netflix.spinnaker.spek.shouldEqual
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandlerSpec.kt
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca.q.handler
 
-import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
@@ -54,8 +53,7 @@ object ConfigurationErrorHandlerSpec : SubjectSpek<ConfigurationErrorHandler>({
         verify(queue).push(CompleteExecution(
           Pipeline::class.java,
           message.executionId,
-          "foo",
-          TERMINAL
+          "foo"
         ))
       }
     }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandlerSpec.kt
@@ -46,7 +46,7 @@ object DeadMessageHandlerSpec : SubjectSpek<DeadMessageHandler>({
     }
 
     it("terminates the execution") {
-      verify(queue).push(CompleteExecution(message, TERMINAL))
+      verify(queue).push(CompleteExecution(message))
     }
   }
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/PauseStageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/PauseStageHandlerSpec.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
+import com.netflix.spinnaker.spek.shouldEqual
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/PauseTaskHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/PauseTaskHandlerSpec.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
+import com.netflix.spinnaker.spek.shouldEqual
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerSpec.kt
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
+import com.netflix.spinnaker.spek.shouldEqual
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
@@ -335,8 +336,4 @@ fun <T : Execution<T>> StageDefinitionBuilder.plan(stage: Stage<T>) {
   stage.type = type
   buildTasks(stage)
   buildSyntheticStages(stage)
-}
-
-infix fun <T> T.shouldEqual(expected: T) {
-  this shouldMatch equalTo(expected)
 }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeStageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeStageHandlerSpec.kt
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus.*
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
+import com.netflix.spinnaker.spek.shouldEqual
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeTaskHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeTaskHandlerSpec.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
+import com.netflix.spinnaker.spek.shouldEqual
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerSpec.kt
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
 import com.netflix.spinnaker.orca.time.fixedClock
 import com.netflix.spinnaker.spek.and
+import com.netflix.spinnaker.spek.shouldEqual
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerSpec.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.events.ExecutionStarted
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
+import com.netflix.spinnaker.spek.shouldEqual
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerSpec.kt
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.q.*
 import com.netflix.spinnaker.orca.time.fixedClock
 import com.netflix.spinnaker.spek.and
+import com.netflix.spinnaker.spek.shouldEqual
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandlerSpec.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
 import com.netflix.spinnaker.orca.time.fixedClock
+import com.netflix.spinnaker.spek.shouldEqual
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/spek/should.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/spek/should.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.spek
+
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.should.shouldMatch
+
+infix fun <T> T.shouldEqual(expected: T) {
+  this shouldMatch equalTo(expected)
+}


### PR DESCRIPTION
Instead of the `CompleteExecution` message carrying a status (that might get overridden), the handler now works out the status based on the pipeline state. That way it can ignore messages sent early when un-joined branches complete, can override status sensibly, etc.