### PR TITLE
Fixes to restart handling in v3

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -227,6 +227,7 @@ class JedisExecutionRepository implements ExecutionRepository {
     withJedis(getJedisPoolForId(key)) { Jedis jedis ->
       Map<String, String> map = [status: status.name()]
       if (status == ExecutionStatus.RUNNING) {
+        map.canceled = "false"
         map.startTime = String.valueOf(currentTimeMillis())
       } else if (status.complete) {
         map.endTime = String.valueOf(currentTimeMillis())

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
@@ -164,10 +164,11 @@ data class RestartStage(
   override val executionType: Class<out Execution<*>>,
   override val executionId: String,
   override val application: String,
-  override val stageId: String
+  override val stageId: String,
+  val user: String?
 ) : Message(), StageLevel {
-  constructor(source: Execution<*>, stageId: String) :
-    this(source.javaClass, source.getId(), source.getApplication(), stageId)
+  constructor(source: Execution<*>, stageId: String, user: String) :
+    this(source.javaClass, source.getId(), source.getApplication(), stageId, user)
 }
 
 data class ResumeStage(

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueExecutionRunner.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueExecutionRunner.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.q
 import com.netflix.spinnaker.orca.pipeline.ExecutionRunner
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionEngine
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -31,7 +32,7 @@ import org.springframework.stereotype.Component
     queue.push(StartExecution(execution))
 
   override fun <T : Execution<T>> restart(execution: T, stageId: String) {
-    queue.push(RestartStage(execution, stageId))
+    queue.push(RestartStage(execution, stageId, AuthenticatedRequest.getSpinnakerUser().orElse(null)))
   }
 
   override fun <T : Execution<T>> unpause(execution: T) {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
@@ -71,13 +71,18 @@ open class RestartStageHandler
     builder().prepareStageForRestart(repository, this, stageDefinitionBuilders)
     repository.storeStage(this)
 
+    removeSynthetics()
+
+    downstreamStages().forEach { it.reset() }
+  }
+
+  private fun Stage<*>.removeSynthetics() {
     getExecution()
       .getStages()
       .filter { it.getParentStageId() == getId() }
       .forEach {
+        it.removeSynthetics()
         repository.removeStage(getExecution(), it.getId())
       }
-
-    downstreamStages().forEach { it.reset() }
   }
 }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
@@ -95,6 +95,14 @@ val stageWithSyntheticAfterAndNoTasks = object : StageDefinitionBuilder {
   )
 }
 
+val stageWithNestedSynthetics = object : StageDefinitionBuilder {
+  override fun getType() = "stageWithNestedSynthetics"
+
+  override fun <T : Execution<T>> aroundStages(stage: Stage<T>) = listOf(
+    newStage(stage.execution, stageWithSyntheticBefore.type, "post", mutableMapOf(), stage, STAGE_AFTER)
+  )
+}
+
 val stageWithParallelBranches = object : BranchingStageDefinitionBuilder {
   override fun <T : Execution<T>> parallelContexts(stage: Stage<T>): Collection<Map<String, Any>> =
     listOf(

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerSpec.kt
@@ -76,7 +76,7 @@ object RestartStageHandlerSpec : SubjectSpek<RestartStageHandler>({
             startTime = clock.instant().minus(1, HOURS).toEpochMilli()
           }
         }
-        val message = RestartStage(Pipeline::class.java, pipeline.id, "foo", pipeline.stageByRef("1").id)
+        val message = RestartStage(Pipeline::class.java, pipeline.id, "foo", pipeline.stageByRef("1").id, "fzlem@netflix.com")
 
         beforeGroup {
           whenever(repository.retrievePipeline(message.executionId)) doReturn pipeline
@@ -124,7 +124,7 @@ object RestartStageHandlerSpec : SubjectSpek<RestartStageHandler>({
           context["exception"] = "o noes"
         }
       }
-      val message = RestartStage(Pipeline::class.java, pipeline.id, "foo", pipeline.stageByRef("2").id)
+      val message = RestartStage(Pipeline::class.java, pipeline.id, "foo", pipeline.stageByRef("2").id, "fzlem@netflix.com")
 
       beforeGroup {
         stageWithSyntheticBefore.plan(pipeline.stageByRef("2>1"))
@@ -157,7 +157,7 @@ object RestartStageHandlerSpec : SubjectSpek<RestartStageHandler>({
         verify(repository).storeStage(check {
           it.getContext().keys shouldNotMatch hasElement("exception")
           it.getContext()["restartDetails"] shouldEqual mapOf(
-            "restartedBy" to "anonymous",
+            "restartedBy" to "fzlem@netflix.com",
             "restartTime" to clock.millis(),
             "previousException" to "o noes"
           )
@@ -244,7 +244,7 @@ object RestartStageHandlerSpec : SubjectSpek<RestartStageHandler>({
         endTime = clock.instant().minus(57, MINUTES).toEpochMilli()
       }
     }
-    val message = RestartStage(Pipeline::class.java, pipeline.id, "foo", pipeline.stageByRef("1").id)
+    val message = RestartStage(Pipeline::class.java, pipeline.id, "foo", pipeline.stageByRef("1").id, "fzlem@netflix.com")
 
     beforeGroup {
       whenever(repository.retrievePipeline(message.executionId)) doReturn pipeline
@@ -317,7 +317,7 @@ object RestartStageHandlerSpec : SubjectSpek<RestartStageHandler>({
         endTime = clock.instant().minus(57, MINUTES).toEpochMilli()
       }
     }
-    val message = RestartStage(Pipeline::class.java, pipeline.id, "foo", pipeline.stageByRef("1").id)
+    val message = RestartStage(Pipeline::class.java, pipeline.id, "foo", pipeline.stageByRef("1").id, "fzlem@netflix.com")
 
     beforeGroup {
       whenever(repository.retrievePipeline(message.executionId)) doReturn pipeline


### PR DESCRIPTION
- fixes propagation of user as handler doesn't have access to authenticated request
- clears `canceled` flag on restart so it's possible to restart canceled pipelines
- clears nested synthetic stages of stages being reset