### PR TITLE
Revert "fix(queue): instance lock logic was backward"

### DIFF
--- a/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueSpec.kt
+++ b/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueSpec.kt
@@ -39,5 +39,3 @@ private fun shutdownCallback() {
   println("shutting down the redis")
   redis?.destroy()
 }
-
-// TODO: test instance locking once I can figure out how to extend tests


### PR DESCRIPTION
This caused some unexpected behavior with re-delivering messages