### PR TITLE
feat(task): Tasks can specify a dynamic `backoffPeriod`

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/RetryableTask.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/RetryableTask.java
@@ -1,5 +1,7 @@
 package com.netflix.spinnaker.orca;
 
+import java.time.Duration;
+
 /**
  * A retryable task defines its backoff period (the period between delays) and its timeout (the total period of the task)
  */
@@ -7,4 +9,8 @@ public interface RetryableTask extends Task {
   long getBackoffPeriod();
 
   long getTimeout();
+
+  default long getDynamicBackoffPeriod(Duration taskDuration) {
+    return getBackoffPeriod();
+  }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -17,7 +17,7 @@ import com.netflix.spinnaker.orca.libdiffs.ComparableLooseVersion;
 import com.netflix.spinnaker.orca.libdiffs.DefaultComparableLooseVersion;
 import com.netflix.spinnaker.orca.listeners.ExecutionCleanupListener;
 import com.netflix.spinnaker.orca.listeners.ExecutionListener;
-import com.netflix.spinnaker.orca.listeners.OnCompleteMetricExecutionListener;
+import com.netflix.spinnaker.orca.listeners.MetricsExecutionListener;
 import com.netflix.spinnaker.orca.notifications.scheduling.SuspendedPipelinesNotificationHandler;
 import com.netflix.spinnaker.orca.pipeline.PipelineStartTracker;
 import com.netflix.spinnaker.orca.pipeline.PipelineStarterListener;
@@ -133,7 +133,7 @@ public class OrcaConfiguration {
 
   @Bean
   public ApplicationListener<ExecutionEvent> onCompleteMetricExecutionListenerAdapter(Registry registry, ExecutionRepository repository) {
-    return new ExecutionListenerAdapter(new OnCompleteMetricExecutionListener(registry), repository);
+    return new ExecutionListenerAdapter(new MetricsExecutionListener(registry), repository);
   }
 
   // TODO: this is a weird place to have this, feels like it should be a bean configurer or something

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/MetricsExecutionListener.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/listeners/MetricsExecutionListener.java
@@ -24,11 +24,25 @@ import com.netflix.spinnaker.orca.pipeline.model.Orchestration;
 
 import java.util.concurrent.TimeUnit;
 
-public class OnCompleteMetricExecutionListener implements ExecutionListener {
+public class MetricsExecutionListener implements ExecutionListener {
   private final Registry registry;
 
-  public OnCompleteMetricExecutionListener(Registry registry) {
+  public MetricsExecutionListener(Registry registry) {
     this.registry = registry;
+  }
+
+  @Override
+  public void beforeExecution(Persister persister, Execution execution) {
+    if (execution.getApplication() == null) {
+      return;
+    }
+
+    Id id = registry
+      .createId("executions.started")
+      .withTag("executionType", execution.getClass().getSimpleName().toLowerCase())
+      .withTag("application", execution.getApplication().toLowerCase());
+
+    registry.counter(id).increment();
   }
 
   @Override


### PR DESCRIPTION
This PR also introduces a few new metrics:
- `executions.started`: A counter for all started pipelines/orchestrations
  including application name.
- `task.invocations.duration`: A distribution summary for tasks grouped by
  duration (lt5m, gt5m, gt15m, gt30m, gt60m).
