### PR TITLE
don't retry ContinueParentStage if a BEFORE stage has failed

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
@@ -107,6 +107,9 @@ fun Stage<*>.beforeStages(): List<Stage<*>> =
 fun Stage<*>.allBeforeStagesComplete(): Boolean =
   beforeStages().all { it.getStatus() in listOf(SUCCEEDED, FAILED_CONTINUE, SKIPPED) }
 
+fun Stage<*>.anyBeforeStagesFailed(): Boolean =
+  beforeStages().any { it.getStatus() in listOf(TERMINAL, STOPPED, CANCELED) }
+
 fun Stage<*>.hasTasks(): Boolean =
   getTasks().isNotEmpty()
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandler.kt
@@ -49,7 +49,7 @@ open class ContinueParentStageHandler
         } else {
           queue.push(CompleteStage(stage, SUCCEEDED))
         }
-      } else {
+      } else if (!stage.anyBeforeStagesFailed()) {
         log.warn("Re-queuing $message as other BEFORE stages are still running")
         queue.push(message, retryDelay)
       }


### PR DESCRIPTION
If any BEFORE stage failed this would just have kept retrying its message forever. The condition was if all BEFORE stages have passed (or skipped or whatever) then continue this stage otherwise retry later. If any BEFORE stage failed the condition would never be true.