### PR TITLE
feat(dcd) support setting templates from trigger context using spel

### DIFF
--- a/orca-pipelinetemplate/src/test/resources/templates/spel-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/spel-001.yml
@@ -1,0 +1,8 @@
+schema: "1"
+id: spel1
+stages:
+- id: wait
+  type: wait
+  name: spel1
+  config:
+    waitTime: 5

--- a/orca-pipelinetemplate/src/test/resources/templates/spel-002.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/spel-002.yml
@@ -1,0 +1,8 @@
+schema: "1"
+id: spel2
+stages:
+- id: wait
+  type: wait
+  name: spel2
+  config:
+    waitTime: 5


### PR DESCRIPTION
This enables us to use spel to override what template source to use. This means you can upload a template in your ci build and use that one in the pipeline execution. This means we can have pipeline definitions following the same flow as other code and still be able to rollback easily.

```
{
  "appConfig": {},
  "config": {
    "pipeline": {
      "application": "gardtest",
      "name": "My wait pipeline",
      "pipelineConfigId": "eebaa78d-ecc2-4638-86aa-1afa9defebec",
      "template": {
        "source": "file:///opt/orca/templates/${trigger.parameters.template}"
      },
      "variables": {}
    },
    "schema": "1"
  },
  "executionEngine": "v2",
  "keepWaitingPipelines": false,
  "lastModifiedBy": "gard.rimestad@schibsted.com",
  "limitConcurrent": true,
  "parallel": true,
  "parameterConfig": [
    {
      "default": "test.yml",
      "name": "template"
    }
  ],
  "stages": [],
  "type": "templatedPipeline",
  "updateTs": "1494415568000"
}

```