### PR TITLE
move stage timeout and failure override settings out of context

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AlertOnAccessMap.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AlertOnAccessMap.java
@@ -25,18 +25,14 @@ import com.netflix.spectator.api.Registry;
 
 class AlertOnAccessMap<E extends Execution<E>> extends ForwardingMap<String, Object> {
 
+  private final Execution<E> execution;
   private final Map<String, Object> delegate;
   private final Registry registry;
-  private final Id counterId;
 
-  AlertOnAccessMap(Execution<E> execution, Registry registry, Map<String, Object> delegate) {
+  private AlertOnAccessMap(Execution<E> execution, Registry registry, Map<String, Object> delegate) {
+    this.execution = execution;
     this.registry = registry;
     this.delegate = delegate;
-    counterId = registry
-      .createId("global.context.access")
-      .withTag("execution", execution.getId())
-      .withTag("application", execution.getApplication())
-      .withTag("name", execution.getName());
   }
 
   AlertOnAccessMap(Execution<E> execution, Registry registry) {
@@ -46,8 +42,14 @@ class AlertOnAccessMap<E extends Execution<E>> extends ForwardingMap<String, Obj
   @Override protected Map<String, Object> delegate() { return delegate; }
 
   @Override public Object get(@Nullable Object key) {
+    Id counterId = registry
+      .createId("global.context.access")
+      .withTag("execution", execution.getId())
+      .withTag("application", execution.getApplication())
+      .withTag("name", execution.getName())
+      .withTag("key", String.valueOf(key));
     registry
-      .counter(counterId.withTag("key", String.valueOf(key)))
+      .counter(counterId)
       .increment();
     return super.get(key);
   }


### PR DESCRIPTION
Stage gets 2 new fields:

* `Long timeoutMs` — `null` if default timeout should apply.
* `FailurePolicy onFailure` — enum replacing 3 booleans `failPipeline`, `continuePipeline` and `completeOtherBranchesThenFail` that were in context.

Both will require migrations in front50 and latter will need corresponding change in deck.