### PR TITLE
fix(aws): fix monitor task name on delete scaling policy stage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/scalingpolicy/DeleteScalingPolicyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/scalingpolicy/DeleteScalingPolicyStage.groovy
@@ -31,7 +31,7 @@ class DeleteScalingPolicyStage implements StageDefinitionBuilder {
   <T extends Execution<T>> void taskGraph(Stage<T> stage, TaskNode.Builder builder) {
     builder
       .withTask("deleteScalingPolicy", DeleteScalingPolicyTask)
-      .withTask("monitorUpsert", MonitorKatoTask)
+      .withTask("monitorDelete", MonitorKatoTask)
       .withTask("forceCacheRefresh", ServerGroupCacheForceRefreshTask)
   }
 }


### PR DESCRIPTION
Not breaking anything, just a little surprising when you see it.