### PR TITLE
feat(clouddriver): Support sharding read-only requests by `origin`

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingClouddriverService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingClouddriverService.java
@@ -27,14 +27,15 @@ class DelegatingClouddriverService<T> {
   }
 
   T getService() {
-    SelectableService.Criteria criteria = new SelectableService.Criteria(null, null);
+    SelectableService.Criteria criteria = new SelectableService.Criteria(null, null, null, null);
 
     ExecutionContext executionContext = ExecutionContext.get();
     if (executionContext != null) {
       criteria = new SelectableService.Criteria(
         executionContext.getApplication(),
         executionContext.getExecutionType(),
-        executionContext.getExecutionId()
+        executionContext.getExecutionId(),
+        executionContext.getOrigin()
       );
     }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ByOriginServiceSelector.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ByOriginServiceSelector.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ByOriginServiceSelector implements ServiceSelector {
+  private final Object service;
+  private final int priority;
+  private final String origin;
+
+  public ByOriginServiceSelector(Object service, Integer priority, Map<String, Object> config) {
+    this.service = service;
+    this.priority = priority;
+    this.origin = (String) config.get("origin");
+  }
+
+  @Override
+  public Object getService() {
+    return service;
+  }
+
+  @Override
+  public int getPriority() {
+    return priority;
+  }
+
+  @Override
+  public boolean supports(SelectableService.Criteria criteria) {
+    return origin != null && origin.equalsIgnoreCase(criteria.getOrigin());
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/SelectableService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/SelectableService.java
@@ -43,17 +43,20 @@ public class SelectableService {
     private final String application;
     private final String executionType;
     private final String executionId;
+    private final String origin;
 
-    public Criteria(String application, String executionType) {
-      this(application, executionType, null);
+    public Criteria(String application, String executionType, String origin) {
+      this(application, executionType, null, origin);
     }
 
     public Criteria(String application,
                     String executionType,
-                    String executionId) {
+                    String executionId,
+                    String origin) {
       this.application = application;
       this.executionType = executionType;
       this.executionId = executionId;
+      this.origin = origin;
     }
 
     public String getApplication() {
@@ -66,6 +69,10 @@ public class SelectableService {
 
     public String getExecutionId() {
       return executionId;
+    }
+
+    public String getOrigin() {
+      return origin;
     }
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionContext.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionContext.java
@@ -22,11 +22,13 @@ public class ExecutionContext {
   private final String application;
   private final String executionType;
   private final String executionId;
+  private final String origin;
 
-  public ExecutionContext(String application, String executionType, String executionId) {
+  public ExecutionContext(String application, String executionType, String executionId, String origin) {
     this.application = application;
     this.executionType = executionType;
     this.executionId = executionId;
+    this.origin = origin;
   }
 
   public static void set(ExecutionContext executionContext) {
@@ -52,4 +54,6 @@ public class ExecutionContext {
   public String getExecutionId() {
     return executionId;
   }
+
+  public String getOrigin() { return origin; }
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AuthenticationAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AuthenticationAware.kt
@@ -44,7 +44,8 @@ interface AuthenticationAware {
       ExecutionContext.set(ExecutionContext(
         getExecution().getApplication(),
         getExecution().javaClass.simpleName.toLowerCase(),
-        getExecution().getId()
+        getExecution().getId(),
+        getExecution().getOrigin()
       ))
       AuthenticatedRequest.propagate(block, false, currentUser).call()
     } finally {


### PR DESCRIPTION
This allows you serve all pipeline/orchestrations generated by the UI
with a dedicated clouddriver read replica.
