### PR TITLE
feat(task): add flag to let stage succeed on timeout

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -64,7 +64,11 @@ open class RunTaskHandler
         queue.push(PauseTask(message))
       } else if (task.isTimedOut(stage, taskModel)) {
         // TODO: probably want something specific in the execution log
-        queue.push(CompleteTask(message, TERMINAL))
+        if (stage.getContext()["markSuccessfulOnTimeout"] == true) {
+          queue.push(CompleteTask(message, SUCCEEDED))
+        } else {
+          queue.push(CompleteTask(message, TERMINAL))
+        }
       } else {
         try {
           task.executeTask(stage) { result ->

--- a/orca-spring-batch/src/test/groovy/com/netflix/spinnaker/orca/batch/adapters/RetryableTaskTaskletSpec.groovy
+++ b/orca-spring-batch/src/test/groovy/com/netflix/spinnaker/orca/batch/adapters/RetryableTaskTaskletSpec.groovy
@@ -54,7 +54,7 @@ class RetryableTaskTaskletSpec extends Specification {
   }
 
   @Unroll
-  void "should raise TimeoutException if timeout exceeded"() {
+  void "should raise TimeoutException if timeout exceeded and markSuccessfulOnTimeout is not true"() {
     given:
     def clock = Clock.fixed(Instant.ofEpochMilli(currentTime), UTC)
     def chunkContext = new ChunkContext(
@@ -89,6 +89,9 @@ class RetryableTaskTaskletSpec extends Specification {
     timeout - 1                                | [(STAGE_TIMEOUT_OVERRIDE_KEY): timeout - 2]                                  || true
     RetryableTaskTasklet.MAX_PAUSE_TIME_MS     | [(STAGE_TIMEOUT_OVERRIDE_KEY): RetryableTaskTasklet.MAX_PAUSE_TIME_MS + 100] || false
     RetryableTaskTasklet.MAX_PAUSE_TIME_MS + 1 | [(STAGE_TIMEOUT_OVERRIDE_KEY): RetryableTaskTasklet.MAX_PAUSE_TIME_MS + 100] || true
+    timeout + 1                                | [markSuccessfulOnTimeout: false]                                             || true
+    timeout + 1                                | [markSuccessfulOnTimeout: true]                                              || false
+    timeout                                    | [markSuccessfulOnTimeout: true]                                              || false
   }
 
   void "should mark RUNNING tasks as PAUSED (and vice-versa) when pausing and resuming a pipeline"() {


### PR DESCRIPTION
There are cases where a manual judgment stage should be marked successful if no user input is ever provided and the stage times out.

@robfletcher PTAL - is the stage context the right place to declare this (seems like it to me)? Also, happy to make it a `const` somewhere instead of a string in the tasklet.
