### PR TITLE
fix(expressions): fixes an issue with toJson on expressions.

### DIFF
--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
@@ -586,6 +586,22 @@ class ContextParameterProcessorSpec extends Specification {
     result.comments == "NOT_STARTED"
   }
 
+  def "can not toJson an execution with expressions in the context"() {
+    given:
+    def pipe = Pipeline.builder()
+        .withStage("wait", "Wait1", [comments: '${#toJson(execution)}', waitTime: 1, refId: "1", requisiteStageRefIds:[]])
+        .build()
+
+    def stage = pipe.stages.find { it.name == "Wait1" }
+    def ctx = contextParameterProcessor.buildExecutionContext(stage, true)
+
+    when:
+    def result = contextParameterProcessor.process(stage.context, ctx, true)
+
+    then:
+    result.comments == '${#toJson(execution)}'
+  }
+
   def "can read authenticated user in an execution"() {
     given:
     def pipe = Pipeline.builder()

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -213,7 +213,7 @@ open class RunTaskHandler
 
         val result = processed[key] ?: execution.getContext()[key]
 
-        if (result is String && contextParameterProcessor.containsExpression(result)) {
+        if (result is String && ContextParameterProcessor.containsExpression(result)) {
           val augmentedContext = processed.augmentContext(execution)
           return contextParameterProcessor.process(mapOf(key to result), augmentedContext, true)[key]
         }


### PR DESCRIPTION
calling toJson on an object with expressions in it (execution, stage, stage.context) returns
a String containing an expression which is then reevaluated. This string typically contains
the orignal toJson expression and the result is infinitely evaluating the expression and hanging
the execution

this rejects a toJson call that returns a String that still contains an expression