### PR TITLE
fix(front50): Throw exception if using old gate version API

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
@@ -62,6 +62,10 @@ public class SavePipelineTask implements RetryableTask {
       throw new IllegalArgumentException("pipeline context must be provided");
     }
 
+    if (!(stage.getContext().get("pipeline") instanceof String)) {
+      throw new IllegalArgumentException("'pipeline' context key must be a base64-encoded string: Ensure you're on the most recent version of gate");
+    }
+
     byte[] pipelineData;
     try {
       pipelineData = Base64.getDecoder().decode((String) stage.getContext().get("pipeline"));


### PR DESCRIPTION
Someone in OSS hit an error caused by upgrading orca, but not gate, which caused a ClassCastException to be thrown. Adding an explicit check & prompt for upgrading gate.