### PR TITLE
fix(stage): Fixed an issue with authentication details propagation.

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/MessageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/MessageHandler.kt
@@ -16,10 +16,13 @@
 
 package com.netflix.spinnaker.orca.q
 
+import com.netflix.spinnaker.orca.AuthenticatedStage
 import com.netflix.spinnaker.orca.batch.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.pipeline.model.*
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.security.AuthenticatedRequest
+import com.netflix.spinnaker.security.User
 
 /**
  * Implementations handle a single message type from the queue.
@@ -66,7 +69,20 @@ interface MessageHandler<M : Message> : (Message) -> Unit {
           if (stage == null) {
             queue.push(InvalidStageId(this))
           } else {
-            block.invoke(stage)
+            val authenticatedUser = stage
+              .ancestors()
+              .filter { it.stageBuilder is AuthenticatedStage }
+              .firstOrNull()
+              ?.let { (it.stageBuilder as AuthenticatedStage).authenticatedUser(it.stage).orElse(null) }
+
+            val currentUser = authenticatedUser ?: User().apply {
+              email = stage.getExecution().getAuthentication()?.user
+              allowedAccounts = stage.getExecution().getAuthentication()?.allowedAccounts
+            }
+
+            AuthenticatedRequest.propagate({
+              block.invoke(stage)
+            }, false, currentUser).call()
           }
         }
     }


### PR DESCRIPTION
This was encountered when trying to destroy a server group in Deck via authentication and authorization enabled.

With this change the authentication information is propagated from either:

a) A previous AuthenticatedStage
b) AuthenticationDetails inside of the Execution (which can be set in OrchestrationLauncher, for example)

Here is an example log showing the issue:

```bash
2017-07-06 13:40:54.740 DEBUG 22241 --- [0.1-8083-exec-3] c.n.s.f.shared.FiatAuthenticationFilter  : [testuser] Set SecurityContext to user: testuser
2017-07-06 13:40:54.791  INFO 22241 --- [0.1-8083-exec-3] c.n.s.o.c.OperationsController           : [testuser] requested task:{
  "application" : "test123",
  "name" : "Destroy Server Group: test123-v002",
  "appConfig" : null,
  "stages" : [ {
    "interestingHealthProviderNames" : [ "KubernetesService" ],
    "namespace" : "default",
    "asgName" : "test123-v002",
    "serverGroupName" : "test123-v002",
    "type" : "destroyServerGroup",
    "region" : "default",
    "credentials" : "my-cluster",
    "cloudProvider" : "kubernetes",
    "user" : "testuser",
    "refId" : "0",
    "requisiteStageRefIds" : [ ]
  } ],
  "parallel" : true
}
2017-07-06 13:40:55.598 DEBUG 22241 --- [ Service Thread] com.netflix.spectator.gc.GcLogger        : [] YOUNG: PS Scavenge, id=13, at=Thu Jul 06 13:40:54 UTC 2017, duration=64ms, cause=[Metadata GC Threshold], 0.4GiB => 0.2GiB / 3.1GiB (13.5% => 5.0%)
2017-07-06 13:40:55.600 DEBUG 22241 --- [ Service Thread] com.netflix.spectator.gc.GcLogger        : [] OLD: PS MarkSweep, id=3, at=Thu Jul 06 13:40:55 UTC 2017, duration=573ms, cause=[Metadata GC Threshold], 0.2GiB => 0.2GiB / 3.1GiB (5.0% => 4.8%)
2017-07-06 13:40:56.218  INFO 22241 --- [pool-2-thread-1] c.n.spinnaker.orca.q.QueueProcessor      : [] Received message StartExecution(executionType=class com.netflix.spinnaker.orca.pipeline.model.Orchestration, executionId=aab00ae7-591c-4b8d-bff1-06ebcdad3d58, application=test123)
2017-07-06 13:40:56.290  INFO 22241 --- [pool-2-thread-1] c.n.spinnaker.orca.q.QueueProcessor      : [] Received message StartStage(executionType=class com.netflix.spinnaker.orca.pipeline.model.Orchestration, executionId=aab00ae7-591c-4b8d-bff1-06ebcdad3d58, application=test123, stageId=9cd87a24-f6c3-49e4-b9bd-e29a0b1b9328)
2017-07-06 13:40:56.401  INFO 22241 --- [geHandlerPool-2] c.n.s.orca.clouddriver.OortService       : [] ---> HTTP GET http://localhost:7002/applications/test123/clusters/my-cluster/test123/kubernetes/serverGroups/test123-v002
2017-07-06 13:40:56.410  INFO 22241 --- [geHandlerPool-2] c.n.s.orca.clouddriver.OortService       : [] <--- HTTP 403 http://localhost:7002/applications/test123/clusters/my-cluster/test123/kubernetes/serverGroups/test123-v002 (9ms)
2017-07-06 13:40:56.444 ERROR 22241 --- [geHandlerPool-2] c.n.s.orca.q.handler.StartStageHandler   : [] Error running destroyServerGroup stage for Orchestration[aab00ae7-591c-4b8d-bff1-06ebcdad3d58]
retrofit.RetrofitError: 403 Forbidden
        at retrofit.RetrofitError.httpError(RetrofitError.java:40)
        at retrofit.RestAdapter$RestHandler.invokeRequest(RestAdapter.java:388)
        at retrofit.RestAdapter$RestHandler.invoke(RestAdapter.java:240)
        at com.sun.proxy.$Proxy89.getServerGroup(Unknown Source)
        at com.netflix.spinnaker.orca.clouddriver.OortService$getServerGroup.call(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver$_resolveByServerGroupName_closure3.doCall(TargetServerGroupResolver.groovy:77)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver$_resolveByServerGroupName_closure3.doCall(TargetServerGroupResolver.groovy)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:294)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1024)
        at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:42)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:117)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver.fetchWithRetries(TargetServerGroupResolver.groovy:158)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:59)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:52)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:154)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:174)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver.resolveByServerGroupName(TargetServerGroupResolver.groovy:76)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:384)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1024)
        at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.callCurrent(PogoMetaClassSite.java:69)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:52)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:154)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:174)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver$_resolveByParams_closure1.doCall(TargetServerGroupResolver.groovy:54)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:294)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1024)
        at groovy.lang.Closure.call(Closure.java:414)
        at groovy.lang.Closure.call(Closure.java:430)
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.collect(DefaultGroovyMethods.java:3170)
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.collect(DefaultGroovyMethods.java:3140)
        at org.codehaus.groovy.runtime.dgm$66.invoke(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:274)
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:56)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver.resolveByParams(TargetServerGroupResolver.groovy:50)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver$resolveByParams.call(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport.composeStaticTargets(TargetServerGroupLinearStageSupport.groovy:66)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:59)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:52)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:154)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:174)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport.memoizedMethodPriv$composeTargetsStage(TargetServerGroupLinearStageSupport.groovy:54)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:384)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1024)
        at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.callCurrent(PogoMetaClassSite.java:69)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:52)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:154)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:166)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport$_closure1.doCall(TargetServerGroupLinearStageSupport.groovy)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:294)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1024)
        at groovy.lang.Closure.call(Closure.java:414)
        at org.codehaus.groovy.runtime.memoize.Memoize$MemoizeFunction.call(Memoize.java:132)
        at groovy.lang.Closure.call(Closure.java:430)
        at groovy.lang.Closure$call.call(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport.composeTargets(TargetServerGroupLinearStageSupport.groovy)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport$composeTargets.callCurrent(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:52)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:154)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:166)
        at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport.aroundStages(TargetServerGroupLinearStageSupport.groovy:43)
        at com.netflix.spinnaker.orca.q.StageDefinitionBuildersKt.syntheticStages(StageDefinitionBuilders.kt:106)
        at com.netflix.spinnaker.orca.q.StageDefinitionBuildersKt.buildSyntheticStages(StageDefinitionBuilders.kt:85)
        at com.netflix.spinnaker.orca.q.handler.StartStageHandler.plan(StartStageHandler.kt:100)
        at com.netflix.spinnaker.orca.q.handler.StartStageHandler.access$plan(StartStageHandler.kt:38)
        at com.netflix.spinnaker.orca.q.handler.StartStageHandler$handle$1.invoke(StartStageHandler.kt:66)
        at com.netflix.spinnaker.orca.q.handler.StartStageHandler$handle$1.invoke(StartStageHandler.kt:38)
        at com.netflix.spinnaker.orca.q.MessageHandler$withStage$1.invoke(MessageHandler.kt:69)
        at com.netflix.spinnaker.orca.q.MessageHandler$withStage$1.invoke(MessageHandler.kt:27)
        at com.netflix.spinnaker.orca.q.MessageHandler$DefaultImpls.withExecution(MessageHandler.kt:84)
        at com.netflix.spinnaker.orca.q.handler.StartStageHandler.withExecution(StartStageHandler.kt:38)
        at com.netflix.spinnaker.orca.q.MessageHandler$DefaultImpls.withStage(MessageHandler.kt:62)
        at com.netflix.spinnaker.orca.q.handler.StartStageHandler.withStage(StartStageHandler.kt:38)
        at com.netflix.spinnaker.orca.q.handler.StartStageHandler.handle(StartStageHandler.kt:54)
        at com.netflix.spinnaker.orca.q.handler.StartStageHandler.handle(StartStageHandler.kt:38)
        at com.netflix.spinnaker.orca.q.MessageHandler$DefaultImpls.invoke(MessageHandler.kt:36)
        at com.netflix.spinnaker.orca.q.handler.StartStageHandler.invoke(StartStageHandler.kt:38)
        at com.netflix.spinnaker.orca.q.QueueProcessor$pollOnce$1$1$1.run(QueueProcessor.kt:56)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
2017-07-06 13:40:56.494  INFO 22241 --- [pool-2-thread-1] c.n.spinnaker.orca.q.QueueProcessor      : [] Received message CompleteStage(executionType=class com.netflix.spinnaker.orca.pipeline.model.Orchestration, executionId=aab00ae7-591c-4b8d-bff1-06ebcdad3d58, application=test123, stageId=9cd87a24-f6c3-49e4-b9bd-e29a0b1b9328, status=TERMINAL)
2017-07-06 13:40:56.533  INFO 22241 --- [pool-2-thread-1] c.n.spinnaker.orca.q.QueueProcessor      : [] Received message CancelStage(executionType=class com.netflix.spinnaker.orca.pipeline.model.Orchestration, executionId=aab00ae7-591c-4b8d-bff1-06ebcdad3d58, application=test123, stageId=9cd87a24-f6c3-49e4-b9bd-e29a0b1b9328)
2017-07-06 13:40:56.562  INFO 22241 --- [pool-2-thread-1] c.n.spinnaker.orca.q.QueueProcessor      : [] Received message CompleteExecution(executionType=class com.netflix.spinnaker.orca.pipeline.model.Orchestration, executionId=aab00ae7-591c-4b8d-bff1-06ebcdad3d58, application=test123)
```