### PR TITLE
fix(pipelinetemplate): Disable risky jinja tags

### DIFF
--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -20,9 +20,3 @@ dependencies {
   testCompile spinnaker.dependency("slf4jSimple")
   testCompile 'org.spockframework:spock-unitils:1.1-groovy-2.4-rc-2'
 }
-
-test {
-  testLogging {
-    showStandardStreams = true
-  }
-}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.Context.Library;
 import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -40,6 +41,8 @@ import org.yaml.snakeyaml.parser.ParserException;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashSet;
 
 public class JinjaRenderer implements Renderer {
 
@@ -57,6 +60,7 @@ public class JinjaRenderer implements Renderer {
     this.renderedValueConverter = renderedValueConverter;
 
     JinjavaConfig config = new JinjavaConfig();
+    config.getDisabled().put(Library.TAG, new HashSet<>(Arrays.asList("from", "import", "include")));
     jinja = new Jinjava(config);
     jinja.setResourceLocator(new NoopResourceLocator());
     jinja.getGlobalContext().registerTag(new ModuleTag(this, pipelineTemplateObjectMapper));


### PR DESCRIPTION
We don't want userland code interacting with the filesystem.

Also, making test output less bad and noisy. @robfletcher FYI