### PR TITLE
feat(queue): Prioritized message capacity guarantees support

### DIFF
--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisTrafficShapingConfiguration.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisTrafficShapingConfiguration.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.config
 
 import com.netflix.spinnaker.orca.q.handler.DeadMessageHandler
+import com.netflix.spinnaker.orca.q.redis.RedisPriorityCapacityRepository
 import com.netflix.spinnaker.orca.q.redis.RedisQueue
 import com.netflix.spinnaker.orca.q.redis.RedisRateLimitBackend
 import org.springframework.beans.factory.annotation.Qualifier
@@ -31,11 +32,18 @@ import java.time.Clock
 
 @Configuration
 @ConditionalOnExpression("\${queue.redis.enabled:true} && \${queue.trafficShaping.enabled:false}")
-open class RedisRateLimitConfiguration {
+open class RedisTrafficShapingConfiguration {
   @Bean open fun redisRateLimitBackend(
     @Qualifier("jedisPool") redisPool: Pool<Jedis>,
     clock: Clock
   ) =
     RedisRateLimitBackend(redisPool, clock)
+
+  @Bean open fun redisPriorityCapacityRepository(
+    @Qualifier("jedisPool") redisPool: Pool<Jedis>,
+    clock: Clock,
+    properties: TrafficShapingProperties.PriorityCapacityProperties
+  ) =
+    RedisPriorityCapacityRepository(redisPool, clock, properties)
 
 }

--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisPriorityCapacityRepository.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisPriorityCapacityRepository.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.q.redis
+
+import com.netflix.spinnaker.config.TrafficShapingProperties
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.GlobalCapacity
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.Priority
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.PriorityCapacityRepository
+import redis.clients.jedis.Jedis
+import redis.clients.util.Pool
+import java.time.Clock
+
+class RedisPriorityCapacityRepository(
+  private val pool: Pool<Jedis>,
+  private val clock: Clock,
+  private val properties: TrafficShapingProperties.PriorityCapacityProperties
+) : PriorityCapacityRepository {
+
+  private val key = "queue:trafficShaping:priorityCapacity:capacity"
+
+  override fun incrementExecutions(priority: Priority) {
+    pool.resource.use { redis ->
+      redis.hincrBy(key, priority.name, 1)
+    }
+  }
+
+  override fun decrementExecutions(priority: Priority) {
+    pool.resource.use { redis ->
+      redis.hincrBy(key, priority.name, -1)
+    }
+  }
+
+  override fun getGlobalCapacity(): GlobalCapacity {
+    pool.resource.use { redis ->
+      val capacity = redis.hgetAll(key) ?: return GlobalCapacity(ceiling = properties.capacity, criticalUsage = 0, highUsage = 0, mediumUsage = 0, lowUsage = 0)
+      return GlobalCapacity(
+        ceiling = capacity.getOrDefault("ceiling", properties.capacity).toString().toInt(),
+        criticalUsage = capacity.getOrDefault(Priority.CRITICAL.name, 0).toString().toInt(),
+        highUsage = capacity.getOrDefault(Priority.HIGH.name, 0).toString().toInt(),
+        mediumUsage = capacity.getOrDefault(Priority.MEDIUM.name, 0).toString().toInt(),
+        lowUsage = capacity.getOrDefault(Priority.LOW.name, 0).toString().toInt(),
+        learning = if (capacity.containsKey("learning")) capacity["learning"]!!.toBoolean() else null
+      )
+    }
+  }
+}

--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisRateLimitBackend.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisRateLimitBackend.kt
@@ -15,9 +15,9 @@
  */
 package com.netflix.spinnaker.orca.q.redis
 
-import com.netflix.spinnaker.orca.q.ratelimit.RateLimit
-import com.netflix.spinnaker.orca.q.ratelimit.RateLimitBackend
-import com.netflix.spinnaker.orca.q.ratelimit.RateLimitContext
+import com.netflix.spinnaker.orca.q.trafficshaping.ratelimit.RateLimit
+import com.netflix.spinnaker.orca.q.trafficshaping.ratelimit.RateLimitBackend
+import com.netflix.spinnaker.orca.q.trafficshaping.ratelimit.RateLimitContext
 import redis.clients.jedis.Jedis
 import redis.clients.util.Pool
 import java.time.Clock

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
@@ -37,7 +37,7 @@ import java.time.Clock
 import java.util.concurrent.Executor
 
 @Configuration
-@ComponentScan(basePackages = arrayOf("com.netflix.spinnaker.orca.q", "com.netflix.spinnaker.orca.log"))
+@ComponentScan(basePackages = arrayOf("com.netflix.spinnaker.orca.q", "com.netflix.spinnaker.orca.log", "com.netflix.spinnaker.orca.q.trafficshaping"))
 @EnableScheduling
 open class QueueConfiguration {
   @Bean @ConditionalOnMissingBean(Clock::class)

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/TrafficShapingQueue.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/TrafficShapingQueue.kt
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.orca.q
+package com.netflix.spinnaker.orca.q.trafficshaping
 
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.orca.q.Message
+import com.netflix.spinnaker.orca.q.Queue
+import com.netflix.spinnaker.orca.q.QueueCallback
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -49,7 +52,7 @@ import java.time.temporal.TemporalAmount
   val messageInterceptionsId: Id = registry.createId("queue.trafficShaping.messageInterceptions")
 
   init {
-    log.info("Starting with interceptors: ${interceptors.map { it.getName() }.joinToString()}")
+    log.info("Starting with interceptors: ${interceptors.sortedBy { it.getPriority() }.map { it.getName() }.joinToString()}")
   }
 
   override fun poll(callback: QueueCallback) {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PrioritizationStrategy.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PrioritizationStrategy.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.q.trafficshaping.capacity
+
+import com.netflix.spinnaker.orca.events.ExecutionEvent
+import com.netflix.spinnaker.orca.q.ApplicationAware
+
+interface PrioritizationStrategy {
+  fun getPriority(execution: ExecutionEvent): Priority
+  fun getPriority(message: ApplicationAware): Priority
+}
+
+class ConstantPrioritizationStrategy : PrioritizationStrategy {
+  override fun getPriority(execution: ExecutionEvent) = Priority.MEDIUM
+  override fun getPriority(message: ApplicationAware) = Priority.MEDIUM
+}

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PriorityCapacityListener.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PriorityCapacityListener.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.q.trafficshaping.capacity
+
+import com.netflix.spinnaker.orca.events.ExecutionComplete
+import com.netflix.spinnaker.orca.events.ExecutionEvent
+import com.netflix.spinnaker.orca.events.ExecutionStarted
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationListener
+
+class PriorityCapacityListener(
+  private val priorityCapacityRepository: PriorityCapacityRepository,
+  private val prioritizationStrategy: PrioritizationStrategy
+) : ApplicationListener<ExecutionEvent> {
+
+  private val log: Logger = LoggerFactory.getLogger(javaClass)
+
+  override fun onApplicationEvent(event: ExecutionEvent) {
+    var priority: Priority
+    try {
+      priority = prioritizationStrategy.getPriority(event)
+    } catch (e: Exception) {
+      log.error("Could not determine priority of execution, assigning MEDIUM (message: $event)", e)
+      priority = Priority.MEDIUM
+    }
+
+    when (event) {
+      is ExecutionStarted -> priorityCapacityRepository.incrementExecutions(priority)
+      is ExecutionComplete -> priorityCapacityRepository.decrementExecutions(priority)
+    }
+  }
+}

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PriorityCapacityRepository.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PriorityCapacityRepository.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.q.trafficshaping.capacity
+
+enum class Priority {
+  CRITICAL, HIGH, MEDIUM, LOW
+}
+
+data class GlobalCapacity(
+  val ceiling: Int,
+  val criticalUsage: Int,
+  val highUsage: Int,
+  val mediumUsage: Int,
+  val lowUsage: Int,
+  val learning: Boolean? = null
+) {
+  fun getTotalUsage() = criticalUsage + highUsage + mediumUsage + lowUsage
+  fun shouldShedLoad() = ceiling <= getTotalUsage()
+}
+
+interface PriorityCapacityRepository {
+  fun incrementExecutions(priority: Priority)
+  fun decrementExecutions(priority: Priority)
+  fun getGlobalCapacity(): GlobalCapacity
+}

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/PriorityCapacityQueueInterceptor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/PriorityCapacityQueueInterceptor.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.q.trafficshaping.interceptor
+
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.config.TrafficShapingProperties
+import com.netflix.spinnaker.orca.q.ApplicationAware
+import com.netflix.spinnaker.orca.q.Message
+import com.netflix.spinnaker.orca.q.trafficshaping.InterceptorType
+import com.netflix.spinnaker.orca.q.trafficshaping.TrafficShapingInterceptor
+import com.netflix.spinnaker.orca.q.trafficshaping.TrafficShapingInterceptorCallback
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.GlobalCapacity
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.PrioritizationStrategy
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.Priority
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.PriorityCapacityRepository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.*
+
+/**
+ * Throttles messages by priority. If the system reaches a ceiling of
+ * concurrent active executions, lower priority messages will have a
+ * higher chance of being throttled to keep a higher quality of service
+ * for more important messages.
+ *
+ * Prioritization is assigned via an PrioritizationStrategy
+ * out of band of actual queue processing.
+ */
+class PriorityCapacityQueueInterceptor(
+  private val repository: PriorityCapacityRepository,
+  private val prioritizationStrategy: PrioritizationStrategy,
+  private val registry: Registry,
+  private val properties: TrafficShapingProperties.PriorityCapacityProperties,
+  private val timeShapedId: Id
+  ) : TrafficShapingInterceptor {
+
+  companion object {
+    private val THROTTLE_TIME = Duration.of(5, ChronoUnit.SECONDS)
+  }
+
+  private val log: Logger = LoggerFactory.getLogger(javaClass)
+
+  private val r: Random = Random()
+
+  private val throttledMessagesId = registry.createId("queue.trafficShaping.priorityCapacity.throttledMessages")
+
+  override fun getName() = "priorityCapacity"
+  override fun supports(type: InterceptorType) = type == InterceptorType.MESSAGE
+  override fun interceptPoll() = false
+  override fun getPriority() = properties.priority
+
+  override fun interceptMessage(message: Message): TrafficShapingInterceptorCallback? {
+    val cap: GlobalCapacity
+    try {
+      cap = repository.getGlobalCapacity()
+    } catch (e: Exception) {
+      log.error("ScoredCapacityBackend threw exception getting global capacity, disabling interceptor for message", e)
+      return null
+    }
+
+    if (!cap.shouldShedLoad()) {
+      return null
+    }
+
+    val callback = when (message) {
+      !is ApplicationAware -> handleUnknownMessage(message)
+      else -> handleApplicationMessage(message)
+    }
+
+    if (callback != null) {
+      if (isLearning(cap.learning)) {
+        log.info("Would have throttled message, but learning-mode enabled: $message")
+        registry.counter(throttledMessagesId.withTag("learning", "true")).increment()
+        return null
+      }
+      registry.counter(throttledMessagesId.withTag("learning", "false")).increment()
+    }
+
+    return callback
+  }
+
+  private fun handleUnknownMessage(message: Message): TrafficShapingInterceptorCallback? {
+    log.info("Global capacity at maximum limit: Throttling unknown message: $message")
+    return defaultThrottleCallback()
+  }
+
+  private fun handleApplicationMessage(message: ApplicationAware): TrafficShapingInterceptorCallback? {
+    val priority: Priority
+    try {
+      priority = prioritizationStrategy.getPriority(message)
+    } catch (e: Exception) {
+      log.error("Failed determining message priority, disabling interceptor for message", e)
+      return null
+    }
+
+    // TODO rz - configuration of throttle chances
+    return when (priority) {
+      Priority.CRITICAL -> null
+      Priority.HIGH -> if (r.nextInt(4) == 0) defaultThrottleCallback() else null
+      Priority.MEDIUM -> if (r.nextInt(1) == 0) defaultThrottleCallback() else null
+      Priority.LOW -> defaultThrottleCallback()
+    }
+  }
+
+  // TODO rz - configuration of throttle duration
+  private fun defaultThrottleCallback(): TrafficShapingInterceptorCallback = { queue, msg, ack ->
+    queue.push(msg, THROTTLE_TIME)
+    registry.counter(timeShapedId.withTags("interceptor", getName())).increment(THROTTLE_TIME.toMillis())
+    ack.invoke()
+  }
+
+  private fun isLearning(capLearningFlag: Boolean?) = capLearningFlag ?: properties.learning
+}

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/ratelimit/RateLimitBackend.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/ratelimit/RateLimitBackend.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.orca.q.ratelimit
+package com.netflix.spinnaker.orca.q.trafficshaping.ratelimit
 
 import java.time.Duration
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/TrafficShapingQueueSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/TrafficShapingQueueSpec.kt
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.orca.q
+package com.netflix.spinnaker.orca.q.trafficshaping
 
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.q.Queue
+import com.netflix.spinnaker.orca.q.QueueCallback
+import com.netflix.spinnaker.orca.q.StartStage
 import com.netflix.spinnaker.orca.q.memory.InMemoryQueue
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.describe

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/ApplicationRateLimitQueueInterceptorSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/ApplicationRateLimitQueueInterceptorSpec.kt
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.orca.q.interceptor
+package com.netflix.spinnaker.orca.q.trafficshaping.interceptor
 
+import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.TrafficShapingProperties
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.q.StartStage
-import com.netflix.spinnaker.orca.q.ratelimit.RateLimit
-import com.netflix.spinnaker.orca.q.ratelimit.RateLimitBackend
+import com.netflix.spinnaker.orca.q.trafficshaping.ratelimit.RateLimit
+import com.netflix.spinnaker.orca.q.trafficshaping.ratelimit.RateLimitBackend
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
@@ -35,10 +36,11 @@ object ApplicationRateLimitQueueInterceptorSpec : Spek({
   val backend: RateLimitBackend = mock()
   val registry = NoopRegistry()
   val props = TrafficShapingProperties.ApplicationRateLimitingProperties()
+  val timeShapedId: Id = mock()
 
   describe("an application rate limit queue interceptor") {
     val message = StartStage(Pipeline::class.java, "1", "foo", "1")
-    val subject = ApplicationRateLimitQueueInterceptor(backend, registry, props)
+    val subject = ApplicationRateLimitQueueInterceptor(backend, registry, props, timeShapedId)
 
     describe("when learning") {
       describe("when limited no callback is returned") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/GlobalRateLimitQueueInterceptorSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/GlobalRateLimitQueueInterceptorSpec.kt
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.orca.q.interceptor
+package com.netflix.spinnaker.orca.q.trafficshaping.interceptor
 
+import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.TrafficShapingProperties
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.q.StartStage
-import com.netflix.spinnaker.orca.q.ratelimit.RateLimit
-import com.netflix.spinnaker.orca.q.ratelimit.RateLimitBackend
+import com.netflix.spinnaker.orca.q.trafficshaping.ratelimit.RateLimit
+import com.netflix.spinnaker.orca.q.trafficshaping.ratelimit.RateLimitBackend
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
@@ -35,10 +36,11 @@ object GlobalRateLimitQueueInterceptorSpec : Spek({
   val backend: RateLimitBackend = mock()
   val registry = NoopRegistry()
   val props = TrafficShapingProperties.GlobalRateLimitingProperties()
+  val timeShapedId: Id = mock()
 
   describe("an application rate limit queue interceptor") {
     val message = StartStage(Pipeline::class.java, "1", "foo", "1")
-    val subject = GlobalRateLimitQueueInterceptor(backend, registry, props)
+    val subject = GlobalRateLimitQueueInterceptor(backend, registry, props, timeShapedId)
 
     describe("when learning") {
       describe("when limited no callback is returned") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/PriorityCapacityQueueInterceptorSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/PriorityCapacityQueueInterceptorSpec.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.q.trafficshaping.interceptor
+
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.TrafficShapingProperties
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.q.StartExecution
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.GlobalCapacity
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.PrioritizationStrategy
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.Priority
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.PriorityCapacityRepository
+import com.nhaarman.mockito_kotlin.*
+import junit.framework.Assert.assertNotNull
+import junit.framework.Assert.assertNull
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+
+object PriorityCapacityQueueInterceptorSpec : Spek({
+
+  val repository: PriorityCapacityRepository = mock()
+  val strategy: PrioritizationStrategy = mock()
+  val registry = NoopRegistry()
+  val properties = TrafficShapingProperties.PriorityCapacityProperties()
+  val timeShapedId: Id = mock()
+
+  describe("a priority capacity queue interceptor") {
+    val subject = PriorityCapacityQueueInterceptor(repository, strategy, registry, properties, timeShapedId)
+
+    afterGroup {
+      reset(strategy)
+    }
+
+    describe("when learning") {
+      properties.learning = true
+
+      whenever(strategy.getPriority(execution = any())) doReturn Priority.MEDIUM
+      whenever(strategy.getPriority(message = any())) doReturn Priority.MEDIUM
+
+      afterGroup {
+        reset(repository)
+      }
+
+      val message = StartExecution(Pipeline::class.java, "1", "foo")
+
+      describe("when under capacity") {
+        whenever(repository.getGlobalCapacity()) doReturn GlobalCapacity(ceiling = 10, criticalUsage = 0, highUsage = 0, mediumUsage = 0, lowUsage = 0)
+        assertNull(subject.interceptMessage(message))
+      }
+
+      describe("when over capacity") {
+        whenever(repository.getGlobalCapacity()) doReturn GlobalCapacity(ceiling = 10, criticalUsage = 10, highUsage = 10, mediumUsage = 10, lowUsage = 10)
+        assertNull(subject.interceptMessage(message))
+      }
+    }
+
+    describe("when enforcing") {
+      properties.learning = false
+
+      afterGroup {
+        reset(repository)
+      }
+
+      describe("when under capacity") {
+        val message = StartExecution(Pipeline::class.java, "1", "foo")
+
+        whenever(repository.getGlobalCapacity()) doReturn GlobalCapacity(ceiling = 10, criticalUsage = 0, highUsage = 0, mediumUsage = 0, lowUsage = 0)
+        assertNull(subject.interceptMessage(message))
+      }
+
+      describe("when over capacity") {
+        whenever(repository.getGlobalCapacity()) doReturn GlobalCapacity(ceiling = 10, criticalUsage = 10, highUsage = 10, mediumUsage = 10, lowUsage = 10)
+
+        afterGroup {
+          reset(strategy)
+        }
+
+        describe("when intercepting critical message") {
+          whenever(strategy.getPriority(message = any())) doReturn Priority.CRITICAL
+
+          val message = StartExecution(Pipeline::class.java, "1", "foo")
+
+          assertNull(subject.interceptMessage(message))
+        }
+
+        describe("when intercepting low message") {
+          whenever(strategy.getPriority(message = any())) doReturn Priority.LOW
+
+          val message = StartExecution(Pipeline::class.java, "1", "foo")
+
+          assertNotNull(subject.interceptMessage(message))
+        }
+      }
+    }
+  }
+})


### PR DESCRIPTION
An interceptor designed to help maintain message processing SLAs by
assigning Priority to each individual message according to a custom
PrioritizationStrategy.

It can be configured with a ceiling of concurrent executions, which
once exceeded, will begin to throttle lower-priority messages to make
room for higher ones.

As of this PR, OSS Orca will only ship with a ConstantPrioritizationStrategy,
which assigns all messages MEDIUM Priority. It's expected that each
organization running Spinnaker would have varying opinions of what
types of messages have certain priorities, and how to determine them. At
Netflix, I'll be writing a strategy that will allow us to blanket assign
priority to certain applications & teams, and eventually, take into account
the cloud account that a pipeline is deploying into (test is lower priority than
prod, for example).

I also moved all of the traffic shaping stuff under its own package.

@robfletcher PTAL