### PR TITLE
feat(core): include exception message when stage times out

### DIFF
--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -36,11 +36,12 @@ import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.on
 import org.jetbrains.spek.api.lifecycle.CachingMode.GROUP
 import org.jetbrains.spek.subject.SubjectSpek
+import org.junit.Assert
 import org.threeten.extra.Minutes
 import java.lang.RuntimeException
 import java.time.Duration
 
-object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
+object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
 
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
@@ -501,6 +502,10 @@ object RunTaskHandlerSpec : SubjectSpek<RunTaskHandler>({
 
         it("does not execute the task") {
           verify(task, never()).execute(any())
+        }
+
+        it("adds an error message to the context") {
+          Assert.assertEquals(pipeline.stages[0].context["exception"], hashMapOf("details" to ExceptionHandler.responseDetails("Task timed out after 300 seconds")))
         }
       }
 


### PR DESCRIPTION
When a task times out, its status is set to `TERMINAL`, but no additional information is provided.

This PR adds a simple exception with an error message explaining that the task has timed out, which will be surfaced in the UI. Not sure if this is the right way to do this, or if there's a better mechanism to add an exception to a stage's context.

I renamed the spec file to conform with IntelliJ's accepted naming conventions for Spek tests, which let me run the individual spec in the IDE. Happy to either a) not do that or b) rename the other `*Spec` files to conform to the naming convention and allow us to run them via the IDE.

@robfletcher or @robzienert or @ajordens PTAL.