### PR TITLE
fix(queue): Sets boundary on thread pool work queue and aborts work when full

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
@@ -34,7 +34,7 @@ import org.springframework.context.event.SimpleApplicationEventMulticaster
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.time.Clock
-import java.util.concurrent.Executor
+import java.util.concurrent.ThreadPoolExecutor
 
 @Configuration
 @ComponentScan(basePackages = arrayOf("com.netflix.spinnaker.orca.q", "com.netflix.spinnaker.orca.log", "com.netflix.spinnaker.orca.q.trafficshaping"))
@@ -60,7 +60,8 @@ open class QueueConfiguration {
       registry,
       ThreadPoolTaskExecutor().apply {
         corePoolSize = 20
-        maxPoolSize = 150
+        maxPoolSize = 20
+        setQueueCapacity(0)
       },
       "messageHandler"
     )


### PR DESCRIPTION
The current messageHandler thread pool never expands its capacity because the queue never fills (default capacity is `Integer.MAX_VALUE`) so the new `QueueExecutor` will never stop polling the redis queue.

@cfieber @robfletcher PTAL