### PR TITLE
fix(pipeline_template): Fix base64 filter via lib upgrade

### DIFF
--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -5,7 +5,7 @@ dependencies {
   compile project(":orca-core")
   compile project(":orca-front50")
 
-  compile('com.hubspot.jinjava:jinjava:2.1.14')
+  compile('com.hubspot.jinjava:jinjava:2.2.3')
 
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${spinnaker.version('jackson')}"
   compile('com.jayway.jsonpath:json-path:2.2.0')

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/filters/Base64Filter.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/filters/Base64Filter.java
@@ -25,6 +25,9 @@ public class Base64Filter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    if (var == null) {
+      return null;
+    }
     if (args.length != 0) {
       throw new InterpretException("base64 does not accept any arguments");
     }


### PR DESCRIPTION
There was a bug in the previously used jinjava version that caused empty filters (e.g. `'hello'|base64`) to fail, but work when called as a function. Also a null-check fix.