### PR TITLE
fix(queue): consider throttle time before timeout

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Message.kt
@@ -37,6 +37,12 @@ interface Attribute {
 data class MaxAttemptsAttribute(val maxAttempts: Int = -1) : Attribute {
 }
 
+data class TotalThrottleTimeAttribute(var totalThrottleTimeMs: Long = 0) : Attribute {
+  fun add(throttleTimeMs: Long) {
+    this.totalThrottleTimeMs += throttleTimeMs
+  }
+}
+
 data class AttemptsAttribute(var attempts: Int = 0) : Attribute {
   fun increment() {
     this.attempts = attempts + 1

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/ApplicationRateLimitQueueInterceptor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/ApplicationRateLimitQueueInterceptor.kt
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.TrafficShapingProperties
 import com.netflix.spinnaker.orca.q.ApplicationAware
 import com.netflix.spinnaker.orca.q.Message
+import com.netflix.spinnaker.orca.q.TotalThrottleTimeAttribute
 import com.netflix.spinnaker.orca.q.trafficshaping.InterceptorType
 import com.netflix.spinnaker.orca.q.trafficshaping.TrafficShapingInterceptor
 import com.netflix.spinnaker.orca.q.trafficshaping.TrafficShapingInterceptorCallback
@@ -72,6 +73,7 @@ class ApplicationRateLimitQueueInterceptor(
           if (rateLimit.enforcing) {
             log.info("Throttling message: $message")
             return { queue, msg, ack ->
+              msg.setAttribute(msg.getAttribute<TotalThrottleTimeAttribute>(TotalThrottleTimeAttribute())).add(rateLimit.duration.toMillis())
               queue.push(msg, rateLimit.duration)
               ack.invoke()
               registry.counter(throttledMessagesId.withTags("learning", "false", "application", message.application)).increment()

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/GlobalRateLimitQueueInterceptor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/GlobalRateLimitQueueInterceptor.kt
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.TrafficShapingProperties
 import com.netflix.spinnaker.orca.q.ApplicationAware
 import com.netflix.spinnaker.orca.q.Message
+import com.netflix.spinnaker.orca.q.TotalThrottleTimeAttribute
 import com.netflix.spinnaker.orca.q.trafficshaping.InterceptorType
 import com.netflix.spinnaker.orca.q.trafficshaping.TrafficShapingInterceptor
 import com.netflix.spinnaker.orca.q.trafficshaping.TrafficShapingInterceptorCallback
@@ -69,6 +70,7 @@ class GlobalRateLimitQueueInterceptor(
       if (rateLimit.enforcing) {
         log.info("Throttling message: $message")
         return { queue, msg, ack ->
+          msg.setAttribute(msg.getAttribute<TotalThrottleTimeAttribute>(TotalThrottleTimeAttribute())).add(rateLimit.duration.toMillis())
           queue.push(message, rateLimit.duration)
           ack.invoke()
           val app = when (msg) {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/PriorityCapacityQueueInterceptor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/PriorityCapacityQueueInterceptor.kt
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.TrafficShapingProperties
 import com.netflix.spinnaker.orca.q.ApplicationAware
 import com.netflix.spinnaker.orca.q.Message
+import com.netflix.spinnaker.orca.q.TotalThrottleTimeAttribute
 import com.netflix.spinnaker.orca.q.trafficshaping.InterceptorType
 import com.netflix.spinnaker.orca.q.trafficshaping.TrafficShapingInterceptor
 import com.netflix.spinnaker.orca.q.trafficshaping.TrafficShapingInterceptorCallback
@@ -114,6 +115,7 @@ class PriorityCapacityQueueInterceptor(
   }
 
   private fun defaultThrottleCallback(): TrafficShapingInterceptorCallback = { queue, msg, ack ->
+    msg.setAttribute(msg.getAttribute<TotalThrottleTimeAttribute>(TotalThrottleTimeAttribute())).add(properties.durationMs)
     queue.push(msg, Duration.of(properties.durationMs, ChronoUnit.MILLIS))
     val app = when (msg) {
       is ApplicationAware -> msg.application

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/TotalThrottleTimeAttributeTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/TotalThrottleTimeAttributeTest.kt
@@ -1,0 +1,40 @@
+package com.netflix.spinnaker.orca.q
+
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.junit.Assert
+
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+object TotalThrottleTimeAttributeSpec : Spek({
+
+  describe("defaults to zero") {
+    val attr = TotalThrottleTimeAttribute()
+    Assert.assertEquals(0, attr.totalThrottleTimeMs);
+  }
+
+  describe("uses default") {
+    val attr = TotalThrottleTimeAttribute(3)
+    Assert.assertEquals(3, attr.totalThrottleTimeMs);
+  }
+
+  describe("add is additive") {
+    val attr = TotalThrottleTimeAttribute(4)
+    attr.add(5)
+    Assert.assertEquals(9, attr.totalThrottleTimeMs);
+  }
+})

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/GlobalRateLimitQueueInterceptorTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/interceptor/GlobalRateLimitQueueInterceptorTest.kt
@@ -19,17 +19,23 @@ import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.TrafficShapingProperties
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.q.Message
+import com.netflix.spinnaker.orca.q.Queue
 import com.netflix.spinnaker.orca.q.StartStage
+import com.netflix.spinnaker.orca.q.TotalThrottleTimeAttribute
+import com.netflix.spinnaker.orca.q.memory.InMemoryQueue
 import com.netflix.spinnaker.orca.q.trafficshaping.ratelimit.RateLimit
 import com.netflix.spinnaker.orca.q.trafficshaping.ratelimit.RateLimitBackend
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
-import junit.framework.Assert.assertNotNull
-import junit.framework.Assert.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
+import java.time.Clock
 import java.time.Duration
 
 object GlobalRateLimitQueueInterceptorTest : Spek({
@@ -55,9 +61,36 @@ object GlobalRateLimitQueueInterceptorTest : Spek({
     }
 
     describe("when enforcing") {
-      describe("when limited callback is returned") {
-        whenever(backend.incrementAndGet(any(), any())) doReturn RateLimit(limiting = true, duration = Duration.ZERO, enforcing = true)
-        assertNotNull(subject.interceptMessage(message))
+      describe("when limited") {
+
+        val queueImpl: Queue = InMemoryQueue(Clock.systemDefaultZone(), deadMessageHandler = mock(), publisher = mock())
+
+        describe("when limited callback is returned") {
+          whenever(backend.incrementAndGet(any(), any())) doReturn RateLimit(limiting = true, duration = Duration.ZERO, enforcing = true)
+          assertNotNull(subject.interceptMessage(message))
+        }
+
+        describe("callback message contains throttle time") {
+          val msg: Message = StartStage(Pipeline::class.java, "1", "foo", "1")
+          whenever(backend.incrementAndGet(any(), any())) doReturn RateLimit(limiting = true, duration = Duration.ZERO, enforcing = true)
+          subject.interceptMessage(msg)?.invoke(queueImpl, msg, {})
+          assertNotNull(msg.getAttribute<TotalThrottleTimeAttribute>())
+        }
+
+        describe("throttle time is being set") {
+          val msg: Message = StartStage(Pipeline::class.java, "1", "foo", "1")
+          whenever(backend.incrementAndGet(any(), any())) doReturn RateLimit(limiting = true, duration = Duration.ofMillis(5), enforcing = true)
+          subject.interceptMessage(msg)?.invoke(queueImpl, msg, {})
+          assertEquals(5L, msg.getAttribute<TotalThrottleTimeAttribute>()?.totalThrottleTimeMs)
+        }
+
+        describe("throttle time is being added") {
+          val msg: Message = StartStage(Pipeline::class.java, "1", "foo", "1")
+          whenever(backend.incrementAndGet(any(), any())) doReturn RateLimit(limiting = true, duration = Duration.ofMillis(5), enforcing = true)
+          subject.interceptMessage(msg)?.invoke(queueImpl, msg, {})
+          subject.interceptMessage(msg)?.invoke(queueImpl, msg, {})
+          assertEquals(10L, msg.getAttribute<TotalThrottleTimeAttribute>()?.totalThrottleTimeMs)
+        }
       }
 
       describe("when not limited, no callback is returned") {


### PR DESCRIPTION
* add new message attribute for keeping track of the total amount of
time a message is throttled.
* modify the task handler to deduct the total throttled time in the
calculation of how long a task has been executing before timing out.
