### PR TITLE
fix(v2executions): do not mark pipeline terminal if skipped stage is …

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/ExecutionPropagationListener.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/ExecutionPropagationListener.groovy
@@ -48,7 +48,7 @@ class ExecutionPropagationListener implements ExecutionListener {
       executionStatus = TERMINAL
     }
 
-    def failedStages = execution.stages.findAll { it.status.complete && it.status != SUCCEEDED }
+    def failedStages = execution.stages.findAll { it.status.complete && ![SUCCEEDED, SKIPPED].contains(it.status) }
     if (failedStages.any { it.context.completeOtherBranchesThenFail }) {
       executionStatus = TERMINAL
     }


### PR DESCRIPTION
…completeOtherBranchesThenFail

(this only applies to v2; v3 has cleaner, better logic)

If a stage is skipped, but is marked to completeOtherBranchesThenFail, the entire pipeline is marked terminal.

@robfletcher PTAL
