### PR TITLE
fix(executionwindows): allow windows to encompass entire day if no wi…

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindow.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindow.groovy
@@ -141,6 +141,10 @@ class RestrictExecutionDuringTimeWindow implements StageDefinitionBuilder {
 
     private Date calculateScheduledTime(Date scheduledTime, List<TimeWindow> whitelistWindows, List<Integer> whitelistDays, boolean dayIncremented) throws IncorrectTimeWindowsException {
 
+      if ((!whitelistWindows || whitelistWindows.empty) && whitelistDays && !whitelistDays.empty) {
+        whitelistWindows = [ new TimeWindow(new HourMinute(0, 0), new HourMinute(23, 59))]
+      }
+
       boolean inWindow = false
       Collections.sort(whitelistWindows)
       List<TimeWindow> normalized = normalizeTimeWindows(whitelistWindows)

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindowSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindowSpec.groovy
@@ -151,6 +151,25 @@ class RestrictExecutionDuringTimeWindowSpec extends Specification {
     date("02/13 16:01:00") | date("02/14 10:00:00") | stage([window("10:00", "11:00"), window("13:00", "14:00"), window("15:00", "16:00")]) //*
   }
 
+  @Unroll
+  void 'should be valid all day if no time window selected but some days are selected'() {
+    when:
+    SuspendExecutionDuringTimeWindowTask suspendExecutionDuringTimeWindowTask = new SuspendExecutionDuringTimeWindowTask()
+    suspendExecutionDuringTimeWindowTask.timeZoneId = "America/Los_Angeles"
+    Date result = suspendExecutionDuringTimeWindowTask.calculateScheduledTime(scheduledTime, timeWindows, days)
+
+    then:
+    result.equals(expectedTime)
+
+    where:
+    scheduledTime           | timeWindows                                        | days            || expectedTime
+
+    date("02/25 01:00:00")  | [] | [1,2,3,4,5,6,7] || date("02/25 01:00:00")
+    date("02/25 00:00:00")  | [] | [1,2,3,4,5,6,7] || date("02/25 00:00:00")
+    date("02/25 23:59:00")  | [] | [1,2,3,4,5,6,7] || date("02/25 23:59:00")
+    date("02/25 01:00:00")  | [] | [1]             || date("03/02 00:00:00")
+  }
+
   private hourMinute(String hourMinuteStr) {
     int hour = hourMinuteStr.tokenize(":").get(0) as Integer
     int min = hourMinuteStr.tokenize(":").get(1) as Integer


### PR DESCRIPTION
…ndows selected

If a user selects a specific day, but no time windows, the stage will just never run, which is pretty confusing, and not something we considered when we added the days of the week option to execution windows.

There's a 59-second gap between 11:59 and midnight with this change, but I think that's okay.
