### PR TITLE
fix(pipeline_templates) ignore yaml keywords in rendered value converter

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/YamlRenderedValueConverter.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/YamlRenderedValueConverter.java
@@ -16,6 +16,8 @@
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render;
 
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
+import java.util.Arrays;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -23,6 +25,8 @@ import org.yaml.snakeyaml.composer.ComposerException;
 import org.yaml.snakeyaml.parser.ParserException;
 
 public class YamlRenderedValueConverter implements RenderedValueConverter {
+
+  private static final List<String> YAML_KEYWORDS = Arrays.asList("yes", "no", "on", "off");
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -34,7 +38,7 @@ public class YamlRenderedValueConverter implements RenderedValueConverter {
 
   @Override
   public Object convertRenderedValue(String renderedValue) {
-    if (containsEL(renderedValue)) {
+    if (containsEL(renderedValue) || isYamlKeyword(renderedValue)) {
       return renderedValue;
     }
 
@@ -54,5 +58,9 @@ public class YamlRenderedValueConverter implements RenderedValueConverter {
 
   private static boolean containsEL(String renderedValue) {
     return renderedValue.trim().startsWith("${");
+  }
+
+  private static boolean isYamlKeyword(String renderedValue) {
+    return YAML_KEYWORDS.contains(renderedValue.toLowerCase());
   }
 }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
@@ -56,6 +56,8 @@ class JinjaRendererSpec extends Specification {
     '1.1'             || Double       | 1.1
     'true'            || Boolean      | true
     '{{ stringVar }}' || String       | 'myStringValue'
+    'yes'             || String       | 'yes'
+    'on'              || String       | 'on'
     '''
 
 [


### PR DESCRIPTION
@robzienert please review.

If your template had
```
keyA: yes
keyB: 'yes'
```
Orca was mapping it in the rendered pipeline to

```
{
  "keyA": true,
  "keyB": true
}
```

Should now map to 

```
{
  "keyA": true,
  "keyB": "yes"
}
```

Open to suggestions for a better approach.