### PR TITLE
Fix occasional stalled pipelines

### DIFF
--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueue.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueue.kt
@@ -89,7 +89,7 @@ class RedisQueue(
     fire<MessagePushed>()
   }
 
-  @Scheduled(fixedDelayString = "\${queue.retry.frequency:10000}")
+  @Scheduled(fixedDelayString = "\${queue.retry.frequency.ms:10000}")
   override fun retry() {
     pool.resource.use { redis ->
       redis.apply {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
@@ -103,3 +103,9 @@ fun Stage<*>.beforeStages(): List<Stage<*>> =
 
 fun Stage<*>.allBeforeStagesComplete(): Boolean =
   beforeStages().all { it.getStatus() in listOf(SUCCEEDED, FAILED_CONTINUE, SKIPPED) }
+
+fun Stage<*>.hasTasks(): Boolean =
+  getTasks().isNotEmpty()
+
+fun Stage<*>.hasAfterStages(): Boolean =
+  firstAfterStages().isNotEmpty()

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
@@ -133,6 +133,16 @@ data class StartStage(
     this(source.getExecution().javaClass, source.getExecution().getId(), source.getExecution().getApplication(), source.getId())
 }
 
+data class ContinueParentStage(
+  override val executionType: Class<out Execution<*>>,
+  override val executionId: String,
+  override val application: String,
+  override val stageId: String
+) : Message(), StageLevel {
+  constructor(source: Stage<*>) :
+    this(source.getExecution().javaClass, source.getExecution().getId(), source.getExecution().getApplication(), source.getId())
+}
+
 data class CompleteStage(
   override val executionType: Class<out Execution<*>>,
   override val executionId: String,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
@@ -63,6 +63,9 @@ data class StartTask(
 
   constructor(source: Stage<*>, taskId: String) :
     this(source.getExecution().javaClass, source.getExecution().getId(), source.getExecution().getApplication(), source.getId(), taskId)
+
+  constructor(source: Stage<*>, task: com.netflix.spinnaker.orca.pipeline.model.Task) :
+    this(source.getExecution().javaClass, source.getExecution().getId(), source.getExecution().getApplication(), source.getId(), task.id)
 }
 
 data class CompleteTask(

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueProcessor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueProcessor.kt
@@ -43,7 +43,7 @@ open class QueueProcessor
   private val pollOpsRateId = registry.createId("orca.nu.worker.pollOpsRate")
   private val pollErrorRateId = registry.createId("orca.nu.worker.pollErrorRate")
 
-  @Scheduled(fixedDelayString = "\${queue.poll.frequency:10}")
+  @Scheduled(fixedDelayString = "\${queue.poll.frequency.ms:10}")
   fun pollOnce() =
     ifEnabled {
       registry.counter(pollOpsRateId).increment()

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -68,20 +68,7 @@ open class CompleteStageHandler
           queue.push(StartStage(it))
         }
       } else if (getSyntheticStageOwner() == STAGE_BEFORE) {
-        // TODO: I'm not convinced this is a good approach, we should probably signal completion of the branch and have downstream handler no-op if other branches are incomplete
-        parent().let { parent ->
-          if (parent.allBeforeStagesComplete()) {
-            if (parent.hasTasks()) {
-              queue.push(StartTask(parent, parent.getTasks().first()))
-            } else if (parent.hasAfterStages()) {
-              parent.firstAfterStages().forEach {
-                queue.push(StartStage(it))
-              }
-            } else {
-              queue.push(CompleteStage(parent, SUCCEEDED))
-            }
-          }
-        }
+        queue.push(ContinueParentStage(parent()))
       } else if (getSyntheticStageOwner() == STAGE_AFTER) {
         parent().let { parent ->
           queue.push(CompleteStage(parent, SUCCEEDED))

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -71,9 +71,9 @@ open class CompleteStageHandler
         // TODO: I'm not convinced this is a good approach, we should probably signal completion of the branch and have downstream handler no-op if other branches are incomplete
         parent().let { parent ->
           if (parent.allBeforeStagesComplete()) {
-            if (parent.getTasks().isNotEmpty()) {
-              queue.push(StartTask(parent, parent.getTasks().first().id))
-            } else if (parent.firstAfterStages().isNotEmpty()) {
+            if (parent.hasTasks()) {
+              queue.push(StartTask(parent, parent.getTasks().first()))
+            } else if (parent.hasAfterStages()) {
               parent.firstAfterStages().forEach {
                 queue.push(StartStage(it))
               }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandler.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.q.handler
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.q.*
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+open class ContinueParentStageHandler
+@Autowired constructor(
+  override val queue: Queue,
+  override val repository: ExecutionRepository,
+  @Value("\${queue.retry.delay.ms:5000}") retryDelayMs: Long
+) : MessageHandler<ContinueParentStage> {
+
+  private val log: Logger = LoggerFactory.getLogger(javaClass)
+  private val retryDelay = Duration.ofMillis(retryDelayMs)
+
+  override fun handle(message: ContinueParentStage) {
+    message.withStage { stage ->
+      if (stage.allBeforeStagesComplete()) {
+        if (stage.hasTasks()) {
+          queue.push(StartTask(stage, stage.getTasks().first()))
+        } else if (stage.hasAfterStages()) {
+          stage.firstAfterStages().forEach {
+            queue.push(StartStage(it))
+          }
+        } else {
+          queue.push(CompleteStage(stage, ExecutionStatus.SUCCEEDED))
+        }
+      } else {
+        log.warn("Re-queuing $message as other BEFORE stages are still running")
+        queue.push(message, retryDelay)
+        // TODO: no-op if message already processed
+      }
+    }
+  }
+
+  override val messageType = ContinueParentStage::class.java
+}

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/memory/InMemoryQueue.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/memory/InMemoryQueue.kt
@@ -67,7 +67,7 @@ class InMemoryQueue(
     fire<MessagePushed>()
   }
 
-  @Scheduled(fixedDelayString = "\${queue.retry.frequency:10000}")
+  @Scheduled(fixedDelayString = "\${queue.retry.frequency.ms:10000}")
   override fun retry() {
     val now = clock.instant()
     fire<RetryPolled>()

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandlerSpec.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.q.handler
+
+import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
+import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.q.*
+import com.nhaarman.mockito_kotlin.*
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.jetbrains.spek.api.lifecycle.CachingMode
+import org.jetbrains.spek.subject.SubjectSpek
+import java.time.Duration
+
+object ContinueParentStageHandlerSpec : SubjectSpek<ContinueParentStageHandler>({
+
+  val queue: Queue = mock()
+  val repository: ExecutionRepository = mock()
+  val retryDelay = Duration.ofSeconds(5)
+
+  subject(CachingMode.GROUP) {
+    ContinueParentStageHandler(queue, repository, retryDelay.toMillis())
+  }
+
+  fun resetMocks() = reset(queue, repository)
+
+  describe("running a parent stage after its pre-stages complete") {
+    given("other pre-stages are not yet complete") {
+      val pipeline = pipeline {
+        application = "foo"
+        stage {
+          refId = "1"
+          type = stageWithSyntheticBefore.type
+          stageWithSyntheticBefore.buildSyntheticStages(this)
+          stageWithSyntheticBefore.buildTasks(this)
+        }
+      }
+
+      val message = ContinueParentStage(pipeline.stageByRef("1"))
+
+      beforeGroup {
+        pipeline.stageByRef("1<1").status = SUCCEEDED
+        pipeline.stageByRef("1<2").status = RUNNING
+        whenever(repository.retrievePipeline(pipeline.id)) doReturn pipeline
+      }
+
+      afterGroup(::resetMocks)
+
+      on("receiving $message") {
+        subject.handle(message)
+      }
+
+      it("re-queues the message for later evaluation") {
+        verify(queue).push(message, retryDelay)
+      }
+    }
+
+    given("the parent stage has tasks") {
+      val pipeline = pipeline {
+        application = "foo"
+        stage {
+          refId = "1"
+          type = stageWithSyntheticBefore.type
+          stageWithSyntheticBefore.buildSyntheticStages(this)
+          stageWithSyntheticBefore.buildTasks(this)
+        }
+      }
+
+      val message = ContinueParentStage(pipeline.stageByRef("1"))
+
+      beforeGroup {
+        pipeline.stageByRef("1").beforeStages().forEach { it.setStatus(SUCCEEDED) }
+        whenever(repository.retrievePipeline(pipeline.id)) doReturn pipeline
+      }
+
+      afterGroup(::resetMocks)
+
+      on("receiving $message") {
+        subject.handle(message)
+      }
+
+      it("runs the parent stage's first task") {
+        verify(queue).push(StartTask(pipeline.stageByRef("1"), "1"))
+      }
+    }
+
+    given("the parent stage has no tasks") {
+      val pipeline = pipeline {
+        application = "foo"
+        stage {
+          refId = "1"
+          type = stageWithSyntheticBeforeAndNoTasks.type
+          stageWithSyntheticBeforeAndNoTasks.buildSyntheticStages(this)
+          stageWithSyntheticBeforeAndNoTasks.buildTasks(this)
+        }
+      }
+
+      val message = ContinueParentStage(pipeline.stageByRef("1"))
+
+      beforeGroup {
+        pipeline.stageByRef("1").beforeStages().forEach { it.setStatus(SUCCEEDED) }
+        whenever(repository.retrievePipeline(pipeline.id)) doReturn pipeline
+      }
+
+      afterGroup(::resetMocks)
+
+      on("receiving $message") {
+        subject.handle(message)
+      }
+
+      it("completes the stage") {
+        verify(queue).push(CompleteStage(pipeline.stageByRef("1"), SUCCEEDED))
+      }
+    }
+
+    given("the parent stage has no tasks but does have after stages") {
+      val pipeline = pipeline {
+        application = "foo"
+        stage {
+          refId = "1"
+          type = stageWithSyntheticBeforeAndAfterAndNoTasks.type
+          stageWithSyntheticBeforeAndAfterAndNoTasks.buildSyntheticStages(this)
+          stageWithSyntheticBeforeAndAfterAndNoTasks.buildTasks(this)
+        }
+      }
+
+      val message = ContinueParentStage(pipeline.stageByRef("1"))
+
+      beforeGroup {
+        pipeline.stageByRef("1").beforeStages().forEach { it.setStatus(SUCCEEDED) }
+        whenever(repository.retrievePipeline(pipeline.id)) doReturn pipeline
+      }
+
+      afterGroup(::resetMocks)
+
+      on("receiving $message") {
+        subject.handle(message)
+      }
+
+      it("starts the first after stage") {
+        verify(queue).push(StartStage(pipeline.stageByRef("1>1")))
+      }
+    }
+  }
+})

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerSpec.kt
@@ -41,6 +41,7 @@ import org.jetbrains.spek.api.dsl.*
 import org.jetbrains.spek.api.lifecycle.CachingMode.GROUP
 import org.jetbrains.spek.subject.SubjectSpek
 import org.springframework.context.ApplicationEventPublisher
+import java.time.Duration
 
 object StartStageHandlerSpec : SubjectSpek<StartStageHandler>({
 
@@ -48,6 +49,7 @@ object StartStageHandlerSpec : SubjectSpek<StartStageHandler>({
   val repository: ExecutionRepository = mock()
   val publisher: ApplicationEventPublisher = mock()
   val clock = fixedClock()
+  val retryDelay = Duration.ofSeconds(5)
 
   subject(GROUP) {
     StartStageHandler(
@@ -66,7 +68,8 @@ object StartStageHandlerSpec : SubjectSpek<StartStageHandler>({
       ),
       publisher,
       clock,
-      ContextParameterProcessor()
+      ContextParameterProcessor(),
+      retryDelayMs = retryDelay.toMillis()
     )
   }
 
@@ -386,7 +389,7 @@ object StartStageHandlerSpec : SubjectSpek<StartStageHandler>({
         }
 
         it("re-queues the message with a delay") {
-          verify(queue).push(message, StartStageHandler.retryDelay)
+          verify(queue).push(message, retryDelay)
         }
       }
 


### PR DESCRIPTION
This aims to prevent 2 scenarios:

1. two parallel stages complete essentially at the same time and CompleteStageHandler thinks the other one is still running so it no-ops.
2. two branches complete at the same time and CompleteExecutionHandler makes the same mistake.