### PR TITLE
fix(upsert_lb_task): Fix up context name defaulting.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerTask.groovy
@@ -53,7 +53,16 @@ class UpsertLoadBalancerTask extends AbstractCloudProviderAwareTask implements R
     String account = getCredentials(stage)
 
     def context = new HashMap(stage.context)
-    context.name = context.name ?: "${stage.context.clusterName}-frontend"
+    if (!context.name) {
+      if (context.clusterName) {
+        context.name = "${stage.context.clusterName}-frontend"
+      } else if (context.loadBalancerName) {
+        context.name = context.loadBalancerName
+      } else {
+        throw new IllegalArgumentException("Context for ${CLOUD_OPERATION_TYPE} is missing a name and has no default fallback options.")
+      }
+    }
+
     context.availabilityZones = context.availabilityZones ?: [(context.region): context.regionZones]
 
     def operations = [


### PR DESCRIPTION
Prior to this PR, defaulting to `clusterName` without null-checking would cause the context name to default to 'null-frontend' in some cases when Orca asked Clouddriver for a cache refresh, which would cause failures that were subtle and hard to debug without `FULL` debug levels on Orca and Clouddriver. This way is safer and clearer in case of defaulting failures.