### PR TITLE
fix(pipelinetemplate): Prefer pipeline ID over templated value; map on save

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutator.java
@@ -67,11 +67,22 @@ public class TemplatedPipelineModelMutator implements PipelineModelMutator {
       applyConfigurationsFromTemplate(configuration.getConfiguration(), template.getConfiguration(), pipeline);
     }
 
+    mapPipelineConfigId(pipeline, configuration);
+
     pipeline.computeIfAbsent("application", k -> configuration.getPipeline().getApplication());
     pipeline.computeIfAbsent("name", k -> configuration.getPipeline().getName());
 
     applyConfigurations(configuration.getConfiguration(), pipeline);
     renderConfigurations(pipeline, RenderUtil.createDefaultRenderContext(template, configuration, null));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void mapPipelineConfigId(Map<String, Object> pipeline, TemplateConfiguration configuration) {
+    if (pipeline.containsKey("id") && pipeline.get("id") != configuration.getPipeline().getPipelineConfigId()) {
+      Map<String, Object> config = (Map<String, Object>) pipeline.get("config");
+      Map<String, Object> p = (Map<String, Object>) config.get("pipeline");
+      p.put("pipelineConfigId", pipeline.get("id"));
+    }
   }
 
   private void applyConfigurationsFromTemplate(PipelineConfiguration configuration, Configuration templateConfiguration, Map<String, Object> pipeline) {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
@@ -32,7 +32,7 @@ public class V1SchemaExecutionGenerator implements ExecutionGenerator {
   @Override
   public Map<String, Object> generate(PipelineTemplate template, TemplateConfiguration configuration, String id) {
     Map<String, Object> pipeline = new HashMap<>();
-    pipeline.put("id", Optional.ofNullable(configuration.getPipeline().getPipelineConfigId()).orElse(Optional.ofNullable(id).orElse(configuration.getRuntimeId())));
+    pipeline.put("id", Optional.ofNullable(id).orElse(Optional.ofNullable(configuration.getPipeline().getPipelineConfigId()).orElse("unknown")));
     pipeline.put("application", configuration.getPipeline().getApplication());
     pipeline.put("name", Optional.ofNullable(configuration.getPipeline().getName()).orElse("Unnamed Execution"));
 

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutatorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutatorSpec.groovy
@@ -114,4 +114,28 @@ class TemplatedPipelineModelMutatorSpec extends Specification {
     pipeline.parallel == null
     pipeline.parameters == null
   }
+
+  def "should map pipeline config id if it is unset"() {
+    given:
+    def pipeline = [
+      id: 'pipeline-id',
+      config: [
+        schema: '1',
+        pipeline: [
+          template: [
+            source: 'static-template'
+          ]
+        ]
+      ]
+    ]
+
+    when:
+    subject.mutate(pipeline)
+
+    then:
+    1 * templateLoader.load(_) >> { [new PipelineTemplate(
+      schema: '1'
+    )] }
+    pipeline.id == pipeline.config.pipeline.pipelineConfigId
+  }
 }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGeneratorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGeneratorSpec.groovy
@@ -60,7 +60,7 @@ class V1SchemaExecutionGeneratorSpec extends Specification {
   }
 
   @Unroll
-  def "should default to pipelineConfigId if pipelineConfigId is set and fall back to the pipelines id if not set"() {
+  def "should fallback to pipelineConfigId if id is not set"() {
     given:
     PipelineTemplate template = getPipelineTemplate()
     TemplateConfiguration configuration = new TemplateConfiguration(
@@ -78,7 +78,7 @@ class V1SchemaExecutionGeneratorSpec extends Specification {
     where:
     pipelineId | pipelineDefinitionData             || expectedId
     "124"  | [application: 'orca',
-              pipelineConfigId: 'pipelineConfigId'] || "pipelineConfigId"
+              pipelineConfigId: 'pipelineConfigId'] || "124"
     null   | [application: 'orca',
               pipelineConfigId: 'pipelineConfigId'] || "pipelineConfigId"
     "124"  | [application: 'orca']                  || "124"


### PR DESCRIPTION
@danielpeach Sorta what I'm thinking to fix that TODO in roer. I think the mutator work is superfluous to the reordering in the JSON generator, though. I'd be interested to hear what version of orca they're running that they don't see the auto-mapping already working - maybe this reordering will do the trick alone.