### PR TITLE
fix(expressions): further restrict object traversal in expression processing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
   group = "com.netflix.spinnaker.orca"
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.90.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.91.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionStatus.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionStatus.java
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.orca
+package com.netflix.spinnaker.orca;
 
-import groovy.transform.CompileStatic
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 
-@CompileStatic
-enum ExecutionStatus {
+public enum ExecutionStatus {
   /**
    * The task has yet to start.
    */
@@ -79,31 +80,40 @@ enum ExecutionStatus {
   /**
    * The task was skipped and the pipeline will proceed to the next task.
    */
-    SKIPPED(true, false)
+    SKIPPED(true, false);
 
   /**
    * Indicates that the task/stage/pipeline has finished its work (successfully or not).
    */
-  final boolean complete
+  public final boolean isComplete() {
+    return complete;
+  }
 
   /**
    * Indicates an abnormal completion so nothing downstream should run afterward.
    */
-  final boolean halt
+  public final boolean isHalt() {
+    return halt;
+  }
 
-  private static final Collection<ExecutionStatus> SUCCESSFUL = [SUCCEEDED, STOPPED, SKIPPED]
-  private static final Collection<ExecutionStatus> FAILURE = [TERMINAL, STOPPED, FAILED_CONTINUE]
+  private static final Collection<ExecutionStatus> SUCCESSFUL = Collections.unmodifiableList(Arrays.asList(SUCCEEDED, STOPPED, SKIPPED));
+  private static final Collection<ExecutionStatus> FAILURE = Collections.unmodifiableList(Arrays.asList(TERMINAL, STOPPED, FAILED_CONTINUE));
+
+  private final boolean complete;
+  private final boolean halt;
 
   ExecutionStatus(boolean complete, boolean halt) {
-    this.complete = complete
-    this.halt = halt
+    this.complete = complete;
+    this.halt = halt;
   }
 
-  boolean isSuccessful() {
-    return SUCCESSFUL.contains(this)
+
+  public boolean isSuccessful() {
+    return SUCCESSFUL.contains(this);
   }
 
-  boolean isFailure() {
-    return FAILURE.contains(this)
+  public boolean isFailure() {
+    return FAILURE.contains(this);
   }
+
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupportSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupportSpec.groovy
@@ -25,14 +25,15 @@ import spock.lang.Unroll
 
 class OptionalStageSupportSpec extends Specification {
 
-  @Shared ContextParameterProcessor contextParameterProcessor = new ContextParameterProcessor()
+  @Shared
+  ContextParameterProcessor contextParameterProcessor = new ContextParameterProcessor()
 
   @Unroll
-  def "should support expression-based optionality"() {
+  def "should support expression-based optionality #desc"() {
     given:
     def pipeline = new Pipeline()
     pipeline.trigger.parameters = [
-      "p1": "v1"
+        "p1": "v1"
     ]
     pipeline.stages << new Stage<>(pipeline, "", "Test1", [:])
     pipeline.stages[0].status = ExecutionStatus.FAILED_CONTINUE
@@ -42,24 +43,25 @@ class OptionalStageSupportSpec extends Specification {
 
     and:
     def stage = new Stage<>(pipeline, "", [
-      stageEnabled: optionalConfig
+        stageEnabled: optionalConfig
     ])
 
     expect:
     OptionalStageSupport.isOptional(stage, contextParameterProcessor) == expectedOptionality
 
     where:
-    optionalConfig                                                                                                   || expectedOptionality
-    [:]                                                                                                              || false
-    [type: "expression"]                                                                                             || false
-    [type: "expression", expression: ""]                                                                             || false
-    [type: "expression", expression: null]                                                                           || false
-    [type: "expression", expression: "parameters.p1 == 'v1'"]                                                        || false
-    [type: "expression", expression: "parameters.p1 == 'v2'"]                                                        || true
-    [type: "expression", expression: "execution.stages.?[name == 'Test2'][0]['status'].name() == 'FAILED_CONTINUE'"] || true
-    [type: "expression", expression: "execution.stages.?[name == 'Test1'][0]['status'].name() == 'FAILED_CONTINUE'"] || false
-    [type: "expression", expression: "true"]                                                                         || false
-    [type: "expression", expression: "false"]                                                                        || true
+    desc                        | optionalConfig                                                                                                       || expectedOptionality
+    "empty config"              | [:]                                                                                                                  || false
+    "no expression"             | [type: "expression"]                                                                                                 || false
+    "empty expression"          | [type: "expression", expression: ""]                                                                                 || false
+    "null expression"           | [type: "expression", expression: null]                                                                               || false
+    "evals to true expression"  | [type: "expression", expression: "parameters.p1 == 'v1'"]                                                            || false
+    "evals to false expression" | [type: "expression", expression: "parameters.p1 == 'v2'"]                                                            || true
+    "nested"                    | [type: "expression", expression: "execution.stages.?[name == 'Test2'][0]['status'].toString() == 'FAILED_CONTINUE'"] || true
+    "nested"                    | [type: "expression", expression: "execution.stages.?[name == 'Test2'][0]['status'] == 'FAILED_CONTINUE'"]            || true
+    "nested2"                   | [type: "expression", expression: "execution.stages.?[name == 'Test1'][0]['status'] == 'FAILED_CONTINUE'"]            || false
+    "explicitly true"           | [type: "expression", expression: "true"]                                                                             || false
+    "explicitly false"          | [type: "expression", expression: "false"]                                                                            || true
   }
 
   @Unroll
@@ -67,10 +69,10 @@ class OptionalStageSupportSpec extends Specification {
     given:
     def pipeline = new Pipeline()
     pipeline.trigger.parameters = [
-      "p1": "v1"
+        "p1": "v1"
     ]
     pipeline.stages << new Stage<>(pipeline, "", "Test1", [
-      stageEnabled: optionalConfig
+        stageEnabled: optionalConfig
     ])
     pipeline.stages[0].status = ExecutionStatus.FAILED_CONTINUE
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandler.kt
@@ -40,7 +40,7 @@ open class CancelStageHandler
 
   override fun handle(message: CancelStage) {
     message.withStage { stage ->
-      if (stage.getStatus().halt) {
+      if (stage.getStatus().isHalt) {
         stage.builder().let { builder ->
           if (builder is CancellableStage) {
             // for the time being we execute this off-thread as some cancel

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
@@ -43,7 +43,7 @@ open class CompleteExecutionHandler
 
   override fun handle(message: CompleteExecution) {
     message.withExecution { execution ->
-      if (execution.getStatus().complete) {
+      if (execution.getStatus().isComplete) {
         log.info("Execution ${execution.getId()} already completed with ${execution.getStatus()} status")
       } else {
         execution.determineFinalStatus { status ->

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
@@ -42,7 +42,7 @@ open class RestartStageHandler
 
   override fun handle(message: RestartStage) {
     message.withStage { stage ->
-      if (stage.getStatus().complete) {
+      if (stage.getStatus().isComplete) {
         stage.addRestartDetails(message.user)
         stage.reset()
         repository.updateStatus(stage.getExecution().getId(), RUNNING)

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -58,7 +58,7 @@ open class RunTaskHandler
   override fun handle(message: RunTask) {
     message.withTask { stage, taskModel, task ->
       val execution = stage.getExecution()
-      if (execution.isCanceled() || execution.getStatus().complete) {
+      if (execution.isCanceled() || execution.getStatus().isComplete) {
         queue.push(CompleteTask(message, CANCELED))
       } else if (execution.getStatus() == PAUSED) {
         queue.push(PauseTask(message))

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/ExecutionLatch.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/ExecutionLatch.kt
@@ -66,6 +66,6 @@ fun <E : Execution<E>> ConfigurableApplicationContext.runToCompletion(execution:
     }
       .getStages()
       .map(Stage<*>::getStatus)
-      .all { it.complete || it == NOT_STARTED }
+      .all { it.isComplete || it == NOT_STARTED }
   }
 }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerSpec.kt
@@ -62,7 +62,7 @@ object RestartStageHandlerSpec : SubjectSpek<RestartStageHandler>({
 
   ExecutionStatus
     .values()
-    .filter { !it.complete }
+    .filter { !it.isComplete }
     .forEach { incompleteStatus ->
       describe("trying to restart a $incompleteStatus stage") {
         val pipeline = pipeline {


### PR DESCRIPTION
the existing restrictions weren't being applied when the object graph was traversed using property notation

additionally this change removes all the types from the expression root object (it will just be a JSON object of Map<String, Object> where as before it was actually a reference to the execution object

finally this converts ExecutionStatus from groovy to java which had a minor ripple into some of the kotlin code (@robfletcher might have a suggestion on naming the property acccessor differently on ExecutionStatus?)

@spinnaker/netflix-reviewers PTAL