### PR TITLE
fix(core): provide better error message on invalid useSourceCapacity …

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTask.groovy
@@ -55,7 +55,10 @@ class DetermineSourceServerGroupTask implements RetryableTask {
       def source = sourceResolver.getSource(stage)
       Boolean useSourceCapacity = useSourceCapacity(stage, source)
       if (useSourceCapacity && !source) {
-        throw new IllegalStateException( "useSourceCapacity requested, but unable to determine source for ${stageData.account}/${stageData.availabilityZones?.keySet()?.getAt(0)}/${stageData.cluster}")
+        throw new IllegalStateException( "Cluster is configured to copy capacity from the current server group, " +
+          "but no server group was found for the cluster '${stageData.cluster}' in " +
+          "${stageData.account}/${stageData.availabilityZones?.keySet()?.getAt(0)}. If this is a new cluster, you must " +
+          "explicitly specify the capacity in your cluster configuration for the first deployment.")
       }
       def stageOutputs = [:]
       if (source) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTaskSpec.groovy
@@ -244,6 +244,6 @@ class DetermineSourceServerGroupTaskSpec extends Specification {
     1 * resolver.getSource(_) >> null
 
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs.lastException.contains("useSourceCapacity requested, but unable to determine source for test/us-east-1/foo")
+    result.stageOutputs.lastException.contains("Cluster is configured to copy capacity from the current server group")
   }
 }


### PR DESCRIPTION
Current message is turning out to be a little too opaque:
<img width="392" alt="screen shot 2017-07-27 at 1 26 36 pm" src="https://user-images.githubusercontent.com/73450/28690860-902a2c84-72cf-11e7-9a4b-aab26be55c5e.png">

Changing to the extremely verbose but more helpful(?):
<img width="392" alt="screen shot 2017-07-27 at 1 28 42 pm" src="https://user-images.githubusercontent.com/73450/28690877-9c881e0a-72cf-11e7-9db5-51102afb152d.png">

