### PR TITLE
fix(pipeline_templates): require scopes

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/SavePipelineTemplateTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/SavePipelineTemplateTask.java
@@ -35,6 +35,9 @@ public interface SavePipelineTemplateTask {
     if (template.getMetadata().getDescription() == null || "".equalsIgnoreCase(template.getMetadata().getDescription())) {
       missingFields.add("metadata.description");
     }
+    if (template.getMetadata().getScopes() == null || template.getMetadata().getScopes().isEmpty()) {
+      missingFields.add("metadata.scopes");
+    }
 
     if (!missingFields.isEmpty()) {
       throw new IllegalArgumentException("Missing required fields: " + Strings.join(",", missingFields.iterator()));


### PR DESCRIPTION
@robzienert 
Changed my mind from this morning, since templates without scopes don't show up under `{front50}/pipelineTemplates`, which is pretty confusing. Also the dcd-spec says they're required.