### PR TITLE
Deprecate use of the global context

### DIFF
--- a/orca-applications/src/test/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTaskSpec.groovy
+++ b/orca-applications/src/test/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTaskSpec.groovy
@@ -67,6 +67,6 @@ class DeleteApplicationTaskSpec extends Specification {
     def taskResult = task.execute(new Stage<>(new Pipeline(), "DeleteApplication", config))
 
     then:
-    taskResult.stageOutputs.previousState == application
+    taskResult.context.previousState == application
   }
 }

--- a/orca-applications/src/test/groovy/com/netflix/spinnaker/orca/applications/tasks/UpsertApplicationTaskSpec.groovy
+++ b/orca-applications/src/test/groovy/com/netflix/spinnaker/orca/applications/tasks/UpsertApplicationTaskSpec.groovy
@@ -102,8 +102,8 @@ class UpsertApplicationTaskSpec extends Specification {
     def result = task.execute(new Stage<>(new Pipeline(), "UpsertApplication", config))
 
     then:
-    result.stageOutputs.previousState == (initialState ?: [:])
-    result.stageOutputs.newState == application
+    result.context.previousState == (initialState ?: [:])
+    result.context.newState == application
 
     where:
     initialState      | operation

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -52,7 +52,7 @@ class MonitorBakeTask implements RetryableTask {
       if (isCanceled(newStatus.state) && previousStatus.state == BakeStatus.State.PENDING) {
         log.info("Original bake was 'canceled', re-baking (executionId: ${stage.execution.id}, previousStatus: ${previousStatus.state})")
         def rebakeResult = createBakeTask.execute(stage)
-        return new TaskResult(ExecutionStatus.RUNNING, rebakeResult.stageOutputs, rebakeResult.globalOutputs)
+        return new TaskResult(ExecutionStatus.RUNNING, rebakeResult.context, rebakeResult.outputs)
       }
 
       new TaskResult(mapStatus(newStatus), [status: newStatus])

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
@@ -92,7 +92,7 @@ class BakeStageSpec extends Specification {
     def taskResult = new BakeStage.CompleteParallelBakeTask().execute(pipelineStage)
 
     then:
-    taskResult.globalOutputs == [
+    taskResult.outputs == [
       deploymentDetails: [
         ["ami": 1], ["ami": 2], ["ami": 3]
       ]

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
@@ -57,7 +57,7 @@ class CompletedBakeTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.outputs.ami == ami
+    result.stageOutputs.ami == ami
 
     where:
     region = "us-west-1"

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
@@ -57,7 +57,7 @@ class CompletedBakeTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs.ami == ami
+    result.context.ami == ami
 
     where:
     region = "us-west-1"

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -257,7 +257,7 @@ class CreateBakeTaskSpec extends Specification {
 
     then:
     bake.packageName == 'hodor_1.1_all'
-    result.outputs.bakePackageName == 'hodor_1.1_all'
+    result.stageOutputs.bakePackageName == 'hodor_1.1_all'
 
     where:
     triggerInfo      | contextInfo
@@ -324,7 +324,7 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    with(result.outputs.status) {
+    with(result.stageOutputs.status) {
       id == runningStatus.id
       state == runningStatus.state
     }
@@ -340,7 +340,7 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.outputs.bakePackageName == bakeConfig.package
+    result.stageOutputs.bakePackageName == bakeConfig.package
   }
 
   @Unroll
@@ -359,11 +359,11 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.outputs.bakePackageName == "hodor_1.1_all"
-    result.outputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
-    result.outputs.job == jobName
-    result.outputs.buildNumber == "69"
-    !result.outputs.commitHash
+    result.stageOutputs.bakePackageName == "hodor_1.1_all"
+    result.stageOutputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
+    result.stageOutputs.job == jobName
+    result.stageOutputs.buildNumber == "69"
+    !result.stageOutputs.commitHash
 
     where:
     triggerInfo             | contextInfo             | jobName
@@ -389,11 +389,11 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.outputs.bakePackageName == "hodor_1.1_all"
-    result.outputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
-    result.outputs.job == "SPINNAKER-package-echo"
-    result.outputs.buildNumber == "69"
-    result.outputs.commitHash == "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"
+    result.stageOutputs.bakePackageName == "hodor_1.1_all"
+    result.stageOutputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
+    result.stageOutputs.job == "SPINNAKER-package-echo"
+    result.stageOutputs.buildNumber == "69"
+    result.stageOutputs.commitHash == "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"
 
     where:
     triggerInfo            | contextInfo
@@ -417,11 +417,11 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.outputs.bakePackageName == "hodor_1.1_all"
-    result.outputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
-    result.outputs.job == "SPINNAKER-package-echo"
-    result.outputs.buildNumber == "69"
-    result.outputs.commitHash == "1234567f8d02a40fa84ec9d4d0dccd263d51782d"
+    result.stageOutputs.bakePackageName == "hodor_1.1_all"
+    result.stageOutputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
+    result.stageOutputs.job == "SPINNAKER-package-echo"
+    result.stageOutputs.buildNumber == "69"
+    result.stageOutputs.commitHash == "1234567f8d02a40fa84ec9d4d0dccd263d51782d"
 
     where:
     triggerInfo                | contextInfo
@@ -445,11 +445,11 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.outputs.bakePackageName == "hodor_1.1_all"
-    result.outputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
-    result.outputs.job == "SPINNAKER-package-echo"
-    result.outputs.buildNumber == "69"
-    result.outputs.commitHash == "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"
+    result.stageOutputs.bakePackageName == "hodor_1.1_all"
+    result.stageOutputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
+    result.stageOutputs.job == "SPINNAKER-package-echo"
+    result.stageOutputs.buildNumber == "69"
+    result.stageOutputs.commitHash == "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"
 
     where:
     triggerInfo                             | contextInfo
@@ -473,11 +473,11 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.outputs.bakePackageName == "hodor_1.1_all"
-    !result.outputs.buildHost
-    !result.outputs.job
-    !result.outputs.buildNumber
-    !result.outputs.commitHash
+    result.stageOutputs.bakePackageName == "hodor_1.1_all"
+    !result.stageOutputs.buildHost
+    !result.stageOutputs.job
+    !result.stageOutputs.buildNumber
+    !result.stageOutputs.commitHash
 
     where:
     triggerInfo | contextInfo | extractBuildDetails

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -257,7 +257,7 @@ class CreateBakeTaskSpec extends Specification {
 
     then:
     bake.packageName == 'hodor_1.1_all'
-    result.stageOutputs.bakePackageName == 'hodor_1.1_all'
+    result.context.bakePackageName == 'hodor_1.1_all'
 
     where:
     triggerInfo      | contextInfo
@@ -324,7 +324,7 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    with(result.stageOutputs.status) {
+    with(result.context.status) {
       id == runningStatus.id
       state == runningStatus.state
     }
@@ -340,7 +340,7 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.bakePackageName == bakeConfig.package
+    result.context.bakePackageName == bakeConfig.package
   }
 
   @Unroll
@@ -359,11 +359,11 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.bakePackageName == "hodor_1.1_all"
-    result.stageOutputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
-    result.stageOutputs.job == jobName
-    result.stageOutputs.buildNumber == "69"
-    !result.stageOutputs.commitHash
+    result.context.bakePackageName == "hodor_1.1_all"
+    result.context.buildHost == "http://spinnaker.builds.test.netflix.net/"
+    result.context.job == jobName
+    result.context.buildNumber == "69"
+    !result.context.commitHash
 
     where:
     triggerInfo             | contextInfo             | jobName
@@ -389,11 +389,11 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.bakePackageName == "hodor_1.1_all"
-    result.stageOutputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
-    result.stageOutputs.job == "SPINNAKER-package-echo"
-    result.stageOutputs.buildNumber == "69"
-    result.stageOutputs.commitHash == "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"
+    result.context.bakePackageName == "hodor_1.1_all"
+    result.context.buildHost == "http://spinnaker.builds.test.netflix.net/"
+    result.context.job == "SPINNAKER-package-echo"
+    result.context.buildNumber == "69"
+    result.context.commitHash == "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"
 
     where:
     triggerInfo            | contextInfo
@@ -417,11 +417,11 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.bakePackageName == "hodor_1.1_all"
-    result.stageOutputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
-    result.stageOutputs.job == "SPINNAKER-package-echo"
-    result.stageOutputs.buildNumber == "69"
-    result.stageOutputs.commitHash == "1234567f8d02a40fa84ec9d4d0dccd263d51782d"
+    result.context.bakePackageName == "hodor_1.1_all"
+    result.context.buildHost == "http://spinnaker.builds.test.netflix.net/"
+    result.context.job == "SPINNAKER-package-echo"
+    result.context.buildNumber == "69"
+    result.context.commitHash == "1234567f8d02a40fa84ec9d4d0dccd263d51782d"
 
     where:
     triggerInfo                | contextInfo
@@ -445,11 +445,11 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.bakePackageName == "hodor_1.1_all"
-    result.stageOutputs.buildHost == "http://spinnaker.builds.test.netflix.net/"
-    result.stageOutputs.job == "SPINNAKER-package-echo"
-    result.stageOutputs.buildNumber == "69"
-    result.stageOutputs.commitHash == "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"
+    result.context.bakePackageName == "hodor_1.1_all"
+    result.context.buildHost == "http://spinnaker.builds.test.netflix.net/"
+    result.context.job == "SPINNAKER-package-echo"
+    result.context.buildNumber == "69"
+    result.context.commitHash == "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"
 
     where:
     triggerInfo                             | contextInfo
@@ -473,11 +473,11 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.bakePackageName == "hodor_1.1_all"
-    !result.stageOutputs.buildHost
-    !result.stageOutputs.job
-    !result.stageOutputs.buildNumber
-    !result.stageOutputs.commitHash
+    result.context.bakePackageName == "hodor_1.1_all"
+    !result.context.buildHost
+    !result.context.job
+    !result.context.buildNumber
+    !result.context.commitHash
 
     where:
     triggerInfo | contextInfo | extractBuildDetails
@@ -617,8 +617,8 @@ class CreateBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.status == status
-    result.stageOutputs.previouslyBaked == previouslyBaked
+    result.context.status == status
+    result.context.previouslyBaked == previouslyBaked
 
     where:
     status          | previouslyBaked

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTaskSpec.groovy
@@ -106,7 +106,7 @@ class MonitorBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    with(result.outputs.status) {
+    with(result.stageOutputs.status) {
       id == previousStatus.id
       state == BakeStatus.State.COMPLETED
     }

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTaskSpec.groovy
@@ -85,8 +85,8 @@ class MonitorBakeTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.RUNNING
-    (result.stageOutputs as Map) == [stage: 1]
-    (result.globalOutputs as Map) == [global: 2]
+    (result.context as Map) == [stage: 1]
+    (result.outputs as Map) == [global: 2]
 
     where:
     state << [BakeStatus.State.CANCELED, BakeStatus.State.CANCELLED]
@@ -106,7 +106,7 @@ class MonitorBakeTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    with(result.stageOutputs.status) {
+    with(result.context.status) {
       id == previousStatus.id
       state == BakeStatus.State.COMPLETED
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
@@ -53,7 +53,7 @@ class WaitForClusterDisableTask extends AbstractWaitForClusterWideClouddriverTas
     def duration = System.currentTimeMillis() - stage.startTime
     if (taskResult.status == ExecutionStatus.SUCCEEDED && duration < MINIMUM_WAIT_TIME_MS) {
       // wait at least MINIMUM_WAIT_TIME to account for any necessary connection draining to occur
-      return new TaskResult(ExecutionStatus.RUNNING, taskResult.stageOutputs, taskResult.globalOutputs)
+      return new TaskResult(ExecutionStatus.RUNNING, taskResult.context, taskResult.outputs)
     }
 
     return taskResult

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
@@ -188,7 +188,7 @@ abstract class AbstractInstancesCheckTask extends AbstractCloudProviderAwareTask
     serverGroups.each { String region, List<String> serverGroupNames ->
       serverGroupNames.each {
         if (!oortHelper.getTargetServerGroup(account, it, region, getCloudProvider(stage)).isPresent()) {
-          log.error("Server group '${region}:${it}' does not exist (forceCacheRefreshResult: ${forceCacheRefreshResult.stageOutputs}")
+          log.error("Server group '${region}:${it}' does not exist (forceCacheRefreshResult: ${forceCacheRefreshResult.context}")
           throw new MissingServerGroupException("Server group '${region}:${it}' does not exist")
         }
       }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTaskSpec.groovy
@@ -55,7 +55,7 @@ class DetermineHealthProvidersTaskSpec extends Specification {
 
     then:
     taskResult.status == ExecutionStatus.SUCCEEDED
-    (taskResult.getStageOutputs() as Map) == expectedStageOutputs
+    (taskResult.getContext() as Map) == expectedStageOutputs
 
     where:
     stageContext                                  | application            || expectedStageOutputs

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MigratePipelineClustersTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MigratePipelineClustersTaskSpec.groovy
@@ -49,7 +49,7 @@ class MigratePipelineClustersTaskSpec extends Specification {
     then:
     1 * front50Service.getPipelines('theapp') >> [[id: 'def']]
     result.status == ExecutionStatus.TERMINAL
-    result.stageOutputs.exception == "Could not find pipeline with ID abc"
+    result.context.exception == "Could not find pipeline with ID abc"
   }
 
   void 'extracts clusters, sends them to clouddriver, and puts pipeline into context for later retrieval'() {
@@ -78,7 +78,7 @@ class MigratePipelineClustersTaskSpec extends Specification {
       it[0].migrateClusterConfigurations.sources.cluster.id == [1,2,3,4]
       it[0].migrateClusterConfigurations.regionMapping == ['us-east-1': 'us-west-1']
     }) >> rx.Observable.from([new TaskId(id: "1")])
-    result.stageOutputs['source.pipeline'] == pipeline
+    result.context['source.pipeline'] == pipeline
   }
 
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTaskSpec.groovy
@@ -16,9 +16,11 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks
 
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.model.Task
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
@@ -31,10 +33,6 @@ import rx.Observable
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
-
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneId
 
 class MonitorKatoTaskSpec extends Specification {
 
@@ -105,8 +103,8 @@ class MonitorKatoTaskSpec extends Specification {
 
     then:
     result.status
-    result.stageOutputs.isEmpty()
-    result.globalOutputs.isEmpty()
+    result.context.isEmpty()
+    result.outputs.isEmpty()
 
     where:
     context                     | _
@@ -137,7 +135,7 @@ class MonitorKatoTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs['kato.task.notFoundRetryCount'] == 1
+    result.context['kato.task.notFoundRetryCount'] == 1
 
     where:
     taskId = "katoTaskId"

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTaskSpec.groovy
@@ -52,7 +52,7 @@ class AbstractWaitForClusterWideClouddriverTaskSpec extends Specification {
     1 * oortHelper.getCluster(application, credentials, cluster, cloudProvider) >> Optional.of([serverGroups: serverGroups])
 
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs.remainingDeployServerGroups == expected
+    result.context.remainingDeployServerGroups == expected
 
     where:
     serverGroups = [sg('s1', 'r1'), sg('s2', 'r1'), sg('s3', 'r2'), sg('s4', 'r2')]
@@ -95,7 +95,7 @@ class AbstractWaitForClusterWideClouddriverTaskSpec extends Specification {
     1 * oortHelper.getCluster(application, credentials, cluster, cloudProvider) >> Optional.of([serverGroups: [sg('c1')]])
 
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs.remainingDeployServerGroups == [dsg('c1')]
+    result.context.remainingDeployServerGroups == [dsg('c1')]
   }
 
   def 'finishes when last serverGroups disappear'() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
@@ -63,8 +63,12 @@ class FindImageFromClusterTaskSpec extends Specification {
           "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse1
       1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location2.value,
           "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse2
-      assertNorth result.globalOutputs?.deploymentDetails?.find { it.region == "north" } as Map
-      assertSouth result.globalOutputs?.deploymentDetails?.find { it.region == "south" } as Map
+    assertNorth result.outputs?.deploymentDetails?.find {
+      it.region == "north"
+    } as Map
+    assertSouth result.outputs?.deploymentDetails?.find {
+      it.region == "south"
+    } as Map
 
     where:
       location1 = new Location(type: Location.Type.REGION, value: "north")
@@ -195,8 +199,12 @@ class FindImageFromClusterTaskSpec extends Specification {
       throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), null, Map)
     }
     1 * oortService.findImage("cloudProvider", "ami-012-name-ebs*", "test", null, null) >> imageSearchResult
-    assertNorth(result.globalOutputs?.deploymentDetails?.find { it.region == "north" } as Map, [imageName: "ami-012-name-ebs"])
-    assertSouth(result.globalOutputs?.deploymentDetails?.find { it.region == "south" } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
+    assertNorth(result.outputs?.deploymentDetails?.find {
+      it.region == "north"
+    } as Map, [imageName: "ami-012-name-ebs"])
+    assertSouth(result.outputs?.deploymentDetails?.find {
+      it.region == "south"
+    } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
 
     where:
     location1 = new Location(type: Location.Type.REGION, value: "north")
@@ -254,8 +262,12 @@ class FindImageFromClusterTaskSpec extends Specification {
       throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), null, Map)
     }
     1 * oortService.findImage("cloudProvider", "ami-012-name-ebs*", "test", null, null) >> imageSearchResult
-    assertNorth(result.globalOutputs?.deploymentDetails?.find { it.region == "north" } as Map, [imageName: "ami-012-name-ebs"])
-    assertSouth(result.globalOutputs?.deploymentDetails?.find { it.region == "south" } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
+    assertNorth(result.outputs?.deploymentDetails?.find {
+      it.region == "north"
+    } as Map, [imageName: "ami-012-name-ebs"])
+    assertSouth(result.outputs?.deploymentDetails?.find {
+      it.region == "south"
+    } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
 
     where:
     location1 = new Location(type: Location.Type.REGION, value: "north")
@@ -314,8 +326,12 @@ class FindImageFromClusterTaskSpec extends Specification {
     }
     1 * oortService.findImage("aws", "ami-012-name-ebs*", "test", null, null) >> null
     1 * oortService.findImage("aws", "ami-012-name-ebs*", "bakery", null, null) >> imageSearchResult
-    assertNorth(result.globalOutputs?.deploymentDetails?.find { it.region == "north" } as Map, [imageName: "ami-012-name-ebs"])
-    assertSouth(result.globalOutputs?.deploymentDetails?.find { it.region == "south" } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
+    assertNorth(result.outputs?.deploymentDetails?.find {
+      it.region == "north"
+    } as Map, [imageName: "ami-012-name-ebs"])
+    assertSouth(result.outputs?.deploymentDetails?.find {
+      it.region == "south"
+    } as Map, [sourceServerGroup: "foo-test", imageName: "ami-012-name-ebs1", foo: "bar"])
 
     where:
     location1 = new Location(type: Location.Type.REGION, value: "north")

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTaskSpec.groovy
@@ -132,7 +132,7 @@ class AbstractInstancesCheckTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.zeroDesiredCapacityCount == expected
+    result.context.zeroDesiredCapacityCount == expected
     1 * task.oortService.getServerGroup("front50", "test", "us-west-1", "front50-v000") >> constructResponse(200, '''
 {
     "name": "front50-v000",
@@ -178,7 +178,7 @@ class AbstractInstancesCheckTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.zeroDesiredCapacityCount == 1
+    result.context.zeroDesiredCapacityCount == 1
     1 * task.oortService.getServerGroup("front50", "test", "us-west-1", "front50-v000") >> constructResponse(200, '''
 {
     "name": "front50-v000",

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/CaptureInstanceUptimeTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/CaptureInstanceUptimeTaskSpec.groovy
@@ -34,7 +34,7 @@ class CaptureInstanceUptimeTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    (result.stageOutputs as Map) == [instanceUptimes: [:]]
+    (result.context as Map) == [instanceUptimes: [:]]
   }
 
   def "should capture instance uptime for every instanceId"() {
@@ -55,7 +55,7 @@ class CaptureInstanceUptimeTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    (result.stageOutputs as Map) == [instanceUptimes: ["1": 1, "2": 2]]
+    (result.context as Map) == [instanceUptimes: ["1": 1, "2": 2]]
 
     1 * task.instanceUptimeCommand.uptime("aws", [instanceId: "1"]) >> {
       return new InstanceUptimeCommand.InstanceUptimeResult(1)

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/DeregisterInstancesFromLoadBalancerTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/DeregisterInstancesFromLoadBalancerTaskSpec.groovy
@@ -76,7 +76,7 @@ class DeregisterInstancesFromLoadBalancerTaskSpec extends Specification {
 
     then:
       result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
-    result.stageOutputs.interestingHealthProviderNames == ["LoadBalancer", "TargetGroup"]
+    result.context."kato.last.task.id" == taskId
+    result.context.interestingHealthProviderNames == ["LoadBalancer", "TargetGroup"]
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/DeregisterInstancesFromLoadBalancerTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/DeregisterInstancesFromLoadBalancerTaskSpec.groovy
@@ -76,7 +76,7 @@ class DeregisterInstancesFromLoadBalancerTaskSpec extends Specification {
 
     then:
       result.status == ExecutionStatus.SUCCEEDED
-      result.outputs."kato.last.task.id" == taskId
-      result.outputs.interestingHealthProviderNames == ["LoadBalancer", "TargetGroup"]
+    result.stageOutputs."kato.last.task.id" == taskId
+    result.stageOutputs.interestingHealthProviderNames == ["LoadBalancer", "TargetGroup"]
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/RegisterInstancesWithLoadBalancerTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/RegisterInstancesWithLoadBalancerTaskSpec.groovy
@@ -76,7 +76,7 @@ class RegisterInstancesWithLoadBalancerTaskSpec extends Specification {
 
     then:
       result.status == ExecutionStatus.SUCCEEDED
-      result.outputs."kato.last.task.id" == taskId
-      result.outputs.interestingHealthProviderNames == ["LoadBalancer", "TargetGroup"]
+    result.stageOutputs."kato.last.task.id" == taskId
+    result.stageOutputs.interestingHealthProviderNames == ["LoadBalancer", "TargetGroup"]
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/RegisterInstancesWithLoadBalancerTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/RegisterInstancesWithLoadBalancerTaskSpec.groovy
@@ -76,7 +76,7 @@ class RegisterInstancesWithLoadBalancerTaskSpec extends Specification {
 
     then:
       result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
-    result.stageOutputs.interestingHealthProviderNames == ["LoadBalancer", "TargetGroup"]
+    result.context."kato.last.task.id" == taskId
+    result.context.interestingHealthProviderNames == ["LoadBalancer", "TargetGroup"]
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerTaskSpec.groovy
@@ -75,7 +75,7 @@ class DeleteLoadBalancerTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
-    result.stageOutputs."delete.account.name" == deleteLoadBalancerConfig.credentials
+    result.context."kato.last.task.id" == taskId
+    result.context."delete.account.name" == deleteLoadBalancerConfig.credentials
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerTaskSpec.groovy
@@ -75,7 +75,7 @@ class DeleteLoadBalancerTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.outputs."kato.last.task.id" == taskId
-    result.outputs."delete.account.name" == deleteLoadBalancerConfig.credentials
+    result.stageOutputs."kato.last.task.id" == taskId
+    result.stageOutputs."delete.account.name" == deleteLoadBalancerConfig.credentials
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerResultObjectExtrapolationTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerResultObjectExtrapolationTaskSpec.groovy
@@ -53,7 +53,7 @@ class UpsertLoadBalancerResultObjectExtrapolationTaskSpec extends Specification 
     def result = task.execute(stage)
 
     then:
-    result.outputs.dnsName == dnsName
+    result.stageOutputs.dnsName == dnsName
   }
 
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerResultObjectExtrapolationTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerResultObjectExtrapolationTaskSpec.groovy
@@ -53,7 +53,7 @@ class UpsertLoadBalancerResultObjectExtrapolationTaskSpec extends Specification 
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.dnsName == dnsName
+    result.context.dnsName == dnsName
   }
 
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/scalingprocess/AbstractAwsScalingProcessTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/scalingprocess/AbstractAwsScalingProcessTaskSpec.groovy
@@ -48,8 +48,8 @@ class AbstractAwsScalingProcessTaskSpec extends Specification {
 
     when:
       def result = task.execute(stage)
-      def outputs = result.stageOutputs
-      def globalOutputs = result.globalOutputs
+    def outputs = result.context
+    def globalOutputs = result.outputs
 
     then:
       outputs.processes == expectedScalingProcesses

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupTaskSpec.groovy
@@ -95,7 +95,7 @@ class DeleteSecurityGroupTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.outputs."kato.last.task.id" == taskId
-    result.outputs."delete.account.name" == config.credentials
+    result.stageOutputs."kato.last.task.id" == taskId
+    result.stageOutputs."delete.account.name" == config.credentials
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupTaskSpec.groovy
@@ -95,7 +95,7 @@ class DeleteSecurityGroupTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
-    result.stageOutputs."delete.account.name" == config.credentials
+    result.context."kato.last.task.id" == taskId
+    result.context."delete.account.name" == config.credentials
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/UpsertSecurityGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/UpsertSecurityGroupTaskSpec.groovy
@@ -61,7 +61,7 @@ class UpsertSecurityGroupTaskSpec extends Specification {
     then:
       1 * katoService.requestOperations(cloudProvider, ops) >> { Observable.from(taskId) }
       result
-      result.stageOutputs == outputs
+    result.context == outputs
 
     where:
       cloudProvider | ops              || outputs

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTaskSpec.groovy
@@ -85,8 +85,8 @@ class AbstractServerGroupTaskSpec extends Specification {
 
     then:
       result.status == ExecutionStatus.SUCCEEDED
-      result.stageOutputs."kato.last.task.id" == taskId
-      result.stageOutputs."deploy.account.name" == stageContext.credentials
+    result.context."kato.last.task.id" == taskId
+    result.context."deploy.account.name" == stageContext.credentials
   }
 
   void "should get target dynamically when configured"() {
@@ -104,9 +104,9 @@ class AbstractServerGroupTaskSpec extends Specification {
       1 * TargetServerGroupResolver.fromPreviousStage(stage) >> new TargetServerGroup(
         name: "foo-v001", region: "us-east-1"
       )
-      result.stageOutputs.asgName == "foo-v001"
-      result.stageOutputs.serverGroupName == "foo-v001"
-      result.stageOutputs."deploy.server.groups" == ["us-east-1": ["foo-v001"]]
+    result.context.asgName == "foo-v001"
+    result.context.serverGroupName == "foo-v001"
+    result.context."deploy.server.groups" == ["us-east-1": ["foo-v001"]]
   }
 
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CaptureParentInterestingHealthProviderNamesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CaptureParentInterestingHealthProviderNamesTaskSpec.groovy
@@ -43,7 +43,7 @@ class CaptureParentInterestingHealthProviderNamesTaskSpec extends Specification 
 
     then:
     taskResult.status == ExecutionStatus.SUCCEEDED
-    (taskResult.getStageOutputs() as Map) == expectedStageOutputs
+    (taskResult.getContext() as Map) == expectedStageOutputs
 
     where:
     context                                       || expectedStageOutputs

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CaptureSourceServerGroupCapacityTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CaptureSourceServerGroupCapacityTaskSpec.groovy
@@ -42,8 +42,8 @@ class CaptureSourceServerGroupCapacityTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.globalOutputs.isEmpty()
-    result.stageOutputs.isEmpty()
+    result.outputs.isEmpty()
+    result.context.isEmpty()
     stage.context == stageContext
 
     where:
@@ -90,19 +90,19 @@ class CaptureSourceServerGroupCapacityTaskSpec extends Specification {
       stage.context.cloudProvider as String
     ) >> Optional.of(targetServerGroup)
 
-    result.stageOutputs.useSourceCapacity == false
-    result.stageOutputs.source.useSourceCapacity == false
-    result.stageOutputs.capacity == [
+    result.context.useSourceCapacity == false
+    result.context.source.useSourceCapacity == false
+    result.context.capacity == [
       min    : 5,
       desired: 5,
       max    : 10
     ]
-    result.stageOutputs.sourceServerGroupCapacitySnapshot == [
+    result.context.sourceServerGroupCapacitySnapshot == [
       min    : 0,
       desired: 5,
       max    : 10
 
     ]
-    result.globalOutputs.isEmpty()
+    result.outputs.isEmpty()
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
@@ -71,7 +71,7 @@ class CreateServerGroupTaskSpec extends Specification {
     then:
       1 * katoService.requestOperations(cloudProvider, ops) >> { Observable.from(taskId) }
       result
-      result.stageOutputs == outputs
+    result.context == outputs
 
     where:
       cloudProvider | ops              || outputs
@@ -116,7 +116,7 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    result?.context == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
@@ -167,7 +167,7 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    result?.context == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
@@ -236,7 +236,7 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    result?.context == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
@@ -287,7 +287,7 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    result?.context == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
@@ -346,7 +346,7 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    result?.context == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
@@ -400,7 +400,7 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    result?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    result?.context == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
@@ -485,7 +485,7 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    resultA?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    resultA?.context == baseOutput + ["kato.result.expected": katoResultExpected]
 
     when:
     def resultB = deployTaskB.execute(deployStageB)
@@ -497,7 +497,7 @@ class CreateServerGroupTaskSpec extends Specification {
     }) >> { Observable.from(taskId) }
     // This helps avoid an NPE within CreateServerGroupTask; this results in better error-reporting on a test failure.
     _ * katoService.requestOperations(operationCloudProvider, _) >> { Observable.from(taskId) }
-    resultB?.stageOutputs == baseOutput + ["kato.result.expected": katoResultExpected]
+    resultB?.context == baseOutput + ["kato.result.expected": katoResultExpected]
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageIdBranchA | expectedImageIdBranchB

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTaskSpec.groovy
@@ -79,8 +79,8 @@ class DestroyServerGroupTaskSpec extends Specification {
 
     then:
       result.status == ExecutionStatus.SUCCEEDED
-      result.stageOutputs."kato.last.task.id" == taskId
-      result.stageOutputs."deploy.account.name" == destroyASGConfig.credentials
+    result.context."kato.last.task.id" == taskId
+    result.context."deploy.account.name" == destroyASGConfig.credentials
   }
 
   void "should get target dynamically when configured"() {
@@ -98,8 +98,8 @@ class DestroyServerGroupTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-      result.stageOutputs.asgName == "foo-v001"
-      result.stageOutputs."deploy.server.groups" == ["us-west-1": ["foo-v001"]]
+    result.context.asgName == "foo-v001"
+    result.context."deploy.server.groups" == ["us-west-1": ["foo-v001"]]
   }
 
   def "task uses serverGroupName if present"() {
@@ -120,9 +120,9 @@ class DestroyServerGroupTaskSpec extends Specification {
 
     then:
       result.status == ExecutionStatus.SUCCEEDED
-      result.stageOutputs."kato.last.task.id" == taskId
-      result.stageOutputs."deploy.account.name" == 'test'
-      result.stageOutputs."asgName" == 'test-server-group'
-      result.stageOutputs."serverGroupName" == 'test-server-group'
+    result.context."kato.last.task.id" == taskId
+    result.context."deploy.account.name" == 'test'
+    result.context."asgName" == 'test-server-group'
+    result.context."serverGroupName" == 'test-server-group'
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
@@ -106,7 +106,7 @@ class ServerGroupCacheForceRefreshTaskSpec extends Specification {
     optionalTaskResult.present == !forceCacheUpdatedServerGroups.isEmpty()
     forceCacheUpdatedServerGroups.every {
       optionalTaskResult.get().status == executionStatus
-      (optionalTaskResult.get().stageOutputs."refreshed.server.groups" as Set<Map>)*.serverGroupName == expectedRefreshedServerGroups
+      (optionalTaskResult.get().context."refreshed.server.groups" as Set<Map>)*.serverGroupName == expectedRefreshedServerGroups
     }
     stageData.refreshedServerGroups*.serverGroupName == expectedRefreshedServerGroups
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/UpdateLaunchConfigTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/UpdateLaunchConfigTaskSpec.groovy
@@ -45,7 +45,7 @@ class UpdateLaunchConfigTaskSpec extends Specification {
 
     then:
       1 * katoService.requestOperations("aws", _) >> rx.Observable.just(new TaskId("blerg"))
-      result.stageOutputs."deploy.server.groups" == [(region): [asgName]]
+    result.context."deploy.server.groups" == [(region): [asgName]]
 
     where:
       region = "us-east-1"

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/UpsertServerGroupTagsTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/UpsertServerGroupTagsTaskSpec.groovy
@@ -78,9 +78,9 @@ class UpsertServerGroupTagsTaskSpec extends Specification {
 
     then:
       result.status == ExecutionStatus.SUCCEEDED
-      result.outputs."kato.last.task.id" == taskId
-      result.outputs."deploy.account.name" == upsertServerGroupTagsConfig.credentials
-      result.outputs."deploy.server.groups" == [
+    result.stageOutputs."kato.last.task.id" == taskId
+    result.stageOutputs."deploy.account.name" == upsertServerGroupTagsConfig.credentials
+    result.stageOutputs."deploy.server.groups" == [
           (upsertServerGroupTagsConfig.regions[0]): [upsertServerGroupTagsConfig.serverGroupName]
       ]
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/UpsertServerGroupTagsTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/UpsertServerGroupTagsTaskSpec.groovy
@@ -78,9 +78,9 @@ class UpsertServerGroupTagsTaskSpec extends Specification {
 
     then:
       result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
-    result.stageOutputs."deploy.account.name" == upsertServerGroupTagsConfig.credentials
-    result.stageOutputs."deploy.server.groups" == [
+    result.context."kato.last.task.id" == taskId
+    result.context."deploy.account.name" == upsertServerGroupTagsConfig.credentials
+    result.context."deploy.server.groups" == [
           (upsertServerGroupTagsConfig.regions[0]): [upsertServerGroupTagsConfig.serverGroupName]
       ]
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTaskSpec.groovy
@@ -45,11 +45,11 @@ class DetermineSourceServerGroupTaskSpec extends Specification {
     1 * resolver.getSource(_) >> new StageData.Source(account: account, region: region, asgName: asgName, serverGroupName: asgName)
 
     and:
-    result.stageOutputs.source.account == account
-    result.stageOutputs.source.region == region
-    result.stageOutputs.source.asgName == asgName
-    result.stageOutputs.source.serverGroupName == asgName
-    result.stageOutputs.source.useSourceCapacity == null
+    result.context.source.account == account
+    result.context.source.region == region
+    result.context.source.asgName == asgName
+    result.context.source.serverGroupName == asgName
+    result.context.source.useSourceCapacity == null
 
     where:
     account = 'test'
@@ -70,7 +70,7 @@ class DetermineSourceServerGroupTaskSpec extends Specification {
     1 * resolver.getSource(stage) >> new StageData.Source(account: account, region: region, asgName: "$application-v001", useSourceCapacity: sourceUseSourceCapacity)
 
     and:
-    result.stageOutputs.source.useSourceCapacity == expectedUseSourceCapacity
+    result.context.source.useSourceCapacity == expectedUseSourceCapacity
 
     where:
     account = 'test'
@@ -151,9 +151,9 @@ class DetermineSourceServerGroupTaskSpec extends Specification {
     1 * resolver.getSource(_) >> { throw expected }
 
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs.lastException.contains(expected.message)
-    result.stageOutputs.attempt == 2
-    result.stageOutputs.consecutiveNotFound == 0
+    result.context.lastException.contains(expected.message)
+    result.context.attempt == 2
+    result.context.consecutiveNotFound == 0
   }
 
   void 'should reset consecutiveNotFound on non 404 exception'() {
@@ -174,9 +174,9 @@ class DetermineSourceServerGroupTaskSpec extends Specification {
     1 * resolver.getSource(_) >> { throw expected }
 
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs.lastException.contains(expected.message)
-    result.stageOutputs.attempt == 2
-    result.stageOutputs.consecutiveNotFound == 0
+    result.context.lastException.contains(expected.message)
+    result.context.attempt == 2
+    result.context.consecutiveNotFound == 0
   }
 
   void 'should fail after MAX_ATTEMPTS'() {
@@ -244,6 +244,6 @@ class DetermineSourceServerGroupTaskSpec extends Specification {
     1 * resolver.getSource(_) >> null
 
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs.lastException.contains("Cluster is configured to copy capacity from the current server group")
+    result.context.lastException.contains("Cluster is configured to copy capacity from the current server group")
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/CopyAmazonLoadBalancerTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/CopyAmazonLoadBalancerTaskSpec.groovy
@@ -87,9 +87,9 @@ class CopyAmazonLoadBalancerTaskSpec extends Specification {
     ]))
 
     then:
-    result.stageOutputs."notification.type" == "upsertamazonloadbalancer"
-    result.stageOutputs."kato.last.task.id" == taskId
-    (result.stageOutputs.targets as List<Map>) == targets.collect {
+    result.context."notification.type" == "upsertamazonloadbalancer"
+    result.context."kato.last.task.id" == taskId
+    (result.context.targets as List<Map>) == targets.collect {
       return [
         credentials      : it.credentials,
         availabilityZones: it.availabilityZones,

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateDeployTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/CreateDeployTaskSpec.groovy
@@ -244,7 +244,7 @@ class CreateDeployTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
+    result.context."kato.last.task.id" == taskId
   }
 
   def "prefers the ami from an upstream stage to one from deployment details"() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/DestroyAwsServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/DestroyAwsServerGroupTaskSpec.groovy
@@ -82,8 +82,8 @@ class DestroyAwsServerGroupTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
-    result.stageOutputs."deploy.account.name" == destroyASGConfig.credentials
+    result.context."kato.last.task.id" == taskId
+    result.context."deploy.account.name" == destroyASGConfig.credentials
   }
 
   void "should pop inputs off destroyAsgDescriptions context field when present"() {
@@ -101,7 +101,7 @@ class DestroyAwsServerGroupTaskSpec extends Specification {
 
     then:
     1 == stage.context.destroyAsgDescriptions.size()
-    result.stageOutputs."deploy.account.name" == account
+    result.context."deploy.account.name" == account
 
     where:
     account = "account"
@@ -123,8 +123,8 @@ class DestroyAwsServerGroupTaskSpec extends Specification {
       asg: [name: "foo-v001"],
       region: "us-west-1"
     ]
-    result.stageOutputs.asgName == "foo-v001"
-    result.stageOutputs."deploy.server.groups" == ["us-west-1": ["foo-v001"]]
+    result.context.asgName == "foo-v001"
+    result.context."deploy.server.groups" == ["us-west-1": ["foo-v001"]]
   }
 
   def "task uses serverGroupName if present"() {
@@ -145,9 +145,9 @@ class DestroyAwsServerGroupTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
-    result.stageOutputs."deploy.account.name" == 'test'
-    result.stageOutputs."asgName" == 'test-server-group'
-    result.stageOutputs."serverGroupName" == 'test-server-group'
+    result.context."kato.last.task.id" == taskId
+    result.context."deploy.account.name" == 'test'
+    result.context."asgName" == 'test-server-group'
+    result.context."serverGroupName" == 'test-server-group'
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/DisableAsgTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/DisableAsgTaskSpec.groovy
@@ -82,8 +82,8 @@ class DisableAsgTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
-    result.stageOutputs."deploy.account.name" == disableASGConfig.credentials
+    result.context."kato.last.task.id" == taskId
+    result.context."deploy.account.name" == disableASGConfig.credentials
   }
 
   void "should get target dynamically when configured"() {
@@ -102,7 +102,7 @@ class DisableAsgTaskSpec extends Specification {
       asg: [name: "foo-v001"],
       region: "us-east-1"
     ]
-    result.stageOutputs.asgName == "foo-v001"
-    result.stageOutputs."deploy.server.groups" == ["us-west-1": ["foo-v001"], "us-east-1": ["foo-v001"]]
+    result.context.asgName == "foo-v001"
+    result.context."deploy.server.groups" == ["us-west-1": ["foo-v001"], "us-east-1": ["foo-v001"]]
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/EnableAsgTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/EnableAsgTaskSpec.groovy
@@ -87,8 +87,8 @@ class EnableAsgTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
-    result.stageOutputs."deploy.account.name" == disableASGConfig.credentials
+    result.context."kato.last.task.id" == taskId
+    result.context."deploy.account.name" == disableASGConfig.credentials
   }
 
   void "should get target dynamically when configured"() {
@@ -107,8 +107,8 @@ class EnableAsgTaskSpec extends Specification {
       asg: [name: "foo-v001"],
       region: "us-east-1"
     ]
-    result.stageOutputs.asgName == "foo-v001"
-    result.stageOutputs."deploy.server.groups" == ["us-west-1": ["foo-v001"], "us-east-1": ["foo-v001"]]
+    result.context.asgName == "foo-v001"
+    result.context."deploy.server.groups" == ["us-west-1": ["foo-v001"], "us-east-1": ["foo-v001"]]
   }
 
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTaskSpec.groovy
@@ -181,7 +181,7 @@ class JarDiffsTaskSpec extends Specification {
     TaskResult result = task.execute(stage)
 
     then:
-    result.stageOutputs.jarDiffs.downgraded.size() == 1
+    result.context.jarDiffs.downgraded.size() == 1
 
     where:
     sourceExpectedInstances = ["i-1234" : [hostName : "foo.com", healthCheckUrl : "http://foo.com:7001/healthCheck"]]
@@ -219,7 +219,7 @@ class JarDiffsTaskSpec extends Specification {
     TaskResult result = task.execute(stage)
 
     then:
-    with (result.stageOutputs.jarDiffs) {
+    with(result.context.jarDiffs) {
       downgraded == []
       duplicates == []
       removed    == []

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/ResizeAsgTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/ResizeAsgTaskSpec.groovy
@@ -86,8 +86,8 @@ class ResizeAsgTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
-    result.stageOutputs."deploy.account.name" == resizeASGConfig.credentials
+    result.context."kato.last.task.id" == taskId
+    result.context."deploy.account.name" == resizeASGConfig.credentials
   }
 
   def "gets target dynamically when configured"() {
@@ -117,9 +117,9 @@ class ResizeAsgTaskSpec extends Specification {
     1 * targetReferenceSupport.getDynamicallyBoundTargetAsgReference(stage) >> []
     1 * resizeSupport.createResizeStageDescriptors(stage, _) >> [resizeDescriptor]
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."kato.last.task.id" == taskId
-    result.stageOutputs."deploy.account.name" == "prod"
-    result.stageOutputs.capacity == calculatedCapacity
-    result.stageOutputs."deploy.server.groups" == [ "us-east-1" : ["asg-v003"]]
+    result.context."kato.last.task.id" == taskId
+    result.context."deploy.account.name" == "prod"
+    result.context.capacity == calculatedCapacity
+    result.context."deploy.server.groups" == ["us-east-1": ["asg-v003"]]
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDestroyedAsgTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDestroyedAsgTaskSpec.groovy
@@ -109,7 +109,7 @@ class WaitForDestroyedAsgTaskSpec extends Specification {
     def result = task.execute(stage)
 
     expect:
-    result.stageOutputs.remainingInstances == []
+    result.context.remainingInstances == []
   }
 
   @Unroll
@@ -136,7 +136,7 @@ class WaitForDestroyedAsgTaskSpec extends Specification {
     def result = task.execute(stage)
 
     expect:
-    result.stageOutputs.remainingInstances == remainingInstances
+    result.context.remainingInstances == remainingInstances
 
     where:
     instances                         || remainingInstances

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitTaskSpec.groovy
@@ -38,7 +38,7 @@ class WaitTaskSpec extends Specification {
 
     then:
       result.status == ExecutionStatus.RUNNING
-    stage.context.putAll(result.stageOutputs)
+    stage.context.putAll(result.context)
 
     when:
       timeProvider.millis = System.currentTimeMillis() + 10000
@@ -61,7 +61,7 @@ class WaitTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.RUNNING
-    stage.context.putAll(result.stageOutputs)
+    stage.context.putAll(result.context)
 
     when:
     timeProvider.millis = System.currentTimeMillis() + 10000

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitTaskSpec.groovy
@@ -38,7 +38,7 @@ class WaitTaskSpec extends Specification {
 
     then:
       result.status == ExecutionStatus.RUNNING
-      stage.context.putAll(result.outputs)
+    stage.context.putAll(result.stageOutputs)
 
     when:
       timeProvider.millis = System.currentTimeMillis() + 10000
@@ -61,7 +61,7 @@ class WaitTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.RUNNING
-    stage.context.putAll(result.outputs)
+    stage.context.putAll(result.stageOutputs)
 
     when:
     timeProvider.millis = System.currentTimeMillis() + 10000

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/InstanceHealthCheckTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/InstanceHealthCheckTaskSpec.groovy
@@ -121,7 +121,7 @@ class InstanceHealthCheckTaskSpec extends Specification {
     1 * task.createInstanceService(_) >> instanceService
 
     def result = task.execute(stage)
-    stage.context << result.stageOutputs
+    stage.context << result.context
     result = task.execute(stage)
 
     then:

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTaskSpec.groovy
@@ -92,10 +92,10 @@ class TriggerQuipTaskSpec extends Specification {
 
     then:
     instances.size() * instanceService.patchInstance(app, "1.2", "") >>> response
-    result.stageOutputs.taskIds == dnsTaskMap
-    result.stageOutputs.instanceIds.sort() == instances.keySet().sort()
-    result.stageOutputs.skippedInstances == [:]
-    result.stageOutputs.remainingInstances == [:]
+    result.context.taskIds == dnsTaskMap
+    result.context.instanceIds.sort() == instances.keySet().sort()
+    result.context.skippedInstances == [:]
+    result.context.remainingInstances == [:]
     result.status == ExecutionStatus.SUCCEEDED
 
     where:
@@ -133,10 +133,10 @@ class TriggerQuipTaskSpec extends Specification {
     2 * instanceService.getCurrentVersion(app) >>> currentVersions
     1 * instanceService.patchInstance(app, "1.2", "") >> patchResponse
 
-    result.stageOutputs.instances == patchInstances
-    result.stageOutputs.skippedInstances == skipInstances
-    result.stageOutputs.instanceIds.sort() == ['i-1', 'i-2'].sort()
-    result.stageOutputs.remainingInstances == [:]
+    result.context.instances == patchInstances
+    result.context.skippedInstances == skipInstances
+    result.context.instanceIds.sort() == ['i-1', 'i-2'].sort()
+    result.context.remainingInstances == [:]
 
     where:
     cluster = 'foo-test'
@@ -252,7 +252,7 @@ class TriggerQuipTaskSpec extends Specification {
       throw RetrofitError.networkError('http://foo', new IOException('failed'))
     } >> mkResponse([version: patchVersion])
 
-    result.stageOutputs.skippedInstances.keySet() == ["i-1234"] as Set
+    result.context.skippedInstances.keySet() == ["i-1234"] as Set
 
     where:
     cluster = 'foo-test'

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTaskSpec.groovy
@@ -247,7 +247,7 @@ class VerifyQuipTaskSpec extends Specification {
     //1 * oortService.getCluster(app, account, cluster, 'aws') >> oortResponse
     1 * instanceService.listTasks() >> instanceResponse
     1 * instanceService.listTasks() >> {throw new RetrofitError(null, null, null, null, null, null, null)}
-    !result?.stageOutputs
+    !result?.context
     thrown(RuntimeException)
 
     where:
@@ -283,7 +283,7 @@ class VerifyQuipTaskSpec extends Specification {
     2 * task.createInstanceService(_) >> instanceService
     //1 * oortService.getCluster(app, account, cluster, 'aws') >> oortResponse
     2 * instanceService.listTasks() >> instanceResponse
-    //result.stageOutputs?.instances?.size() == 2
+    //result.context?.instances?.size() == 2
     result.status == ExecutionStatus.SUCCEEDED
 
     where:

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTaskSpec.groovy
@@ -57,8 +57,8 @@ class DetermineTerminationCandidatesTaskSpec extends Specification {
 
     then:
     1 * oortService.getServerGroupFromCluster(application, account, cluster, serverGroup, region, cloudProvider) >> oortResponse
-    response.stageOutputs.terminationInstanceIds == expectedTerminations
-    response.stageOutputs.knownInstanceIds.toSet() == knownInstanceIds.toSet()
+    response.context.terminationInstanceIds == expectedTerminations
+    response.context.knownInstanceIds.toSet() == knownInstanceIds.toSet()
 
     where:
     order    | relaunchAllInstances | totalRelaunches | instances             || expectedTerminations

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationPhaseInstancesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationPhaseInstancesTaskSpec.groovy
@@ -33,8 +33,8 @@ class DetermineTerminationPhaseInstancesTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.instanceIds == expectedInstanceIds
-    result.stageOutputs.terminationInstanceIds == expectedTerminationIds
+    result.context.instanceIds == expectedInstanceIds
+    result.context.terminationInstanceIds == expectedTerminationIds
 
     where:
     concurrentRelaunches | terminationInstanceIds | expectedInstanceIds | expectedTerminationIds

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/scalingprocess/AbstractScalingProcessTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/scalingprocess/AbstractScalingProcessTaskSpec.groovy
@@ -48,8 +48,8 @@ class AbstractScalingProcessTaskSpec extends Specification {
 
     when:
     def result = task.execute(stage)
-    def outputs = result.stageOutputs
-    def globalOutputs = result.globalOutputs
+    def outputs = result.context
+    def globalOutputs = result.outputs
 
     then:
     outputs.processes == expectedScalingProcesses

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/TaskResult.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/TaskResult.java
@@ -13,37 +13,39 @@ public final class TaskResult {
   public static final TaskResult SUCCEEDED = new TaskResult(ExecutionStatus.SUCCEEDED);
 
   private final ExecutionStatus status;
-  private final Map<String, ?> stageOutputs;
-  private final Map<String, ?> globalOutputs;
+  private final ImmutableMap<String, ?> context;
+  private final ImmutableMap<String, ?> outputs;
 
   public TaskResult(ExecutionStatus status) {
     this(status, emptyMap(), emptyMap());
   }
 
-  public TaskResult(ExecutionStatus status, Map<String, ?> stageOutputs, Map<String, ?> globalOutputs) {
+  public TaskResult(ExecutionStatus status, Map<String, ?> context, Map<String, ?> outputs) {
     this.status = status;
-    this.stageOutputs = ImmutableMap.copyOf(stageOutputs);
-    this.globalOutputs = ImmutableMap.copyOf(globalOutputs);
+    this.context = ImmutableMap.copyOf(context);
+    this.outputs = ImmutableMap.copyOf(outputs);
   }
 
-  public TaskResult(ExecutionStatus status, Map<String, ?> stageOutputs) {
-    this(status, stageOutputs, emptyMap());
-  }
-
-  @Deprecated
-  public @Nonnull Map<String, ?> getOutputs() {
-    return stageOutputs;
+  public TaskResult(ExecutionStatus status, Map<String, ?> context) {
+    this(status, context, emptyMap());
   }
 
   public @Nonnull ExecutionStatus getStatus() {
     return status;
   }
 
-  public @Nonnull Map<String, ?> getStageOutputs() {
-    return stageOutputs;
+  /**
+   * Updates to the current stage context.
+   */
+  public @Nonnull Map<String, ?> getContext() {
+    return context;
   }
 
-  public @Nonnull Map<String, ?> getGlobalOutputs() {
-    return globalOutputs;
+  /**
+   * Values to be output from the stage and potentially accessed by downstream
+   * stages.
+   */
+  public @Nonnull Map<String, ?> getOutputs() {
+    return outputs;
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AlertOnAccessMap.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AlertOnAccessMap.java
@@ -34,9 +34,9 @@ class AlertOnAccessMap<E extends Execution<E>> extends ForwardingMap<String, Obj
     this.delegate = delegate;
     counterId = registry
       .createId("global.context.access")
-      .withTag("execution", execution.id)
-      .withTag("application", execution.application)
-      .withTag("name", execution.name);
+      .withTag("execution", execution.getId())
+      .withTag("application", execution.getApplication())
+      .withTag("name", execution.getName());
   }
 
   AlertOnAccessMap(Execution<E> execution, Registry registry) {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AlertOnAccessMap.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AlertOnAccessMap.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import com.google.common.collect.ForwardingMap;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+
+class AlertOnAccessMap<E extends Execution<E>> extends ForwardingMap<String, Object> {
+
+  private final Map<String, Object> delegate;
+  private final Registry registry;
+  private final Id counterId;
+
+  AlertOnAccessMap(Execution<E> execution, Registry registry, Map<String, Object> delegate) {
+    this.registry = registry;
+    this.delegate = delegate;
+    counterId = registry
+      .createId("global.context.access")
+      .withTag("execution", execution.id)
+      .withTag("application", execution.application)
+      .withTag("name", execution.name);
+  }
+
+  AlertOnAccessMap(Execution<E> execution, Registry registry) {
+    this(execution, registry, new HashMap<>());
+  }
+
+  @Override protected Map<String, Object> delegate() { return delegate; }
+
+  @Override public Object get(@Nullable Object key) {
+    registry
+      .counter(counterId.withTag("key", String.valueOf(key)))
+      .increment();
+    return super.get(key);
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -134,11 +134,15 @@ public abstract class Execution<T extends Execution<T>> implements Serializable 
     this.keepWaitingPipelines = keepWaitingPipelines;
   }
 
-  private final Map<String, Object> context = new HashMap<>();
+  private Map<String, Object> context = new HashMap<>();
 
   @Deprecated
-  public Map<String, Object> getContext() {
+  public @Nonnull Map<String, Object> getContext() {
     return context;
+  }
+
+  public void setContext(@Nonnull Map<String, Object> context) {
+    this.context = context;
   }
 
   private List<Stage<T>> stages = new ArrayList<>();

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -222,6 +222,7 @@ public abstract class Execution<T extends Execution<T>> implements Serializable 
     this.origin = origin;
   }
 
+  @Nullable
   public Stage<T> namedStage(String type) {
     return stages
       .stream()
@@ -230,12 +231,22 @@ public abstract class Execution<T extends Execution<T>> implements Serializable 
       .orElse(null);
   }
 
+  @Nonnull
   public Stage<T> stageById(String stageId) {
     return stages
       .stream()
       .filter(it -> it.getId().equals(stageId))
       .findFirst()
-      .orElse(null);
+      .orElseThrow(() -> new IllegalArgumentException(String.format("No stage with id %s exists", stageId)));
+  }
+
+  @Nonnull
+  public Stage<T> stageByRef(String refId) {
+    return stages
+      .stream()
+      .filter(it -> it.getRefId().equals(refId))
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException(String.format("No stage with refId %s exists", refId)));
   }
 
   @Override public boolean equals(Object o) {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -136,6 +136,7 @@ public abstract class Execution<T extends Execution<T>> implements Serializable 
 
   private final Map<String, Object> context = new HashMap<>();
 
+  @Deprecated
   public Map<String, Object> getContext() {
     return context;
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Pipeline.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Pipeline.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import com.netflix.spectator.api.Registry;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -79,6 +80,10 @@ public class Pipeline extends Execution<Pipeline> {
 
   @Override public final int hashCode() {
     return super.hashCode();
+  }
+
+  public static PipelineBuilder builder(Registry registry) {
+    return new PipelineBuilder(registry);
   }
 
   public static PipelineBuilder builder() {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.pipeline.model
 
 import java.util.concurrent.atomic.AtomicInteger
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.ExecutionStatus
 import groovy.transform.CompileStatic
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.DEFAULT_EXECUTION_ENGINE
@@ -26,6 +27,12 @@ class PipelineBuilder {
 
   private final Pipeline pipeline = new Pipeline()
   private final AtomicInteger nextRefid = new AtomicInteger(1)
+
+  PipelineBuilder(Registry registry) {
+    pipeline.context = new AlertOnAccessMap<Pipeline>(pipeline, registry)
+  }
+
+  PipelineBuilder() {}
 
   PipelineBuilder withTrigger(Map<String, Object> trigger = [:]) {
     pipeline.trigger.clear()

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -153,7 +153,7 @@ public class Stage<T extends Execution<T>> implements Serializable {
   /**
    * The context driving this stage. Provides inputs necessary to component steps
    */
-  private Map<String, Object> context = new HashMap<>();
+  private Map<String, Object> context = new StageContext(this);
 
   public @Nonnull Map<String, Object> getContext() {
     return context;
@@ -306,12 +306,13 @@ public class Stage<T extends Execution<T>> implements Serializable {
         .addAll(previousStages.stream().flatMap(it -> it.ancestorsOnly().stream()).collect(toList()))
         .build();
     } else if (parentStageId != null) {
-      Stage<T> parent = execution.getStages().stream().filter(it -> it.id.equals(parentStageId)).findFirst().orElseThrow(IllegalStateException::new);
-      return ImmutableList
+      return execution.getStages().stream().filter(it -> it.id.equals(parentStageId)).findFirst()
+      .<List<Stage<T>>>map(parent -> ImmutableList
         .<Stage<T>>builder()
         .add(parent)
         .addAll(parent.ancestorsOnly())
-        .build();
+        .build())
+        .orElse(emptyList());
     } else {
       return emptyList();
     }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -164,6 +164,11 @@ public class Stage<T extends Execution<T>> implements Serializable {
   }
 
   /**
+   * Outputs from this stage which may be accessed by downstream stages.
+   */
+  private Map<String, Object> outputs = new HashMap<>();
+
+  /**
    * Returns the tasks that are associated with this stage. Tasks are the most granular unit of work in a stage.
    * Because tasks can be dynamically composed, this list is open updated during a stage's execution.
    *

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -168,6 +168,14 @@ public class Stage<T extends Execution<T>> implements Serializable {
    */
   private Map<String, Object> outputs = new HashMap<>();
 
+  public @Nonnull Map<String, Object> getOutputs() {
+    return outputs;
+  }
+
+  public void setOutputs(@Nonnull Map<String, Object> outputs) {
+    this.outputs = outputs;
+  }
+
   /**
    * Returns the tasks that are associated with this stage. Tasks are the most granular unit of work in a stage.
    * Because tasks can be dynamically composed, this list is open updated during a stage's execution.

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import com.google.common.collect.ForwardingMap;
+
+public class StageContext extends ForwardingMap<String, Object> {
+
+  private final Stage<?> stage;
+  private final Map<String, Object> delegate = new HashMap<>();
+
+  public StageContext(Stage<?> stage) {
+    this.stage = stage;
+  }
+
+  @Override protected Map<String, Object> delegate() {
+    return delegate;
+  }
+
+  @Override public Object get(@Nullable Object key) {
+    if (delegate().containsKey(key)) {
+      return super.get(key);
+    } else {
+      return stage
+        .ancestors()
+        .stream()
+        .filter(it -> it.getOutputs().containsKey(key))
+        .findFirst()
+        .map(it -> it.getOutputs().get(key))
+        .orElse(null);
+    }
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.pipeline.model;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import com.google.common.collect.ForwardingMap;
 
@@ -44,7 +45,12 @@ public class StageContext extends ForwardingMap<String, Object> {
         .filter(it -> it.getOutputs().containsKey(key))
         .findFirst()
         .map(it -> it.getOutputs().get(key))
-        .orElseGet(() -> stage.getExecution().getContext().get(key));
+        .orElseGet(() ->
+          Optional
+            .ofNullable(stage.getExecution())
+            .map(execution -> execution.getContext().get(key))
+            .orElse(null)
+        );
     }
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
@@ -44,7 +44,7 @@ public class StageContext extends ForwardingMap<String, Object> {
         .filter(it -> it.getOutputs().containsKey(key))
         .findFirst()
         .map(it -> it.getOutputs().get(key))
-        .orElse(null);
+        .orElseGet(() -> stage.getExecution().getContext().get(key));
     }
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -584,6 +584,7 @@ class JedisExecutionRepository implements ExecutionRepository {
     map["stage.${stage.id}.requisiteStageRefIds".toString()] = stage.requisiteStageRefIds?.join(",")
     map["stage.${stage.id}.scheduledTime".toString()] = stage.scheduledTime?.toString()
     map["stage.${stage.id}.context".toString()] = mapper.writeValueAsString(stage.context)
+    map["stage.${stage.id}.outputs".toString()] = mapper.writeValueAsString(stage.outputs)
     map["stage.${stage.id}.tasks".toString()] = mapper.writeValueAsString(stage.tasks)
     map["stage.${stage.id}.lastModified".toString()] = stage.lastModified ? mapper.writeValueAsString(stage.lastModified) : null
     return map
@@ -659,6 +660,7 @@ class JedisExecutionRepository implements ExecutionRepository {
         stage.requisiteStageRefIds = map["stage.${stageId}.requisiteStageRefIds".toString()]?.tokenize(",")
         stage.scheduledTime = map["stage.${stageId}.scheduledTime".toString()]?.toLong()
         stage.context = map["stage.${stageId}.context".toString()] ? mapper.readValue(map["stage.${stageId}.context".toString()], MAP_STRING_TO_OBJECT) : emptyMap()
+        stage.outputs = map["stage.${stageId}.outputs".toString()] ? mapper.readValue(map["stage.${stageId}.outputs".toString()], MAP_STRING_TO_OBJECT) : emptyMap()
         stage.tasks = map["stage.${stageId}.tasks".toString()] ? mapper.readValue(map["stage.${stageId}.tasks".toString()], LIST_OF_TASKS) : emptyList()
         if (map["stage.${stageId}.lastModified".toString()]) {
           stage.lastModified = map["stage.${stageId}.lastModified".toString()] ? mapper.readValue(map["stage.${stageId}.lastModified".toString()], MAP_STRING_TO_OBJECT) : emptyMap()

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherSpec.groovy
@@ -49,7 +49,7 @@ class PipelineLauncherSpec extends ExecutionLauncherSpec<Pipeline, PipelineLaunc
 
   @Override
   PipelineLauncher create() {
-    return new PipelineLauncher(objectMapper, executionRepository, executionRunner, Optional.of(startTracker), Optional.of(pipelineValidator))
+    return new PipelineLauncher(objectMapper, executionRepository, executionRunner, Optional.of(startTracker), Optional.of(pipelineValidator), Optional.empty())
   }
 
   def "can autowire pipeline launcher with optional dependencies"() {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContextSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContextSpec.groovy
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.model
+
+import spock.lang.Specification
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionEngine.v3
+import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_AFTER
+import static java.lang.System.currentTimeMillis
+
+class StageContextSpec extends Specification {
+
+  def pipeline = pipeline {
+  }
+  .stage {
+    refId = "1"
+    outputs.foo = "root-foo"
+    outputs.bar = "root-bar"
+    outputs.baz = "root-baz"
+    outputs.qux = "root-qux"
+  }
+  .stage {
+    refId = "2"
+    requisiteStageRefIds = ["1"]
+    outputs.foo = "ancestor-foo"
+    outputs.bar = "ancestor-bar"
+    outputs.baz = "ancestor-baz"
+  }
+  .stage {
+    refId = "3"
+    requisiteStageRefIds = ["2"]
+    outputs.foo = "parent-foo"
+    outputs.bar = "parent-bar"
+  }
+  .stage {
+    refId = "3>1"
+    parentStageId = execution.stageByRef("3").id
+    syntheticStageOwner = STAGE_AFTER
+    context.foo = "child-foo"
+  }
+  .stage {
+    refId = "4"
+    outputs.covfefe = "unrelated-covfefe"
+  }
+  .stage {
+    refId = "3>2"
+    requisiteStageRefIds = ["3>1"]
+    parentStageId = execution.stageByRef("3").id
+    syntheticStageOwner = STAGE_AFTER
+    outputs.covfefe = "downstream-covfefe"
+  }
+  .build()
+
+  def "a stage's own context takes priority"() {
+    expect:
+    pipeline.stageByRef("3>1").context.foo == "child-foo"
+  }
+
+  def "parent takes priority over ancestor"() {
+    expect:
+    pipeline.stageByRef("3>1").context.bar == "parent-bar"
+  }
+
+  def "missing keys resolve in ancestor stage context"() {
+    expect:
+    pipeline.stageByRef("3>1").context.baz == "ancestor-baz"
+  }
+
+  def "can chain back up ancestors"() {
+    expect:
+    pipeline.stageByRef("3>1").context.qux == "root-qux"
+  }
+
+  def "can't resolve keys from unrelated or downstream stages"() {
+    expect:
+    pipeline.stageByRef("3>1").context.covfefe == null
+  }
+
+  private static PipelineInit pipeline(
+    @DelegatesTo(PipelineInit) Closure init = {}) {
+    def pipeline = new Pipeline()
+    pipeline.id = UUID.randomUUID().toString()
+    pipeline.executionEngine = v3
+    pipeline.buildTime = currentTimeMillis()
+
+    def builder = new PipelineInit(pipeline)
+    init.delegate = builder
+    init()
+
+    return builder
+  }
+
+  private static class PipelineInit {
+    final @Delegate Pipeline pipeline
+
+    PipelineInit(Pipeline pipeline) {
+      this.pipeline = pipeline
+    }
+
+    PipelineInit stage(@DelegatesTo(Stage) Closure init) {
+      def stage = new Stage<Pipeline>()
+      stage.execution = pipeline
+      pipeline.stages.add(stage)
+
+      init.delegate = stage
+      init()
+
+      return this
+    }
+
+    Pipeline build() {
+      return pipeline
+    }
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContextSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContextSpec.groovy
@@ -24,6 +24,11 @@ import static java.lang.System.currentTimeMillis
 class StageContextSpec extends Specification {
 
   def pipeline = pipeline {
+    context.foo = "global-foo"
+    context.bar = "global-bar"
+    context.baz = "global-baz"
+    context.qux = "global-qux"
+    context.fnord = "global-fnord"
   }
   .stage {
     refId = "1"
@@ -89,15 +94,20 @@ class StageContextSpec extends Specification {
     pipeline.stageByRef("3>1").context.covfefe == null
   }
 
+  def "if all else fails will read from global context"() {
+    expect:
+    pipeline.stageByRef("3>1").context.fnord == "global-fnord"
+  }
+
   private static PipelineInit pipeline(
-    @DelegatesTo(PipelineInit) Closure init = {}) {
+    @DelegatesTo(Pipeline) Closure init = {}) {
     def pipeline = new Pipeline()
     pipeline.id = UUID.randomUUID().toString()
     pipeline.executionEngine = v3
     pipeline.buildTime = currentTimeMillis()
 
     def builder = new PipelineInit(pipeline)
-    init.delegate = builder
+    init.delegate = pipeline
     init()
 
     return builder

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContextSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContextSpec.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.orca.pipeline.model
 
 import spock.lang.Specification
-import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionEngine.v3
 import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_AFTER
 import static java.lang.System.currentTimeMillis
 
@@ -103,7 +102,6 @@ class StageContextSpec extends Specification {
     @DelegatesTo(Pipeline) Closure init = {}) {
     def pipeline = new Pipeline()
     pipeline.id = UUID.randomUUID().toString()
-    pipeline.executionEngine = v3
     pipeline.buildTime = currentTimeMillis()
 
     def builder = new PipelineInit(pipeline)

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/ExpressionPreconditionTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/ExpressionPreconditionTaskSpec.groovy
@@ -42,7 +42,7 @@ class ExpressionPreconditionTaskSpec extends Specification {
 
     then:
     taskResult.status == taskResultStatus
-    taskResult.stageOutputs.context == [
+    taskResult.context.context == [
       expression      : expression,
       expressionResult: expressionResult
     ]

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
@@ -35,7 +35,7 @@ class ManualJudgmentStageSpec extends Specification {
 
     then:
     result.status == expectedStatus
-    result.stageOutputs.isEmpty()
+    result.context.isEmpty()
 
     where:
     context                      || expectedStatus
@@ -61,7 +61,9 @@ class ManualJudgmentStageSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs.notifications.findAll { it.lastNotifiedByNotificationState[NotificationState.manualJudgment] }*.type == ["email", "hipchat", "sms"]
+    result.context.notifications.findAll {
+      it.lastNotifiedByNotificationState[NotificationState.manualJudgment]
+    }*.type == ["email", "hipchat", "sms"]
   }
 
   @Unroll
@@ -80,7 +82,7 @@ class ManualJudgmentStageSpec extends Specification {
 
     then:
     result.status == executionStatus
-    if (sent) result.stageOutputs.notifications?.getAt(0)?.lastNotifiedByNotificationState?.containsKey(notificationState)
+    if (sent) result.context.notifications?.getAt(0)?.lastNotifiedByNotificationState?.containsKey(notificationState)
 
     where:
     sendNotifications | notificationState                        | judgmentStatus | executionStatus           || sent

--- a/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/AssociateElasticIpTaskSpec.groovy
+++ b/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/AssociateElasticIpTaskSpec.groovy
@@ -50,8 +50,8 @@ class AssociateElasticIpTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."notification.type" == task.getNotificationType()
-    result.stageOutputs."elastic.ip.assignment" == elasticIpResult
+    result.context."notification.type" == task.getNotificationType()
+    result.context."elastic.ip.assignment" == elasticIpResult
 
     where:
     account | region      | cluster      | elasticIpType | elasticIpAddress || application || elasticIpResult

--- a/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/AssociateElasticIpTaskSpec.groovy
+++ b/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/AssociateElasticIpTaskSpec.groovy
@@ -50,8 +50,8 @@ class AssociateElasticIpTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.outputs."notification.type" == task.getNotificationType()
-    result.outputs."elastic.ip.assignment" == elasticIpResult
+    result.stageOutputs."notification.type" == task.getNotificationType()
+    result.stageOutputs."elastic.ip.assignment" == elasticIpResult
 
     where:
     account | region      | cluster      | elasticIpType | elasticIpAddress || application || elasticIpResult

--- a/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/DisassociateElasticIpTaskSpec.groovy
+++ b/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/DisassociateElasticIpTaskSpec.groovy
@@ -46,8 +46,8 @@ class DisassociateElasticIpTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.outputs."notification.type" == task.getNotificationType()
-    result.outputs."elastic.ip.assignment" == elasticIpResult
+    result.stageOutputs."notification.type" == task.getNotificationType()
+    result.stageOutputs."elastic.ip.assignment" == elasticIpResult
 
     where:
     account | region      | cluster      | elasticIpAddress || application || elasticIpResult

--- a/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/DisassociateElasticIpTaskSpec.groovy
+++ b/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/DisassociateElasticIpTaskSpec.groovy
@@ -46,8 +46,8 @@ class DisassociateElasticIpTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs."notification.type" == task.getNotificationType()
-    result.stageOutputs."elastic.ip.assignment" == elasticIpResult
+    result.context."notification.type" == task.getNotificationType()
+    result.context."elastic.ip.assignment" == elasticIpResult
 
     where:
     account | region      | cluster      | elasticIpAddress || application || elasticIpResult

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
@@ -89,7 +89,7 @@ class MonitorPipelineTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.stageOutputs.exception == [details: [errors: [
+    result.context.exception == [details: [errors: [
       "Exception in child pipeline stage (some child: a pipeline): Some error",
       "Exception in child pipeline stage (some child: pipeline): Some other error",
       "Exception in child pipeline stage (some child: deploy): task failed, no exception",

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTaskSpec.groovy
@@ -58,7 +58,7 @@ class SavePipelineTaskSpec extends Specification {
       new Response('http://front50', 200, 'OK', [], null)
     }
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs == ImmutableMap.copyOf([
+    result.context == ImmutableMap.copyOf([
       'notification.type': 'savepipeline',
       'application': 'orca',
       'pipeline.name': 'my pipeline'

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
@@ -231,20 +231,20 @@ class GetCommitsTaskSpec extends Specification {
 
   boolean assertResults(def result, def taskStatus) {
     assert result.status == taskStatus
-    assert result.outputs.commits.size == 2
-    assert result.outputs.commits[0].displayId == "abcdab"
-    assert result.outputs.commits[0].id == "abcdabcdabcdabcd"
-    assert result.outputs.commits[0].authorDisplayName == "Joe Coder"
-    assert result.outputs.commits[0].timestamp == 1432081865000
-    assert result.outputs.commits[0].commitUrl == "http://stash.com/abcdabcdabcdabcd"
-    assert result.outputs.commits[0].message == "my commit"
+    assert result.stageOutputs.commits.size == 2
+    assert result.stageOutputs.commits[0].displayId == "abcdab"
+    assert result.stageOutputs.commits[0].id == "abcdabcdabcdabcd"
+    assert result.stageOutputs.commits[0].authorDisplayName == "Joe Coder"
+    assert result.stageOutputs.commits[0].timestamp == 1432081865000
+    assert result.stageOutputs.commits[0].commitUrl == "http://stash.com/abcdabcdabcdabcd"
+    assert result.stageOutputs.commits[0].message == "my commit"
 
-    assert result.outputs.commits[1].displayId == "efghefgh"
-    assert result.outputs.commits[1].id == "efghefghefghefghefgh"
-    assert result.outputs.commits[1].authorDisplayName == "Jane Coder"
-    assert result.outputs.commits[1].timestamp == 1432081256000
-    assert result.outputs.commits[1].commitUrl == "http://stash.com/efghefghefghefghefgh"
-    assert result.outputs.commits[1].message == "bug fix"
+    assert result.stageOutputs.commits[1].displayId == "efghefgh"
+    assert result.stageOutputs.commits[1].id == "efghefghefghefghefgh"
+    assert result.stageOutputs.commits[1].authorDisplayName == "Jane Coder"
+    assert result.stageOutputs.commits[1].timestamp == 1432081256000
+    assert result.stageOutputs.commits[1].commitUrl == "http://stash.com/efghefghefghefghefgh"
+    assert result.stageOutputs.commits[1].message == "bug fix"
     return true
   }
 
@@ -450,7 +450,7 @@ class GetCommitsTaskSpec extends Specification {
 
     then:
     result.status == taskStatus
-    result.outputs.commits.size == 0
+    result.stageOutputs.commits.size == 0
 
     where:
     app = "myapp"
@@ -503,7 +503,7 @@ class GetCommitsTaskSpec extends Specification {
 
     then:
     result.status == taskStatus
-    result.outputs.commits.size == 0
+    result.stageOutputs.commits.size == 0
 
     where:
     app = "myapp"
@@ -544,7 +544,7 @@ class GetCommitsTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.outputs.commits.size == 0
+    result.stageOutputs.commits.size == 0
 
     where:
     app = "myapp"
@@ -611,8 +611,8 @@ class GetCommitsTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result?.outputs?.buildInfo?.ancestor == ancestorBuild
-    result?.outputs?.buildInfo?.target == targetBuild
+    result?.stageOutputs?.buildInfo?.ancestor == ancestorBuild
+    result?.stageOutputs?.buildInfo?.target == targetBuild
 
     where:
     app = "myapp"

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.igor.tasks
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.front50.model.Application
@@ -229,22 +230,22 @@ class GetCommitsTaskSpec extends Specification {
     return stage
   }
 
-  boolean assertResults(def result, def taskStatus) {
+  boolean assertResults(TaskResult result, ExecutionStatus taskStatus) {
     assert result.status == taskStatus
-    assert result.stageOutputs.commits.size == 2
-    assert result.stageOutputs.commits[0].displayId == "abcdab"
-    assert result.stageOutputs.commits[0].id == "abcdabcdabcdabcd"
-    assert result.stageOutputs.commits[0].authorDisplayName == "Joe Coder"
-    assert result.stageOutputs.commits[0].timestamp == 1432081865000
-    assert result.stageOutputs.commits[0].commitUrl == "http://stash.com/abcdabcdabcdabcd"
-    assert result.stageOutputs.commits[0].message == "my commit"
+    assert result.context.commits.size == 2
+    assert result.context.commits[0].displayId == "abcdab"
+    assert result.context.commits[0].id == "abcdabcdabcdabcd"
+    assert result.context.commits[0].authorDisplayName == "Joe Coder"
+    assert result.context.commits[0].timestamp == 1432081865000
+    assert result.context.commits[0].commitUrl == "http://stash.com/abcdabcdabcdabcd"
+    assert result.context.commits[0].message == "my commit"
 
-    assert result.stageOutputs.commits[1].displayId == "efghefgh"
-    assert result.stageOutputs.commits[1].id == "efghefghefghefghefgh"
-    assert result.stageOutputs.commits[1].authorDisplayName == "Jane Coder"
-    assert result.stageOutputs.commits[1].timestamp == 1432081256000
-    assert result.stageOutputs.commits[1].commitUrl == "http://stash.com/efghefghefghefghefgh"
-    assert result.stageOutputs.commits[1].message == "bug fix"
+    assert result.context.commits[1].displayId == "efghefgh"
+    assert result.context.commits[1].id == "efghefghefghefghefgh"
+    assert result.context.commits[1].authorDisplayName == "Jane Coder"
+    assert result.context.commits[1].timestamp == 1432081256000
+    assert result.context.commits[1].commitUrl == "http://stash.com/efghefghefghefghefgh"
+    assert result.context.commits[1].message == "bug fix"
     return true
   }
 
@@ -450,7 +451,7 @@ class GetCommitsTaskSpec extends Specification {
 
     then:
     result.status == taskStatus
-    result.stageOutputs.commits.size == 0
+    result.context.commits.size == 0
 
     where:
     app = "myapp"
@@ -503,7 +504,7 @@ class GetCommitsTaskSpec extends Specification {
 
     then:
     result.status == taskStatus
-    result.stageOutputs.commits.size == 0
+    result.context.commits.size == 0
 
     where:
     app = "myapp"
@@ -544,7 +545,7 @@ class GetCommitsTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs.commits.size == 0
+    result.context.commits.size == 0
 
     where:
     app = "myapp"
@@ -611,8 +612,8 @@ class GetCommitsTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result?.stageOutputs?.buildInfo?.ancestor == ancestorBuild
-    result?.stageOutputs?.buildInfo?.target == targetBuild
+    result?.context?.buildInfo?.ancestor == ancestorBuild
+    result?.context?.buildInfo?.target == targetBuild
 
     where:
     app = "myapp"

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
@@ -155,8 +155,8 @@ class MonitorJenkinsJobTaskSpec extends Specification {
     TaskResult result = task.execute(stage)
 
     then:
-    result.outputs.val1 == 'one'
-    result.outputs.val2 == 'two'
+    result.stageOutputs.val1 == 'one'
+    result.stageOutputs.val2 == 'two'
 
   }
 

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
@@ -155,8 +155,8 @@ class MonitorJenkinsJobTaskSpec extends Specification {
     TaskResult result = task.execute(stage)
 
     then:
-    result.stageOutputs.val1 == 'one'
-    result.stageOutputs.val2 == 'two'
+    result.context.val1 == 'one'
+    result.context.val2 == 'two'
 
   }
 
@@ -217,8 +217,8 @@ class MonitorJenkinsJobTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    taskResult.globalOutputs.buildInfo.artifacts*.fileName == expectedArtifacts
-    taskResult.stageOutputs.buildInfo.artifacts*.fileName == expectedArtifacts
+    taskResult.outputs.buildInfo.artifacts*.fileName == expectedArtifacts
+    taskResult.context.buildInfo.artifacts*.fileName == expectedArtifacts
 
     where:
     maxArtifacts | preferredArtifacts | expectedArtifacts

--- a/orca-kayenta/src/test/groovy/com/netflix/spinnaker/orca/kayenta/tasks/AggregateCanaryResultsTaskSpec.groovy
+++ b/orca-kayenta/src/test/groovy/com/netflix/spinnaker/orca/kayenta/tasks/AggregateCanaryResultsTaskSpec.groovy
@@ -43,7 +43,7 @@ class AggregateCanaryResultsTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    taskResult.stageOutputs.canaryScores == outputCanaryScores
+    taskResult.context.canaryScores == outputCanaryScores
     taskResult.status == overallExecutionStatus
 
     where:

--- a/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTaskSpec.groovy
+++ b/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTaskSpec.groovy
@@ -147,7 +147,7 @@ class CreatePropertiesTaskSpec extends Specification {
 
     then:
 
-    with(results.stageOutputs) {
+    with(results.context) {
       propertyIdList.size() == 1
       propertyIdList.contains(propertyId: 'propertyId')
     }
@@ -173,7 +173,7 @@ class CreatePropertiesTaskSpec extends Specification {
     }
 
     then: "deleting a fast property does not return a property ID"
-    with(results.stageOutputs) {
+    with(results.context) {
       propertyIdList.size() == 0
     }
 
@@ -242,7 +242,7 @@ class CreatePropertiesTaskSpec extends Specification {
     }
 
     then:
-    with(results.stageOutputs) {
+    with(results.context) {
       propertyIdList.size() == 2
       propertyIdList.contains(propertyId: "${properties[0].key}|${properties[0].value}".toString())
       propertyIdList.contains(propertyId: "${properties[1].key}|${properties[1].value}".toString())

--- a/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/DeletePropertiesTaskSpec.groovy
+++ b/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/DeletePropertiesTaskSpec.groovy
@@ -83,7 +83,7 @@ class DeletePropertiesTaskSpec extends Specification {
     }
 
     then:
-    with(results.stageOutputs) {
+    with(results.context) {
       deletedPropertyIdList.size() == 1
       deletedPropertyIdList.contains(propertyIdList.first())
     }

--- a/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/MonitorPropertiesTaskSpec.groovy
+++ b/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/MonitorPropertiesTaskSpec.groovy
@@ -69,9 +69,9 @@ class MonitorPropertiesTaskSpec extends Specification {
 
     then:
     result.status == SUCCEEDED
-    result.stageOutputs.persistedProperties.size() == 1
+    result.context.persistedProperties.size() == 1
 
-    with(result.stageOutputs.persistedProperties.first()) {
+    with(result.context.persistedProperties.first()) {
       propertyId == propId
       key == "foo"
       value == "bar"

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
@@ -112,7 +112,7 @@ class DeployCanaryStage extends ParallelDeployStage implements CloudProviderAwar
     Stage s = new Stage<>(new Orchestration(), "findImage", findImageCtx)
     TaskResult result = findImage.execute(s)
     try {
-      return result.stageOutputs.amiDetails
+      return result.context.amiDetails
     } catch (Exception e) {
       throw new IllegalStateException("Could not determine image for baseline deployment (account: ${findImageCtx.account}, " +
         "cluster: ${findImageCtx.cluster}, regions: ${findImageCtx.regions}, " +

--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTaskSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTaskSpec.groovy
@@ -116,8 +116,8 @@ class RegisterCanaryTaskSpec extends Specification {
     1 * mineService.getCanary("canaryId") >> {
       captured
     }
-    result.stageOutputs.canary
-    with(result.stageOutputs.canary) {
+    result.context.canary
+    with(result.context.canary) {
       canaryDeployments.size() == 1
 //      canaryDeployments[0]["@class"] == ".ClusterCanaryDeployment"
       canaryDeployments[0].canaryCluster.name == 'foo--cfieber-canary'
@@ -148,7 +148,7 @@ class RegisterCanaryTaskSpec extends Specification {
     }
     1 * mineService.getCanary("canaryId") >> canary
 
-    result.stageOutputs.stageTimeoutMs == expectedTimeoutHours * 60 * 60 * 1000
+    result.context.stageTimeoutMs == expectedTimeoutHours * 60 * 60 * 1000
 
     where:
     lifetimeHours | warmupMinutes || expectedTimeoutHours

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
@@ -80,13 +80,6 @@ fun Stage<out Execution<*>>.nextTask(task: Task) =
   }
 
 /**
- * @return the stage with the specified [refId].
- * @throws IllegalArgumentException if there is no such stage.
- */
-fun <T : Execution<T>> Execution<T>.stageByRef(refId: String) =
-  stages.find { it.refId == refId } ?: throw IllegalArgumentException("No such stage")
-
-/**
  * @return all upstream stages of this stage.
  */
 fun Stage<*>.upstreamStages(): List<Stage<*>> =

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/MessageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/MessageHandler.kt
@@ -60,15 +60,13 @@ interface MessageHandler<M : Message> : (Message) -> Unit {
 
   fun StageLevel.withStage(block: (Stage<*>) -> Unit) =
     withExecution { execution ->
-      execution
-        .stageById(stageId)
-        .let { stage ->
-          if (stage == null) {
-            queue.push(InvalidStageId(this))
-          } else {
-            block.invoke(stage)
-          }
-        }
+      try {
+        execution
+          .stageById(stageId)
+          .let(block)
+      } catch (e: IllegalArgumentException) {
+        queue.push(InvalidStageId(this))
+      }
     }
 
   fun ExecutionLevel.withExecution(block: (Execution<*>) -> Unit) =

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -207,8 +207,9 @@ open class RunTaskHandler
   }
 
   private fun Stage<*>.processTaskOutput(result: TaskResult) {
-    if (result.stageOutputs.isNotEmpty()) {
+    if (result.stageOutputs.isNotEmpty() || result.globalOutputs.isNotEmpty()) {
       getContext().putAll(result.stageOutputs)
+      getOutputs().putAll(result.globalOutputs)
       repository.storeStage(this)
     }
     if (result.globalOutputs.isNotEmpty()) {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -207,15 +207,15 @@ open class RunTaskHandler
   }
 
   private fun Stage<*>.processTaskOutput(result: TaskResult) {
-    if (result.stageOutputs.isNotEmpty() || result.globalOutputs.isNotEmpty()) {
-      getContext().putAll(result.stageOutputs)
-      getOutputs().putAll(result.globalOutputs)
+    if (result.context.isNotEmpty() || result.outputs.isNotEmpty()) {
+      getContext().putAll(result.context)
+      getOutputs().putAll(result.outputs)
       repository.storeStage(this)
     }
-    if (result.globalOutputs.isNotEmpty()) {
+    if (result.outputs.isNotEmpty()) {
       repository.storeExecutionContext(
         getExecution().getId(),
-        result.globalOutputs
+        result.outputs
       )
     }
   }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -530,7 +530,6 @@ open class QueueIntegrationTest {
           )
         )
       }
-      status = TERMINAL
     }
     repository.store(pipeline)
     repository.storeExecutionContext(pipeline.id, mapOf("foo" to false))

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -82,7 +82,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
       val message = RunTask(Pipeline::class.java, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
 
-      and("has no outputs") {
+      and("has no context updates outputs") {
         val taskResult = TaskResult(SUCCEEDED)
 
         beforeGroup {
@@ -106,13 +106,13 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           })
         }
 
-        it("does not update the stage or global contexts") {
+        it("does not update the stage or global context") {
           verify(repository, never()).storeStage(any())
           verify(repository, never()).storeExecutionContext(any(), any())
         }
       }
 
-      and("has stage level outputs") {
+      and("has context updates") {
         val stageOutputs = mapOf("foo" to "covfefe")
         val taskResult = TaskResult(SUCCEEDED, stageOutputs, emptyMap<String, Any>())
 
@@ -138,7 +138,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
         }
       }
 
-      and("has global outputs") {
+      and("has outputs") {
         val globalOutputs = mapOf("foo" to "covfefe")
         val taskResult = TaskResult(SUCCEEDED, emptyMap<String, Any>(), globalOutputs)
 
@@ -153,7 +153,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           subject.handle(message)
         }
 
-        it("update the stage outputs and global context") {
+        it("updates the stage outputs and global context") {
           verify(repository).storeStage(check {
             it.getOutputs() shouldEqual globalOutputs
           })

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.pipeline.model.Execution.PausedDetails
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.pipeline.model.Task
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
@@ -82,27 +81,84 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
         }
       }
       val message = RunTask(Pipeline::class.java, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
-      val taskResult = TaskResult(SUCCEEDED)
 
-      beforeGroup {
-        whenever(task.execute(any<Stage<*>>())) doReturn taskResult
-        whenever(repository.retrievePipeline(message.executionId)) doReturn pipeline
+      and("has no outputs") {
+        val taskResult = TaskResult(SUCCEEDED)
+
+        beforeGroup {
+          whenever(task.execute(any<Stage<*>>())) doReturn taskResult
+          whenever(repository.retrievePipeline(message.executionId)) doReturn pipeline
+        }
+
+        afterGroup(::resetMocks)
+
+        action("the handler receives a message") {
+          subject.handle(message)
+        }
+
+        it("executes the task") {
+          verify(task).execute(pipeline.stages.first())
+        }
+
+        it("completes the task") {
+          verify(queue).push(check<CompleteTask> {
+            it.status shouldEqual SUCCEEDED
+          })
+        }
+
+        it("does not update the stage or global contexts") {
+          verify(repository, never()).storeStage(any())
+          verify(repository, never()).storeExecutionContext(any(), any())
+        }
       }
 
-      afterGroup(::resetMocks)
+      and("has stage level outputs") {
+        val stageOutputs = mapOf("foo" to "covfefe")
+        val taskResult = TaskResult(SUCCEEDED, stageOutputs, emptyMap<String, Any>())
 
-      action("the handler receives a message") {
-        subject.handle(message)
+        beforeGroup {
+          whenever(task.execute(any<Stage<*>>())) doReturn taskResult
+          whenever(repository.retrievePipeline(message.executionId)) doReturn pipeline
+        }
+
+        afterGroup(::resetMocks)
+
+        action("the handler receives a message") {
+          subject.handle(message)
+        }
+
+        it("updates the stage context") {
+          verify(repository).storeStage(check {
+            stageOutputs shouldEqual it.getContext()
+          })
+        }
+
+        it("does not update stage outputs or global context") {
+          verify(repository, never()).storeExecutionContext(any(), any())
+        }
       }
 
-      it("executes the task") {
-        verify(task).execute(pipeline.stages.first())
-      }
+      and("has global outputs") {
+        val globalOutputs = mapOf("foo" to "covfefe")
+        val taskResult = TaskResult(SUCCEEDED, emptyMap<String, Any>(), globalOutputs)
 
-      it("completes the task") {
-        verify(queue).push(check<CompleteTask> {
-          it.status shouldEqual SUCCEEDED
-        })
+        beforeGroup {
+          whenever(task.execute(any<Stage<*>>())) doReturn taskResult
+          whenever(repository.retrievePipeline(message.executionId)) doReturn pipeline
+        }
+
+        afterGroup(::resetMocks)
+
+        action("the handler receives a message") {
+          subject.handle(message)
+        }
+
+        it("update the stage outputs and global context") {
+          verify(repository).storeStage(check {
+            it.getOutputs() shouldEqual globalOutputs
+          })
+          verify(repository).storeExecutionContext(pipeline.id, globalOutputs)
+        }
       }
     }
 

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
@@ -58,7 +58,7 @@ class CreateWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs as Map == [statusCode: HttpStatus.OK]
+    result.context as Map == [statusCode: HttpStatus.OK]
   }
 
   def "should default to POST if no method is specified"() {
@@ -130,7 +130,7 @@ class CreateWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.TERMINAL
-    result.stageOutputs as Map == [statusCode: HttpStatus.BAD_REQUEST, buildInfo: [error: "Oh noes, you can't do this"], error: "The request did not return a 2xx/3xx status"]
+    result.context as Map == [statusCode: HttpStatus.BAD_REQUEST, buildInfo: [error: "Oh noes, you can't do this"], error: "The request did not return a 2xx/3xx status"]
   }
 
   def "if statusUrlResolution is getMethod, should return SUCCEEDED status"() {
@@ -150,7 +150,7 @@ class CreateWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs as Map == [statusCode: HttpStatus.CREATED, buildInfo: [success: true], statusEndpoint: "https://my-service.io/api/"]
+    result.context as Map == [statusCode: HttpStatus.CREATED, buildInfo: [success: true], statusEndpoint: "https://my-service.io/api/"]
     stage.context.statusEndpoint == "https://my-service.io/api/"
   }
 
@@ -173,7 +173,7 @@ class CreateWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs as Map == [statusCode: HttpStatus.CREATED, buildInfo: [success: true], statusEndpoint: "https://my-service.io/api/status/123"]
+    result.context as Map == [statusCode: HttpStatus.CREATED, buildInfo: [success: true], statusEndpoint: "https://my-service.io/api/status/123"]
     stage.context.statusEndpoint == "https://my-service.io/api/status/123"
   }
 
@@ -197,7 +197,7 @@ class CreateWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs as Map == [statusCode: HttpStatus.CREATED, buildInfo: body, statusEndpoint: "https://my-service.io/api/status/123"]
+    result.context as Map == [statusCode: HttpStatus.CREATED, buildInfo: body, statusEndpoint: "https://my-service.io/api/status/123"]
     stage.context.statusEndpoint == "https://my-service.io/api/status/123"
   }
 
@@ -227,7 +227,7 @@ class CreateWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.TERMINAL
-    result.stageOutputs as Map == [
+    result.context as Map == [
       statusCode: HttpStatus.CREATED,
       buildInfo: body,
       error: "The status URL couldn't be resolved, but 'Wait for completion' was checked",

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTaskSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTaskSpec.groovy
@@ -90,7 +90,7 @@ class MonitorWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs == [buildInfo: [status:"RUNNING"]]
+    result.context == [buildInfo: [status: "RUNNING"]]
   }
 
   def "should find correct element using statusJsonPath parameter"() {
@@ -112,7 +112,7 @@ class MonitorWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.TERMINAL
-    result.stageOutputs == [buildInfo: [status: "TERMINAL"]]
+    result.context == [buildInfo: [status: "TERMINAL"]]
   }
 
   def "should return percentComplete if supported by endpoint"() {
@@ -135,7 +135,7 @@ class MonitorWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.RUNNING
-    result.stageOutputs == [percentComplete: 42, buildInfo: [status: 42]]
+    result.context == [percentComplete: 42, buildInfo: [status: 42]]
   }
 
   def "100 percent complete should result in SUCCEEDED status"() {
@@ -157,7 +157,7 @@ class MonitorWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.SUCCEEDED
-    result.stageOutputs == [percentComplete: 100, buildInfo: [status: 100]]
+    result.context == [percentComplete: 100, buildInfo: [status: 100]]
   }
 
   def "should return TERMINAL status if jsonPath can not be found"() {
@@ -176,7 +176,7 @@ class MonitorWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.TERMINAL
-    result.stageOutputs == [error: [reason: 'Missing property in path $[\'doesnt\']', response: [status: "SUCCESS"]]]
+    result.context == [error: [reason: 'Missing property in path $[\'doesnt\']', response: [status: "SUCCESS"]]]
   }
 
   def "should return TERMINAL status if jsonPath isn't evaluated to single value"() {
@@ -195,6 +195,6 @@ class MonitorWebhookTaskSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.TERMINAL
-    result.stageOutputs == [error: [reason: "The json path '\$.status' did not resolve to a single value", value: ["some", "complex", "list"]]]
+    result.context == [error: [reason: "The json path '\$.status' did not resolve to a single value", value: ["some", "complex", "list"]]]
   }
 }


### PR DESCRIPTION
Instead of reading from global context, the stage context tries to resolve missing values from the outputs of prior stages before falling back to the global context. We'll get an Atlas counter incremented if the global context is accessed so we can start to track down usages.