### PR TITLE
fix(orca) prevent bean override

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/AdminController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/AdminController.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.kork.web.exceptions.HasAdditionalAttributes
 import com.netflix.spinnaker.orca.eureka.NoDiscoveryApplicationStatusPublisher
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.ApplicationListener
 import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.http.HttpStatus
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.*
 @Slf4j
 class AdminController {
   @Autowired(required = false)
+  @Qualifier("discoveryStatusPoller")
   ApplicationListener<ContextRefreshedEvent> discoveryStatusPoller
 
   @RequestMapping(value = "/instance/enabled", method = RequestMethod.POST)


### PR DESCRIPTION
Commit 09e2933c185871c4ac91168f6f816394da3ce84f fails on startup as there are > 1 `ApplicationListener` beans in play.