### PR TITLE
fix(webhook) Allow text/plain  content-type in webhook stage.

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.groovy
@@ -17,14 +17,16 @@
 
 package com.netflix.spinnaker.orca.webhook.config
 
-import com.netflix.spinnaker.orca.webhook.service.WebhookService
+import ch.qos.logback.classic.pattern.MessageConverter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.client.RestTemplate;
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.converter.StringHttpMessageConverter
+import org.springframework.web.client.RestTemplate
 
 @Configuration
 @ConditionalOnProperty(prefix = "webhook.stage", value = "enabled", matchIfMissing = true)
@@ -35,7 +37,17 @@ class WebhookConfiguration {
   @Bean
   @ConditionalOnMissingBean(RestTemplate)
   RestTemplate restTemplate() {
-    new RestTemplate()
+    RestTemplate restTemplate = new RestTemplate()
+    List<MessageConverter> converters = restTemplate.getMessageConverters()
+    converters.add(new ObjectStringHttpMessageConverter())
+    restTemplate.setMessageConverters(converters)
+    return restTemplate
   }
 
+  class ObjectStringHttpMessageConverter extends StringHttpMessageConverter implements HttpMessageConverter<Object> {
+    @Override
+    boolean supports(Class<?> clazz) {
+      return Object.class.equals(clazz)
+    }
+  }
 }


### PR DESCRIPTION
Within a webhook stage any response with content-type text/plain will throw an exception. Here is an example:

![Exception example](https://cl.ly/2N093x2o3a2A/[49705e49cc5ca4847fd1e5026e226725]_Image%202017-08-22%20at%203.26.00%20PM.png)

The same pipeline after this fix:

![Fixed example](https://cl.ly/0E322S0f2Q3y/[33ac4cc96cd2578dbbe286b156732313]_Image%202017-08-22%20at%203.28.13%20PM.png)