### PR TITLE
fix(core): Clone stage before evaluating optional condition.

### DIFF
--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.config.QueueConfiguration
 import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
 import com.netflix.spinnaker.orca.ExecutionStatus.*
 import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.config.OrcaConfiguration
 import com.netflix.spinnaker.orca.exceptions.DefaultExceptionHandler
 import com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWindow
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
@@ -604,7 +605,8 @@ open class QueueIntegrationTest {
   EmbeddedRedisConfiguration::class,
   JedisExecutionRepository::class,
   StageNavigator::class,
-  RestrictExecutionDuringTimeWindow::class
+  RestrictExecutionDuringTimeWindow::class,
+  OrcaConfiguration::class
 )
 open class TestConfig {
   @Bean open fun registry(): Registry = NoopRegistry()

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.q.handler
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.natpryce.hamkrest.allElements
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
@@ -54,6 +55,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
   val stageNavigator: StageNavigator = mock()
   val publisher: ApplicationEventPublisher = mock()
   val exceptionHandler: ExceptionHandler = mock()
+  val objectMapper = ObjectMapper()
   val clock = fixedClock()
   val retryDelay = Duration.ofSeconds(5)
 
@@ -77,6 +79,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       ContextParameterProcessor(),
       publisher,
       listOf(exceptionHandler),
+      objectMapper,
       clock,
       retryDelayMs = retryDelay.toMillis()
     )


### PR DESCRIPTION
This commit https://github.com/spinnaker/orca/commit/03ebaf54ff9742a02b00b91f736a062d561e057d changed the behavior such that ${region} fails to evaluate properly when used in a bake stage (e.g. `aws_$region$.json` when specified for `varFileName` evaluates to `aws_.json`.

This PR uses a cloned stage when determining whether a stage can be skipped, to avoid the (too early) side-effects of swapping out the context of the real stage.