### PR TITLE
feat(sharding): Support for execution type restriction in `ByOriginSelector`

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ByOriginServiceSelector.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ByOriginServiceSelector.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.config;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -24,11 +25,20 @@ public class ByOriginServiceSelector implements ServiceSelector {
   private final Object service;
   private final int priority;
   private final String origin;
+  private final Set<String> executionTypes;
 
   public ByOriginServiceSelector(Object service, Integer priority, Map<String, Object> config) {
     this.service = service;
     this.priority = priority;
     this.origin = (String) config.get("origin");
+
+    if (config.containsKey("executionTypes")) {
+      executionTypes = new HashSet(
+        ((Map<String, String>) config.get("executionTypes")).values()
+      );
+    } else {
+      executionTypes = new HashSet<>(Arrays.asList("pipeline", "orchestration"));
+    }
   }
 
   @Override
@@ -43,6 +53,8 @@ public class ByOriginServiceSelector implements ServiceSelector {
 
   @Override
   public boolean supports(SelectableService.Criteria criteria) {
-    return origin != null && origin.equalsIgnoreCase(criteria.getOrigin());
+    return origin != null &&
+           origin.equalsIgnoreCase(criteria.getOrigin()) &&
+           executionTypes.contains(criteria.getExecutionType());
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/config/SelectableServiceSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/config/SelectableServiceSpec.groovy
@@ -44,7 +44,7 @@ class SelectableServiceSpec extends Specification {
       [
         new ByApplicationServiceSelector(mortService, 10, ["applicationPattern": ".*spindemo.*"]),
         new ByExecutionTypeServiceSelector(oortService, 5, ["executionTypes": [0: "orchestration"]]),
-        new ByOriginServiceSelector(instanceService, 20, ["origin": "deck"]),
+        new ByOriginServiceSelector(instanceService, 20, ["origin": "deck", "executionTypes": [0: "orchestration"]]),
         new DefaultServiceSelector(katoService, 1, [:])
       ]
     )
@@ -60,8 +60,14 @@ class SelectableServiceSpec extends Specification {
     new SelectableService.Criteria(null, null, null)                       || katoService      // the default service selector
     new SelectableService.Criteria("spindemo", "orchestration", "api")     || mortService
     new SelectableService.Criteria("1-spindemo-1", "orchestration", "api") || mortService
-    new SelectableService.Criteria("spindemo", "orchestration", "deck")    || instanceService  // by origin selector is higher priority
+    new SelectableService.Criteria("spindemo", "orchestration", "deck")    || instanceService  // origin selector is higher priority
+    new SelectableService.Criteria("spindemo", "pipeline", "deck")         || mortService      // fall back to application selector as origin selector does not support pipeline
     new SelectableService.Criteria("spintest", "orchestration", "api")     || oortService
     new SelectableService.Criteria("spintest", "pipeline", "api")          || katoService
+  }
+
+  def "should default to all execution types if none configured (by origin selector)"() {
+    expect:
+    new ByOriginServiceSelector(instanceService, 20, [:]).executionTypes.sort() == ["orchestration", "pipeline"]
   }
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
@@ -36,7 +36,7 @@ open class CompleteExecutionHandler
   override val queue: Queue,
   override val repository: ExecutionRepository,
   private val publisher: ApplicationEventPublisher,
-  @Value("\${queue.retry.delay.ms:5000}") retryDelayMs: Long
+  @Value("\${queue.retry.delay.ms:30000}") retryDelayMs: Long
 ) : MessageHandler<CompleteExecution> {
 
   private val log = LoggerFactory.getLogger(javaClass)

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
@@ -59,7 +59,7 @@ open class StartStageHandler
     message.withStage { stage ->
       if (stage.anyUpstreamStagesFailed()) {
         // this only happens in restart scenarios
-        log.warn("Tried to start stage ${stage.getId()} but something upstream had failed")
+        log.warn("Tried to start stage ${stage.getId()} but something upstream had failed (executionId: ${message.executionId})")
         queue.push(CompleteExecution(message))
       } else if (stage.allUpstreamStagesComplete()) {
         if (stage.getStatus() != NOT_STARTED) {


### PR DESCRIPTION
```
clouddriver:
  readonly:
    baseUrls:
    - baseUrl: https://clouddriver-deck-only.com
      priority: 20
      config:
        selectorClass: com.netflix.spinnaker.orca.clouddriver.config.ByOriginServiceSelector
        origin: deck
        executionTypes:
          - orchestration
```

Also adjusted logging around the `CompleteExecution` message.