### PR TITLE
fix queue locks and skipping execution windows

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -590,9 +590,13 @@ class JedisExecutionRepository implements ExecutionRepository {
 
     def serializedStage = serializeStage(stage)
     tx.hmset(key, filterValues(serializedStage, notNull()))
-    tx.hdel(key, serializedStage.keySet().findAll {
+
+    def keysToRemove = serializedStage.keySet().findAll {
       serializedStage[it] == null
-    } as String[])
+    }
+    if (!keysToRemove.empty) {
+      tx.hdel(key, keysToRemove as String[])
+    }
   }
 
   @CompileDynamic

--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueue.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueue.kt
@@ -119,7 +119,7 @@ class RedisQueue(
                 }
               } else {
                 log.warn("Re-delivering message $id after $attempts attempts")
-                move(unackedKey, queueKey, ZERO, setOf(id))
+                move(unackedKey, queueKey, ZERO, id)
               }
             }
           }
@@ -167,25 +167,24 @@ class RedisQueue(
    */
   private fun Jedis.pop(from: String, to: String, delay: TemporalAmount = ZERO) =
     zrangeByScore(from, 0.0, score(), 0, 1)
-      .takeIf {
-        // TODO: this isn't right, `it` is a set (often an empty one)
-        getSet("$locksKey:$it", currentInstanceId) in listOf(null, currentInstanceId)
+      .firstOrNull()
+      .takeIf { id ->
+        id != null && getSet("$locksKey:$id", currentInstanceId) in listOf(null, currentInstanceId)
       }
-      ?.also {
-        expire("$locksKey:$it", lockTtlSeconds)
-        move(from, to, delay, it)
+      ?.also { id ->
+        expire("$locksKey:$id", lockTtlSeconds)
+        move(from, to, delay, id)
       }
-      ?.firstOrNull()
 
   /**
-   * Move [values] from sorted set [from] to sorted set [to]
+   * Move [value] from sorted set [from] to sorted set [to]
    */
-  private fun Jedis.move(from: String, to: String, delay: TemporalAmount, values: Set<String>) {
-    if (values.isNotEmpty()) {
+  private fun Jedis.move(from: String, to: String, delay: TemporalAmount, value: String) {
+    if (value.isNotEmpty()) {
       val score = score(delay)
       multi {
-        zrem(from, *values.toTypedArray())
-        zadd(to, values.associate { Pair(it, score) })
+        zrem(from, value)
+        zadd(to, score, value)
       }
     }
   }

--- a/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueSpec.kt
+++ b/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueSpec.kt
@@ -39,3 +39,5 @@ private fun shutdownCallback() {
   println("shutting down the redis")
   redis?.destroy()
 }
+
+// TODO: test instance locking once I can figure out how to extend tests


### PR DESCRIPTION
Queue locks were trying to apply the lock to a set. It would kinda work but was spawning tons of unnecessary redis keys.

Execution windows could not be skipped because of an obscure snag in the execution repository. If a stage actually had data for all its fields (nothing `null`) we'd try to issue an `hdel` command with no fields which is invalid. Execution windows showed this up as they're one of the few things that sets the `lastModified` details field on stages.