### PR TITLE
fix(provider/aws): Prevent NullPointerException when image id is not in the cache

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageFinder.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageFinder.java
@@ -44,6 +44,7 @@ public class AmazonImageFinder implements ImageFinder {
     List<AmazonImage> allMatchedImages =
         oortService.findImage(getCloudProvider(), packageName, null, null, prefixTags(tags)).stream()
         .map(image -> objectMapper.convertValue(image, AmazonImage.class))
+        .filter(image -> image.tagsByImageId != null && image.tagsByImageId.size() != 0)
         .sorted()
         .collect(Collectors.toList());
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageFinderSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageFinderSpec.groovy
@@ -96,6 +96,63 @@ class AmazonImageFinderSpec extends Specification {
     imageDetails.find { it.region == "us-west-2" }.imageName == "image-3"
   }
 
+  def "should skip images with incomplete information"() {
+    given:
+    def stage = new Stage<>(new Pipeline(), "", [
+      regions: ["us-west-2"]
+    ])
+    def tags = [
+      appversion: "mypackage-2.79.0-h247.d14bad0/mypackage/247",
+      build_host: "http://build.host"
+    ]
+
+    when:
+    def imageDetails = amazonImageFinder.byTags(stage, "mypackage", ["engine": "spinnaker"])
+
+    then:
+    1 * oortService.findImage("aws", "mypackage", null, null, ["tag:engine": "spinnaker"]) >> {
+      [
+        [
+          imageName    : "image-0",
+          attributes   : [creationDate: bCD("2015")],
+          tagsByImageId: [:],
+          amis         : [
+            "us-west-2": ["ami-0"],
+            "us-west-2": ["ami-1"]
+          ]
+        ],
+        [
+          imageName    : "image-2",
+          attributes   : [creationDate: bCD("2016")],
+          tagsByImageId: ["ami-2": tags],
+          amis         : [
+            "us-west-2": ["ami-2"]
+          ]
+        ],
+        [
+          imageName    : "image-3",
+          attributes   : [creationDate: bCD("2017")],
+          tagsByImageId: [:],
+          amis         : [
+            "us-west-2": ["ami-3"]
+          ]
+        ]
+      ]
+    }
+    0 * _
+
+    imageDetails.size() == 1
+    imageDetails.every {
+      (it.jenkins as Map) == [
+        "number": "247",
+        "host"  : "http://build.host",
+        "name"  : "mypackage"
+      ]
+    }
+    imageDetails.find { it.region == "us-west-2" }.imageId == "ami-2"
+    imageDetails.find { it.region == "us-west-2" }.imageName == "image-2"
+  }
+
   def "should sort images by 'creationDate'"() {
     given:
     def images = creationDates.collect {


### PR DESCRIPTION
When using Redis to cache AMIs it is possible to receive a NullPointerException such as this:

```
java.lang.NullPointerException
 at com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.AmazonImageFinder$AmazonImage.toAmazonImageDetails(AmazonImageFinder.java:98)
 at com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.AmazonImageFinder.lambda$null$2(AmazonImageFinder.java:59)
 at java.util.Optional.map(Optional.java:215)
 at com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.AmazonImageFinder.lambda$byTags$3(AmazonImageFinder.java:59)
 at java.util.ArrayList.forEach(ArrayList.java:1249)
 at com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.AmazonImageFinder.byTags(AmazonImageFinder.java:56)
 at com.netflix.spinnaker.orca.clouddriver.tasks.image.FindImageFromTagsTask.execute(FindImageFromTagsTask.java:50)
 at com.netflix.spinnaker.orca.batch.TaskTasklet.doExecuteTask(TaskTasklet.groovy:196)
 ...
```

It all started by somebody deleting an AMI using the AWS Console. Somehow Spinnaker retained the cache entries keyed by AMI-name but removed entries keyed by AMI-id. Specifically, the `:relationships` entries had references to AMI id's that did not exist.

For example, this cache entry exists and refers to an ami-1234abcd:
```
com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider:namedImages:relationships... = "[ \"aws:images:production:us-west-2:ami-1234abcd\" ]"
```
However, this cache entry does *not* exist:
```
com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider:images:attributes:aws:images:production:us-west-2:ami-1234abcd
```

When this occurs the `/find` endpoint on clouddriver will have an empty `tagsByImageId` field. Ultimately that is what leads to the NullPointerException.

This PR will require an image to have a non-empty `tagsByImageId` field in order to be considered eligible by the 'Find Images by Tags' stage.

For reference the related code in clouddriver can be found [here AmazonNamedImageLookupController.groovy#L98](https://github.com/spinnaker/clouddriver/blob/4fc0c1e0f2a2ac89dc4e7cc9249407a12293edb6/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonNamedImageLookupController.groovy#L98)