### PR TITLE
perf(*): WaitForXXX instance checks should favor loading server group…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -36,8 +36,13 @@ public class DelegatingOortService
   }
 
   @Override
-  public Response getServerGroup(String app, String account, String cluster, String serverGroup, String region, String cloudProvider) {
-    return getService().getServerGroup(app, account, cluster, serverGroup, region, cloudProvider);
+  public Response getServerGroupFromCluster(String app, String account, String cluster, String serverGroup, String region, String cloudProvider) {
+    return getService().getServerGroupFromCluster(app, account, cluster, serverGroup, region, cloudProvider);
+  }
+
+  @Override
+  public Response getServerGroup(String app, String account, String region, String serverGroup) {
+    return getService().getServerGroup(app, account, region, serverGroup);
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -31,12 +31,18 @@ interface OortService {
                       @Path("cloudProvider") String cloudProvider)
 
   @GET("/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/serverGroups/{serverGroup}")
+  Response getServerGroupFromCluster(@Path("app") String app,
+                                     @Path("account") String account,
+                                     @Path("cluster") String cluster,
+                                     @Path("serverGroup") String serverGroup,
+                                     @Query("region") String region,
+                                     @Path("cloudProvider") String cloudProvider)
+
+  @GET("/applications/{app}/serverGroups/{account}/{region}/{serverGroup}")
   Response getServerGroup(@Path("app") String app,
-                          @Path("account") String account,
-                          @Path("cluster") String cluster,
-                          @Path("serverGroup") String serverGroup,
-                          @Query("region") String region,
-                          @Path("cloudProvider") String cloudProvider)
+                     @Path("account") String account,
+                     @Path("region") String region,
+                     @Path("serverGroup") String serverGroup)
 
   @GET("/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/{scope}/serverGroups/target/{target}")
   Response getTargetServerGroup(@Path("app") String app,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolver.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolver.groovy
@@ -79,12 +79,14 @@ class TargetServerGroupResolver {
 
   private TargetServerGroup resolveByServerGroupName(TargetServerGroup.Params params, Location location) {
     List<Map> tsgList = fetchWithRetries(List) {
-      oortService.getServerGroup(params.app,
+      oortService.getServerGroupFromCluster(
+        params.app,
         params.credentials,
         params.cluster,
         params.serverGroupName,
         null /* region */, // TODO(ttomsu): Add zonal support to this op.
-        params.cloudProvider)
+        params.cloudProvider
+      )
     }
     // Without zonal support in the getServerGroup call above, we have to do the filtering here.
     def tsg = tsgList?.find { Map tsg -> tsg.region == location.value || tsg.zones?.contains(location.value) || tsg.namespace == location.value }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/TitusInterestingHealthProviderNamesSupplier.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/TitusInterestingHealthProviderNamesSupplier.java
@@ -69,7 +69,7 @@ public class TitusInterestingHealthProviderNamesSupplier implements InterestingH
         StageData.Source source = sourceData.get();
         String serverGroupName =  source.getServerGroupName() != null ? source.getServerGroupName() : source.getAsgName();
 
-        Response response = oortService.getServerGroup(
+        Response response = oortService.getServerGroupFromCluster(
           stageData.getApplication(),
           source.getAccount(),
           stageData.getCluster(),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/OortHelper.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/OortHelper.groovy
@@ -60,7 +60,7 @@ class OortHelper {
                                                    String location,
                                                    String cloudProvider) {
     def name = Names.parseName(serverGroupName)
-    return convertedResponse(List) { oortService.getServerGroup(name.app, account, name.cluster, serverGroupName, null, cloudProvider) }
+    return convertedResponse(List) { oortService.getServerGroupFromCluster(name.app, account, name.cluster, serverGroupName, null, cloudProvider) }
     .map({ List<Map> serverGroups ->
       serverGroups.find {
         it.region == location || it.zones?.contains(location) || it.namespace == location

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/CleanUpTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/CleanUpTagsTask.java
@@ -61,7 +61,7 @@ public class CleanUpTagsTask extends AbstractCloudProviderAwareTask implements R
       Names name = Names.parseName(serverGroupName);
       String cloudProvider = getCloudProvider(stage);
 
-      Response serverGroupResponse = oortService.getServerGroup(
+      Response serverGroupResponse = oortService.getServerGroupFromCluster(
         name.getApp(),
         source.getAccount(),
         name.getCluster(),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTask.groovy
@@ -37,7 +37,7 @@ class DetermineTerminationCandidatesTask implements Task {
   @Override
   TaskResult execute(Stage stage) {
     def stageData = stage.mapTo(StageData)
-    def response = oortService.getServerGroup(stageData.application, stageData.account, stageData.cluster, stage.context.asgName, stage.context.region, stage.context.cloudProvider ?: 'aws')
+    def response = oortService.getServerGroupFromCluster(stageData.application, stageData.account, stageData.cluster, stage.context.asgName, stage.context.region, stage.context.cloudProvider ?: 'aws')
     def serverGroup = objectMapper.readValue(response.body.in(), Map)
     boolean ascending = stage.context.termination?.order != 'newest'
     def serverGroupInstances = serverGroup.instances.sort { ascending ? it.launchTime : -it.launchTime }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/WaitForNewUpInstancesLaunchTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/WaitForNewUpInstancesLaunchTask.groovy
@@ -42,7 +42,7 @@ class WaitForNewUpInstancesLaunchTask implements RetryableTask {
   @Override
   TaskResult execute(Stage stage) {
     StageData stageData = stage.mapTo(StageData)
-    def response = oortService.getServerGroup(stageData.application, stageData.account, stageData.cluster, stage.context.asgName as String, stage.context.region as String, stageData.cloudProvider ?: 'aws' )
+    def response = oortService.getServerGroupFromCluster(stageData.application, stageData.account, stageData.cluster, stage.context.asgName as String, stage.context.region as String, stageData.cloudProvider ?: 'aws' )
 
     Map serverGroup = objectMapper.readValue(response.body.in(), Map)
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolverSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolverSpec.groovy
@@ -67,7 +67,7 @@ class TargetServerGroupResolverSpec extends Specification {
       ))
 
     then:
-      1 * oort.getServerGroup("test", "testCreds", "test-app", "test-app-v010", null, "gce") >>
+      1 * oort.getServerGroupFromCluster("test", "testCreds", "test-app", "test-app-v010", null, "gce") >>
         new Response("clouddriver", 200, 'ok', [], new TypedString(mapper.writeValueAsString([[
                                                                                                 name  : "test-app-v010",
                                                                                                 region: "north-pole",

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTaskSpec.groovy
@@ -87,23 +87,19 @@ class AbstractInstancesCheckTaskSpec extends Specification {
     task.execute(stage)
 
     then:
-    1 * task.oortService.getCluster("front50", "test", "front50", "aws") >> constructResponse(200, '''
+    1 * task.oortService.getServerGroup("front50", "test", "us-west-1", "front50-v000") >> constructResponse(200, '''
 {
-    "serverGroups": [
+    "name": "front50-v000",
+    "region": "us-west-1",
+    "asg": {
+        "minSize": 1
+    },
+    "capacity": {
+        "min": 1
+    },
+    "instances": [
         {
-            "name": "front50-v000",
-            "region": "us-west-1",
-            "asg": {
-                "minSize": 1
-            },
-            "capacity": {
-                "min": 1
-            },
-            "instances": [
-                {
-                    "name": "i-12345678"
-                }
-            ]
+            "name": "i-12345678"
         }
     ]
 }
@@ -137,25 +133,21 @@ class AbstractInstancesCheckTaskSpec extends Specification {
 
     then:
     result.stageOutputs.zeroDesiredCapacityCount == expected
-    1 * task.oortService.getCluster("front50", "test", "front50", "aws") >> constructResponse(200, '''
+    1 * task.oortService.getServerGroup("front50", "test", "us-west-1", "front50-v000") >> constructResponse(200, '''
 {
-    "serverGroups": [
+    "name": "front50-v000",
+    "region": "us-west-1",
+    "asg": {
+        "minSize": 1,
+        "desiredCapacity": ''' + desiredCapacity + '''
+    },
+    "capacity": {
+        "min": 1,
+        "desired": ''' + desiredCapacity + '''
+    },
+    "instances": [
         {
-            "name": "front50-v000",
-            "region": "us-west-1",
-            "asg": {
-                "minSize": 1,
-                "desiredCapacity": ''' + desiredCapacity + '''
-            },
-            "capacity": {
-                "min": 1,
-                "desired": ''' + desiredCapacity + '''
-            },
-            "instances": [
-                {
-                    "name": "i-12345678"
-                }
-            ]
+            "name": "i-12345678"
         }
     ]
 }
@@ -187,25 +179,21 @@ class AbstractInstancesCheckTaskSpec extends Specification {
 
     then:
     result.stageOutputs.zeroDesiredCapacityCount == 1
-    1 * task.oortService.getCluster("front50", "test", "front50", "aws") >> constructResponse(200, '''
+    1 * task.oortService.getServerGroup("front50", "test", "us-west-1", "front50-v000") >> constructResponse(200, '''
 {
-    "serverGroups": [
+    "name": "front50-v000",
+    "region": "us-west-1",
+    "asg": {
+        "minSize": 1,
+        "desiredCapacity": 0
+    },
+    "capacity": {
+        "min": 1,
+        "desired": 0
+    },
+    "instances": [
         {
-            "name": "front50-v000",
-            "region": "us-west-1",
-            "asg": {
-                "minSize": 1,
-                "desiredCapacity": 0
-            },
-            "capacity": {
-                "min": 1,
-                "desired": 0
-            },
-            "instances": [
-                {
-                    "name": "i-12345678"
-                }
-            ]
+            "name": "i-12345678"
         }
     ]
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
@@ -47,7 +47,7 @@ class WaitForUpInstancesTaskSpec extends Specification {
           serverGroups: [
             [
               region   : "us-east-1",
-              name     : "front50-v000",
+              name     : "front50-v001",
               asg      : [
                 desiredCapacity: 1
               ],
@@ -105,7 +105,7 @@ class WaitForUpInstancesTaskSpec extends Specification {
     def stage = new Stage<>(pipeline, "whatever", [
       "account.name"                  : "test",
       "targetop.asg.enableAsg.name"   : "front50-v000",
-      "targetop.asg.enableAsg.regions": ["us-west-1"]
+      "targetop.asg.enableAsg.regions": ["us-west-1", "us-east-1"]
     ])
 
     expect:

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/WaitForAllNetflixAWSInstancesDownTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/WaitForAllNetflixAWSInstancesDownTaskSpec.groovy
@@ -45,31 +45,26 @@ class WaitForAllNetflixAWSInstancesDownTaskSpec extends Specification {
 
   def mapper = OrcaObjectMapper.newInstance()
 
-  void "should check cluster to get server groups"() {
+  void "should fetch server group"() {
     given:
     def pipeline = new Pipeline()
     task.objectMapper = mapper
     def response = mapper.writeValueAsString([
-      name        : "front50",
-      serverGroups: [
+      region   : "us-west-1",
+      name     : "front50-v000",
+      asg      : [
+        minSize: 1
+      ],
+      instances: [
         [
-          region   : "us-west-1",
-          name     : "front50-v000",
-          asg      : [
-            minSize: 1
-          ],
-          instances: [
-            [
-              health: [ [ state : "Down"] ]
-            ]
-          ]
+          health: [[state: "Down"]]
         ]
       ]
     ])
 
 
     task.oortService = Stub(OortService) {
-      getCluster(*_) >> new Response('oort', 200, 'ok', [], new TypedString(response))
+      getServerGroup(*_) >> new Response('oort', 200, 'ok', [], new TypedString(response))
     }
 
     and:

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/TitusInterestingHealthProviderNamesSupplierSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/TitusInterestingHealthProviderNamesSupplierSpec.groovy
@@ -64,7 +64,7 @@ class TitusInterestingHealthProviderNamesSupplierSpec extends Specification {
     ])
 
     and:
-    1 * oortService.getServerGroup(*_) >> new Response('oort', 200, 'ok', [], new TypedString(response))
+    1 * oortService.getServerGroupFromCluster(*_) >> new Response('oort', 200, 'ok', [], new TypedString(response))
 
     when:
     def interestingHealthProviderNames = titusInterestingHealthProviderNamesSupplier.process("titus", stage)

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTaskSpec.groovy
@@ -47,7 +47,7 @@ class WaitForCapacityMatchTaskSpec extends Specification {
   void "should properly wait for a scale up operation"() {
     setup:
       oort = Stub(OortService)
-      oort.getCluster("kato", "test", "kato-main", "aws") >> { new Response('kato', 200, 'ok', [], new TypedString(mapper.writeValueAsString(cluster))) }
+      oort.getServerGroup("kato", "test", "us-east-1", "kato-main-v000") >> { new Response('kato', 200, 'ok', [], new TypedString(mapper.writeValueAsString(serverGroup))) }
       task.oortService = oort
       def context = [account: "test", "deploy.server.groups": ["us-east-1": ["kato-main-v000"]]]
       def stage = new Stage<>(new Orchestration(), "resizeAsg", context)
@@ -59,7 +59,7 @@ class WaitForCapacityMatchTaskSpec extends Specification {
       result.status == ExecutionStatus.RUNNING
 
     when:
-      cluster.serverGroups[0].instances.addAll([makeInstance("i-5678"), makeInstance("i-0000")])
+      serverGroup.instances.addAll([makeInstance("i-5678"), makeInstance("i-0000")])
 
     and:
       result = task.execute(stage)
@@ -68,11 +68,7 @@ class WaitForCapacityMatchTaskSpec extends Specification {
       result.status == ExecutionStatus.SUCCEEDED
 
     where:
-      cluster = [
-        name: "kato-main",
-        account: "test",
-        serverGroups: [
-          [
+      serverGroup = [
             name: "kato-main-v000",
             region: "us-east-1",
             instances: [
@@ -85,19 +81,13 @@ class WaitForCapacityMatchTaskSpec extends Specification {
               desired: 3
             ]
           ]
-        ]
-      ]
   }
 
   @Unroll
   void "should return status #status for a scale up operation when server group is not disabled and instance health is #healthState"() {
     setup:
     oort = Stub(OortService)
-    def cluster = [
-      name: "kato-main",
-      account: "test",
-      serverGroups: [
-        [
+    def serverGroup = [
           name: "kato-main-v000",
           region: "us-east-1",
           instances: [
@@ -112,10 +102,8 @@ class WaitForCapacityMatchTaskSpec extends Specification {
             desired: 3
           ]
         ]
-      ],
-      disabled: false
-    ]
-    oort.getCluster("kato", "test", "kato-main", "aws") >> { new Response('kato', 200, 'ok', [], new TypedString(mapper.writeValueAsString(cluster))) }
+
+    oort.getServerGroup("kato", "test", "us-east-1", "kato-main-v000") >> { new Response('kato', 200, 'ok', [], new TypedString(mapper.writeValueAsString(serverGroup))) }
     task.oortService = oort
     def context = [account: "test", "deploy.server.groups": ["us-east-1": ["kato-main-v000"]]]
     def stage = new Stage<>(new Orchestration(), "resizeAsg", context)
@@ -127,7 +115,7 @@ class WaitForCapacityMatchTaskSpec extends Specification {
     result.status == ExecutionStatus.RUNNING
 
     when:
-    cluster.serverGroups[0].instances.addAll([
+    serverGroup.instances.addAll([
       makeInstance("i-5678", healthState),
       makeInstance("i-0000", healthState)
       ])
@@ -148,7 +136,7 @@ class WaitForCapacityMatchTaskSpec extends Specification {
   void "should properly wait for a scale down operation"() {
     setup:
     oort = Stub(OortService)
-    oort.getCluster("kato", "test", "kato-main", "aws") >> { new Response('kato', 200, 'ok', [], new TypedString(mapper.writeValueAsString(cluster))) }
+    oort.getServerGroup("kato", "test", "us-east-1", "kato-main-v000") >> { new Response('kato', 200, 'ok', [], new TypedString(mapper.writeValueAsString(serverGroup))) }
     task.oortService = oort
     def context = [account: "test", "deploy.server.groups": ["us-east-1": ["kato-main-v000"]]]
     def stage = new Stage<>(new Orchestration(), "resizeAsg", context)
@@ -160,7 +148,7 @@ class WaitForCapacityMatchTaskSpec extends Specification {
     result.status == ExecutionStatus.RUNNING
 
     when:
-    cluster.serverGroups[0].instances = [makeInstance("i-0000")]
+    serverGroup.instances = [makeInstance("i-0000")]
 
     and:
     result = task.execute(stage)
@@ -169,11 +157,7 @@ class WaitForCapacityMatchTaskSpec extends Specification {
     result.status == ExecutionStatus.SUCCEEDED
 
     where:
-    cluster = [
-      name: "kato-main",
-      account: "test",
-      serverGroups: [
-        [
+    serverGroup = [
           name: "kato-main-v000",
           region: "us-east-1",
           instances: [
@@ -188,8 +172,6 @@ class WaitForCapacityMatchTaskSpec extends Specification {
             desired: 1
           ]
         ]
-      ]
-    ]
   }
 
   private static Map makeInstance(id, healthState = 'Up') {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForRequiredInstancesDownTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForRequiredInstancesDownTaskSpec.groovy
@@ -36,14 +36,11 @@ class WaitForRequiredInstancesDownTaskSpec extends Specification {
 
   def mapper = OrcaObjectMapper.newInstance()
 
-  void "should check cluster to get server groups"() {
+  void "should fetch server groups"() {
     given:
     def pipeline = new Pipeline()
     task.objectMapper = mapper
     def response = mapper.writeValueAsString([
-      name        : 'front50',
-      serverGroups: [
-        [
           region   : 'us-east-1',
           name     : 'front50-v000',
           asg      : [
@@ -54,12 +51,10 @@ class WaitForRequiredInstancesDownTaskSpec extends Specification {
               health: [[state: 'Down']]
             ]
           ]
-        ]
-      ]
-    ])
+      ])
 
     task.oortService = Stub(OortService) {
-      getCluster(*_) >> new Response('oort', 200, 'ok', [], new TypedString(response))
+      getServerGroup(*_) >> new Response('oort', 200, 'ok', [], new TypedString(response))
     }
     task.serverGroupCacheForceRefreshTask = Mock(ServerGroupCacheForceRefreshTask) {
       2 * execute(_) >> new TaskResult(ExecutionStatus.SUCCEEDED)

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/CleanUpTagsTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/CleanUpTagsTaskSpec.groovy
@@ -72,13 +72,15 @@ class CleanUpTagsTaskSpec extends Specification {
     List<Map> operations = []
     task.objectMapper = new ObjectMapper();
     task.oortService = Mock(OortService) {
-      1* getServerGroup("app","test", "app", "app-v00", "us-east-1", "aws") >> {
+      1* getServerGroupFromCluster("app","test", "app", "app-v00", "us-east-1", "aws") >> {
         oortResponse
       }
 
       1* getEntityTags("aws", "servergroup", "app-v00", "test", "us-east-1") >> {
         tags
       }
+
+      0 * _
     }
 
     task.katoService = Mock(KatoService) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTaskSpec.groovy
@@ -56,7 +56,7 @@ class DetermineTerminationCandidatesTaskSpec extends Specification {
     def response = task.execute(stage)
 
     then:
-    1 * oortService.getServerGroup(application, account, cluster, serverGroup, region, cloudProvider) >> oortResponse
+    1 * oortService.getServerGroupFromCluster(application, account, cluster, serverGroup, region, cloudProvider) >> oortResponse
     response.stageOutputs.terminationInstanceIds == expectedTerminations
     response.stageOutputs.knownInstanceIds.toSet() == knownInstanceIds.toSet()
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/WaitForNewUpInstancesLaunchTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/WaitForNewUpInstancesLaunchTaskSpec.groovy
@@ -54,7 +54,7 @@ class WaitForNewUpInstancesLaunchTaskSpec extends Specification {
     def response = task.execute(stage)
 
     then:
-    1 * oortService.getServerGroup(application, account, cluster, serverGroup, region, cloudProvider) >> oortResponse
+    1 * oortService.getServerGroupFromCluster(application, account, cluster, serverGroup, region, cloudProvider) >> oortResponse
     response.status == expectedStatus
 
 

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
@@ -192,7 +192,7 @@ class GetCommitsTask implements DiffTask {
       }
 
       TypeReference<Map> jsonMapType = new TypeReference<Map>() {}
-      Map sourceServerGroup = objectMapper.readValue(oortService.getServerGroup(context.application,
+      Map sourceServerGroup = objectMapper.readValue(oortService.getServerGroupFromCluster(context.application,
         account, sourceCluster,
         ancestorAsg, region, "aws").body.in(), jsonMapType)
       return sourceServerGroup.launchConfig.imageId

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
@@ -221,7 +221,7 @@ class GetCommitsTaskSpec extends Specification {
     def oortResponse = "{\"launchConfig\" : {\"imageId\" : \"${sourceImage}\"}}".stripIndent()
     Response response = new Response('http://oort', 200, 'OK', [], new TypedString(oortResponse))
     task.oortService = oortService
-    serverGroupCalls * oortService.getServerGroup(app, account, cluster, serverGroup, region, "aws") >> response
+    serverGroupCalls * oortService.getServerGroupFromCluster(app, account, cluster, serverGroup, region, "aws") >> response
     List<Map> sourceResponse = [[ "tags": [ "appversion" : "myapp-1.143-h216.186605b/MYAPP-package-myapp/216" ]]]
     List<Map> targetResponse = [[ "tags": [ "appversion" : "myapp-1.144-h217.a86305d/MYAPP-package-myapp/217" ]]]
     oortCalls * oortService.getByAmiId("aws", account, region, sourceImage) >> sourceResponse
@@ -269,7 +269,7 @@ class GetCommitsTaskSpec extends Specification {
     List<Map> targetResponse = [[ "tags" : [ "appversion" : "myapp-1.144-h217.a86305d/MYAPP-package-myapp/217" ]]]
 
     task.oortService = oortService
-    1 * oortService.getServerGroup(app, account, cluster, serverGroup, region, "aws") >> response
+    1 * oortService.getServerGroupFromCluster(app, account, cluster, serverGroup, region, "aws") >> response
     1 * oortService.getByAmiId("aws", account, region, sourceImage) >> sourceResponse
     1 * oortService.getByAmiId("aws", account, region, targetImage) >> targetResponse
 
@@ -373,7 +373,7 @@ class GetCommitsTaskSpec extends Specification {
     def oortResponse = "{\"launchConfig\" : {\"imageId\" : \"${sourceImage}\"}}".stripIndent()
     Response response = new Response('http://oort', 200, 'OK', [], new TypedString(oortResponse))
     task.oortService = oortService
-    1 * oortService.getServerGroup(app, account, cluster, serverGroup, region, "aws") >> response
+    1 * oortService.getServerGroupFromCluster(app, account, cluster, serverGroup, region, "aws") >> response
     oortService.getByAmiId("aws", account, region, sourceImage) >> sourceTags
     oortService.getByAmiId("aws", account, region, targetImage) >> targetTags
 
@@ -425,7 +425,7 @@ class GetCommitsTaskSpec extends Specification {
     List<Map> sourceResponse = [[ "tags" : [ "appversion" : "myapp-1.143-h216.186605b/MYAPP-package-myapp/216" ]]]
     List<Map> targetResponse = [[ "tags" : [ "appversion" : "myapp-1.144-h217.a86305d/MYAPP-package-myapp/217" ]]]
     task.oortService = oortService
-    1 * oortService.getServerGroup(app, account, cluster, serverGroup, region, "aws") >>> response
+    1 * oortService.getServerGroupFromCluster(app, account, cluster, serverGroup, region, "aws") >>> response
 
     if(sourceThrowRetrofitError) {
       1 * oortService.getByAmiId("aws", account, region, sourceImage) >> {
@@ -494,7 +494,7 @@ class GetCommitsTaskSpec extends Specification {
     List<Map> sourceResponse = [[ "tags" : [ "appversion" : "myapp-1.143-h216.186605b/MYAPP-package-myapp/216" ]]]
     List<Map> targetResponse = [[ "tags" : [ "appversion" : "myapp-1.144-h217.a86305d/MYAPP-package-myapp/217" ]]]
     task.oortService = oortService
-    1 * oortService.getServerGroup(app, account, cluster, serverGroup, region, "aws") >> response
+    1 * oortService.getServerGroupFromCluster(app, account, cluster, serverGroup, region, "aws") >> response
     1 * oortService.getByAmiId("aws", account, region, sourceImage) >> sourceResponse
     1 * oortService.getByAmiId("aws", account, region, targetImage) >> targetResponse
 


### PR DESCRIPTION
… over cluster

Most WaitForXXX instance checks operate on a single server group
but pay a performance penalty by loading a cluster and filtering
to a specific server group client-side.

In particular, we noticed that clouddriver response times significant
degrade when fetching clusters containing dozens of server groups and
thousands of instances.

This PR is a targeted at `AbstractInstancesCheckTask`, there has been
no effort to improve other callers of `getCluster()` and
`getServerGroupFromCluster()` (future improvement).
