### PR TITLE
feat(amazon): allow preferSourceCapacity as fallback on deploy when u…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageData.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageData.groovy
@@ -33,6 +33,7 @@ class StageData {
   Map<String, List<String>> availabilityZones
   int maxRemainingAsgs
   Boolean useSourceCapacity
+  Boolean preferSourceCapacity
   Source source
 
   String getCluster() {
@@ -67,12 +68,21 @@ class StageData {
     return useSourceCapacity ?: false
   }
 
+  Boolean getPreferSourceCapacity() {
+    if (source?.preferSourceCapacity != null) {
+      return source.preferSourceCapacity
+    }
+
+    return preferSourceCapacity ?: false
+  }
+
   static class Source {
     String account
     String region
     String asgName
     String serverGroupName
     Boolean useSourceCapacity
+    Boolean preferSourceCapacity
   }
 
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CaptureSourceServerGroupCapacityTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CaptureSourceServerGroupCapacityTaskSpec.groovy
@@ -52,6 +52,17 @@ class CaptureSourceServerGroupCapacityTaskSpec extends Specification {
     [source: [useSourceCapacity: false]] || _
   }
 
+  void "should set useSourceCapacity to false if no source found and preferSourceCapacity is true"() {
+    given:
+    def stage = new Stage<>(new Pipeline(), "", [useSourceCapacity: true, preferSourceCapacity: true])
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.context == [useSourceCapacity: false]
+  }
+
   void "should capture source server group capacity and update target capacity"() {
     given:
     def stage = new Stage<>(new Pipeline(), "", [


### PR DESCRIPTION
…seSourceCapacity does not find a source

We see a lot of user frustration with the "use source capacity" option, since it will fail if the cluster does not exist. This is a common occurrence in parameterized pipelines and pipelines that are generated by other systems for users.

This introduces an additional flag, `preferSourceCapacity`, which will act as a fallback if the specified source cannot be found and the stage has a `capacity` map configured.

I'm assuming this will work for all providers - there's a change in here on the `CaptureSourceServerGroupCapacityTask`, but I think that's just around to pin the `min` when doing a deploy.
