### PR TITLE
feat(queue): Configurable rate limit durations

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/TrafficShapingProperties.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/TrafficShapingProperties.kt
@@ -39,6 +39,7 @@ open class InterceptorProperties {
   open var learning: Boolean = true
   open var priority: Int = 500
   open var capacity: Int = 100
+  open var durationMs: Long = 5000
 }
 
 open class OverridableCapacityProperties : InterceptorProperties() {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/ApplicationRateLimitQueueInterceptor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/ApplicationRateLimitQueueInterceptor.kt
@@ -60,7 +60,8 @@ class ApplicationRateLimitQueueInterceptor(
             RateLimitContext(
               getName(),
               applicationRateLimitingProperties.getCapacity(message.application),
-              applicationRateLimitingProperties.getEnforcing(message.application)
+              applicationRateLimitingProperties.getEnforcing(message.application),
+              applicationRateLimitingProperties.durationMs
             )
           )
         } catch (e: Exception) {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/GlobalRateLimitQueueInterceptor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/GlobalRateLimitQueueInterceptor.kt
@@ -56,7 +56,8 @@ class GlobalRateLimitQueueInterceptor(
         RateLimitContext(
           getName(),
           properties.capacity,
-          !properties.learning
+          !properties.learning,
+          properties.durationMs
         )
       )
     } catch (e: Exception) {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/PriorityCapacityQueueInterceptor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/PriorityCapacityQueueInterceptor.kt
@@ -50,10 +50,6 @@ class PriorityCapacityQueueInterceptor(
   private val timeShapedId: Id
   ) : TrafficShapingInterceptor {
 
-  companion object {
-    private val THROTTLE_TIME = Duration.of(5, ChronoUnit.SECONDS)
-  }
-
   private val log: Logger = LoggerFactory.getLogger(javaClass)
 
   private val r: Random = Random()
@@ -117,14 +113,13 @@ class PriorityCapacityQueueInterceptor(
     }
   }
 
-  // TODO rz - configuration of throttle duration
   private fun defaultThrottleCallback(): TrafficShapingInterceptorCallback = { queue, msg, ack ->
-    queue.push(msg, THROTTLE_TIME)
+    queue.push(msg, Duration.of(properties.durationMs, ChronoUnit.MILLIS))
     val app = when (msg) {
       is ApplicationAware -> msg.application
       else -> "UNKNOWN"
     }
-    registry.counter(timeShapedId.withTags("interceptor", getName(), "application", app)).increment(THROTTLE_TIME.toMillis())
+    registry.counter(timeShapedId.withTags("interceptor", getName(), "application", app)).increment(properties.durationMs)
     ack.invoke()
   }
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/ratelimit/RateLimitBackend.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/ratelimit/RateLimitBackend.kt
@@ -22,7 +22,8 @@ data class RateLimit(val limiting: Boolean, val duration: Duration, val enforcin
 data class RateLimitContext(
   val namespace: String,
   val capacity: Int,
-  val enforcing: Boolean
+  val enforcing: Boolean,
+  val duration: Long
 )
 
 interface RateLimitBackend {


### PR DESCRIPTION
Allows static & dynamic configuration of queue traffic shaper rate limit durations.

@spinnaker/netflix-reviewers PTAL