### PR TITLE
fix(mine): Allow canary instance cleanup to trigger lifecycle hooks

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/CleanupCanaryTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/CleanupCanaryTask.groovy
@@ -43,7 +43,7 @@ class CleanupCanaryTask extends AbstractCloudProviderAwareTask implements Task {
       return TaskResult.SUCCEEDED
     }
 
-    def ops = DeployedClustersUtil.toKatoAsgOperations('destroyServerGroup', stage.context)
+    def ops = DeployedClustersUtil.toKatoAsgOperations('destroyServerGroup', stage.context, false)
     log.info "Cleaning up canary clusters in ${stage.id} with ${ops}"
     String cloudProvider = ops && !ops.empty ? ops.first()?.values().first()?.cloudProvider : getCloudProvider(stage) ?: 'aws'
     def taskId = katoService.requestOperations(cloudProvider, ops).toBlocking().first()

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/DeployedClustersUtil.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/DeployedClustersUtil.groovy
@@ -17,12 +17,12 @@
 package com.netflix.spinnaker.orca.mine.tasks
 
 class DeployedClustersUtil {
-  static List<Map> toKatoAsgOperations(String asgOperationDescription, Map stageContext) {
+  static List<Map> toKatoAsgOperations(String asgOperationDescription, Map stageContext, boolean forceAsgDelete = true) {
     stageContext.deployedClusterPairs.findAll { it.canaryStage == stageContext.canaryStageId }.collect {
       [it.canaryCluster, it.baselineCluster].collect {
         [
           (asgOperationDescription): [
-            serverGroupName: it.serverGroup, asgName: it.serverGroup, regions: [it.region], region: it.region, credentials: it.clusterAccount ?: it.accountName, cloudProvider: it.type ?: 'aws'
+            serverGroupName: it.serverGroup, asgName: it.serverGroup, regions: [it.region], region: it.region, credentials: it.clusterAccount ?: it.accountName, cloudProvider: it.type ?: 'aws', force: forceAsgDelete
           ]
         ]
       }


### PR DESCRIPTION
Depends on https://github.com/spinnaker/clouddriver/pull/1643

@spinnaker/netflix-reviewers ptal