### PR TITLE
feat(pipelinetemplate): Pipeline Template Partials support

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/GraphMutator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/GraphMutator.java
@@ -19,6 +19,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisitor;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConditionalStanzaTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConfigModuleReplacementTransform;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConfigPartialReplacementTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConfigStageInjectionTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.DefaultVariableAssignmentTransform;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.PipelineConfigInheritanceTransform;
@@ -40,9 +41,10 @@ public class GraphMutator {
     visitors.add(new DefaultVariableAssignmentTransform(configuration));
     visitors.add(new ConditionalStanzaTransform(configuration, renderer, trigger));
     visitors.add(new ConfigModuleReplacementTransform(configuration));
+    visitors.add(new ConfigPartialReplacementTransform(configuration));
     visitors.add(new PipelineConfigInheritanceTransform(configuration));
-    visitors.add(new ConfigStageInjectionTransform(configuration));
     visitors.add(new RenderTransform(configuration, renderer, registry, trigger));
+    visitors.add(new ConfigStageInjectionTransform(configuration));
     visitors.add(new StageInheritanceControlTransform());
   }
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigPartialReplacementTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigPartialReplacementTransform.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform;
+
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisitor;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.TemplateMerge;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
+
+public class ConfigPartialReplacementTransform implements PipelineTemplateVisitor {
+
+  private TemplateConfiguration templateConfiguration;
+
+  public ConfigPartialReplacementTransform(TemplateConfiguration templateConfiguration) {
+    this.templateConfiguration = templateConfiguration;
+  }
+
+  @Override
+  public void visitPipelineTemplate(PipelineTemplate pipelineTemplate) {
+    pipelineTemplate.setPartials(TemplateMerge.mergeIdentifiable(pipelineTemplate.getPartials(), templateConfiguration.getPartials()));
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/RenderTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/RenderTransform.java
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.Timer;
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.IllegalTemplateConfigurationException;
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisitor;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PartialDefinition;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate.Variable;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinition;
@@ -31,9 +32,11 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class RenderTransform implements PipelineTemplateVisitor {
 
@@ -75,43 +78,54 @@ public class RenderTransform implements PipelineTemplateVisitor {
     context.getVariables().putAll(templateConfiguration.getPipeline().getVariables());
 
     // We only render the stages here, whereas modules will be rendered only if used within stages.
-    renderStages(template.getStages(), context, "template");
-    renderStages(templateConfiguration.getStages(), context, "configuration");
+    renderStages(filterStages(template.getStages(), false), context, "template");
+    renderStages(filterStages(templateConfiguration.getStages(), false), context, "configuration");
+
+    // We don't care about configuration partials, they were already merged into the template at this point
+    renderPartials(template.getPartials(), filterStages(template.getStages(), true), context);
   }
 
-  @SuppressWarnings("unchecked")
   private void renderStages(List<StageDefinition> stages, RenderContext context, String locationNamespace) {
     if (stages == null) {
       return;
     }
 
     for (StageDefinition stage : stages) {
+      if (stage.isPartialType()) {
+        // Partials are handled separately
+        continue;
+      }
+
       context.setLocation(String.format("%s:stages.%s", locationNamespace, stage.getId()));
-
-      Object rendered;
-      try {
-        rendered = RenderUtil.deepRender(renderer, stage.getConfig(), context);
-      } catch (TemplateRenderException e) {
-        throw TemplateRenderException.fromError(
-          new Error()
-            .withMessage("Failed rendering stage")
-            .withLocation(context.getLocation()),
-          e
-        );
-      }
-
-      if (!(rendered instanceof Map)) {
-        throw new IllegalTemplateConfigurationException(new Errors.Error()
-          .withMessage("A stage's rendered config must be a map")
-          .withCause("Received type " + rendered.getClass().toString())
-          .withLocation(context.getLocation())
-        );
-      }
-      stage.setConfig((Map<String, Object>) rendered);
-
-      stage.setName(renderStageProperty(stage.getName(), context, getStagePropertyLocation(locationNamespace, stage.getId(), "name")));
-      stage.setComments(renderStageProperty(stage.getComments(), context, getStagePropertyLocation(locationNamespace, stage.getId(), "comments")));
+      renderStage(stage, context, locationNamespace);
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void renderStage(StageDefinition stage, RenderContext context, String locationNamespace) {
+    Object rendered;
+    try {
+      rendered = RenderUtil.deepRender(renderer, stage.getConfig(), context);
+    } catch (TemplateRenderException e) {
+      throw TemplateRenderException.fromError(
+        new Error()
+          .withMessage("Failed rendering stage")
+          .withLocation(context.getLocation()),
+        e
+      );
+    }
+
+    if (!(rendered instanceof Map)) {
+      throw new IllegalTemplateConfigurationException(new Errors.Error()
+        .withMessage("A stage's rendered config must be a map")
+        .withCause("Received type " + rendered.getClass().toString())
+        .withLocation(context.getLocation())
+      );
+    }
+    stage.setConfig((Map<String, Object>) rendered);
+
+    stage.setName(renderStageProperty(stage.getName(), context, getStagePropertyLocation(locationNamespace, stage.getId(), "name")));
+    stage.setComments(renderStageProperty(stage.getComments(), context, getStagePropertyLocation(locationNamespace, stage.getId(), "comments")));
   }
 
   private String renderStageProperty(String input, RenderContext context, String location) {
@@ -129,5 +143,60 @@ public class RenderTransform implements PipelineTemplateVisitor {
 
   private static String getStagePropertyLocation(String namespace, String stageId, String propertyName) {
     return String.format("%s:stages.%s.%s", namespace, stageId, propertyName);
+  }
+
+  private static List<StageDefinition> filterStages(List<StageDefinition> stages, boolean partialsOnly) {
+    return stages.stream().filter(s -> partialsOnly == s.isPartialType()).collect(Collectors.toList());
+  }
+
+  private void renderPartials(List<PartialDefinition> partials, List<StageDefinition> stages, RenderContext context) {
+    for (StageDefinition stage : stages) {
+      String partialId = stage.getPartialId();
+      if (partialId == null) {
+        throw TemplateRenderException.fromError(
+          new Error()
+            .withMessage("Stage with partial type has malformed ID format")
+            .withCause(String.format("Expected 'partial:PARTIAL_ID' got '%s'", stage.getType()))
+            .withLocation(String.format("template:stages.%s", stage.getId()))
+        );
+      }
+      PartialDefinition partial = partials.stream().filter(p -> p.getId().equals(partialId)).findFirst().orElseThrow(() -> new TemplateRenderException("guh"));
+
+      RenderContext partialContext = context.copy();
+      partialContext.getVariables().putAll(stage.getConfig());
+      partialContext.setLocation(String.format("partial:%s.%s", stage.getId(), partial.getId()));
+
+      List<StageDefinition> renderedStages = new ArrayList<>();
+      for (StageDefinition partialStage : partial.getStages()) {
+        // TODO rz - add recursive partials support
+        if (partialStage.isPartialType()) {
+          throw TemplateRenderException.fromError(
+            new Error()
+              .withMessage("Recursive partials support is not currently implemented")
+              .withLocation(String.format("partial:%s", partial.getId()))
+          );
+        }
+
+        StageDefinition renderedStage;
+        try {
+          renderedStage = (StageDefinition) partialStage.clone();
+        } catch (CloneNotSupportedException e) {
+          // This definitely should never happen. Yay checked exceptions.
+          throw new TemplateRenderException("StageDefinition clone unsupported", e);
+        }
+
+        renderedStage.setId(String.format("%s.%s", stage.getId(), renderedStage.getId()));
+        renderedStage.setDependsOn(
+          renderedStage.getDependsOn().stream()
+            .map(d -> String.format("%s.%s", stage.getId(), d))
+            .collect(Collectors.toSet())
+        );
+
+        renderStage(renderedStage, partialContext, String.format("partial:%s.%s", stage.getId(), partial.getId()));
+
+        renderedStages.add(renderedStage);
+      }
+      partial.getRenderedPartials().put(stage.getId(), renderedStages);
+    }
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PartialDefinition.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PartialDefinition.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PartialDefinition implements Identifiable {
+
+  private String id;
+  private String usage;
+  private List<NamedHashMap> variables = new ArrayList<>();
+  private List<StageDefinition> stages = new ArrayList<>();
+
+  private Map<String, List<StageDefinition>> renderedPartials = new HashMap<>();
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getUsage() {
+    return usage;
+  }
+
+  public void setUsage(String usage) {
+    this.usage = usage;
+  }
+
+  public List<NamedHashMap> getVariables() {
+    return variables;
+  }
+
+  public void setVariables(List<NamedHashMap> variables) {
+    this.variables = variables;
+  }
+
+  public List<StageDefinition> getStages() {
+    return stages;
+  }
+
+  public void setStages(List<StageDefinition> stages) {
+    this.stages = stages;
+  }
+
+  public Map<String, List<StageDefinition>> getRenderedPartials() {
+    return renderedPartials;
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
@@ -36,6 +36,7 @@ public class PipelineTemplate implements VersionedSchema {
   private Configuration configuration;
   private List<StageDefinition> stages;
   private List<TemplateModule> modules;
+  private List<PartialDefinition> partials = new ArrayList<>();
 
   public static class Metadata {
     private String name;
@@ -255,6 +256,14 @@ public class PipelineTemplate implements VersionedSchema {
 
   public void setModules(List<TemplateModule> modules) {
     this.modules = modules;
+  }
+
+  public List<PartialDefinition> getPartials() {
+    return partials;
+  }
+
+  public void setPartials(List<PartialDefinition> partials) {
+    this.partials = partials;
   }
 
   public void accept(PipelineTemplateVisitor visitor) {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
@@ -17,29 +17,31 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.LinkedHashSet;
 
-public class StageDefinition implements Identifiable, Conditional {
+public class StageDefinition implements Identifiable, Conditional, Cloneable {
 
   private String id;
   private String name;
   private InjectionRule inject;
-  private Set<String> dependsOn;
+  private Set<String> dependsOn = new LinkedHashSet<>();
   private String type;
   private Map<String, Object> config;
-  private List<Map<String, Object>> notifications;
+  private List<Map<String, Object>> notifications = new ArrayList<>();
   private String comments;
-  private List<String> when;
+  private List<String> when = new ArrayList<>();
   private InheritanceControl inheritanceControl;
   private Boolean removed = false;
 
   private Set<String> requisiteStageRefIds = new LinkedHashSet<>();
 
-  public static class InjectionRule {
+  public static class InjectionRule implements Cloneable {
 
     private Boolean first = false;
     private Boolean last = false;
@@ -98,9 +100,14 @@ public class StageDefinition implements Identifiable, Conditional {
       }
       return count > 1;
     }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+      return super.clone();
+    }
   }
 
-  public static class InheritanceControl {
+  public static class InheritanceControl implements Cloneable {
 
     private Collection<Rule> merge;
     private Collection<Rule> replace;
@@ -150,6 +157,11 @@ public class StageDefinition implements Identifiable, Conditional {
     public void setRemove(Collection<Rule> remove) {
       this.remove = remove;
     }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+      return super.clone();
+    }
   }
 
   @Override
@@ -178,7 +190,7 @@ public class StageDefinition implements Identifiable, Conditional {
   }
 
   public Set<String> getDependsOn() {
-    return Optional.ofNullable(dependsOn).orElse(new LinkedHashSet<>());
+    return dependsOn;
   }
 
   public void setDependsOn(Set<String> dependsOn) {
@@ -249,6 +261,28 @@ public class StageDefinition implements Identifiable, Conditional {
 
   public void setRequisiteStageRefIds(Set<String> requisiteStageRefIds) {
     this.requisiteStageRefIds = requisiteStageRefIds;
+  }
+
+  public boolean isPartialType() {
+    return type != null && type.startsWith("partial.");
+  }
+
+  public String getPartialId() {
+    if (type == null) {
+      return null;
+    }
+    String[] bits = type.split("\\.");
+    return bits[bits.length - 1];
+  }
+
+  @Override
+  public Object clone() throws CloneNotSupportedException {
+    StageDefinition stage = (StageDefinition) super.clone();
+    stage.setDependsOn(new LinkedHashSet<>(getDependsOn()));
+    stage.setConfig(new HashMap<>(getConfig()));
+    Collections.copy(stage.getNotifications(), getNotifications());
+    Collections.copy(stage.getWhen(), getWhen());
+    return stage;
   }
 
   @Override

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateConfiguration.java
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.VersionedSchema;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -32,6 +33,7 @@ public class TemplateConfiguration implements VersionedSchema {
   private PipelineConfiguration configuration = new PipelineConfiguration();
   private List<StageDefinition> stages;
   private List<TemplateModule> modules;
+  private List<PartialDefinition> partials = new ArrayList<>();
 
   private final String runtimeId = UUID.randomUUID().toString();
 
@@ -215,5 +217,13 @@ public class TemplateConfiguration implements VersionedSchema {
 
   public void setModules(List<TemplateModule> modules) {
     this.modules = modules;
+  }
+
+  public List<PartialDefinition> getPartials() {
+    return partials;
+  }
+
+  public void setPartials(List<PartialDefinition> partials) {
+    this.partials = partials;
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/DefaultRenderContext.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/DefaultRenderContext.java
@@ -25,6 +25,11 @@ public class DefaultRenderContext implements RenderContext {
   private Map<String, Object> variables = new HashMap<>();
   private String location;
 
+  private DefaultRenderContext(DefaultRenderContext source) {
+    this.variables = new HashMap<>(source.getVariables());
+    this.location = source.getLocation();
+  }
+
   public DefaultRenderContext(String application, PipelineTemplate pipelineTemplate, Map<String, Object> trigger) {
     variables.put("application", application);
     variables.put("pipelineTemplate", pipelineTemplate);
@@ -44,5 +49,10 @@ public class DefaultRenderContext implements RenderContext {
   @Override
   public String getLocation() {
     return location;
+  }
+
+  @Override
+  public RenderContext copy() {
+    return new DefaultRenderContext(this);
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/RenderContext.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/RenderContext.java
@@ -24,4 +24,6 @@ public interface RenderContext {
   void setLocation(String location);
 
   String getLocation();
+
+  RenderContext copy();
 }


### PR DESCRIPTION
Implements the common cases for [Template Partials](https://github.com/spinnaker/dcd-spec/blob/master/PIPELINE_TEMPLATES.md#partials). There's some cleanup necessary (some fairly rough code in here), as well as adding support for recursive partials before this can go in.

I also departed from the spec in some ways that I'll need to go back and update. Most notably, instead of adding a `ref` field into `StageDefinition`, I rolled it up into the `type`:

```yaml
stages:
- id: foo
  type: partial:myPartial
partials:
- id: myPartial
```

@jeyrschabu PTAL