### PR TITLE
feat(pipeline_template): Prettify optional stage names

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
@@ -199,7 +199,7 @@ public class StageDefinition implements Identifiable, Conditional, Cloneable {
   }
 
   public String getName() {
-    return Optional.ofNullable(name).orElse(id);
+    return Optional.ofNullable(name).orElse(camelCaseToTitleCaseWords(id));
   }
 
   public void setName(String name) {
@@ -308,6 +308,17 @@ public class StageDefinition implements Identifiable, Conditional, Cloneable {
 
   public void setPartialDefinitionContext(PartialDefinitionContext partialDefinitionContext) {
     this.partialDefinitionContext = partialDefinitionContext;
+  }
+
+  private static String camelCaseToTitleCaseWords(String s) {
+    return (s.substring(0, 1).toUpperCase() + s.substring(1)).replaceAll(
+      String.format("%s|%s|%s",
+        "(?<=[A-Z])(?=[A-Z][a-z])",
+        "(?<=[^A-Z])(?=[A-Z])",
+        "(?<=[A-Za-z])(?=[^A-Za-z])"
+      ),
+      " "
+    );
   }
 
   @Override

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinitionSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinitionSpec.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class StageDefinitionSpec extends Specification {
+
+  @Unroll
+  def "should generate name if unset"() {
+    given:
+    StageDefinition subject = new StageDefinition(
+      id: id,
+      name: name
+    )
+
+    expect:
+    subject.name == expectedName
+
+    where:
+    id        | name  || expectedName
+    'foo'     | null  || 'Foo'
+    'barBaz'  | null  || 'Bar Baz'
+    'bang'    | 'WOW' || 'WOW'
+  }
+}


### PR DESCRIPTION
Small quality of life change, will now convert a camel-cased stage ID to title-cased words for stages that do not define a name.

@t0mpson FYI