### PR TITLE
fix(pipelinetemplate): Ignore rendering anything that might look like an EL

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/YamlRenderedValueConverter.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/YamlRenderedValueConverter.java
@@ -34,6 +34,10 @@ public class YamlRenderedValueConverter implements RenderedValueConverter {
 
   @Override
   public Object convertRenderedValue(String renderedValue) {
+    if (containsEL(renderedValue)) {
+      return renderedValue;
+    }
+
     try {
       Object converted = yaml.load(renderedValue);
       return (converted == null || converted instanceof String) ? renderedValue : converted;
@@ -46,5 +50,9 @@ public class YamlRenderedValueConverter implements RenderedValueConverter {
       }
       throw pe;
     }
+  }
+
+  private static boolean containsEL(String renderedValue) {
+    return renderedValue.trim().startsWith("${");
   }
 }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
@@ -81,6 +81,7 @@ class JinjaRendererSpec extends Specification {
 '''                   || String       | '"${ false }".equalsIgnoreCase("True")'
     '#stage("First Wait")["status"].toString() == "SUCCESS"' || String | '#stage("First Wait")["status"].toString() == "SUCCESS"'
     '${ #stage("First Wait")["status"].toString() == "SUCCESS" }' || String | '${ #stage("First Wait")["status"].toString() == "SUCCESS" }'
+    '${ parameters.CONFIG_FOLDER ?: \'\' }' || String | '${ parameters.CONFIG_FOLDER ?: \'\' }'
   }
 
 


### PR DESCRIPTION
We had some more edge cases with ternary ops that break the YAML converter. This change will blanket treat anything that looks like a potential EL as the final rendered value.