### PR TITLE
fix(orca/find-mutiple-images) : fixed issue to run parallel multiple …

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesContainerFinder.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesContainerFinder.groovy
@@ -63,6 +63,15 @@ class KubernetesContainerFinder {
 
     containers.forEach { container ->
       if (container.imageDescription.fromContext) {
+	//  If there are parallel Find images stages , then deploymentDetails would be fetched from it. 
+	// e.g.  parallelContext = [stageid:[deployDetails],stageId2:[deployDetails]]
+	def paraContext = (stage.parallelContext ? stage.parallelContext.find {it.key == container.imageDescription.stageId}?.value : null)
+
+	if (paraContext) {
+           stage.context.deploymentDetails = paraContext.deploymentDetails
+           deploymentDetails = (paraContext.deploymentDetails ?: []) as List<Map>
+        }
+
         def image = deploymentDetails.find {
           // stageId is used here to match the source of the image to the find image stage specified by the user.
           // Previously, this was done by matching the pattern used to the pattern selected in the deploy stage, but

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -47,6 +47,15 @@ public class Stage<T extends Execution<T>> implements Serializable {
     this(execution, type, null, context);
   }
 
+  @SuppressWarnings("unchecked")
+  public Stage(T execution, String type, String name, Map<String, Object> context, Map<String,  Map<String, Object>> parallelContext) {
+    this.execution = execution;
+    this.type = type;
+    this.name = name;
+    this.parallelContext = parallelContext;
+    this.context = context;
+  }
+
   public Stage(T execution, String type) {
     this(execution, type, emptyMap());
   }
@@ -92,6 +101,11 @@ public class Stage<T extends Execution<T>> implements Serializable {
    * The context driving this stage. Provides inputs necessary to component steps
    */
   private Map<String, Object> context = new HashMap<>();
+ 
+  /**
+   *  The context used for parallel executon of Find images and Delpoy stage
+   */
+  private Map<String , Map<String, Object>> parallelContext= new HashMap<>();
 
   /**
    * Returns a flag indicating if the stage is a parallel initialization stage

--- a/orca-spring-batch/src/main/groovy/com/netflix/spinnaker/orca/batch/ExecutionContextManager.groovy
+++ b/orca-spring-batch/src/main/groovy/com/netflix/spinnaker/orca/batch/ExecutionContextManager.groovy
@@ -28,6 +28,8 @@ import org.springframework.batch.core.scope.context.ChunkContext
 @Slf4j
 @Canonical
 class ExecutionContextManager {
+  static Map<String, DelegatingHashMap> prevContext = [:]
+
   static <T extends Execution> Stage<T> retrieve(Stage<T> stage, ChunkContext chunkContext, ContextParameterProcessor contextParameterProcessor) {
     Map<String, Object> processed = processEntries(stage.context, stage, chunkContext, contextParameterProcessor)
     stage.context = new DelegatingHashMap(processed ?: [:], chunkContext, stage, contextParameterProcessor)


### PR DESCRIPTION
…find images to run with Deploy job stage. 

With Reference to issue no: 
  https://github.com/spinnaker/spinnaker/issues/1724

Find images and deploy stage , if run in parallel with more than one time results in failure , as   parallel find images works in thread , and the last thread save the common context. 

We introduced a new variable in stage   i.e.  parallelContext which is Map of Maps. 
so now result would be stored like this: 
[stageid1 : [DeployementDetails] ,  stageid2 : [DeploymentDetails]]

and used the above variable to  fetch  the deployement details based on the  stage id. 
Above changes are made only for kubernetes cloud-provider. and for Find images and deploy stages only.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
