### PR TITLE
fix(stages/webhook) ensure buildInfo is a Map

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
@@ -65,7 +65,7 @@ class CreateWebhookTask implements RetryableTask {
     def outputs = [:]
     outputs << [statusCode: statusCode]
     if (response.body) {
-      outputs << [buildInfo: response.body]
+      outputs << [buildInfo: [responseBody: response.body]]
     }
     if (statusCode.is2xxSuccessful() || statusCode.is3xxRedirection()) {
       if (waitForCompletion) {

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
@@ -77,7 +77,7 @@ class MonitorWebhookTask implements Task {
         [error: [reason: "The json path '${statusJsonPath}' did not resolve to a single value", value: result]])
     }
 
-    def responsePayload = [buildInfo: response.body]
+    def responsePayload = [buildInfo: [responseBody: response.body]]
 
     if (progressJsonPath) {
       def progress

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
@@ -130,7 +130,7 @@ class CreateWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.TERMINAL
-    result.stageOutputs as Map == [statusCode: HttpStatus.BAD_REQUEST, buildInfo: [error: "Oh noes, you can't do this"], error: "The request did not return a 2xx/3xx status"]
+    result.stageOutputs as Map == [statusCode: HttpStatus.BAD_REQUEST, buildInfo: [responseBody: [error: "Oh noes, you can't do this"]], error: "The request did not return a 2xx/3xx status"]
   }
 
   def "if statusUrlResolution is getMethod, should return SUCCEEDED status"() {
@@ -150,7 +150,7 @@ class CreateWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs as Map == [statusCode: HttpStatus.CREATED, buildInfo: [success: true], statusEndpoint: "https://my-service.io/api/"]
+    result.stageOutputs as Map == [statusCode: HttpStatus.CREATED, buildInfo: [responseBody: [success: true]], statusEndpoint: "https://my-service.io/api/"]
     stage.context.statusEndpoint == "https://my-service.io/api/"
   }
 
@@ -173,7 +173,7 @@ class CreateWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs as Map == [statusCode: HttpStatus.CREATED, buildInfo: [success: true], statusEndpoint: "https://my-service.io/api/status/123"]
+    result.stageOutputs as Map == [statusCode: HttpStatus.CREATED, buildInfo: [responseBody: [success: true]], statusEndpoint: "https://my-service.io/api/status/123"]
     stage.context.statusEndpoint == "https://my-service.io/api/status/123"
   }
 
@@ -197,7 +197,7 @@ class CreateWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs as Map == [statusCode: HttpStatus.CREATED, buildInfo: body, statusEndpoint: "https://my-service.io/api/status/123"]
+    result.stageOutputs as Map == [statusCode: HttpStatus.CREATED, buildInfo: [responseBody: body], statusEndpoint: "https://my-service.io/api/status/123"]
     stage.context.statusEndpoint == "https://my-service.io/api/status/123"
   }
 
@@ -229,7 +229,7 @@ class CreateWebhookTaskSpec extends Specification {
     result.status == ExecutionStatus.TERMINAL
     result.stageOutputs as Map == [
       statusCode: HttpStatus.CREATED,
-      buildInfo: body,
+      buildInfo: [responseBody: body],
       error: "The status URL couldn't be resolved, but 'Wait for completion' was checked",
       statusUrlValue: ["this", "is", "a", "list"]
     ]

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTaskSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTaskSpec.groovy
@@ -90,7 +90,7 @@ class MonitorWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs == [buildInfo: [status:"RUNNING"]]
+    result.stageOutputs == [buildInfo: [responseBody: [status:"RUNNING"]]]
   }
 
   def "should find correct element using statusJsonPath parameter"() {
@@ -112,7 +112,7 @@ class MonitorWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.TERMINAL
-    result.stageOutputs == [buildInfo: [status: "TERMINAL"]]
+    result.stageOutputs == [buildInfo: [responseBody: [status: "TERMINAL"]]]
   }
 
   def "should return percentComplete if supported by endpoint"() {
@@ -135,7 +135,7 @@ class MonitorWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs == [percentComplete: 42, buildInfo: [status: 42]]
+    result.stageOutputs == [percentComplete: 42, buildInfo: [responseBody: [status: 42]]]
   }
 
   def "100 percent complete should result in SUCCEEDED status"() {
@@ -157,7 +157,7 @@ class MonitorWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs == [percentComplete: 100, buildInfo: [status: 100]]
+    result.stageOutputs == [percentComplete: 100, buildInfo: [responseBody: [status: 100]]]
   }
 
   def "should return TERMINAL status if jsonPath can not be found"() {


### PR DESCRIPTION
Fix spinnaker/spinnaker#1842 — Wrap the response body under the key responseBody so we don't cause an exception in the ContextParameterProcessor.

This code change was initially made before realising this only affected JSON string/array bodies. It should be a taken as a grain of salt and is meant to start additional feedback around spinnaker/spinnaker#1842.

**NOTE**: This will change the value of `buildInfo` to be a map for people so is a breaking change to users who use the `stage.context.buildInfo` pipeline expression for a webhook configuration stage.

Another route that may make more sense is doing a type check inside of `ContextParameterProcessor` before calling `scm` on `buildInfo`. I initially opted against that before discovering this only affected non-JSON Object types. Performing a type check keeps backwards compatibility afaik though. 🙆‍♂️ 