### PR TITLE
fix(script, jenkins): put results of properties files in its own map

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -85,6 +85,7 @@ public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implemen
               throw new IllegalStateException("expected properties file ${stage.context.propertyFile} but one was not found or was empty")
             }
             outputs << properties
+            outputs.propertyFileContents = properties
           }
 
           return


### PR DESCRIPTION
This writes out the contents of a properties file to a map called propertiesFileContent. This will allow us to render it in the UI and potentially use it to reconstruct a global context for restarts. 