### PR TITLE
feat(queue): Implement redis-backed dead message handler

### DIFF
--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueProperties.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueProperties.kt
@@ -21,4 +21,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("queue.redis")
 class RedisQueueProperties {
   var queueName: String = "orca.task.queue"
+  var deadLetterQueueName: String = "orca.task.deadLetterQueue"
 }

--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisDeadMessageHandler.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisDeadMessageHandler.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.q.redis
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.netflix.spinnaker.orca.q.Message
+import com.netflix.spinnaker.orca.q.Queue
+import com.netflix.spinnaker.orca.q.handler.DeadMessageHandler
+import redis.clients.jedis.Jedis
+import redis.clients.util.Pool
+import java.time.Clock
+
+class RedisDeadMessageHandler(
+  val deadLetterQueueName: String,
+  private val pool: Pool<Jedis>,
+  private val clock: Clock
+) : DeadMessageHandler() {
+
+  private val dlqKey = "$deadLetterQueueName.messages"
+
+  private val mapper = ObjectMapper().apply {
+    registerModule(KotlinModule())
+  }
+
+  override fun handle(queue: Queue, message: Message) {
+    super.handle(queue, message)
+    pool.resource.use { redis ->
+      redis.zadd(dlqKey, clock.instant().toEpochMilli().toDouble(), mapper.writeValueAsString(message))
+    }
+  }
+}

--- a/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisDeadMessageHandlerSpec.kt
+++ b/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisDeadMessageHandlerSpec.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.q.redis
+
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.q.CompleteExecution
+import com.netflix.spinnaker.orca.q.Queue
+import com.netflix.spinnaker.orca.q.StartExecution
+import com.netflix.spinnaker.spek.and
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.reset
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.lifecycle.CachingMode
+import org.jetbrains.spek.subject.SubjectSpek
+import redis.clients.jedis.Jedis
+import redis.clients.util.Pool
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+object RedisDeadMessageHandlerSpec : SubjectSpek<RedisDeadMessageHandler>({
+
+  val queue: Queue = mock()
+  val redis: Jedis = mock()
+  val redisPool: Pool<Jedis> = mock()
+  val clock = Clock.fixed(Instant.EPOCH, ZoneId.systemDefault())
+
+  subject(CachingMode.GROUP) {
+    whenever(redisPool.resource).thenReturn(redis)
+    RedisDeadMessageHandler("dlq", redisPool, clock)
+  }
+
+  fun resetMocks() = reset(queue, redis)
+
+  describe("handling a message") {
+    val message = StartExecution(Pipeline::class.java, "1", "spinnaker")
+
+    afterGroup(::resetMocks)
+
+    action("the handler receives a message") {
+      subject.handle(queue, message)
+    }
+
+    it("terminates the execution") {
+      verify(queue).push(CompleteExecution(message))
+    }
+
+    it("puts the message onto the DLQ") {
+      verify(redis).zadd("dlq.messages", 0.0, "{\"@class\":\".StartExecution\",\"executionType\":\"com.netflix.spinnaker.orca.pipeline.model.Pipeline\",\"executionId\":\"1\",\"application\":\"spinnaker\"}")
+    }
+  }
+})

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueProcessor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueProcessor.kt
@@ -60,7 +60,7 @@ open class QueueProcessor
           registry.counter(pollErrorRateId).increment()
 
           // TODO: DLQ
-          throw IllegalStateException("Unsupported message type ${message.javaClass.simpleName}")
+          throw IllegalStateException("Unsupported message type ${message.javaClass.simpleName}: $message")
         }
       }
     }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandler.kt
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Component
 @Component open class DeadMessageHandler {
   private val log = LoggerFactory.getLogger(javaClass)
 
-  fun handle(queue: Queue, message: Message) {
+  open fun handle(queue: Queue, message: Message) {
     log.error("Dead message: $message")
     when (message) {
       is TaskLevel -> queue.push(CompleteTask(message, TERMINAL))


### PR DESCRIPTION
I'm not handling unsupported message types at this point. There were no occurrences over the last 24 hours of unsupported message types; everything fell through the `DeadMessageHandler`. However, I did add more context around the QueueProcessor TODO for a DLQ that will output what the message contents actually are if something were to go that path.

@spinnaker/netflix-reviewers PTAL