### PR TITLE
feat(pipeline_templates): Support jinja expressions in template variables

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/HttpTemplateSchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/HttpTemplateSchemeLoader.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -32,6 +34,8 @@ import java.util.stream.Stream;
 
 @Component
 public class HttpTemplateSchemeLoader implements TemplateSchemeLoader {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
   private final ObjectMapper jsonObjectMapper;
   private final ObjectMapper yamlObjectMapper;
 
@@ -56,7 +60,11 @@ public class HttpTemplateSchemeLoader implements TemplateSchemeLoader {
          BufferedReader reader = new BufferedReader(new InputStreamReader(is));
          Stream<String> stream = reader.lines()) {
       ObjectMapper objectMapper = isJson(uri) ? jsonObjectMapper : yamlObjectMapper;
-      return objectMapper.readValue(stream.collect(Collectors.joining("\n")), PipelineTemplate.class);
+
+      String template = stream.collect(Collectors.joining("\n"));
+      log.debug("Loaded Template ({}):\n{}", uri, template);
+
+      return objectMapper.readValue(template, PipelineTemplate.class);
     } catch (Exception e) {
       throw new TemplateLoaderException(e);
     }


### PR DESCRIPTION
Imagine the following managed pipeline that is triggered with:
```
shouldWait: true
   regions: us-west-2,us-east-1
```
```
---
schema: "1"
id: waitChain
variables:
- name: shouldWait
  defaultValue: "{{ trigger.parameters.shouldWait == true }}"
- name: regions
  defaultValue: "{{ trigger.parameters.regions | split(',') }}"
stages:
- id: wait1
  type: wait
  config:
    waitTime: 1
  when:
  - "{{ shouldWait == true }}"
- id: bake
  type: bake
  dependsOn: [wait1]
  config:
    ...
    regions: |
      {% for region in regions %}
      - "{{ region }}"
      {% endfor %}
  when:
  - "{{ regions | length > 0 }}"
```
