### PR TITLE
fix(pipeline_templates): change configuration stanza to pipelineTemplates

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
@@ -30,14 +30,14 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderedValue
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.YamlRenderedValueConverter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.yaml.snakeyaml.Yaml;
 
 import java.util.List;
 
-@ConditionalOnProperty("pipelineTemplate.enabled")
+@ConditionalOnExpression("${pipelineTemplates.enabled:true}")
 @ComponentScan(
   basePackageClasses = PipelineTemplateModule.class,
   basePackages = {"com.netflix.spinnaker.orca.pipelinetemplate.tasks", "com.netflix.spinnaker.orca.pipelinetemplate.pipeline"}

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/PipelineTemplateController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/PipelineTemplateController.groovy
@@ -21,13 +21,13 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTempla
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration.TemplateSource
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
-@ConditionalOnProperty("pipelineTemplate.enabled")
+@ConditionalOnExpression("\${pipelineTemplates.enabled:true}")
 @RestController
 @Slf4j
 class PipelineTemplateController {


### PR DESCRIPTION
Before the configuration stanza was defined in a singular form as `pipelineTemplate`.
To keep it consistent with the feature name it is now changed to plural form.