### PR TITLE
feat(pipelines): Add support for task-backed pipeline config saves

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -52,6 +52,9 @@ interface Front50Service {
   @POST("/pipelines")
   Response savePipeline(@Body Map pipeline)
 
+  @PUT("/pipelines/{pipelineId}")
+  Response updatePipeline(@Path("pipelineId") String pipelineId, @Body Map pipeline)
+
   @GET("/strategies/{applicationName}")
   List<Map<String, Object>> getStrategies(@Path("applicationName") String applicationName)
 

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/PipelineModelMutator.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/PipelineModelMutator.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50;
+
+import java.util.Map;
+
+/**
+ * Allows mutating a pipeline model during a create or update pipeline task operation.
+ */
+public interface PipelineModelMutator {
+
+  boolean supports(Map<String, Object> pipeline);
+
+  void mutate(Map<String, Object> pipeline);
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/SavePipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/SavePipelineStage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.pipeline;
+
+import com.netflix.spinnaker.orca.front50.tasks.SavePipelineTask;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode.Builder;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SavePipelineStage implements StageDefinitionBuilder {
+
+  @Override
+  public <T extends Execution<T>> void taskGraph(Stage<T> stage, Builder builder) {
+    builder
+      .withTask("savePipeline", SavePipelineTask.class);
+  }
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/UpdatePipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/UpdatePipelineStage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.pipeline;
+
+import com.netflix.spinnaker.orca.front50.tasks.SavePipelineTask;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode.Builder;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpdatePipelineStage implements StageDefinitionBuilder {
+
+  @Override
+  public <T extends Execution<T>> void taskGraph(Stage<T> stage, Builder builder) {
+    builder
+      .withTask("updatePipeline", SavePipelineTask.class);
+  }
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.tasks;
+
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.front50.PipelineModelMutator;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class SavePipelineTask implements RetryableTask {
+
+  @Autowired(required = false)
+  private Front50Service front50Service;
+
+  @Autowired(required = false)
+  private List<PipelineModelMutator> pipelineModelMutators = new ArrayList<>();
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public TaskResult execute(Stage stage) {
+    if (front50Service == null) {
+      throw new UnsupportedOperationException("Front50 is not enabled, no way to save pipeline. Fix this by setting front50.enabled: true");
+    }
+
+    if (!stage.getContext().containsKey("pipeline")) {
+      throw new IllegalArgumentException("pipeline context must be provided");
+    }
+
+    Map<String, Object> pipeline = (Map<String, Object>) stage.getContext().get("pipeline");
+    pipelineModelMutators.stream().filter(m -> m.supports(pipeline)).forEach(m -> m.mutate(pipeline));
+
+    Response response = front50Service.savePipeline(pipeline);
+
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put("notification.type", "savepipeline");
+    outputs.put("application", pipeline.get("application"));
+    outputs.put("pipeline.name", pipeline.get("name"));
+
+    return new TaskResult(
+      (response.getStatus() == HttpStatus.OK.value()) ? ExecutionStatus.SUCCEEDED : ExecutionStatus.TERMINAL,
+      outputs
+    );
+  }
+
+  @Override
+  public long getBackoffPeriod() {
+    return 15000;
+  }
+
+  @Override
+  public long getTimeout() {
+    return TimeUnit.MINUTES.toMillis(1);
+  }
+}

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTaskSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.tasks
+
+import com.google.common.collect.ImmutableMap
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.PipelineModelMutator
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import retrofit.client.Response
+import spock.lang.Specification
+import spock.lang.Subject
+
+class SavePipelineTaskSpec extends Specification {
+
+  Front50Service front50Service = Mock()
+
+  PipelineModelMutator mutator = Mock()
+
+  @Subject
+  SavePipelineTask task = new SavePipelineTask(front50Service: front50Service, pipelineModelMutators: [mutator])
+
+  def "should run model mutators with correct context"() {
+    given:
+    def pipeline = [
+      application: 'orca',
+      name: 'my pipeline',
+      stages: []
+    ]
+    def stage = new Stage<>(new Pipeline(), "whatever", [
+      pipeline: pipeline
+    ])
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * mutator.supports(pipeline) >> true
+    1 * mutator.mutate(pipeline)
+    1 * front50Service.savePipeline(pipeline) >> {
+      new Response('http://front50', 200, 'OK', [], null)
+    }
+    result.status == ExecutionStatus.SUCCEEDED
+    result.stageOutputs == ImmutableMap.copyOf([
+      'notification.type': 'savepipeline',
+      'application': 'orca',
+      'pipeline.name': 'my pipeline'
+    ])
+  }
+
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
@@ -20,12 +20,14 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.front50.PipelineModelMutator;
 import com.netflix.spinnaker.orca.pipelinetemplate.PipelineTemplateModule;
+import com.netflix.spinnaker.orca.pipelinetemplate.loader.TemplateLoader;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.TemplatedPipelineModelMutator;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderedValueConverter;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.YamlRenderedValueConverter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -53,5 +55,12 @@ public class PipelineTemplateConfiguration {
   @Bean
   Renderer jinjaRenderer(RenderedValueConverter renderedValueConverter, ObjectMapper pipelineTemplateObjectMapper, Front50Service front50Service) {
     return new JinjaRenderer(renderedValueConverter, pipelineTemplateObjectMapper, front50Service);
+  }
+
+  @Bean
+  PipelineModelMutator schemaV1TemplatedPipelineModelMutator(ObjectMapper pipelineTemplateObjectMapper,
+                                                             TemplateLoader templateLoader,
+                                                             Renderer renderer) {
+    return new TemplatedPipelineModelMutator(pipelineTemplateObjectMapper, templateLoader, renderer);
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutator.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.front50.PipelineModelMutator;
+import com.netflix.spinnaker.orca.pipelinetemplate.loader.TemplateLoader;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.NamedHashMap;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate.Configuration;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration.PipelineConfiguration;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderContext;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderUtil;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Maps pipeline configurations of concurrency settings, notifications,
+ * triggers and parameters from the pipeline template schema to the original
+ * non-templated pipeline schema.
+ */
+public class TemplatedPipelineModelMutator implements PipelineModelMutator {
+
+  private final ObjectMapper pipelineTemplateObjectMapper;
+  private final TemplateLoader templateLoader;
+  private final Renderer renderer;
+
+  public TemplatedPipelineModelMutator(ObjectMapper pipelineTemplateObjectMapper,
+                                       TemplateLoader templateLoader,
+                                       Renderer renderer) {
+    this.pipelineTemplateObjectMapper = pipelineTemplateObjectMapper;
+    this.templateLoader = templateLoader;
+    this.renderer = renderer;
+  }
+
+  @Override
+  public boolean supports(Map<String, Object> pipeline) {
+    return "templatedPipeline".equals(pipeline.get("type")) && pipeline.containsKey("config");
+  }
+
+  @Override
+  public void mutate(Map<String, Object> pipeline) {
+    TemplateConfiguration configuration = pipelineTemplateObjectMapper.convertValue(pipeline.get("config"), TemplateConfiguration.class);
+
+    PipelineTemplate template = null;
+
+    // Dynamically sourced templates don't support configuration inheritance.
+    if (!sourceContainsExpressions(configuration)) {
+      template = getPipelineTemplate(configuration);
+      applyConfigurationsFromTemplate(configuration.getConfiguration(), template.getConfiguration(), pipeline);
+    }
+
+    pipeline.computeIfAbsent("application", k -> configuration.getPipeline().getApplication());
+    pipeline.computeIfAbsent("name", k -> configuration.getPipeline().getName());
+
+    applyConfigurations(configuration.getConfiguration(), pipeline);
+    renderConfigurations(pipeline, RenderUtil.createDefaultRenderContext(template, configuration, null));
+  }
+
+  private void applyConfigurationsFromTemplate(PipelineConfiguration configuration, Configuration templateConfiguration, Map<String, Object> pipeline) {
+    if (configuration.getInherit().contains("concurrentExecutions") && templateConfiguration.getConcurrentExecutions() != null) {
+      applyConcurrentExecutions(pipeline, templateConfiguration.getConcurrentExecutions());
+    }
+    if (configuration.getInherit().contains("triggers")) {
+      pipeline.put("triggers", templateConfiguration.getTriggers());
+    }
+    if (configuration.getInherit().contains("parameters")) {
+      pipeline.put("parameters", templateConfiguration.getParameters());
+    }
+    if (configuration.getInherit().contains("notifications")) {
+      pipeline.put("notifications", templateConfiguration.getNotifications());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void applyConfigurations(PipelineConfiguration configuration, Map<String, Object> pipeline) {
+    if (configuration.getConcurrentExecutions() != null) {
+      applyConcurrentExecutions(pipeline, configuration.getConcurrentExecutions());
+    }
+    if (!configuration.getTriggers().isEmpty()) {
+      pipeline.put("triggers", TemplateMerge.mergeNamedContent((List<NamedHashMap>) pipeline.get("triggers"), configuration.getTriggers()));
+    }
+    if (!configuration.getParameters().isEmpty()) {
+      pipeline.put("parameters", TemplateMerge.mergeNamedContent((List<NamedHashMap>) pipeline.get("parameters"), configuration.getParameters()));
+    }
+    if (!configuration.getNotifications().isEmpty()) {
+      pipeline.put("notifications", TemplateMerge.mergeNamedContent((List<NamedHashMap>) pipeline.get("notifications"), configuration.getNotifications()));
+    }
+  }
+
+  private void applyConcurrentExecutions(Map<String, Object> pipeline, Map<String, Object> concurrentExecutions) {
+    if (concurrentExecutions.containsKey("limitConcurrent")) {
+      pipeline.put("limitConcurrent", concurrentExecutions.get("limitConcurrent"));
+    }
+    if (concurrentExecutions.containsKey("keepWaitingPipelines")) {
+      pipeline.put("keepWaitingPipelines", concurrentExecutions.get("keepWaitingPipelines"));
+    }
+    if (concurrentExecutions.containsKey("parallel")) {
+      pipeline.put("parallel", concurrentExecutions.get("parallel"));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void renderConfigurations(Map<String, Object> pipeline, RenderContext renderContext) {
+    if (pipeline.containsKey("triggers")) {
+      pipeline.put("triggers", renderList((List<Object>) pipeline.get("triggers"), renderContext));
+    }
+    if (pipeline.containsKey("parameters")) {
+      pipeline.put("parameters", renderList((List<Object>) pipeline.get("parameters"), renderContext));
+    }
+    if (pipeline.containsKey("notifications")) {
+      pipeline.put("notifications", renderList((List<Object>) pipeline.get("notifications"), renderContext));
+    }
+  }
+
+  private List<Object> renderList(List<Object> list, RenderContext renderContext) {
+    if (list == null) {
+      return null;
+    }
+    return list.stream().map(i -> RenderUtil.deepRender(renderer, i, renderContext)).collect(Collectors.toList());
+  }
+
+  private boolean sourceContainsExpressions(TemplateConfiguration configuration) {
+    String source = configuration.getPipeline().getTemplate().getSource();
+    return source.contains("{{") || source.contains("{%");
+  }
+
+  private PipelineTemplate getPipelineTemplate(TemplateConfiguration configuration) {
+    List<PipelineTemplate> templates = templateLoader.load(configuration.getPipeline().getTemplate());
+    return TemplateMerge.merge(templates);
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/RenderTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/RenderTransform.java
@@ -22,10 +22,8 @@ import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderExce
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisitor;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PartialDefinition;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate.Variable;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinition;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.DefaultRenderContext;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderContext;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderUtil;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
@@ -67,17 +65,7 @@ public class RenderTransform implements PipelineTemplateVisitor {
   }
 
   private void render(PipelineTemplate template) {
-    RenderContext context = new DefaultRenderContext(templateConfiguration.getPipeline().getApplication(), template, trigger);
-
-    if (template.getVariables() != null) {
-      template.getVariables().stream()
-        .filter(Variable::hasDefaultValue)
-        .forEach(v -> context.getVariables().put(v.getName(), v.getDefaultValue()));
-    }
-
-    if (templateConfiguration.getPipeline().getVariables() != null) {
-      context.getVariables().putAll(templateConfiguration.getPipeline().getVariables());
-    }
+    RenderContext context = RenderUtil.createDefaultRenderContext(template, templateConfiguration, trigger);
 
     // We only render the stages here, whereas modules will be rendered only if used within stages.
     renderStages(filterStages(template.getStages(), false), context, "template");

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/TemplateConfiguration.java
@@ -107,11 +107,11 @@ public class TemplateConfiguration implements VersionedSchema {
 
   public static class PipelineConfiguration {
 
-    private List<String> inherit;
-    private Map<String, Object> concurrentExecutions;
-    private List<NamedHashMap> triggers;
-    private List<NamedHashMap> parameters;
-    private List<NamedHashMap> notifications;
+    private List<String> inherit = new ArrayList<>();
+    private Map<String, Object> concurrentExecutions = new HashMap<>();
+    private List<NamedHashMap> triggers = new ArrayList<>();
+    private List<NamedHashMap> parameters = new ArrayList<>();
+    private List<NamedHashMap> notifications = new ArrayList<>();
     private String description;
 
     public List<String> getInherit() {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/RenderUtil.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/RenderUtil.java
@@ -16,6 +16,9 @@
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render;
 
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate.Variable;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
 
 import java.util.ArrayList;
@@ -85,5 +88,18 @@ public class RenderUtil {
 
   private static boolean isPrimitive(Object o) {
     return CharSequence.class.isInstance(o) || Number.class.isInstance(o) || Boolean.class.isInstance(o);
+  }
+
+  public static RenderContext createDefaultRenderContext(PipelineTemplate template, TemplateConfiguration configuration, Map<String, Object> trigger) {
+    RenderContext context = new DefaultRenderContext(configuration.getPipeline().getApplication(), template, trigger);
+    if (template != null && template.getVariables() != null) {
+      template.getVariables().stream()
+        .filter(Variable::hasDefaultValue)
+        .forEach(v -> context.getVariables().put(v.getName(), v.getDefaultValue()));
+    }
+    if (configuration.getPipeline().getVariables() != null) {
+      context.getVariables().putAll(configuration.getPipeline().getVariables());
+    }
+    return context;
   }
 }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutatorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutatorSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.pipelinetemplate.loader.TemplateLoader
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.NamedHashMap
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate.Configuration
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class TemplatedPipelineModelMutatorSpec extends Specification {
+
+  ObjectMapper objectMapper = new ObjectMapper()
+  TemplateLoader templateLoader = Mock()
+  Renderer renderer = Mock()
+
+  @Subject
+  TemplatedPipelineModelMutator subject = new TemplatedPipelineModelMutator(objectMapper, templateLoader, renderer)
+
+  @Unroll
+  def "should support templated pipelines only"() {
+    expect:
+    result == subject.supports(pipeline)
+
+    where:
+    pipeline                                 || result
+    [stages: []]                             || false
+    [type: 'templatedPipeline']              || false
+    [type: 'templatedPipeline', config: [:]] || true
+  }
+
+  def "should not apply configurations from template if dynamically sourced"() {
+    given:
+    def pipeline = [
+      config: [
+        schema: '1',
+        pipeline: [
+          template: [
+            source: '{{foo}}'
+          ]
+        ],
+        stages: []
+      ]
+    ]
+
+    when:
+    subject.mutate(pipeline)
+
+    then:
+    0 * subject.applyConfigurationsFromTemplate(_, _, pipeline)
+  }
+
+  def "should apply configurations from template if template is statically sourced"() {
+    given:
+    def pipeline = [
+      config: [
+        schema: '1',
+        pipeline: [
+          template: [
+            source: 'static-template'
+          ]
+        ],
+        configuration: [
+          inherit: ['triggers']
+        ]
+      ]
+    ]
+
+    when:
+    subject.mutate(pipeline)
+
+    then:
+    1 * templateLoader.load(_) >> { [new PipelineTemplate(
+      schema: '1',
+      configuration: new Configuration(
+        concurrentExecutions: [
+          parallel: true
+        ],
+        triggers: [
+          [
+            name: 'package',
+            type: 'jenkins',
+            job: 'package-orca',
+            master: 'spinnaker',
+            enabled: true
+          ] as NamedHashMap
+        ],
+        parameters: [
+          [
+            name: 'foo',
+            description: 'blah'
+          ] as NamedHashMap
+        ]
+      )
+    )]}
+    pipeline.triggers.size() == 1
+    pipeline.parallel == null
+    pipeline.parameters == null
+  }
+}


### PR DESCRIPTION
Merging this won't physically change any functionality. A followup PR in gate will move the save path from `gate -> front50` to `gate -> orca -> front50`.

This PR includes a mutator that will allow templated pipelines to correctly save params, triggers, etc to where the rest of spinnaker expects them to be when saved into front50.

@spinnaker/netflix-reviewers PTAL