### PR TITLE
fix(igor): Resolve index out of bound exception and added test for it

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
@@ -143,7 +143,8 @@ class GetCommitsTask implements DiffTask {
     def appVersion = amiDetails[0]?.tags?.appversion
 
     def buildInfo = [:]
-    if (appVersion) {
+    //Regex matches the last dot, some characters and then a slash
+    if (appVersion && appVersion =~ /\.(?=[^.]*$)[a-z0-9]*\//) {
       buildInfo << [commitHash: appVersion.substring(0, appVersion.indexOf('/')).substring(appVersion.lastIndexOf('.') + 1)]
       buildInfo << [build: getBuildFromAppVersion(appVersion)]
     }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
@@ -327,6 +327,28 @@ class GetCommitsTaskSpec extends Specification {
     targetImageName = "amiTargetName"
   }
 
+  def "return info from ami or empty map if not in the right format"() {
+    given:
+    task.oortService = oortService
+    1 * oortService.getByAmiId("aws", account, region, image) >> [[ "tags" : [ "appversion" : appVersion ]]]
+
+    when:
+    Map result = task.resolveInfoFromAmi(image, account, region)
+
+    then:
+    result.commitHash == infoFromAmi.commitHash
+    result.build == infoFromAmi.build
+
+    where:
+    account = "test"
+    region = "us-west-1"
+    image = "ami-image"
+
+    appVersion | infoFromAmi
+    "myapp-1.144-h217.a86305d/MYAPP-package-myapp/217" | [commitHash: "a86305d", build: "217"]
+    "myapp-1.144" | [:]
+  }
+
   def "returns success if commit info is missing"() {
     given:
     String katoTasks = "[{\"resultObjects\": [" +


### PR DESCRIPTION
This fixes a `StringIndexOutOfBoundsException` when calling the function `resolveInfoFromAmi` and the `appVersion` doesn't match the required pattern.

Added a regexp to check for the required pattern and a simple test.
