### PR TITLE
feat(orca) Place produced artifacts in global context

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/Bake.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/Bake.groovy
@@ -18,6 +18,7 @@
 
 package com.netflix.spinnaker.orca.bakery.api
 
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
@@ -35,5 +36,6 @@ class Bake {
   String ami
   String amiName
   String imageName
+  Artifact artifact
   // TODO(duftler): Add a cloudProviderType property here? Will be straightforward once rosco is backed by redis.
 }

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.bakery.tasks
 
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
@@ -39,7 +40,7 @@ class CompletedBakeTask implements Task {
     def bakeStatus = stage.context.status as BakeStatus
     def bake = bakery.lookupBake(region, bakeStatus.resourceId).toBlocking().first()
     // This treatment of ami allows both the aws and gce bake results to be propagated.
-    def results = [ami: bake.ami ?: bake.imageName, imageId: bake.ami ?: bake.imageName]
+    def results = [ami: bake.ami ?: bake.imageName, imageId: bake.ami ?: bake.imageName, artifact: bake.artifact ?: new Artifact()]
     /**
      * TODO:
      * It would be good to standardize on the key here. "imageId" works for all providers.
@@ -49,6 +50,7 @@ class CompletedBakeTask implements Task {
     if (bake.imageName || bake.amiName) {
       results.imageName = bake.imageName ?: bake.amiName
     }
+
     new TaskResult(ExecutionStatus.SUCCEEDED, results)
   }
 }

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.bakery.tasks
 
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.bakery.api.Bake
 import com.netflix.spinnaker.orca.bakery.api.BakeStatus
@@ -44,10 +45,10 @@ class CompletedBakeTaskSpec extends Specification {
     null
   )
 
-  def "finds the AMI created by a bake"() {
+  def "finds the AMI and artifact created by a bake"() {
     given:
     task.bakery = Stub(BakeryService) {
-      lookupBake(region, bakeId) >> Observable.from(new Bake(id: bakeId, ami: ami))
+      lookupBake(region, bakeId) >> Observable.from(new Bake(id: bakeId, ami: ami, artifact: artifact))
     }
 
     and:
@@ -59,11 +60,13 @@ class CompletedBakeTaskSpec extends Specification {
     then:
     result.status == ExecutionStatus.SUCCEEDED
     result.context.ami == ami
+    result.context.artifact.reference == ami
 
     where:
     region = "us-west-1"
     bakeId = "b-5af233wjj78mwt2f420wt8ey3w"
     ami = "ami-280c3b6d"
+    artifact = new Artifact(reference: ami)
   }
 
   def "fails if the bake is not found"() {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/ImageFinder.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/ImageFinder.java
@@ -29,6 +29,7 @@ public interface ImageFinder {
   interface ImageDetails {
     String getImageId();
     String getImageName();
+    String getRegion();
     JenkinsDetails getJenkins();
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageFinder.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageFinder.java
@@ -145,6 +145,11 @@ public class AmazonImageFinder implements ImageFinder {
     }
 
     @Override
+    public String getRegion() {
+      return (String) super.get("region");
+    }
+
+    @Override
     public JenkinsDetails getJenkins() {
       return (JenkinsDetails) super.get("jenkins");
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleImageFinder.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleImageFinder.java
@@ -133,6 +133,11 @@ public class GoogleImageFinder implements ImageFinder {
     }
 
     @Override
+    public String getRegion() {
+      return (String) super.get("region");
+    }
+
+    @Override
     public JenkinsDetails getJenkins() {
       return (JenkinsDetails) super.get("jenkins");
     }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagTaskSpec.groovy
@@ -9,12 +9,13 @@ import spock.lang.Subject
 class FindImageFromTagTaskSpec extends Specification {
 
   def imageFinder = Mock(ImageFinder)
+  def imageDetails = Mock(ImageFinder.ImageDetails)
   Stage stage = new Stage<>(new Pipeline("orca"), "", [packageName: 'myPackage', tags: ['foo': 'bar']])
 
   @Subject
   def task = new FindImageFromTagsTask(imageFinders: [imageFinder])
 
-  def "Not finding an images should throw IllegalStateException"() {
+  def "Not finding images should throw IllegalStateException"() {
     when:
     task.execute(stage)
 
@@ -25,7 +26,7 @@ class FindImageFromTagTaskSpec extends Specification {
     1 * imageFinder.getCloudProvider() >> 'aws'
   }
 
-  def "Finding an images should set task state to SUCCEEDED"() {
+  def "Finding images should set task state to SUCCEEDED"() {
     when:
     def result = task.execute(stage)
 
@@ -33,6 +34,10 @@ class FindImageFromTagTaskSpec extends Specification {
     result.status == ExecutionStatus.SUCCEEDED
 
     1 * imageFinder.getCloudProvider() >> 'aws'
-    1 * imageFinder.byTags(stage, stage.context.packageName, stage.context.tags) >> [[:]]
+    1 * imageFinder.byTags(stage, stage.context.packageName, stage.context.tags) >> [imageDetails]
+    1 * imageDetails.getImageName() >> "somename"
+    1 * imageDetails.getImageId() >> "someId"
+    1 * imageDetails.getJenkins() >> new ImageFinder.JenkinsDetails("somehost", "somename", "42")
   }
+
 }


### PR DESCRIPTION
The idea here is to place artifacts from rosco in the global context along with artifacts from `findImageFromTag` and `findImageFromCluster` so that it's in place when we want to start working on the feature toggle to enable deployment of artifacts. I was a bit unsure on the naming and placement of this object `Artifacts` so feel free to suggest alternative approaches. 