### PR TITLE
chore(model) remove executingInstance field from execution

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -35,17 +35,14 @@ import static java.util.Collections.emptyMap;
 public abstract class ExecutionLauncher<T extends Execution<T>> {
 
   protected final ObjectMapper objectMapper;
-  protected final String currentInstanceId;
   protected final ExecutionRepository executionRepository;
 
   private final ExecutionRunner executionRunner;
 
   protected ExecutionLauncher(ObjectMapper objectMapper,
-                              String currentInstanceId,
                               ExecutionRepository executionRepository,
                               ExecutionRunner executionRunner) {
     this.objectMapper = objectMapper;
-    this.currentInstanceId = currentInstanceId;
     this.executionRepository = executionRepository;
     this.executionRunner = executionRunner;
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/OrchestrationLauncher.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/OrchestrationLauncher.java
@@ -38,12 +38,11 @@ public class OrchestrationLauncher extends ExecutionLauncher<Orchestration> {
   @Autowired
   public OrchestrationLauncher(
     ObjectMapper objectMapper,
-    String currentInstanceId,
     ExecutionRepository executionRepository,
     ExecutionRunner executionRunner,
     Clock clock
   ) {
-    super(objectMapper, currentInstanceId, executionRepository, executionRunner);
+    super(objectMapper, executionRepository, executionRunner);
     this.clock = clock;
   }
 
@@ -82,7 +81,6 @@ public class OrchestrationLauncher extends ExecutionLauncher<Orchestration> {
 
     orchestration.setBuildTime(clock.millis());
     orchestration.setAuthentication(AuthenticationDetails.build().orElse(new AuthenticationDetails()));
-    orchestration.setExecutingInstance(currentInstanceId);
 
     return orchestration;
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineLauncher.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineLauncher.java
@@ -37,12 +37,11 @@ public class PipelineLauncher extends ExecutionLauncher<Pipeline> {
 
   @Autowired
   public PipelineLauncher(ObjectMapper objectMapper,
-                          String currentInstanceId,
                           ExecutionRepository executionRepository,
                           ExecutionRunner executionRunner,
                           Optional<PipelineStartTracker> startTracker,
                           Optional<PipelineValidator> pipelineValidator) {
-    super(objectMapper, currentInstanceId, executionRepository, executionRunner);
+    super(objectMapper, executionRepository, executionRunner);
     this.startTracker = startTracker;
     this.pipelineValidator = pipelineValidator;
   }
@@ -62,7 +61,6 @@ public class PipelineLauncher extends ExecutionLauncher<Pipeline> {
       .withParallel(getBoolean(config, "parallel"))
       .withLimitConcurrent(getBoolean(config, "limitConcurrent"))
       .withKeepWaitingPipelines(getBoolean(config, "keepWaitingPipelines"))
-      .withExecutingInstance(currentInstanceId)
       .withNotifications((List<Map<String, Object>>) config.get("notifications"))
       .withExecutionEngine(getEnum(config, "executionEngine", ExecutionEngine.class))
       .build();

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -32,7 +32,6 @@ public abstract class Execution<T extends Execution<T>> implements Serializable 
 
   String id;
   String application;
-  String executingInstance;
 
   Long buildTime;
 

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.groovy
@@ -118,11 +118,6 @@ class PipelineBuilder {
     return this
   }
 
-  PipelineBuilder withExecutingInstance(String instanceId) {
-    pipeline.executingInstance = instanceId
-    return this
-  }
-
   PipelineBuilder withId(id = UUID.randomUUID().toString()) {
     pipeline.id = id
     return this

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.*;
 import java.util.function.BiFunction;
+import javax.annotation.Nonnull;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -67,6 +68,7 @@ public class Stage<T extends Execution<T>> implements Serializable {
    */
   private String name;
 
+  @Nonnull
   public String getName() {
     return name != null ? name : type;
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -546,7 +546,6 @@ class JedisExecutionRepository implements ExecutionRepository {
       buildTime           : Long.toString(execution.buildTime ?: 0L),
       startTime           : execution.startTime?.toString(),
       endTime             : execution.endTime?.toString(),
-      executingInstance   : execution.executingInstance,
       status              : execution.status?.name(),
       authentication      : mapper.writeValueAsString(execution.authentication),
       paused              : mapper.writeValueAsString(execution.paused),
@@ -640,7 +639,6 @@ class JedisExecutionRepository implements ExecutionRepository {
       execution.buildTime = map.buildTime?.toLong()
       execution.startTime = map.startTime?.toLong()
       execution.endTime = map.endTime?.toLong()
-      execution.executingInstance = map.executingInstance
       execution.status = map.status ? ExecutionStatus.valueOf(map.status) : null
       execution.authentication = mapper.readValue(map.authentication, Execution.AuthenticationDetails)
       execution.paused = map.paused ? mapper.readValue(map.paused, Execution.PausedDetails) : null

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherSpec.groovy
@@ -49,7 +49,7 @@ class PipelineLauncherSpec extends ExecutionLauncherSpec<Pipeline, PipelineLaunc
 
   @Override
   PipelineLauncher create() {
-    return new PipelineLauncher(objectMapper, "currentInstanceId", executionRepository, executionRunner, Optional.of(startTracker), Optional.of(pipelineValidator))
+    return new PipelineLauncher(objectMapper, executionRepository, executionRunner, Optional.of(startTracker), Optional.of(pipelineValidator))
   }
 
   def "can autowire pipeline launcher with optional dependencies"() {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -551,15 +551,15 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<JedisExecution
 
   def "can retrieve orchestrations from multiple redis stores"() {
     given:
-    repository.store(new Orchestration(application: "orca", executingInstance: "current"))
-    repository.store(new Orchestration(application: "orca", executingInstance: "current"))
-    repository.store(new Orchestration(application: "orca", executingInstance: "current"))
+    repository.store(new Orchestration(application: "orca"))
+    repository.store(new Orchestration(application: "orca"))
+    repository.store(new Orchestration(application: "orca"))
 
     and:
     def previousRepository = new JedisExecutionRepository(new NoopRegistry(), jedisPoolPrevious, Optional.empty(), 1, 50)
-    previousRepository.store(new Orchestration(application: "orca", executingInstance: "previous"))
-    previousRepository.store(new Orchestration(application: "orca", executingInstance: "previous"))
-    previousRepository.store(new Orchestration(application: "orca", executingInstance: "previous"))
+    previousRepository.store(new Orchestration(application: "orca"))
+    previousRepository.store(new Orchestration(application: "orca"))
+    previousRepository.store(new Orchestration(application: "orca"))
 
     when:
     // TODO-AJ limits are current applied to each backing redis
@@ -568,8 +568,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<JedisExecution
 
     then:
     // orchestrations are stored in an unsorted set and results are non-deterministic
-    retrieved.findAll { it.executingInstance == "current" }.size() == 2
-    retrieved.findAll { it.executingInstance == "previous" }.size() == 2
+    retrieved.size() == 4
   }
 
   def "can delete orchestrations from multiple redis stores"() {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerSpec.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerSpec.kt
@@ -50,7 +50,15 @@ object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
   val contextParameterProcessor = ContextParameterProcessor()
 
   subject(GROUP) {
-    RunTaskHandler(queue, repository, contextParameterProcessor, listOf(task), clock, listOf(exceptionHandler), NoopRegistry())
+    RunTaskHandler(
+      queue,
+      repository,
+      contextParameterProcessor,
+      listOf(task),
+      clock,
+      listOf(exceptionHandler),
+      NoopRegistry()
+    )
   }
 
   fun resetMocks() = reset(queue, repository, task, exceptionHandler)


### PR DESCRIPTION
This field is meaningless and misleading with v3 in place. Executions are no longer pinned to an instance.