### PR TITLE
fix(pipelinetemplate): Handle converting groovy expression syntax better

### DIFF
--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
@@ -38,6 +38,7 @@ class JinjaRendererSpec extends Specification {
       variables.put('stringVar', 'myStringValue')
       variables.put('regions', ['us-east-1', 'us-west-2'])
       variables.put('objectVar', [key1: 'value1', key2: 'value2'])
+      variables.put('isDebugNeeded', false)
       it
     }
 
@@ -74,6 +75,9 @@ class JinjaRendererSpec extends Specification {
 - {{ region }}
 {% endfor %}
 '''                   || List         | ['us-east-1', 'us-west-2']
+    '''
+"${ {{isDebugNeeded}} }".equalsIgnoreCase("True")
+'''                   || String       | '"${ false }".equalsIgnoreCase("True")'
   }
 
 


### PR DESCRIPTION
When rendering a graph (we assume any root-level render is a graph), we pass the rendered value into a value converter to expand the value into additional renderable objects. When pipeline expressions are used, the YAML converter throws an error attempting to parse the output as a YAML document, which is incorrect.

I'm catching the generalized invalid token parser exception, rather than attempting to determine if the rendered value is a valid expression syntax, which I think should be sufficient.