### PR TITLE
fix(taskHandler): treat FAILED_CONTINUE as SUCCEEDED

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -75,7 +75,7 @@ open class RunTaskHandler
                 queue.push(message, task.backoffPeriod())
                 trackResult(stage, task.javaClass, result.status)
               }
-              SUCCEEDED, REDIRECT -> {
+              SUCCEEDED, REDIRECT, FAILED_CONTINUE -> {
                 queue.push(CompleteTask(message, result.status))
                 trackResult(stage, task.javaClass, result.status)
               }


### PR DESCRIPTION
A handful of tasks explicitly return FAILED_CONTINUE, but we end up dropping those messages in the task handler.