### PR TITLE
feat(clouddriver): Support multiple read-only clouddrivers

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingCloudDriverCacheStatusService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingCloudDriverCacheStatusService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver;
+
+import com.netflix.spinnaker.orca.clouddriver.config.SelectableService;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class DelegatingCloudDriverCacheStatusService
+  extends DelegatingClouddriverService<CloudDriverCacheStatusService>
+  implements CloudDriverCacheStatusService {
+
+  public DelegatingCloudDriverCacheStatusService(SelectableService selectableService) {
+    super(selectableService);
+  }
+
+  @Override
+  public Collection<Map> pendingForceCacheUpdates(String cloudProvider, String type) {
+    return getService().pendingForceCacheUpdates(cloudProvider, type);
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingClouddriverService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingClouddriverService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver;
+
+import com.netflix.spinnaker.orca.ExecutionContext;
+import com.netflix.spinnaker.orca.clouddriver.config.SelectableService;
+
+class DelegatingClouddriverService<T> {
+  private final SelectableService selectableService;
+
+  DelegatingClouddriverService(SelectableService selectableService) {
+    this.selectableService = selectableService;
+  }
+
+  T getService() {
+    SelectableService.Criteria criteria = new SelectableService.Criteria(null, null);
+
+    ExecutionContext executionContext = ExecutionContext.get();
+    if (executionContext != null) {
+      criteria = new SelectableService.Criteria(
+        executionContext.getApplication(),
+        executionContext.getExecutionType(),
+        executionContext.getExecutionId()
+      );
+    }
+
+    return (T) selectableService.getService(criteria);
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingMortService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingMortService.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver;
+
+import com.netflix.spinnaker.orca.clouddriver.config.SelectableService;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class DelegatingMortService
+  extends DelegatingClouddriverService<MortService>
+  implements MortService {
+
+  public DelegatingMortService(SelectableService selectableService) {
+    super(selectableService);
+  }
+
+  @Override
+  public SecurityGroup getSecurityGroup(String account, String type, String securityGroupName, String region) {
+    return getService().getSecurityGroup(account, type, securityGroupName, region);
+  }
+
+  @Override
+  public SecurityGroup getSecurityGroup(String account, String type, String securityGroupName, String region, String vpcId) {
+    return getService().getSecurityGroup(account, type, securityGroupName, region, vpcId);
+  }
+
+  @Override
+  public Collection<VPC> getVPCs() {
+    return getService().getVPCs();
+  }
+
+  @Override
+  public List<SearchResult> getSearchResults(String searchTerm, String type) {
+    return getService().getSearchResults(searchTerm, type);
+  }
+
+  @Override
+  public Map getAccountDetails(String account) {
+    return getService().getAccountDetails(account);
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver;
+
+import com.netflix.spinnaker.orca.clouddriver.config.SelectableService;
+import retrofit.client.Response;
+
+import java.util.List;
+import java.util.Map;
+
+public class DelegatingOortService
+  extends DelegatingClouddriverService<OortService>
+  implements OortService {
+
+  public DelegatingOortService(SelectableService selectableService) {
+    super(selectableService);
+  }
+
+  @Override
+  public Response getCluster(String app, String account, String cluster, String cloudProvider) {
+    return getService().getCluster(app, account, cluster, cloudProvider);
+  }
+
+  @Override
+  public Response getServerGroup(String app, String account, String cluster, String serverGroup, String region, String cloudProvider) {
+    return getService().getServerGroup(app, account, cluster, serverGroup, region, cloudProvider);
+  }
+
+  @Override
+  public Response getTargetServerGroup(String app, String account, String cluster, String cloudProvider, String scope, String target) {
+    return getService().getTargetServerGroup(app, account, cluster, cloudProvider, scope, target);
+  }
+
+  @Override
+  public Map<String, Object> getServerGroupSummary(String app, String account, String cluster, String cloudProvider, String scope, String target, String summaryType, String onlyEnabled) {
+    return getService().getServerGroupSummary(app, account, cluster, cloudProvider, scope, target, summaryType, onlyEnabled);
+  }
+
+  @Override
+  public Response getSearchResults(String searchTerm, String type, String cloudProvider) {
+    return getService().getSearchResults(searchTerm, type, cloudProvider);
+  }
+
+  @Override
+  public Response getApplication(String app) {
+    return getService().getApplication(app);
+  }
+
+  @Override
+  public Response getInstance(String account, String region, String instanceId) {
+    return getService().getInstance(account, region, instanceId);
+  }
+
+  @Override
+  public List<Map> getLoadBalancerDetails(String provider, String account, String region, String name) {
+    return getService().getLoadBalancerDetails(provider, account, region, name);
+  }
+
+  @Override
+  public List<Map> getByAmiId(String type, String account, String region, Object imageId) {
+    return getService().getByAmiId(type, account, region, imageId);
+  }
+
+  @Override
+  public List<Map> findImage(String cloudProvider, String query, String account, String region, Map additionalFilters) {
+    return getService().findImage(cloudProvider, query, account, region, additionalFilters);
+  }
+
+  @Override
+  public List<Map> getEntityTags(String cloudProvider, String entityType, String entityId, String account, String region) {
+    return getService().getEntityTags(cloudProvider, entityType, entityId, account, region);
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ByApplicationServiceSelector.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ByApplicationServiceSelector.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class ByApplicationServiceSelector implements ServiceSelector {
+  private final Object service;
+  private final int priority;
+  private final Pattern applicationPattern;
+
+  public ByApplicationServiceSelector(Object service, Integer priority, Map<String, Object> config) {
+    this.service = service;
+    this.priority = priority;
+    this.applicationPattern = Pattern.compile((String) config.get("applicationPattern"));
+  }
+
+  @Override
+  public Object getService() {
+    return service;
+  }
+
+  @Override
+  public int getPriority() {
+    return priority;
+  }
+
+  @Override
+  public boolean supports(SelectableService.Criteria criteria) {
+    if (criteria.getApplication() == null) {
+      return false;
+    }
+
+    return applicationPattern.matcher(criteria.getApplication().toLowerCase()).matches();
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ByExecutionTypeServiceSelector.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ByExecutionTypeServiceSelector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ByExecutionTypeServiceSelector implements ServiceSelector {
+  private final Object service;
+  private final int priority;
+  private final Set<String> executionTypes;
+
+  public ByExecutionTypeServiceSelector(Object service, Integer priority, Map<String, Object> config) {
+    this.service = service;
+    this.priority = priority;
+    this.executionTypes = new HashSet(
+      ((Map<String, String>) config.get("executionTypes")).values()
+    );
+  }
+
+  @Override
+  public Object getService() {
+    return service;
+  }
+
+  @Override
+  public int getPriority() {
+    return priority;
+  }
+
+  @Override
+  public boolean supports(SelectableService.Criteria criteria) {
+    return executionTypes.contains(criteria.getExecutionType());
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationProperties.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationProperties.groovy
@@ -25,12 +25,19 @@ class CloudDriverConfigurationProperties {
   @Canonical
   static class BaseUrl {
     String baseUrl
+    int priority = 1
+    Map<String, Object> config
+  }
+
+  static class MultiBaseUrl {
+    String baseUrl
+    List<BaseUrl> baseUrls
   }
 
   @Canonical
   static class CloudDriver {
     String baseUrl;
-    BaseUrl readonly;
+    MultiBaseUrl readonly;
   }
 
   BaseUrl mort
@@ -42,7 +49,17 @@ class CloudDriverConfigurationProperties {
     clouddriver?.baseUrl ?: kato?.baseUrl ?: oort?.baseUrl ?: mort?.baseUrl
   }
 
-  String getCloudDriverReadOnlyBaseUrl() {
-    clouddriver?.readonly?.baseUrl ?: getCloudDriverBaseUrl()
+  List<BaseUrl> getCloudDriverReadOnlyBaseUrls() {
+    if (clouddriver?.readonly?.baseUrl) {
+      return [
+        new BaseUrl(baseUrl: clouddriver.readonly.baseUrl)
+      ]
+    } else if (clouddriver?.readonly?.baseUrls) {
+      return clouddriver.readonly.baseUrls
+    }
+
+    return [
+      new BaseUrl(baseUrl: getCloudDriverBaseUrl())
+    ]
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/DefaultServiceSelector.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/DefaultServiceSelector.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config;
+
+import java.util.Map;
+
+public class DefaultServiceSelector implements ServiceSelector {
+  private final Object service;
+  private final int priority;
+
+  public DefaultServiceSelector(Object service, int priority, Map<String, Object> config) {
+    this.service = service;
+    this.priority = priority;
+  }
+
+  @Override
+  public Object getService() {
+    return service;
+  }
+
+  @Override
+  public int getPriority() {
+    return priority;
+  }
+
+  @Override
+  public boolean supports(SelectableService.Criteria criteria) {
+    return true;
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/SelectableService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/SelectableService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config;
+
+import org.springframework.util.Assert;
+
+import java.util.List;
+
+public class SelectableService {
+  private final List<ServiceSelector> serviceSelectors;
+
+  public SelectableService(List<ServiceSelector> serviceSelectors) {
+    this.serviceSelectors = serviceSelectors;
+  }
+
+  public Object getService(Criteria criteria) {
+    Assert.notNull(criteria);
+
+    return serviceSelectors
+      .stream()
+      .filter(it -> it.supports(criteria))
+      .sorted((a,b) -> b.getPriority() - a.getPriority())
+      .findFirst()
+      .map(ServiceSelector::getService)
+      .orElse(serviceSelectors.get(0).getService());
+  }
+
+  public static class Criteria {
+    private final String application;
+    private final String executionType;
+    private final String executionId;
+
+    public Criteria(String application, String executionType) {
+      this(application, executionType, null);
+    }
+
+    public Criteria(String application,
+                    String executionType,
+                    String executionId) {
+      this.application = application;
+      this.executionType = executionType;
+      this.executionId = executionId;
+    }
+
+    public String getApplication() {
+      return application;
+    }
+
+    public String getExecutionType() {
+      return executionType;
+    }
+
+    public String getExecutionId() {
+      return executionId;
+    }
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ServiceSelector.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ServiceSelector.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config;
+
+interface ServiceSelector {
+  Object getService();
+  int getPriority();
+  boolean supports(SelectableService.Criteria criteria);
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationPropertiesSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationPropertiesSpec.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config
+
+import spock.lang.Specification
+import spock.lang.Unroll;
+
+class CloudDriverConfigurationPropertiesSpec extends Specification {
+  @Unroll
+  def "supports 0..* read-only base urls"() {
+    given:
+    def config = new CloudDriverConfigurationProperties(
+      clouddriver: new CloudDriverConfigurationProperties.CloudDriver(
+        baseUrl: baseUrl,
+        readonly: readOnly
+      )
+    )
+
+    when:
+    def baseUrls = config.cloudDriverReadOnlyBaseUrls
+
+    then:
+    baseUrls*.baseUrl == expectedBaseUrls
+
+    where:
+    baseUrl                 | readOnly                                                        || expectedBaseUrls
+    "http://www.google.com" | null                                                            || ["http://www.google.com"]
+    "http://www.google.com" | multiBaseUrl(["http://www.foobar.com"])                         || ["http://www.foobar.com"]
+    "http://www.google.com" | multiBaseUrl(["http://www.foobar.com", "http://www.yahoo.com"]) || ["http://www.foobar.com", "http://www.yahoo.com"]
+  }
+
+  private static CloudDriverConfigurationProperties.MultiBaseUrl multiBaseUrl(List<String> baseUrls) {
+    if (baseUrls.size() == 1) {
+      return new CloudDriverConfigurationProperties.MultiBaseUrl(baseUrl: baseUrls[0])
+    }
+
+    return new CloudDriverConfigurationProperties.MultiBaseUrl(
+      baseUrl: null,
+      baseUrls: baseUrls.collect { new CloudDriverConfigurationProperties.BaseUrl(baseUrl: it) }
+    )
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/config/SelectableServiceSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/config/SelectableServiceSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config
+
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.MortService
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll;
+
+class SelectableServiceSpec extends Specification {
+  @Shared
+  def mortService = Mock(MortService)
+
+  @Shared
+  def oortService = Mock(OortService)
+
+  @Shared
+  def katoService = Mock(KatoService)
+
+  @Unroll
+  def "should lookup service by application or executionType"() {
+    given:
+    def selectableService = new SelectableService(
+      [
+        new ByApplicationServiceSelector(mortService, 10, ["applicationPattern": ".*spindemo.*"]),
+        new ByExecutionTypeServiceSelector(oortService, 5, ["executionTypes": [0: "orchestration"]]),
+        new DefaultServiceSelector(katoService, 1, [:])
+      ]
+    )
+
+    when:
+    def service = selectableService.getService(criteria)
+
+    then:
+    service == expectedService
+
+    where:
+    criteria                                                        || expectedService
+    new SelectableService.Criteria(null, null)                      || katoService      // the default service selector
+    new SelectableService.Criteria("spindemo", "orchestration")     || mortService
+    new SelectableService.Criteria("1-spindemo-1", "orchestration") || mortService
+    new SelectableService.Criteria("spintest", "orchestration")     || oortService
+    new SelectableService.Criteria("spintest", "pipeline")          || katoService
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionContext.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionContext.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca;
+
+public class ExecutionContext {
+  private static final ThreadLocal<ExecutionContext> threadLocal = new ThreadLocal<>();
+
+  private final String application;
+  private final String executionType;
+  private final String executionId;
+
+  public ExecutionContext(String application, String executionType, String executionId) {
+    this.application = application;
+    this.executionType = executionType;
+    this.executionId = executionId;
+  }
+
+  public static void set(ExecutionContext executionContext) {
+    threadLocal.set(executionContext);
+  }
+
+  public static ExecutionContext get() {
+    return threadLocal.get();
+  }
+
+  public static void clear() {
+    threadLocal.remove();
+  }
+
+  public String getApplication() {
+    return application;
+  }
+
+  public String getExecutionType() {
+    return executionType;
+  }
+
+  public String getExecutionId() {
+    return executionId;
+  }
+}

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AuthenticationAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AuthenticationAware.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.AuthenticatedStage
+import com.netflix.spinnaker.orca.ExecutionContext
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
@@ -39,6 +40,15 @@ interface AuthenticationAware {
       allowedAccounts = getExecution().getAuthentication()?.allowedAccounts
     }
 
-    AuthenticatedRequest.propagate(block, false, currentUser).call()
+    try {
+      ExecutionContext.set(ExecutionContext(
+        getExecution().getApplication(),
+        getExecution().javaClass.simpleName.toLowerCase(),
+        getExecution().getId()
+      ))
+      AuthenticatedRequest.propagate(block, false, currentUser).call()
+    } finally {
+      ExecutionContext.clear()
+    }
   }
 }


### PR DESCRIPTION
Criteria can be applied to each clouddriver to filter the types of requests that will be sent to it.

This PR supports execution type and application (regex) criteria.

If no criteria is specified, all requests are eligible to be sent to the particular clouddriver.

Example Configuration:

```
clouddriver:
  baseUrl: https://my-writeable-clouddriver.com
  readonly:
    baseUrls:
    - baseUrl: https://clouddriver-for-orchestrations.com
      priority: 5
      config:
        selectorClass: com.netflix.spinnaker.orca.clouddriver.config.ByExecutionTypeServiceSelector
        executionTypes:
          - orchestration
    - baseUrl: https://clouddriver-for-spindemo.comm
      priority: 10
      config:
        selectorClass: com.netflix.spinnaker.orca.clouddriver.config.ByApplicationServiceSelector
        applicationPattern: .*spindemo.*|.*cdspindemo.*
    - baseUrl: https://clouddriver-for-everything-else.com
      priority: 1
```