### PR TITLE
fix(queue): Changing redis impl for priority capacity traffic shaper

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PriorityCapacityListener.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PriorityCapacityListener.kt
@@ -15,7 +15,6 @@
  */
 package com.netflix.spinnaker.orca.q.trafficshaping.capacity
 
-import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.events.ExecutionComplete
 import com.netflix.spinnaker.orca.events.ExecutionEvent
 import com.netflix.spinnaker.orca.events.ExecutionStarted
@@ -32,8 +31,8 @@ class PriorityCapacityListener(
 
   override fun onApplicationEvent(event: ExecutionEvent) {
     when (event) {
-      is ExecutionStarted -> priorityCapacityRepository.incrementExecutions(getPriority(event))
-      is ExecutionComplete -> priorityCapacityRepository.decrementExecutions(getPriority(event))
+      is ExecutionStarted -> priorityCapacityRepository.incrementExecutions(event.executionId, getPriority(event))
+      is ExecutionComplete -> priorityCapacityRepository.decrementExecutions(event.executionId, getPriority(event))
     }
   }
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PriorityCapacityRepository.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/capacity/PriorityCapacityRepository.kt
@@ -32,7 +32,7 @@ data class GlobalCapacity(
 }
 
 interface PriorityCapacityRepository {
-  fun incrementExecutions(priority: Priority)
-  fun decrementExecutions(priority: Priority)
+  fun incrementExecutions(executionId: String, priority: Priority)
+  fun decrementExecutions(executionId: String, priority: Priority)
   fun getGlobalCapacity(): GlobalCapacity
 }


### PR DESCRIPTION
The current strategy doesn't actually track executions very well (currently the MEDIUM index in prod shows 10000 running executions, which is obviously wrong). Storing by execution ID will allow us to do compensation jobs if things drift due to weirdness, etc.

@ajordens @robfletcher PTAL