### PR TITLE
chore(build): Conditionally include loadtest project in build

### DIFF
--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -3,24 +3,24 @@
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-  ./gradlew -Prelease.useLastTag=true build
+  ./gradlew -Prelease.useLastTag=true -Pskip.loadtest=true build
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-  ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" build snapshot --stacktrace
+  ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -Pskip.loadtest=true build snapshot --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in
   version-*)
     ;; # Ignore Spinnaker product release tags.
   *-rc\.*)
-    ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" candidate --stacktrace
+    ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -Pskip.loadtest=true candidate --stacktrace
     ;;
   *)
-    ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" final --stacktrace
+    ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -Pskip.loadtest=true final --stacktrace
     ;;
   esac
 else
   echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
-  ./gradlew -Prelease.useLastTag=true build
+  ./gradlew -Prelease.useLastTag=true -Pskip.loadtest=true build
 fi
 

--- a/gradle/installViaTravis.sh
+++ b/gradle/installViaTravis.sh
@@ -3,15 +3,15 @@
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Assemble Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-  ./gradlew assemble
+  ./gradlew -Pskip.loadtest=true assemble
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Assemble Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-  ./gradlew -Prelease.travisci=true assemble 
+  ./gradlew -Prelease.travisci=true -Pskip.loadtest=true assemble
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Assemble Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
-  ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true assemble
+  ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -Pskip.loadtest=true assemble
 else
   echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
-  ./gradlew assemble
+  ./gradlew -Pskip.loadtest=true assemble
 fi
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,8 +36,11 @@ include "orca-extensionpoint",
   "orca-queue-redis",
   "orca-queue-sqs",
   "orca-pipelinetemplate",
-  "orca-validation",
-  "orca-loadtest"
+  "orca-validation"
+
+if (!Boolean.parseBoolean(System.getProperty('skip.loadtest'))) {
+  include "orca-loadtest"
+}
 
 rootProject.name = "orca"
 


### PR DESCRIPTION
This will include the loadtest project if the `-Pskip.loadtest=true` is not passed into gradle commands. Explicitly setting this flag in all Travis operations so we can speed up the build.

@cfieber @robfletcher PTAL