### PR TITLE
feat(queue): Transitional message prioritization strategy

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/TrafficShapingConfiguration.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/TrafficShapingConfiguration.kt
@@ -19,10 +19,7 @@ import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.q.trafficshaping.NoopTrafficShapingInterceptor
 import com.netflix.spinnaker.orca.q.trafficshaping.TrafficShapingInterceptor
-import com.netflix.spinnaker.orca.q.trafficshaping.capacity.ConstantPrioritizationStrategy
-import com.netflix.spinnaker.orca.q.trafficshaping.capacity.PrioritizationStrategy
-import com.netflix.spinnaker.orca.q.trafficshaping.capacity.PriorityCapacityListener
-import com.netflix.spinnaker.orca.q.trafficshaping.capacity.PriorityCapacityRepository
+import com.netflix.spinnaker.orca.q.trafficshaping.capacity.*
 import com.netflix.spinnaker.orca.q.trafficshaping.interceptor.ApplicationRateLimitQueueInterceptor
 import com.netflix.spinnaker.orca.q.trafficshaping.interceptor.GlobalRateLimitQueueInterceptor
 import com.netflix.spinnaker.orca.q.trafficshaping.interceptor.PriorityCapacityQueueInterceptor
@@ -71,7 +68,7 @@ open class TrafficShapingConfiguration {
   @Bean
   @ConditionalOnMissingBean(PrioritizationStrategy::class)
   @ConditionalOnProperty("queue.trafficShaping.priorityCapacity.enabled")
-  open fun constantPrioritizationStrategy() = ConstantPrioritizationStrategy()
+  open fun defaultPrioritizationStrategy() = TransitionalPrioritizationStrategy()
 
   @Bean @ConditionalOnProperty("queue.trafficShaping.priorityCapacity.enabled")
   open fun priorityCapacityListener(priorityCapacityRepository: PriorityCapacityRepository,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PrioritizationStrategy.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PrioritizationStrategy.kt
@@ -17,13 +17,14 @@ package com.netflix.spinnaker.orca.q.trafficshaping.capacity
 
 import com.netflix.spinnaker.orca.events.ExecutionEvent
 import com.netflix.spinnaker.orca.q.ApplicationAware
+import com.netflix.spinnaker.orca.q.Message
 
 interface PrioritizationStrategy {
   fun getPriority(execution: ExecutionEvent): Priority
-  fun getPriority(message: ApplicationAware): Priority
+  fun getPriority(message: Message): Priority
 }
 
 class ConstantPrioritizationStrategy : PrioritizationStrategy {
   override fun getPriority(execution: ExecutionEvent) = Priority.MEDIUM
-  override fun getPriority(message: ApplicationAware) = Priority.MEDIUM
+  override fun getPriority(message: Message) = Priority.MEDIUM
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/TransitionalPrioritizationStrategy.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/TransitionalPrioritizationStrategy.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.q.trafficshaping.capacity
+
+import com.netflix.spinnaker.orca.events.*
+import com.netflix.spinnaker.orca.q.*
+
+/**
+ * Simple prioritization strategy that ensures transitional messages
+ * are never throttled.
+ */
+class TransitionalPrioritizationStrategy() : PrioritizationStrategy {
+
+  private val TRANSITIONAL_EVENTS: List<Class<out ExecutionEvent>> = listOf(
+    ExecutionComplete::class.java,
+    ExecutionStarted::class.java,
+    StageComplete::class.java,
+    StageStarted::class.java,
+    TaskComplete::class.java,
+    TaskStarted::class.java
+  )
+
+  private val TRANSITIONAL_MESSAGES: List<Class<out Message>> = listOf(
+    StartTask::class.java,
+    CompleteTask::class.java,
+    StartStage::class.java,
+    CompleteStage::class.java,
+    StartExecution::class.java,
+    CompleteExecution::class.java,
+    ConfigurationError::class.java
+  )
+
+  override fun getPriority(execution: ExecutionEvent): Priority {
+    if (execution::class.java in TRANSITIONAL_EVENTS) {
+      return Priority.CRITICAL
+    }
+    return Priority.MEDIUM
+  }
+
+  override fun getPriority(message: Message): Priority {
+    if (message::class.java in TRANSITIONAL_MESSAGES) {
+      return Priority.CRITICAL
+    }
+    return Priority.MEDIUM
+  }
+}


### PR DESCRIPTION
Changes the default priority traffic shaper strategy to one that prioritizes transitional messages above all else. Not sure if cancel should be included in the mix, but definitely don't want run or resume.

@robfletcher @cfieber WDYT?