### PR TITLE
fix(queue): handle task timeouts correctly

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
@@ -16,8 +16,7 @@
 
 package com.netflix.spinnaker.orca.q
 
-import com.netflix.spinnaker.orca.ExecutionStatus.FAILED_CONTINUE
-import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
+import com.netflix.spinnaker.orca.ExecutionStatus.*
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_AFTER
@@ -97,10 +96,10 @@ fun Stage<*>.upstreamStages(): List<Stage<*>> =
  * @return `true` if all upstream stages of this stage were run successfully.
  */
 fun Stage<*>.allUpstreamStagesComplete(): Boolean =
-  upstreamStages().all { it.getStatus() in listOf(SUCCEEDED, FAILED_CONTINUE) }
+  upstreamStages().all { it.getStatus() in listOf(SUCCEEDED, FAILED_CONTINUE, SKIPPED) }
 
 fun Stage<*>.beforeStages(): List<Stage<*>> =
   getExecution().getStages().filter { it.getParentStageId() == getId() && it.getSyntheticStageOwner() == STAGE_BEFORE }
 
 fun Stage<*>.allBeforeStagesComplete(): Boolean =
-  beforeStages().all { it.getStatus() == SUCCEEDED }
+  beforeStages().all { it.getStatus() in listOf(SUCCEEDED, FAILED_CONTINUE, SKIPPED) }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/time/time.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/time/time.kt
@@ -1,0 +1,22 @@
+import java.time.Duration
+import java.time.Instant
+
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+fun Long?.toInstant() = if (this == null) null else Instant.ofEpochMilli(this)
+
+fun Long.toDuration() = Duration.ofMillis(this)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerSpec.kt
@@ -56,10 +56,10 @@ object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
       val pipeline = pipeline {
         stage {
           type = "whatever"
-          startTime = clock.instant().toEpochMilli()
           task {
             id = "1"
             implementingClass = DummyTask::class.qualifiedName
+            startTime = clock.instant().toEpochMilli()
           }
         }
       }
@@ -92,10 +92,10 @@ object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
       val pipeline = pipeline {
         stage {
           type = "whatever"
-          startTime = clock.instant().toEpochMilli()
           task {
             id = "1"
             implementingClass = DummyTask::class.qualifiedName
+            startTime = clock.instant().toEpochMilli()
           }
         }
       }
@@ -125,10 +125,10 @@ object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
         stage {
           refId = "1"
           type = "whatever"
-          startTime = clock.instant().toEpochMilli()
           task {
             id = "1"
             implementingClass = DummyTask::class.qualifiedName
+            startTime = clock.instant().toEpochMilli()
           }
         }
       }
@@ -209,10 +209,10 @@ object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
       val pipeline = pipeline {
         stage {
           type = "whatever"
-          startTime = clock.instant().toEpochMilli()
           task {
             id = "1"
             implementingClass = DummyTask::class.qualifiedName
+            startTime = clock.instant().toEpochMilli()
           }
         }
       }
@@ -402,11 +402,11 @@ object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
         val pipeline = pipeline {
           stage {
             type = "whatever"
-            startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
             task {
               id = "1"
               implementingClass = DummyTask::class.qualifiedName
               status = RUNNING
+              startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
             }
           }
         }
@@ -441,11 +441,11 @@ object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
           }
           stage {
             type = "whatever"
-            startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
             task {
               id = "1"
               implementingClass = DummyTask::class.qualifiedName
               status = RUNNING
+              startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
             }
           }
         }
@@ -476,11 +476,11 @@ object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
           }
           stage {
             type = "whatever"
-            startTime = clock.instant().minusMillis(timeout.plusMinutes(1).toMillis() + 1).toEpochMilli()
             task {
               id = "1"
               implementingClass = DummyTask::class.qualifiedName
               status = RUNNING
+              startTime = clock.instant().minusMillis(timeout.plusMinutes(1).toMillis() + 1).toEpochMilli()
             }
           }
         }
@@ -506,59 +506,20 @@ object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
         }
       }
 
-      context("the execution spent a long time running before stages") {
+      context("the execution had been paused but only before this task started running") {
         val timeout = Duration.ofMinutes(5)
         val pipeline = pipeline {
-          stage {
-            type = "whatever"
-            startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
-            task {
-              id = "1"
-              implementingClass = DummyTask::class.qualifiedName
-              status = SUCCEEDED
-              startTime = clock.instant().minusMillis(timeout.toMillis() - 1).toEpochMilli()
-            }
-            task {
-              id = "2"
-              implementingClass = DummyTask::class.qualifiedName
-              status = RUNNING
-            }
+          paused = PausedDetails().apply {
+            pauseTime = clock.instant().minus(Minutes.of(10)).toEpochMilli()
+            resumeTime = clock.instant().minus(Minutes.of(9)).toEpochMilli()
           }
-        }
-        val message = RunTask(Pipeline::class.java, pipeline.id, "foo", pipeline.stages.first().id, "2", DummyTask::class.java)
-
-        beforeGroup {
-          whenever(repository.retrievePipeline(message.executionId)) doReturn pipeline
-          whenever(task.timeout) doReturn timeout.toMillis()
-        }
-
-        afterGroup(::resetMocks)
-
-        action("the handler receives a message") {
-          subject.handle(message)
-        }
-
-        it("executes the task") {
-          verify(task).execute(any())
-        }
-      }
-
-      context("the execution spent a long time running before stages but is timed out anyway") {
-        val timeout = Duration.ofMinutes(5)
-        val pipeline = pipeline {
           stage {
             type = "whatever"
-            startTime = clock.instant().minusMillis(timeout.toMillis() + 2).toEpochMilli()
             task {
               id = "1"
               implementingClass = DummyTask::class.qualifiedName
-              status = SUCCEEDED
-              startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
-            }
-            task {
-              id = "2"
-              implementingClass = DummyTask::class.qualifiedName
               status = RUNNING
+              startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
             }
           }
         }
@@ -591,12 +552,12 @@ object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
         context["override"] = "global"
         stage {
           type = "whatever"
-          startTime = clock.instant().toEpochMilli()
           context["stage"] = "foo"
           context["override"] = "stage"
           task {
             id = "1"
             implementingClass = DummyTask::class.qualifiedName
+            startTime = clock.instant().toEpochMilli()
           }
         }
       }


### PR DESCRIPTION
timeout should be based on start time of the task not the stage, also paused time should only be considered if the execution was paused _during_ the task.