### PR TITLE
Initial cut of removing global context from executions

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -113,7 +113,7 @@ class BakeStage implements BranchingStageDefinitionBuilder, RestartableStage {
         it.parentStageId == stage.parentStageId && it.status == ExecutionStatus.RUNNING
       }
 
-      def globalContext = [
+      new TaskResult(ExecutionStatus.SUCCEEDED, [
         deploymentDetails: stage.execution.stages.findAll {
           it.type == PIPELINE_CONFIG_TYPE && bakeInitializationStages*.id.contains(it.parentStageId) && (it.context.ami || it.context.imageId)
         }.collect { Stage bakeStage ->
@@ -126,8 +126,7 @@ class BakeStage implements BranchingStageDefinitionBuilder, RestartableStage {
 
           return deploymentDetails
         }
-      ]
-      new TaskResult(ExecutionStatus.SUCCEEDED, [:], globalContext)
+      ])
     }
   }
 

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -52,7 +52,7 @@ class MonitorBakeTask implements RetryableTask {
       if (isCanceled(newStatus.state) && previousStatus.state == BakeStatus.State.PENDING) {
         log.info("Original bake was 'canceled', re-baking (executionId: ${stage.execution.id}, previousStatus: ${previousStatus.state})")
         def rebakeResult = createBakeTask.execute(stage)
-        return new TaskResult(ExecutionStatus.RUNNING, rebakeResult.stageOutputs, rebakeResult.globalOutputs)
+        return new TaskResult(ExecutionStatus.RUNNING, rebakeResult.stageOutputs)
       }
 
       new TaskResult(mapStatus(newStatus), [status: newStatus])

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
@@ -92,7 +92,7 @@ class BakeStageSpec extends Specification {
     def taskResult = new BakeStage.CompleteParallelBakeTask().execute(pipelineStage)
 
     then:
-    taskResult.globalOutputs == [
+    taskResult.stageOutputs == [
       deploymentDetails: [
         ["ami": 1], ["ami": 2], ["ami": 3]
       ]

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTaskSpec.groovy
@@ -77,7 +77,9 @@ class MonitorBakeTaskSpec extends Specification {
       )
     }
     task.createBakeTask = Mock(CreateBakeTask) {
-      1 * execute(_) >> { return new TaskResult(ExecutionStatus.SUCCEEDED, [stage: 1], [global: 2]) }
+      1 * execute(_) >> {
+        return new TaskResult(ExecutionStatus.SUCCEEDED, [stage: 1])
+      }
     }
 
     when:
@@ -86,7 +88,6 @@ class MonitorBakeTaskSpec extends Specification {
     then:
     result.status == ExecutionStatus.RUNNING
     (result.stageOutputs as Map) == [stage: 1]
-    (result.globalOutputs as Map) == [global: 2]
 
     where:
     state << [BakeStatus.State.CANCELED, BakeStatus.State.CANCELLED]

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -228,8 +228,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
     }.flatten()
 
     return new TaskResult(ExecutionStatus.SUCCEEDED, [
-      amiDetails: deploymentDetails
-    ], [
+      amiDetails       : deploymentDetails,
       deploymentDetails: deploymentDetails
     ])
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
@@ -53,7 +53,7 @@ class WaitForClusterDisableTask extends AbstractWaitForClusterWideClouddriverTas
     def duration = System.currentTimeMillis() - stage.startTime
     if (taskResult.status == ExecutionStatus.SUCCEEDED && duration < MINIMUM_WAIT_TIME_MS) {
       // wait at least MINIMUM_WAIT_TIME to account for any necessary connection draining to occur
-      return new TaskResult(ExecutionStatus.RUNNING, taskResult.stageOutputs, taskResult.globalOutputs)
+      return new TaskResult(ExecutionStatus.RUNNING, taskResult.stageOutputs)
     }
 
     return taskResult

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
@@ -17,18 +17,18 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.image;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.orca.RetryableTask;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED;
 
 @Component
 public class FindImageFromTagsTask extends AbstractCloudProviderAwareTask implements RetryableTask {
@@ -54,12 +54,13 @@ public class FindImageFromTagsTask extends AbstractCloudProviderAwareTask implem
     }
 
     return new TaskResult(
-      ExecutionStatus.SUCCEEDED,
-      Collections.singletonMap("amiDetails", imageDetails),
-      Collections.singletonMap("deploymentDetails", imageDetails)
+      SUCCEEDED,
+      ImmutableMap
+        .<String, Object>builder()
+        .put("amiDetails", imageDetails)
+        .put("deploymentDetails", imageDetails)
+        .build()
     );
-
-
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -97,6 +97,6 @@ public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implemen
       }
     }
 
-    new TaskResult(status, outputs, outputs)
+    new TaskResult(status, outputs)
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/scalingprocess/AbstractAwsScalingProcessTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/scalingprocess/AbstractAwsScalingProcessTask.groovy
@@ -76,22 +76,21 @@ abstract class AbstractAwsScalingProcessTask extends AbstractCloudProviderAwareT
     stageData.asgName = asgName
 
     def stageOutputs = [
-      "notification.type"   : getType().toLowerCase(),
-      "deploy.server.groups": stageData.affectedServerGroupMap,
-      "processes"           : stageContext.processes,
-      "asgName"             : asgName
+      "notification.type"                      : getType().toLowerCase(),
+      "deploy.server.groups"                   : stageData.affectedServerGroupMap,
+      "processes"                              : stageContext.processes,
+      ("scalingProcesses.${asgName}" as String): stageContext.processes,
+      "asgName"                                : asgName
     ]
     if (stageContext.processes) {
       def taskId = katoService.requestOperations(getCloudProvider(stage), [[(getType()): stageContext]])
-                              .toBlocking()
-                              .first()
+        .toBlocking()
+        .first()
 
       stageOutputs."kato.last.task.id" = taskId
     }
 
-    return new TaskResult(ExecutionStatus.SUCCEEDED, stageOutputs, [
-      ("scalingProcesses.${asgName}" as String): stageContext.processes
-    ])
+    return new TaskResult(ExecutionStatus.SUCCEEDED, stageOutputs)
   }
 
   static class StageData {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStage.groovy
@@ -169,7 +169,7 @@ class ParallelDeployStage implements BranchingStageDefinitionBuilder {
   public static class CompleteParallelDeployTask implements Task {
     TaskResult execute(Stage stage) {
       log.info("Completed Parallel Deploy")
-      new TaskResult(ExecutionStatus.SUCCEEDED, [:], [:])
+      new TaskResult(ExecutionStatus.SUCCEEDED)
     }
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
@@ -151,7 +151,9 @@ trait DeploymentDetailsAware {
       // If no deployment details were found in the stage context, check the global context of each pipeline up the tree.
       List<Execution> pipelineExecutions = getPipelineExecutions(stage.execution)
 
-      deploymentDetails = pipelineExecutions?.findResult { it?.context?.deploymentDetails }
+      deploymentDetails = pipelineExecutions?.stages?.flatten()?.findResult {
+        it.context.deploymentDetails
+      }
     }
 
     if (deploymentDetails) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertAmazonDNSTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/UpsertAmazonDNSTask.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca.kato.tasks
 
-import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.KatoService
@@ -26,6 +25,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 
 @Component
 @CompileStatic
@@ -36,10 +36,16 @@ class UpsertAmazonDNSTask implements Task {
 
   @Override
   TaskResult execute(Stage stage) {
-    def operation = [type       : stage.context.recordType, name: stage.context.name, hostedZoneName: stage.context.hostedZone,
-                     credentials: stage.context.credentials]
+    def operation = [
+      type          : stage.context.recordType,
+      name          : stage.context.name,
+      hostedZoneName: stage.context.hostedZone,
+      credentials   : stage.context.credentials
+    ]
 
-    def upsertElbStage = stage.preceding(UpsertAmazonLoadBalancerStage.PIPELINE_CONFIG_TYPE) ?: stage.preceding(UpsertLoadBalancerStage.PIPELINE_CONFIG_TYPE)
+    def upsertElbStage = stage.ancestors().find {
+      it.type in [UpsertAmazonLoadBalancerStage.PIPELINE_CONFIG_TYPE, UpsertLoadBalancerStage.PIPELINE_CONFIG_TYPE]
+    }
 
     if (upsertElbStage) {
       operation.target = upsertElbStage.context.dnsName
@@ -50,10 +56,10 @@ class UpsertAmazonDNSTask implements Task {
     def taskId = kato.requestOperations([[upsertAmazonDNSDescription: operation]]).toBlocking().first()
 
     Map outputs = [
-        "notification.type": "upsertamazondns",
-        "kato.last.task.id": taskId
+      "notification.type": "upsertamazondns",
+      "kato.last.task.id": taskId
     ]
 
-    return new TaskResult(ExecutionStatus.SUCCEEDED, outputs)
+    return new TaskResult(SUCCEEDED, outputs)
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/ResolveQuipVersionTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/ResolveQuipVersionTask.groovy
@@ -71,6 +71,6 @@ class ResolveQuipVersionTask implements RetryableTask {
       objectMapper)
     String version = stage.context?.patchVersion ?:  packageInfo.findTargetPackage(allowMissingPackageInstallation)?.packageVersion
 
-    return new TaskResult(ExecutionStatus.SUCCEEDED, [version: version], [version:version])
+    return new TaskResult(ExecutionStatus.SUCCEEDED, [version: version])
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTask.groovy
@@ -57,7 +57,7 @@ class VerifyQuipTask extends AbstractQuipTask implements Task {
     } else {
       throw new RuntimeException("one or more of these parameters is missing : cluster || region || account || healthProviders")
     }
-    return new TaskResult(executionStatus, stageOutputs, [:])
+    return new TaskResult(executionStatus, stageOutputs)
   }
 
   private boolean checkInstancesForQuip(Map instances) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/scalingprocess/AbstractScalingProcessTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/scalingprocess/AbstractScalingProcessTask.groovy
@@ -65,17 +65,18 @@ abstract class AbstractScalingProcessTask implements Task {
     )
     def stageContext = new HashMap(stage.context) + [
       processes: processes,
-      asgName: asgName
+      asgName  : asgName
     ]
 
     def stageData = stage.mapTo(StageData)
     stageData.asgName = asgName
 
     def stageOutputs = [
-      "notification.type"   : getType().toLowerCase(),
-      "deploy.server.groups": stageData.affectedServerGroupMap,
-      "processes"           : stageContext.processes,
-      "asgName"             : asgName
+      "notification.type"                      : getType().toLowerCase(),
+      "deploy.server.groups"                   : stageData.affectedServerGroupMap,
+      "processes"                              : stageContext.processes,
+      ("scalingProcesses.${asgName}" as String): stageContext.processes,
+      "asgName"                                : asgName
     ]
     if (stageContext.processes) {
       def taskId = katoService.requestOperations([[(getType()): stageContext]])
@@ -84,9 +85,7 @@ abstract class AbstractScalingProcessTask implements Task {
       stageOutputs."kato.last.task.id" = taskId
     }
 
-    return new TaskResult(ExecutionStatus.SUCCEEDED, stageOutputs, [
-      ("scalingProcesses.${asgName}" as String): stageContext.processes
-    ])
+    return new TaskResult(ExecutionStatus.SUCCEEDED, stageOutputs)
   }
 
   static class StageData {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTaskSpec.groovy
@@ -106,7 +106,6 @@ class MonitorKatoTaskSpec extends Specification {
     then:
     result.status
     result.stageOutputs.isEmpty()
-    result.globalOutputs.isEmpty()
 
     where:
     context                     | _

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
@@ -63,8 +63,12 @@ class FindImageFromClusterTaskSpec extends Specification {
           "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse1
       1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location2.value,
           "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse2
-      assertNorth result.globalOutputs?.deploymentDetails?.find { it.region == "north" } as Map
-      assertSouth result.globalOutputs?.deploymentDetails?.find { it.region == "south" } as Map
+    assertNorth result.stageOutputs?.deploymentDetails?.find {
+      it.region == "north"
+    } as Map
+    assertSouth result.stageOutputs?.deploymentDetails?.find {
+      it.region == "south"
+    } as Map
 
     where:
       location1 = new Location(type: Location.Type.REGION, value: "north")
@@ -195,8 +199,12 @@ class FindImageFromClusterTaskSpec extends Specification {
       throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), null, Map)
     }
     1 * oortService.findImage("cloudProvider", "ami-012-name-ebs*", "test", null, null) >> imageSearchResult
-    assertNorth(result.globalOutputs?.deploymentDetails?.find { it.region == "north" } as Map, [imageName: "ami-012-name-ebs"])
-    assertSouth(result.globalOutputs?.deploymentDetails?.find { it.region == "south" } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
+    assertNorth(result.stageOutputs?.deploymentDetails?.find {
+      it.region == "north"
+    } as Map, [imageName: "ami-012-name-ebs"])
+    assertSouth(result.stageOutputs?.deploymentDetails?.find {
+      it.region == "south"
+    } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
 
     where:
     location1 = new Location(type: Location.Type.REGION, value: "north")
@@ -254,8 +262,12 @@ class FindImageFromClusterTaskSpec extends Specification {
       throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), null, Map)
     }
     1 * oortService.findImage("cloudProvider", "ami-012-name-ebs*", "test", null, null) >> imageSearchResult
-    assertNorth(result.globalOutputs?.deploymentDetails?.find { it.region == "north" } as Map, [imageName: "ami-012-name-ebs"])
-    assertSouth(result.globalOutputs?.deploymentDetails?.find { it.region == "south" } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
+    assertNorth(result.stageOutputs?.deploymentDetails?.find {
+      it.region == "north"
+    } as Map, [imageName: "ami-012-name-ebs"])
+    assertSouth(result.stageOutputs?.deploymentDetails?.find {
+      it.region == "south"
+    } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
 
     where:
     location1 = new Location(type: Location.Type.REGION, value: "north")
@@ -314,8 +326,12 @@ class FindImageFromClusterTaskSpec extends Specification {
     }
     1 * oortService.findImage("aws", "ami-012-name-ebs*", "test", null, null) >> null
     1 * oortService.findImage("aws", "ami-012-name-ebs*", "bakery", null, null) >> imageSearchResult
-    assertNorth(result.globalOutputs?.deploymentDetails?.find { it.region == "north" } as Map, [imageName: "ami-012-name-ebs"])
-    assertSouth(result.globalOutputs?.deploymentDetails?.find { it.region == "south" } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
+    assertNorth(result.stageOutputs?.deploymentDetails?.find {
+      it.region == "north"
+    } as Map, [imageName: "ami-012-name-ebs"])
+    assertSouth(result.stageOutputs?.deploymentDetails?.find {
+      it.region == "south"
+    } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
 
     where:
     location1 = new Location(type: Location.Type.REGION, value: "north")

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreatorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreatorSpec.groovy
@@ -194,14 +194,10 @@ class AmazonServerGroupCreatorSpec extends Specification {
   }
 
   @Unroll
-  def "prefers the deployment details from an upstream stage to one from global context"() {
+  def "gets deployment details from an upstream stage"() {
     given:
     def deployRegion = "us-east-1"
     stage.context.amiName = null
-    stage.execution.context.deploymentDetails = [
-        ["ami": "not-my-ami", "region": deployRegion, cloudProvider: "aws"],
-        ["ami": "also-not-my-ami", "region": deployRegion, cloudProvider: "aws"]
-    ]
 
     and:
     def findImageStage =

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/scalingprocess/AbstractAwsScalingProcessTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/scalingprocess/AbstractAwsScalingProcessTaskSpec.groovy
@@ -49,12 +49,11 @@ class AbstractAwsScalingProcessTaskSpec extends Specification {
     when:
       def result = task.execute(stage)
       def outputs = result.stageOutputs
-      def globalOutputs = result.globalOutputs
 
     then:
       outputs.processes == expectedScalingProcesses
       outputs.containsKey("kato.last.task.id") == !expectedScalingProcesses.isEmpty()
-      globalOutputs["scalingProcesses.${context.asgName}" as String] == expectedScalingProcesses
+    outputs["scalingProcesses.${context.asgName}" as String] == expectedScalingProcesses
 
     where:
       isResume | context                         | targetServerGroups             || expectedScalingProcesses

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CaptureSourceServerGroupCapacityTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CaptureSourceServerGroupCapacityTaskSpec.groovy
@@ -42,7 +42,6 @@ class CaptureSourceServerGroupCapacityTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.globalOutputs.isEmpty()
     result.stageOutputs.isEmpty()
     stage.context == stageContext
 
@@ -101,8 +100,6 @@ class CaptureSourceServerGroupCapacityTaskSpec extends Specification {
       min    : 0,
       desired: 5,
       max    : 10
-
     ]
-    result.globalOutputs.isEmpty()
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
@@ -53,31 +53,33 @@ class CreateServerGroupTaskSpec extends Specification {
 
   @Shared
   def baseOutput = [
-      "notification.type"  : "createdeploy",
-      "kato.last.task.id"  : taskId,
-      "deploy.account.name": "abc"
+    "notification.type"  : "createdeploy",
+    "kato.last.task.id"  : taskId,
+    "deploy.account.name": "abc"
   ]
 
   @Unroll
   def "should have cloud provider-specific outputs"() {
     given:
-      KatoService katoService = Mock(KatoService)
-      def task = new CreateServerGroupTask(kato: katoService, serverGroupCreators: [aCreator, bCreator, cCreator])
-      def stage = new Stage<>(new Pipeline(), "whatever", [credentials: "abc", cloudProvider: cloudProvider])
+    KatoService katoService = Mock(KatoService)
+    def task = new CreateServerGroupTask(kato: katoService, serverGroupCreators: [aCreator, bCreator, cCreator])
+    def stage = new Stage<>(new Pipeline(), "whatever", [credentials: "abc", cloudProvider: cloudProvider])
 
     when:
-      def result = task.execute(stage)
+    def result = task.execute(stage)
 
     then:
-      1 * katoService.requestOperations(cloudProvider, ops) >> { Observable.from(taskId) }
-      result
-      result.stageOutputs == outputs
+    1 * katoService.requestOperations(cloudProvider, ops) >> {
+      Observable.from(taskId)
+    }
+    result
+    result.stageOutputs == outputs
 
     where:
-      cloudProvider | ops              || outputs
-      "aCloud"      | [["aOp": "foo"]] || baseOutput + ["kato.result.expected": false]
-      "bCloud"      | [["bOp": "bar"]] || baseOutput + ["kato.result.expected": false]
-      "cCloud"      | [["cOp": "baz"]] || baseOutput + ["kato.result.expected": true]
+    cloudProvider | ops              || outputs
+    "aCloud"      | [["aOp": "foo"]] || baseOutput + ["kato.result.expected": false]
+    "bCloud"      | [["bOp": "bar"]] || baseOutput + ["kato.result.expected": false]
+    "cCloud"      | [["cOp": "baz"]] || baseOutput + ["kato.result.expected": true]
   }
 
   @Unroll
@@ -115,7 +117,9 @@ class CreateServerGroupTaskSpec extends Specification {
       return it[0]?.createServerGroup?.get(imageAttributeKey) == expectedImageId
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
-    _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
+    _ * katoService.requestOperations(operationCloudProvider, _) >> {
+      Observable.from(taskId)
+    }
     result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
@@ -138,12 +142,12 @@ class CreateServerGroupTaskSpec extends Specification {
     KatoService katoService = Mock(KatoService)
     MortService mortService = Mock(MortService)
     def deployRegion = "us-east-1"
-    def parentGlobalContext = [
+    def parentDeploymentDetailsContext = [
       deploymentDetails: [
         ["imageId": "parent-ami", "ami": "parent-ami", "region": deployRegion]
       ]
     ]
-    def parentPipeline = Pipeline.builder().withName("parent").withGlobalContext(parentGlobalContext).build()
+    def parentPipeline = Pipeline.builder().withName("parent").withStage("bake", "bake", parentDeploymentDetailsContext).build()
 
     def childTrigger = [
       parentExecution: parentPipeline
@@ -166,7 +170,9 @@ class CreateServerGroupTaskSpec extends Specification {
       return it[0]?.createServerGroup?.get(imageAttributeKey) == expectedImageId
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
-    _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
+    _ * katoService.requestOperations(operationCloudProvider, _) >> {
+      Observable.from(taskId)
+    }
     result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
@@ -192,18 +198,21 @@ class CreateServerGroupTaskSpec extends Specification {
     KatoService katoService = Mock(KatoService)
     MortService mortService = Mock(MortService)
     def deployRegion = "us-east-1"
-    def grandparentGlobalContext = [
+    def grantparentDeploymentDetailsContext = [
       deploymentDetails: [
         ["imageId": "grandparent-ami", "ami": "grandparent-ami", "region": deployRegion]
       ]
     ]
     // Building these as maps instead of using the pipeline model objects since this configuration was observed in testing.
     def parentTrigger = [
-      isPipeline: true,
+      isPipeline     : true,
       parentExecution: [
-        name: "grandparent",
-        context: grandparentGlobalContext,
+        name  : "grandparent",
         stages: [
+          [
+            type   : "bake",
+            context: grantparentDeploymentDetailsContext
+          ],
           [type: "someStage1"],
           [type: "someStage2"]
         ]
@@ -211,9 +220,9 @@ class CreateServerGroupTaskSpec extends Specification {
     ]
 
     def childTrigger = [
-      isPipeline: true,
+      isPipeline     : true,
       parentExecution: [
-        name: "parent",
+        name   : "parent",
         trigger: parentTrigger
       ]
     ]
@@ -235,7 +244,9 @@ class CreateServerGroupTaskSpec extends Specification {
       return it[0]?.createServerGroup?.get(imageAttributeKey) == expectedImageId
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
-    _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
+    _ * katoService.requestOperations(operationCloudProvider, _) >> {
+      Observable.from(taskId)
+    }
     result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
@@ -286,7 +297,9 @@ class CreateServerGroupTaskSpec extends Specification {
       return it[0]?.createServerGroup?.get(imageAttributeKey) == expectedImageId
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
-    _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
+    _ * katoService.requestOperations(operationCloudProvider, _) >> {
+      Observable.from(taskId)
+    }
     result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
@@ -345,7 +358,9 @@ class CreateServerGroupTaskSpec extends Specification {
       return it[0]?.createServerGroup?.get(imageAttributeKey) == expectedImageId
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
-    _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
+    _ * katoService.requestOperations(operationCloudProvider, _) >> {
+      Observable.from(taskId)
+    }
     result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
@@ -368,17 +383,17 @@ class CreateServerGroupTaskSpec extends Specification {
     KatoService katoService = Mock(KatoService)
     MortService mortService = Mock(MortService)
     def deployRegion = "us-east-1"
-    def parentGlobalContext = [
+    def parentDeploymentDetailsContext = [
       deploymentDetails: [
         ["imageId": "parent-ami", "ami": "parent-ami", "region": deployRegion]
       ]
     ]
-    def parentPipeline = Pipeline.builder().withName("parent").withGlobalContext(parentGlobalContext).build()
+    def parentPipeline = Pipeline.builder().withName("parent").withStage("bake", "bake", parentDeploymentDetailsContext).build()
 
     def pipelineStage = buildStageForPipeline(parentPipeline, "pipeline")
 
     def childTrigger = [
-      parentExecution: parentPipeline,
+      parentExecution      : parentPipeline,
       parentPipelineStageId: pipelineStage.id
     ]
     def childPipeline = Pipeline.builder().withName("child").withTrigger(childTrigger).build()
@@ -399,7 +414,9 @@ class CreateServerGroupTaskSpec extends Specification {
       return it[0]?.createServerGroup?.get(imageAttributeKey) == expectedImageId
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
-    _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
+    _ * katoService.requestOperations(operationCloudProvider, _) >> {
+      Observable.from(taskId)
+    }
     result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
@@ -448,7 +465,7 @@ class CreateServerGroupTaskSpec extends Specification {
     makeDependentOn(pipelineStageA, bakeStage1)
 
     def childTriggerA = [
-      parentExecution: parentPipeline,
+      parentExecution      : parentPipeline,
       parentPipelineStageId: pipelineStageA.id
     ]
     def childPipelineA = Pipeline.builder().withName("child").withTrigger(childTriggerA).build()
@@ -464,7 +481,7 @@ class CreateServerGroupTaskSpec extends Specification {
     makeDependentOn(pipelineStageB, bakeStage2)
 
     def childTriggerB = [
-      parentExecution: parentPipeline,
+      parentExecution      : parentPipeline,
       parentPipelineStageId: pipelineStageB.id
     ]
     def childPipelineB = Pipeline.builder().withName("child").withTrigger(childTriggerB).build()
@@ -484,7 +501,9 @@ class CreateServerGroupTaskSpec extends Specification {
       return it[0]?.createServerGroup?.get(imageAttributeKey) == expectedImageIdBranchA
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
-    _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
+    _ * katoService.requestOperations(operationCloudProvider, _) >> {
+      Observable.from(taskId)
+    }
     resultA?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
 
     when:
@@ -496,7 +515,9 @@ class CreateServerGroupTaskSpec extends Specification {
       return it[0]?.createServerGroup?.get(imageAttributeKey) == expectedImageIdBranchB
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
-    _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
+    _ * katoService.requestOperations(operationCloudProvider, _) >> {
+      Observable.from(taskId)
+    }
     resultB?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
@@ -507,7 +528,8 @@ class CreateServerGroupTaskSpec extends Specification {
     "aws"                  | null              | "imageId"         | true               || "parent-name-branch-a" | "parent-name-branch-b"
   }
 
-  private def buildBakeConfig(String imageId, String deployRegion, String cloudProvider) {
+  private
+  def buildBakeConfig(String imageId, String deployRegion, String cloudProvider) {
     return [
       imageId      : imageId,
       ami          : imageId,
@@ -516,7 +538,8 @@ class CreateServerGroupTaskSpec extends Specification {
     ]
   }
 
-  private def buildDeployConfig(String deployRegion, String operationCloudProvider) {
+  private
+  def buildDeployConfig(String deployRegion, String operationCloudProvider) {
     return [
       application      : "hodor",
       cloudProvider    : operationCloudProvider,
@@ -533,7 +556,8 @@ class CreateServerGroupTaskSpec extends Specification {
     ]
   }
 
-  private def buildStageForPipeline(def pipeline, String stageType, def context = [:]) {
+  private def buildStageForPipeline(
+    def pipeline, String stageType, def context = [:]) {
     def stage = new Stage<>(pipeline, stageType, context)
 
     pipeline.stages << stage

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateDeployTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateDeployTaskSpec.groovy
@@ -306,48 +306,6 @@ class CreateDeployTaskSpec extends Specification {
     amiName = "ami-name-from-bake"
   }
 
-  def "prefers the deployment details from an upstream stage to one from global context"() {
-    given:
-    stage.context.amiName = null
-    def operations = []
-    task.kato = Stub(KatoService) {
-      requestOperations(*_) >> {
-        operations.addAll(it[1].flatten())
-        Observable.from(taskId)
-      }
-    }
-    stage.execution.context.deploymentDetails = [
-      ["ami": "not-my-ami", "region": deployRegion, cloudProvider: "aws"],
-      ["ami": "also-not-my-ami", "region": deployRegion, cloudProvider: "aws"]
-    ]
-
-    and:
-    def findImageStage = new Stage<>(stage.execution, "findImage", [regions: [deployRegion], amiDetails: [[ami: amiName]], cloudProvider: "aws"])
-    findImageStage.id = UUID.randomUUID()
-    findImageStage.refId = "1a"
-    stage.execution.stages << findImageStage
-
-    def intermediateStage = new Stage<>(stage.execution, "whatever")
-    intermediateStage.id = UUID.randomUUID()
-    intermediateStage.refId = "1b"
-    stage.execution.stages << intermediateStage
-
-    and:
-    intermediateStage.requisiteStageRefIds = [findImageStage.refId]
-    stage.requisiteStageRefIds = [intermediateStage.refId]
-
-    when:
-    task.execute(stage)
-
-    then:
-    operations.find {
-      it.containsKey("createServerGroup")
-    }.createServerGroup.amiName == amiName
-
-    where:
-    amiName = "ami-name-from-find-image"
-  }
-
   def "finds the image from an upstream stage matching the cloud provider"() {
     given:
     stage.context.amiName = null

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/scalingprocess/AbstractScalingProcessTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/scalingprocess/AbstractScalingProcessTaskSpec.groovy
@@ -49,12 +49,11 @@ class AbstractScalingProcessTaskSpec extends Specification {
     when:
     def result = task.execute(stage)
     def outputs = result.stageOutputs
-    def globalOutputs = result.globalOutputs
 
     then:
     outputs.processes == expectedScalingProcesses
     outputs.containsKey("kato.last.task.id") == !expectedScalingProcesses.isEmpty()
-    globalOutputs["scalingProcesses.${context.asgName}" as String] == expectedScalingProcesses
+    outputs["scalingProcesses.${context.asgName}" as String] == expectedScalingProcesses
 
     where:
     isResume | context                         | targetReferences              || expectedScalingProcesses

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/TaskResult.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/TaskResult.java
@@ -14,20 +14,14 @@ public final class TaskResult {
 
   ExecutionStatus status;
   ImmutableMap<String, ?> stageOutputs;
-  ImmutableMap<String, ?> globalOutputs;
 
   public TaskResult(ExecutionStatus status) {
-    this(status, emptyMap(), emptyMap());
-  }
-
-  public TaskResult(ExecutionStatus status, Map<String, ?> stageOutputs, Map<String, ?> globalOutputs) {
-    this.status = status;
-    this.stageOutputs = ImmutableMap.copyOf(stageOutputs);
-    this.globalOutputs = ImmutableMap.copyOf(globalOutputs);
+    this(status, emptyMap());
   }
 
   public TaskResult(ExecutionStatus status, Map<String, ?> stageOutputs) {
-    this(status, stageOutputs, emptyMap());
+    this.status = status;
+    this.stageOutputs = ImmutableMap.copyOf(stageOutputs);
   }
 
   @Deprecated

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -17,10 +17,14 @@
 package com.netflix.spinnaker.orca.pipeline.model;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import com.netflix.spinnaker.security.User;
@@ -54,7 +58,7 @@ public abstract class Execution<T extends Execution<T>> implements Serializable 
   boolean limitConcurrent = false;
   boolean keepWaitingPipelines = false;
 
-  final Map<String, Object> context = new HashMap<>();
+  @JsonManagedReference
   List<Stage<T>> stages = new ArrayList<>();
 
   Long startTime;

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -16,6 +16,10 @@
 
 package com.netflix.spinnaker.orca.pipeline.model;
 
+import java.io.Serializable;
+import java.util.*;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
@@ -62,6 +66,7 @@ public abstract class Execution<T extends Execution<T>> implements Serializable 
   ExecutionEngine executionEngine = DEFAULT_EXECUTION_ENGINE;
   String origin;
 
+  @Nullable
   public Stage<T> namedStage(String type) {
     return stages
       .stream()
@@ -70,12 +75,22 @@ public abstract class Execution<T extends Execution<T>> implements Serializable 
       .orElse(null);
   }
 
+  @Nonnull
   public Stage<T> stageById(String stageId) {
     return stages
       .stream()
       .filter(it -> it.getId().equals(stageId))
       .findFirst()
-      .orElse(null);
+      .orElseThrow(() -> new IllegalArgumentException(String.format("No stage with id %s exists", stageId)));
+  }
+
+  @Nonnull
+  public Stage<T> stageByRef(String refId) {
+    return stages
+      .stream()
+      .filter(it -> it.getRefId().equals(refId))
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException(String.format("No stage with refId %s exists", refId)));
   }
 
   @Override public boolean equals(Object o) {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupport.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupport.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package com.netflix.spinnaker.orca.pipeline.model
 
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
@@ -23,7 +22,8 @@ import groovy.util.logging.Slf4j
 
 @Slf4j
 class OptionalStageSupport {
-  public static Map<String, Class<? extends OptionalStageEvaluator>> OPTIONAL_STAGE_TYPES = [
+  public
+  static Map<String, Class<? extends OptionalStageEvaluator>> OPTIONAL_STAGE_TYPES = [
     "expression": ExpressionOptionalStageEvaluator
   ]
 
@@ -31,10 +31,12 @@ class OptionalStageSupport {
    * A Stage is optional if it has an {@link OptionalStageEvaluator} in its context that evaluates {@code false}.
    */
   static boolean isOptional(Stage stage, ContextParameterProcessor contextParameterProcessor) {
-    def optionalType = (stage.context.stageEnabled?.type as String)?.toLowerCase()
+    def optionalType = stage.context.containsKey("stageEnabled") ? (stage.context.stageEnabled?.type as String)?.toLowerCase() : null
     if (!optionalType || !OPTIONAL_STAGE_TYPES[optionalType]) {
       if (stage.syntheticStageOwner || stage.parentStageId) {
-        def parentStage = stage.execution.stages.find { it.id == stage.parentStageId }
+        def parentStage = stage.execution.stages.find {
+          it.id == stage.parentStageId
+        }
         return isOptional(parentStage, contextParameterProcessor)
       }
 
@@ -59,7 +61,8 @@ class OptionalStageSupport {
   /**
    * An {@link OptionalStageEvaluator} that will evaluate an expression against the current execution.
    */
-  private static class ExpressionOptionalStageEvaluator implements OptionalStageEvaluator {
+  private
+  static class ExpressionOptionalStageEvaluator implements OptionalStageEvaluator {
     String expression
 
     @Override

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.groovy
@@ -115,12 +115,6 @@ class PipelineBuilder {
     return this
   }
 
-  PipelineBuilder withGlobalContext(Map<String, Object> context) {
-    pipeline.context.clear()
-    pipeline.context.putAll(context)
-    return this
-  }
-
   PipelineBuilder withStatus(ExecutionStatus executionStatus) {
     pipeline.status = executionStatus
     return this

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -91,7 +91,7 @@ public class Stage<T extends Execution<T>> implements Serializable {
   /**
    * The context driving this stage. Provides inputs necessary to component steps
    */
-  private Map<String, Object> context = new HashMap<>();
+  private Map<String, Object> context = new StageContext(this);
 
   /**
    * Returns the tasks that are associated with this stage. Tasks are the most granular unit of work in a stage.

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -173,12 +173,19 @@ public class Stage<T extends Execution<T>> implements Serializable {
         .addAll(previousStages.stream().flatMap(it -> it.ancestorsOnly().stream()).collect(toList()))
         .build();
     } else if (parentStageId != null) {
-      Stage<T> parent = execution.stages.stream().filter(it -> it.id.equals(parentStageId)).findFirst().orElseThrow(IllegalStateException::new);
-      return ImmutableList
-        .<Stage<T>>builder()
-        .add(parent)
-        .addAll(parent.ancestorsOnly())
-        .build();
+      return execution
+        .stages
+        .stream()
+        .filter(it -> it.id.equals(parentStageId))
+        .findFirst()
+        .map(parent ->
+          ImmutableList
+            .<Stage<T>>builder()
+            .add(parent)
+            .addAll(parent.ancestorsOnly())
+            .build()
+        )
+        .orElse(ImmutableList.of());
     } else {
       return emptyList();
     }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -15,12 +15,10 @@ import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
 import com.netflix.spinnaker.orca.listeners.StageTaskPropagationListener;
 import lombok.Data;
-import org.codehaus.groovy.runtime.ReverseListIterator;
 import static com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED;
 import static java.lang.String.format;
 import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.StreamSupport.stream;
 
 @Data
 public class Stage<T extends Execution<T>> implements Serializable {
@@ -145,23 +143,6 @@ public class Stage<T extends Execution<T>> implements Serializable {
     return tasks
       .stream()
       .filter(it -> it.getId().equals(taskId))
-      .findFirst()
-      .orElse(null);
-  }
-
-  /**
-   * Gets the last stage preceding this stage that has the specified type.
-   */
-  public Stage<T> preceding(String type) {
-    int i = getExecution()
-      .getStages()
-      .indexOf(this);
-    Iterable<Stage<T>> precedingStages = () ->
-      new ReverseListIterator<>(getExecution()
-        .getStages()
-        .subList(0, i + 1));
-    return stream(precedingStages.spliterator(), false)
-      .filter(it -> it.getType().equals(type))
       .findFirst()
       .orElse(null);
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import com.google.common.collect.ForwardingMap;
+
+public class StageContext extends ForwardingMap<String, Object> {
+
+  private final Stage<?> stage;
+  private final Map<String, Object> delegate = new HashMap<>();
+
+  public StageContext(Stage<?> stage) {
+    this.stage = stage;
+  }
+
+  @Override protected Map<String, Object> delegate() {
+    return delegate;
+  }
+
+  @Override public Object get(@Nullable Object key) {
+    if (delegate().containsKey(key)) {
+      return super.get(key);
+    } else {
+      return stage
+        .ancestors()
+        .stream()
+        .filter(it -> it.getContext().containsKey(key))
+        .findFirst()
+        .map(it -> it.getContext().get(key))
+        .orElse(null);
+    }
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
@@ -30,6 +30,11 @@ public class StageContext extends ForwardingMap<String, Object> {
     this.stage = stage;
   }
 
+  public StageContext(Stage<?> stage, Map<String, Object> content) {
+    this.stage = stage;
+    delegate.putAll(content);
+  }
+
   @Override protected Map<String, Object> delegate() {
     return delegate;
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -1,5 +1,10 @@
 package com.netflix.spinnaker.orca.pipeline.persistence;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Orchestration;
@@ -7,17 +12,12 @@ import com.netflix.spinnaker.orca.pipeline.model.Pipeline;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import rx.Observable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-
 public interface ExecutionRepository {
   void store(@Nonnull Orchestration orchestration);
 
   void store(@Nonnull Pipeline pipeline);
 
+  @Deprecated
   void storeExecutionContext(
     @Nonnull String id, @Nonnull Map<String, Object> context);
 

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.orca.pipeline.persistence;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.netflix.spinnaker.orca.ExecutionStatus;
@@ -16,10 +15,6 @@ public interface ExecutionRepository {
   void store(@Nonnull Orchestration orchestration);
 
   void store(@Nonnull Pipeline pipeline);
-
-  @Deprecated
-  void storeExecutionContext(
-    @Nonnull String id, @Nonnull Map<String, Object> context);
 
   void storeStage(@Nonnull Stage<? extends Execution> stage);
 

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -625,7 +625,6 @@ class JedisExecutionRepository implements ExecutionRepository {
       def execution = type.newInstance()
       execution.id = id
       execution.application = map.application
-      execution.context.putAll(map.context ? mapper.readValue(map.context, Map) : [:])
       execution.canceled = Boolean.parseBoolean(map.canceled)
       execution.canceledBy = map.canceledBy
       execution.cancellationReason = map.cancellationReason
@@ -658,7 +657,7 @@ class JedisExecutionRepository implements ExecutionRepository {
         stage.parentStageId = map["stage.${stageId}.parentStageId".toString()]
         stage.requisiteStageRefIds = map["stage.${stageId}.requisiteStageRefIds".toString()]?.tokenize(",")
         stage.scheduledTime = map["stage.${stageId}.scheduledTime".toString()]?.toLong()
-        stage.context = map["stage.${stageId}.context".toString()] ? mapper.readValue(map["stage.${stageId}.context".toString()], MAP_STRING_TO_OBJECT) : emptyMap()
+        stage.context.putAll(map["stage.${stageId}.context".toString()] ? mapper.readValue(map["stage.${stageId}.context".toString()], MAP_STRING_TO_OBJECT) : emptyMap())
         stage.tasks = map["stage.${stageId}.tasks".toString()] ? mapper.readValue(map["stage.${stageId}.tasks".toString()], LIST_OF_TASKS) : emptyList()
         if (map["stage.${stageId}.lastModified".toString()]) {
           stage.lastModified = map["stage.${stageId}.lastModified".toString()] ? mapper.readValue(map["stage.${stageId}.lastModified".toString()], MAP_STRING_TO_OBJECT) : emptyMap()

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -136,23 +136,6 @@ class JedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
-  void storeExecutionContext(String id, Map<String, Object> context) {
-    String key = fetchKey(id)
-    withJedis(getJedisPoolForId(key)) { Jedis jedis ->
-      jedis.watch(key)
-      def committed = false
-      while (!committed) {
-        Map<String, Object> ctx = mapper.readValue(jedis.hget(key, "context") ?: "{}", Map)
-        ctx.putAll(context)
-        jedis.multi().withCloseable { tx ->
-          tx.hset(key, "context", mapper.writeValueAsString(ctx))
-          committed = tx.exec() != null
-        }
-      }
-    }
-  }
-
-  @Override
   void cancel(String id) {
     cancel(id, null, null)
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
@@ -55,7 +55,6 @@ class PackageInfo {
   public Map findTargetPackage(boolean allowMissingPackageInstallation) {
     Map requestMap = [:]
     // copy the context since we may modify it in createAugmentedRequest
-    requestMap.putAll(stage.execution.context)
     requestMap.putAll(stage.context)
 
     if (stage.execution instanceof Pipeline) {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineSpec.groovy
@@ -53,11 +53,6 @@ class PipelineSpec extends Specification {
     pipeline.status == RUNNING
   }
 
-  def "can get a previous stage from a stage by type"() {
-    expect:
-    pipeline.namedStage("stage2").preceding("stage1") is pipeline.stages[0]
-  }
-
   def "trigger is properly build into the pipeline"() {
     expect:
     pipeline.trigger.name == "SPINNAKER-build-job" && pipeline.trigger.lastBuildLabel == 1

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContextSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContextSpec.groovy
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.model
+
+import spock.lang.Specification
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionEngine.v3
+import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_AFTER
+import static java.lang.System.currentTimeMillis
+
+class StageContextSpec extends Specification {
+
+  def pipeline = pipeline {
+  }
+  .stage {
+    refId = "1"
+    context.foo = "root-foo"
+    context.bar = "root-bar"
+    context.baz = "root-baz"
+    context.qux = "root-qux"
+  }
+  .stage {
+    refId = "2"
+    requisiteStageRefIds = ["1"]
+    context.foo = "ancestor-foo"
+    context.bar = "ancestor-bar"
+    context.baz = "ancestor-baz"
+  }
+  .stage {
+    refId = "3"
+    requisiteStageRefIds = ["2"]
+    context.foo = "parent-foo"
+    context.bar = "parent-bar"
+  }
+  .stage {
+    refId = "3>1"
+    parentStageId = execution.stageByRef("3").id
+    syntheticStageOwner = STAGE_AFTER
+    context.foo = "child-foo"
+  }
+  .stage {
+    refId = "4"
+    context.covfefe = "unrelated-covfefe"
+  }
+  .stage {
+    refId = "3>2"
+    requisiteStageRefIds = ["3>1"]
+    parentStageId = execution.stageByRef("3").id
+    syntheticStageOwner = STAGE_AFTER
+    context.covfefe = "downstream-covfefe"
+  }
+  .build()
+
+  def "a stage's own context takes priority"() {
+    expect:
+    pipeline.stageByRef("3>1").context.foo == "child-foo"
+  }
+
+  def "parent takes priority over ancestor"() {
+    expect:
+    pipeline.stageByRef("3>1").context.bar == "parent-bar"
+  }
+
+  def "missing keys resolve in ancestor stage context"() {
+    expect:
+    pipeline.stageByRef("3>1").context.baz == "ancestor-baz"
+  }
+
+  def "can chain back up ancestors"() {
+    expect:
+    pipeline.stageByRef("3>1").context.qux == "root-qux"
+  }
+
+  def "can't resolve keys from unrelated or downstream stages"() {
+    expect:
+    pipeline.stageByRef("3>1").context.covfefe == null
+  }
+
+  private static PipelineInit pipeline(
+    @DelegatesTo(PipelineInit) Closure init = {}) {
+    def pipeline = new Pipeline()
+    pipeline.id = UUID.randomUUID().toString()
+    pipeline.executionEngine = v3
+    pipeline.buildTime = currentTimeMillis()
+
+    def builder = new PipelineInit(pipeline)
+    init.delegate = builder
+    init()
+
+    return builder
+  }
+
+  private static class PipelineInit {
+    final @Delegate Pipeline pipeline
+
+    PipelineInit(Pipeline pipeline) {
+      this.pipeline = pipeline
+    }
+
+    PipelineInit stage(@DelegatesTo(Stage) Closure init) {
+      def stage = new Stage<Pipeline>()
+      stage.execution = pipeline
+      pipeline.stages.add(stage)
+
+      init.delegate = stage
+      init()
+
+      return this
+    }
+
+    Pipeline build() {
+      return pipeline
+    }
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -77,22 +77,6 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     execution << [new Pipeline(buildTime: 0), new Orchestration(id: "a-preassigned-id")]
   }
 
-  def "can update an execution's context"() {
-    given:
-    repository.store(execution)
-
-    when:
-    repository.storeExecutionContext(execution.id, ["value": execution.class.simpleName])
-    def storedExecution = (execution instanceof Pipeline) ? repository.retrievePipeline(execution.id) : repository.retrieveOrchestration(execution.id)
-
-    then:
-    storedExecution.id == execution.id
-    storedExecution.context == ["value": storedExecution.class.simpleName]
-
-    where:
-    execution << [new Pipeline(buildTime: 0), new Orchestration(id: "a-preassigned-id")]
-  }
-
   def "can retrieve pipelines by status"() {
     given:
     def runningExecution = new Pipeline(status: RUNNING, pipelineConfigId: "pipeline-1", buildTime: 0)

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
@@ -87,7 +87,7 @@ class MonitorJenkinsJobTask implements RetryableTask {
         if (result == 'UNSTABLE' && stage.context.markUnstableAsSuccessful) {
           status = ExecutionStatus.SUCCEEDED
         }
-        return new TaskResult(status, outputs, outputs)
+        return new TaskResult(status, outputs)
       } else {
         return new TaskResult(ExecutionStatus.RUNNING, [buildInfo: build])
       }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
@@ -217,7 +217,6 @@ class MonitorJenkinsJobTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    taskResult.globalOutputs.buildInfo.artifacts*.fileName == expectedArtifacts
     taskResult.stageOutputs.buildInfo.artifacts*.fileName == expectedArtifacts
 
     where:

--- a/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
+++ b/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
@@ -72,11 +72,8 @@ class CreatePropertiesTask implements Task {
       propertyAction: propertyAction,
     ]
 
-    return new TaskResult(SUCCEEDED, outputs, outputs)
-
+    return new TaskResult(SUCCEEDED, outputs)
   }
-
-
 
   List assemblePersistedPropertyListFromContext(Map<String, Object> context, List propertyList) {
     Map scope = context.scope

--- a/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/MonitorPropertiesTask.groovy
+++ b/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/MonitorPropertiesTask.groovy
@@ -65,7 +65,7 @@ class MonitorPropertiesTask implements Task{
 
 
     if(outputs.persistedProperties.size() == propertyIds.size()) {
-      return new TaskResult(ExecutionStatus.SUCCEEDED, outputs, outputs)
+      return new TaskResult(ExecutionStatus.SUCCEEDED, outputs)
     }
 
     log.info("create persited properties in progress: ${outputs}")

--- a/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/cleanup/FastPropertyCleanupListenerSpec.groovy
+++ b/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/cleanup/FastPropertyCleanupListenerSpec.groovy
@@ -87,8 +87,6 @@ class FastPropertyCleanupListenerSpec extends Specification {
       new Response("http://mahe", 500, "OK", [], null)
     }
 
-    pipeline.context.rollbackActions == null
-
     IllegalStateException ex = thrown()
     assert ex.message.contains("Unable to rollback DELETE")
 
@@ -165,8 +163,6 @@ class FastPropertyCleanupListenerSpec extends Specification {
     1 * mahe.deleteProperty(propertyId, 'spinnaker rollback', propertyEnv) >> { def res ->
       new Response("http://mahe", 500, "OK", [] , null)
     }
-
-    pipeline.context.rollbackActions == null
 
     IllegalStateException ex = thrown()
     assert ex.message.contains("Unable to rollback CREATE")

--- a/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/cleanup/FastPropertyCleanupListenerSpec.groovy
+++ b/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/cleanup/FastPropertyCleanupListenerSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Netflix, Inc.
+ * Copyright 2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.orca.mahe.tasks
+package com.netflix.spinnaker.orca.mahe.cleanup
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.mahe.MaheService
 import com.netflix.spinnaker.orca.mahe.PropertyAction
-import com.netflix.spinnaker.orca.mahe.cleanup.FastPropertyCleanupListener
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import retrofit.client.Response
@@ -28,10 +27,9 @@ import retrofit.mime.TypedByteArray
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
-
 import static com.netflix.spinnaker.orca.mahe.pipeline.CreatePropertyStage.PIPELINE_CONFIG_TYPE
 
-class PropertyChangeCleanupSpec extends Specification {
+class FastPropertyCleanupListenerSpec extends Specification {
 
   ObjectMapper mapper = new ObjectMapper()
   def repository = Stub(ExecutionRepository)
@@ -42,15 +40,13 @@ class PropertyChangeCleanupSpec extends Specification {
     listener.mapper = mapper
   }
 
-  @Unroll()
+  @Unroll
   def "a deleted property is restored to its original stage if the pipeline is #executionStatus and has matching original property"() {
     given:
-
     def context = [propertyAction: PropertyAction.DELETE.toString(), originalProperties: [[property: originalProperty]]]
     def pipeline = Pipeline
       .builder()
       .withStage(PIPELINE_CONFIG_TYPE, PIPELINE_CONFIG_TYPE, context)
-      .withGlobalContext( context )
       .build()
 
     repository.retrievePipeline(pipeline.id) >> pipeline
@@ -79,7 +75,6 @@ class PropertyChangeCleanupSpec extends Specification {
     def pipeline = Pipeline
       .builder()
       .withStage(PIPELINE_CONFIG_TYPE, PIPELINE_CONFIG_TYPE, context)
-      .withGlobalContext(context)
       .build()
 
     repository.retrievePipeline(pipeline.id) >> pipeline
@@ -110,7 +105,6 @@ class PropertyChangeCleanupSpec extends Specification {
     def pipeline = Pipeline
       .builder()
       .withStage(PIPELINE_CONFIG_TYPE, PIPELINE_CONFIG_TYPE)
-      .withGlobalContext(propertyIdList: [[propertyId: propertyId]], propertyAction: PropertyAction.UPDATE.toString())
       .build()
 
     repository.retrievePipeline(pipeline.id) >> pipeline
@@ -135,7 +129,6 @@ class PropertyChangeCleanupSpec extends Specification {
     def pipeline = Pipeline
       .builder()
       .withStage(PIPELINE_CONFIG_TYPE, PIPELINE_CONFIG_TYPE, context)
-      .withGlobalContext(context)
       .build()
 
     repository.retrievePipeline(pipeline.id) >> pipeline
@@ -161,7 +154,6 @@ class PropertyChangeCleanupSpec extends Specification {
     def pipeline = Pipeline
       .builder()
       .withStage(PIPELINE_CONFIG_TYPE, PIPELINE_CONFIG_TYPE, context)
-      .withGlobalContext(context)
       .build()
 
     repository.retrievePipeline(pipeline.id) >> pipeline
@@ -193,7 +185,6 @@ class PropertyChangeCleanupSpec extends Specification {
     def pipeline = Pipeline
       .builder()
       .withStage(PIPELINE_CONFIG_TYPE, PIPELINE_CONFIG_TYPE, context)
-      .withGlobalContext(context)
       .build()
     repository.retrievePipeline(pipeline.id) >> pipeline
 
@@ -217,7 +208,6 @@ class PropertyChangeCleanupSpec extends Specification {
     def pipeline = Pipeline
       .builder()
       .withStage(PIPELINE_CONFIG_TYPE, PIPELINE_CONFIG_TYPE, context)
-      .withGlobalContext(context)
       .build()
     repository.retrievePipeline(pipeline.id) >> pipeline
 
@@ -239,10 +229,10 @@ class PropertyChangeCleanupSpec extends Specification {
 
   def "a property not marked for 'rollback' and is deleted by pipeline stage and is not reverted"() {
     given:
+    def context = [propertyIdList: [propertyId], originalProperties: [previous], rollback: false, propertyAction: PropertyAction.DELETE]
     def pipeline = Pipeline
       .builder()
-      .withStage(PIPELINE_CONFIG_TYPE, PIPELINE_CONFIG_TYPE)
-      .withGlobalContext(propertyIdList: [propertyId], originalProperties: [previous], rollbackProperties: false, propertyAction: PropertyAction.DELETE )
+      .withStage(PIPELINE_CONFIG_TYPE, PIPELINE_CONFIG_TYPE, context)
       .build()
     repository.retrievePipeline(pipeline.id) >> pipeline
 
@@ -257,7 +247,6 @@ class PropertyChangeCleanupSpec extends Specification {
     propertyId = "test_rfletcher|mahe|test|us-west-1||||asg=mahe-test-v010|cluster=mahe-test"
     propertyEnv = "test"
     previous =  createPropertyWithId(propertyId)
-
   }
 
   def "rollback a pipeline with multiple create stages"() {
@@ -284,7 +273,6 @@ class PropertyChangeCleanupSpec extends Specification {
     propertyId = "test_rfletcher|mahe|test|us-west-1||||asg=mahe-test-v010|cluster=mahe-test"
     propertyEnv = "test"
     previous =  createPropertyWithId(propertyId)
-
   }
 
   def "rollback a pipeline with a create and a delete stages that are created for a scope update"() {
@@ -317,9 +305,7 @@ class PropertyChangeCleanupSpec extends Specification {
     propertyId = "test_rfletcher|mahe|test|us-west-1||||asg=mahe-test-v010|cluster=mahe-test"
     propertyEnv = "test"
     previous =  createPropertyWithId(propertyId)
-
   }
-
 
   def createPropertyWithId(propertyId) {
     [
@@ -338,5 +324,4 @@ class PropertyChangeCleanupSpec extends Specification {
       "ts"             : "2016-03-16T18:20:29.554Z[GMT]",
       "createdAsCanary": false ]
   }
-
 }

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
@@ -180,7 +180,7 @@ class DeployCanaryStage extends ParallelDeployStage implements CloudProviderAwar
             }
           }
           if (!cluster.amiName) {
-            def ami = deployStage.execution.context.deploymentDetails.find {
+            def ami = deployStage.execution.stages.context.flatten().deploymentDetails.find {
               it.region == region
             }
 

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorAcaTaskTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorAcaTaskTask.groovy
@@ -55,7 +55,7 @@ class MonitorAcaTaskTask extends AbstractCloudProviderAwareTask implements Retry
 
     if (outputs.canary.status?.complete) {
       log.info("Canary $stage.id complete")
-      return new TaskResult(ExecutionStatus.SUCCEEDED, outputs, outputs)
+      return new TaskResult(ExecutionStatus.SUCCEEDED, outputs)
     }
 
     log.info("Canary in progress: ${outputs.canary}")

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorCanaryTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorCanaryTask.groovy
@@ -58,7 +58,7 @@ class MonitorCanaryTask extends AbstractCloudProviderAwareTask implements Retrya
 
     if (outputs.canary.status?.complete) {
       log.info("Canary $stage.id complete")
-      return new TaskResult(ExecutionStatus.SUCCEEDED, outputs, outputs)
+      return new TaskResult(ExecutionStatus.SUCCEEDED, outputs)
     }
 
     if (outputs.canary.health?.health == 'UNHEALTHY' && !context.disableRequested) {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
@@ -80,13 +80,6 @@ fun Stage<out Execution<*>>.nextTask(task: Task) =
   }
 
 /**
- * @return the stage with the specified [refId].
- * @throws IllegalArgumentException if there is no such stage.
- */
-fun <T : Execution<T>> Execution<T>.stageByRef(refId: String) =
-  stages.find { it.refId == refId } ?: throw IllegalArgumentException("No such stage")
-
-/**
  * @return all upstream stages of this stage.
  */
 fun Stage<*>.upstreamStages(): List<Stage<*>> =

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/MessageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/MessageHandler.kt
@@ -60,15 +60,13 @@ interface MessageHandler<M : Message> : (Message) -> Unit {
 
   fun StageLevel.withStage(block: (Stage<*>) -> Unit) =
     withExecution { execution ->
-      execution
-        .stageById(stageId)
-        .let { stage ->
-          if (stage == null) {
-            queue.push(InvalidStageId(this))
-          } else {
-            block.invoke(stage)
-          }
-        }
+      try {
+        execution
+          .stageById(stageId)
+          .let(block)
+      } catch(e: IllegalArgumentException) {
+        queue.push(InvalidStageId(this))
+      }
     }
 
   fun ExecutionLevel.withExecution(block: (Execution<*>) -> Unit) =

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -213,12 +213,6 @@ open class RunTaskHandler
       getContext().putAll(result.stageOutputs)
       repository.storeStage(this)
     }
-    if (result.globalOutputs.isNotEmpty()) {
-      repository.storeExecutionContext(
-        getExecution().getId(),
-        result.globalOutputs
-      )
-    }
   }
 
   private fun Stage<*>.failureStatus(default: ExecutionStatus = TERMINAL) =

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
@@ -139,8 +139,8 @@ open class StartStageHandler
       return false
     }
 
-    val clonedContext = objectMapper.convertValue(this.getContext(), Map::class.java) as Map<String, Any>
-    val clonedStage = Stage<Pipeline>(this.getExecution() as Pipeline, this.getType(), clonedContext)
-    return OptionalStageSupport.isOptional(clonedStage.withMergedContext(), contextParameterProcessor)
+//    val clonedContext = StageContext(this).also { it.putAll(this.getContext()) }
+//    val clonedStage = Stage<Pipeline>(this.getExecution() as Pipeline, this.getType(), clonedContext)
+    return OptionalStageSupport.isOptional(this.withMergedContext(), contextParameterProcessor)
   }
 }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -392,7 +392,7 @@ open class QueueIntegrationTest {
       stage {
         refId = "1"
         type = "dummy"
-        context = mapOf(
+        context.putAll(mapOf(
           "restrictExecutionDuringTimeWindow" to true,
           "restrictedExecutionWindow" to mapOf(
             "days" to (1..7).toList(),
@@ -403,7 +403,7 @@ open class QueueIntegrationTest {
               "endMin" to 0
             ))
           )
-        )
+        ))
       }
     }
     repository.store(pipeline)
@@ -501,38 +501,38 @@ open class QueueIntegrationTest {
     }
   }
 
-  @Test fun `conditional stages can depend on global context values`() {
+  @Test fun `conditional stages can depend on ancestor stage context values`() {
     val pipeline = pipeline {
       application = "spinnaker"
       stage {
         refId = "1"
         type = "dummy"
+        context.put("foo", false)
       }
       stage {
         refId = "2a"
         requisiteStageRefIds = setOf("1")
         type = "dummy"
-        context = mapOf(
+        context.putAll(mapOf(
           "stageEnabled" to mapOf(
             "type" to "expression",
             "expression" to "\${foo == true}"
           )
-        )
+        ))
       }
       stage {
         refId = "2b"
         requisiteStageRefIds = setOf("1")
         type = "dummy"
-        context = mapOf(
+        context.putAll(mapOf(
           "stageEnabled" to mapOf(
             "type" to "expression",
             "expression" to "\${foo == false}"
           )
-        )
+        ))
       }
     }
     repository.store(pipeline)
-    repository.storeExecutionContext(pipeline.id, mapOf("foo" to false))
 
     whenever(dummyTask.timeout) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED
@@ -547,42 +547,42 @@ open class QueueIntegrationTest {
     }
   }
 
-  @Test fun `conditional stages can depend on global context values after restart`() {
+  @Test fun `conditional stages can depend on ancestor stage context values after restart`() {
     val pipeline = pipeline {
       application = "spinnaker"
       stage {
         refId = "1"
         type = "dummy"
         status = SUCCEEDED
+        context.put("foo", false)
       }
       stage {
         refId = "2a"
         requisiteStageRefIds = setOf("1")
         type = "dummy"
         status = SKIPPED
-        context = mapOf(
+        context.putAll(mapOf(
           "stageEnabled" to mapOf(
             "type" to "expression",
             "expression" to "\${foo == true}"
           )
-        )
+        ))
       }
       stage {
         refId = "2b"
         requisiteStageRefIds = setOf("1")
         type = "dummy"
         status = TERMINAL
-        context = mapOf(
+        context.putAll(mapOf(
           "stageEnabled" to mapOf(
             "type" to "expression",
             "expression" to "\${foo == false}"
           )
-        )
+        ))
       }
       status = TERMINAL
     }
     repository.store(pipeline)
-    repository.storeExecutionContext(pipeline.id, mapOf("foo" to false))
 
     whenever(dummyTask.timeout) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -425,20 +425,18 @@ open class QueueIntegrationTest {
   @Test fun `can resolve expressions in stage contexts`() {
     val pipeline = pipeline {
       application = "spinnaker"
-      context["global"] = "foo"
       stage {
         refId = "1"
         type = "dummy"
-        context = mapOf(
+        context.putAll(mapOf(
           "expr" to "\${1 == 1}",
           "key" to mapOf(
             "expr" to "\${1 == 1}"
           )
-        )
+        ))
       }
     }
     repository.store(pipeline)
-    repository.storeExecutionContext(pipeline.id, pipeline.context)
 
     whenever(dummyTask.timeout) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult(SUCCEEDED, mapOf("output" to "foo"))

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -530,7 +530,6 @@ open class QueueIntegrationTest {
           )
         )
       }
-      status = TERMINAL
     }
     repository.store(pipeline)
     repository.storeExecutionContext(pipeline.id, mapOf("foo" to false))

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -547,7 +547,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
         val pipeline = pipeline {
           stage {
             type = "whatever"
-            context = hashMapOf("markSuccessfulOnTimeout" to true) as Map<String, Any>?
+            context.put("markSuccessfulOnTimeout", true)
             task {
               id = "1"
               implementingClass = DummyTask::class.qualifiedName
@@ -816,7 +816,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
         stage {
           refId = "1"
           type = "createServerGroup"
-          context = mapOf(
+          context.putAll(mapOf(
             "deploy.server.groups" to mapOf(
               "us-west-1" to listOf(
                 "spindemo-test-v008"
@@ -824,7 +824,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             ),
             "account" to "mgmttest",
             "region" to "us-west-1"
-          )
+          ))
           status = SUCCEEDED
         }
         stage {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.pipeline.model.Execution.PausedDetails
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.pipeline.model.Task
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
@@ -898,11 +897,16 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
     }
 
-    given("an expression in the context that refers to a global context value") {
+    given("an expression in the context that refers to a value in a previous stage") {
       val pipeline = pipeline {
-        context["foo"] = "bar"
         stage {
           refId = "1"
+          context["foo"] = "bar"
+          status = SUCCEEDED
+        }
+        stage {
+          refId = "2"
+          requisiteStageRefIds = setOf("1")
           context["expression"] = "\${foo}"
           type = "whatever"
           task {
@@ -912,7 +916,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           }
         }
       }
-      val message = RunTask(Pipeline::class.java, pipeline.id, "foo", pipeline.stageByRef("1").id, "1", DummyTask::class.java)
+      val message = RunTask(Pipeline::class.java, pipeline.id, "foo", pipeline.stageByRef("2").id, "1", DummyTask::class.java)
 
       beforeGroup {
         whenever(task.execute(any())) doReturn TaskResult.SUCCEEDED


### PR DESCRIPTION
`StageContext` is a new map implementation with transparent read-thru of properties from upstream stages if they are not present in the stage's own context.