### PR TITLE
fix(core)- optional stage support cannot handle expressions with ${}

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupport.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupport.groovy
@@ -64,9 +64,16 @@ class OptionalStageSupport {
 
     @Override
     boolean evaluate(Stage stage, ContextParameterProcessor contextParameterProcessor) {
+
+      Map context = contextParameterProcessor.buildExecutionContext(stage, true)
+
+      String unquoted = contextParameterProcessor.process([
+        expression: expression
+      ], context, true).expression
+
       String expression = contextParameterProcessor.process([
-        "expression": '${' + expression + '}'
-      ], contextParameterProcessor.buildExecutionContext(stage, true), true).expression
+        "expression": '${' + unquoted + '}'
+      ], context, true).expression
 
       def matcher = expression =~ /\$\{(.*)\}/
       if (matcher.matches()) {


### PR DESCRIPTION
There were changes to the order in which expressions get validated for the v3 engine. This makes sure that expressions both with ${} and without are evaluated correctly in the `conditional on expression` field for stages. 