### PR TITLE
fix(core): set use source capacity to false in rolling red black

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
@@ -64,6 +64,7 @@ class RollingRedBlackStrategy implements Strategy, ApplicationContextAware {
         max: 0,
         desired: 0
     ]
+    stage.context.useSourceCapacity = false
 
     def targetPercentages = stageData.getTargetPercentages()
     if (targetPercentages.size() == 0 || targetPercentages[-1] != 100) {


### PR DESCRIPTION
Otherwise the new server group will be started with the original size of the other cluster