### PR TITLE
feat(dcd): support setting templates from trigger context using jinja

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
@@ -29,6 +29,8 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.V1SchemaExecutionGen
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.GraphMutator;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.DefaultRenderContext;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderContext;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator.V1TemplateConfigurationSchemaValidator;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.validator.V1TemplateSchemaValidator;
@@ -96,6 +98,8 @@ public class PipelineTemplatePipelinePreprocessor implements PipelinePreprocesso
 
     Errors validationErrors = new Errors();
 
+    setTemplateSourceWithJinja(request);
+
     TemplateConfiguration templateConfiguration = request.getConfig();
     new V1TemplateConfigurationSchemaValidator().validate(templateConfiguration, validationErrors);
     if (validationErrors.hasErrors(request.plan)) {
@@ -119,6 +123,11 @@ public class PipelineTemplatePipelinePreprocessor implements PipelinePreprocesso
     Map<String, Object> generatedPipeline = executionGenerator.generate(template, templateConfiguration);
 
     return generatedPipeline;
+  }
+
+  private void setTemplateSourceWithJinja(TemplatedPipelineRequest request) {
+    RenderContext context = new DefaultRenderContext(request.getConfig().getPipeline().getApplication(), null, request.getTrigger());
+    request.getConfig().getPipeline().getTemplate().setSource(renderer.render(request.getConfig().getPipeline().getTemplate().getSource(), context ));
   }
 
   private static class TemplatedPipelineRequest {

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -191,6 +191,20 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
     false       || ['wait']                   || ['wait', 'childOfConditionalStage']
   }
 
+  @Unroll
+  def 'should be able to set source using jinja'() {
+      when:
+      def result = subject.process(createInjectedTemplateRequest(template))
+
+      then:
+      result.stages*.name == expectedStageNames
+
+      where:
+      template       || expectedStageNames
+      'jinja-001.yml' || ['jinja1']
+      'jinja-002.yml' || ['jinja2']
+    }
+
 
   Map<String, Object> createTemplateRequest(String templatePath, Map<String, Object> variables = [:], List<Map<String, Object>> stages = [], boolean plan = false) {
     return [
@@ -214,6 +228,28 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
         stages: stages
       ],
       plan: plan
+    ]
+  }
+
+  Map<String, Object> createInjectedTemplateRequest(String templatePath) {
+    return [
+      type: 'templatedPipeline',
+      trigger: [
+        parameters: [
+          template: getClass().getResource("/templates/${templatePath}").toURI()
+        ]
+      ],
+      config: [
+        schema: '1',
+        id: 'myTemplate',
+        pipeline: [
+          application: 'myapp',
+          template: [
+            source: '{{trigger.parameters.template}}'
+          ],
+        ],
+      ],
+      plan: false
     ]
   }
 }

--- a/orca-pipelinetemplate/src/test/resources/templates/jinja-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/jinja-001.yml
@@ -1,0 +1,8 @@
+schema: "1"
+id: jinja1
+stages:
+ - id: wait
+   type: wait
+   name: jinja1
+   config:
+     waitTime: 5

--- a/orca-pipelinetemplate/src/test/resources/templates/jinja-002.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/jinja-002.yml
@@ -1,0 +1,8 @@
+schema: "1"
+id: jinja2
+stages:
+ - id: wait
+   type: wait
+   name: jinja2
+   config:
+     waitTime: 5


### PR DESCRIPTION
This enables us to use jinja to override what template source to use. This means you can upload a template in your ci build and use that one in the pipeline execution. This means we can have pipeline definitions following the same flow as other code and still be able to rollback easily.
```
{
  "appConfig": {},
  "config": {
    "pipeline": {
      "application": "gardtest",
      "name": "My wait pipeline",
      "pipelineConfigId": "eebaa78d-ecc2-4638-86aa-1afa9defebec",
      "template": {
        "source": "file:///opt/orca/templates/{{trigger.parameters.template}}"
      },
      "variables": {}
    },
    "schema": "1"
  },
  "executionEngine": "v2",
  "keepWaitingPipelines": false,
  "lastModifiedBy": "gard.rimestad@schibsted.com",
  "limitConcurrent": true,
  "parallel": true,
  "parameterConfig": [
    {
      "default": "test.yml",
      "name": "template"
    }
  ],
  "stages": [],
  "type": "templatedPipeline",
  "updateTs": "1494415568000"
}
```