### PR TITLE
fix(rollingpush): handle new instance termination

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/RollingPushStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/RollingPushStage.java
@@ -52,8 +52,7 @@ public class RollingPushStage implements StageDefinitionBuilder {
             .withTask("waitForTerminateOperation", MonitorKatoTask.class)
             .withTask("waitForTerminatedInstances", WaitForTerminatedInstancesTask.class)
             .withTask("forceCacheRefresh", ServerGroupCacheForceRefreshTask.class)
-            .withTask("waitForNewInstances", WaitForNewInstanceLaunchTask.class)
-            .withTask("waitForUpInstances", WaitForUpInstanceHealthTask.class)
+            .withTask("waitForNewInstances", WaitForNewUpInstancesLaunchTask.class)
             .withTask("checkForRemainingTerminations", CheckForRemainingTerminationsTask.class);
         });
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/RollingPushStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/RollingPushStageSpec.groovy
@@ -26,14 +26,18 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.instance.TerminateInstancesT
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForDownInstanceHealthTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForTerminatedInstancesTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForUpInstanceHealthTask
-import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CaptureParentInterestingHealthProviderNamesTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.config.JesqueConfiguration
 import com.netflix.spinnaker.orca.config.OrcaConfiguration
 import com.netflix.spinnaker.orca.config.OrcaPersistenceConfiguration
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.kato.tasks.DisableInstancesTask
-import com.netflix.spinnaker.orca.kato.tasks.rollingpush.*
+import com.netflix.spinnaker.orca.kato.tasks.rollingpush.CheckForRemainingTerminationsTask
+import com.netflix.spinnaker.orca.kato.tasks.rollingpush.CleanUpTagsTask
+import com.netflix.spinnaker.orca.kato.tasks.rollingpush.DetermineTerminationCandidatesTask
+import com.netflix.spinnaker.orca.kato.tasks.rollingpush.DetermineTerminationPhaseInstancesTask
+import com.netflix.spinnaker.orca.kato.tasks.rollingpush.WaitForNewUpInstancesLaunchTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CaptureParentInterestingHealthProviderNamesTask
 import com.netflix.spinnaker.orca.pipeline.PipelineLauncher
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.TaskNode
@@ -232,8 +236,8 @@ class RollingPushStageSpec extends Specification {
 
     @Bean
     @Qualifier("inLoop")
-    FactoryBean<WaitForNewInstanceLaunchTask> waitForNewInstanceLaunchTask() {
-      new SpockMockFactoryBean<>(WaitForNewInstanceLaunchTask)
+    FactoryBean<WaitForNewUpInstancesLaunchTask> waitForNewInstanceLaunchTask() {
+      new SpockMockFactoryBean<>(WaitForNewUpInstancesLaunchTask)
     }
 
     @Bean


### PR DESCRIPTION
The current rolling push code assumes every new instance that is started during a rolling push will eventually come up healthy. We've learned that is not a great assumption: instances sometimes never start, or never become healthy and are terminated, which leads the rolling push to enter a terminal state, as the WaitForUpInstanceHealthTask will get a 404 trying to fetch the instance.

This change consolidates the `waitForNewInstances` and `waitForUpInstances` tasks into a single task, which is resilient to these scenarios, as it only records instances once they've become healthy.