### PR TITLE
fix(aws/deploy): before stage preprocessors were not working on v3

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
@@ -65,13 +65,13 @@ abstract class AbstractDeployStrategyStage extends AbstractCloudProviderAwareSta
       .withTask("determineSourceServerGroup", DetermineSourceServerGroupTask)
       .withTask("determineHealthProviders", DetermineHealthProvidersTask)
 
+    correctContext(stage)
     deployStagePreProcessors.findAll { it.supports(stage) }.each {
       it.additionalSteps().each {
         builder.withTask(it.name, it.taskClass)
       }
     }
 
-    correctContext(stage)
     Strategy strategy = (Strategy) strategies.findResult(noStrategy, {
       it.name.equalsIgnoreCase(stage.context.strategy) ? it : null
     })


### PR DESCRIPTION
I really wish I could say I knew why this actually worked the way it was originally on v2...

