### PR TITLE
fix(clouddriver): Stop deployment from hanging when spotPrice is set

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
@@ -80,6 +80,13 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
     Map capacity = (Map) serverGroup.capacity
     Integer targetDesiredSize = capacity.desired as Integer
 
+    // Don't wait for spot instances to come up if the deployment strategy is None. All other deployment strategies rely on
+    // confirming the new serverGroup is up and working correctly, so doing this is only safe with the None strategy
+    // This should probably be moved to an AWS-specific part of the codebase
+    if (serverGroup?.launchConfig?.spotPrice != null && stage.context.strategy == '') {
+      return 0
+    }
+
     if (stage.context.capacitySnapshot) {
       Integer snapshotCapacity = ((Map) stage.context.capacitySnapshot).desiredCapacity as Integer
       // if the server group is being actively scaled down, this operation might never complete,

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
@@ -252,6 +252,34 @@ class WaitForUpInstancesTaskSpec extends Specification {
     )
   }
 
+  void 'should succeed when spotPrice is set and the deployment strategy is None, even if no instances are up'() {
+    when:
+    def serverGroup = [
+      asg: [
+        desiredCapacity: 2
+      ],
+      capacity : [
+        desired: 2
+      ],
+      launchConfig: [
+        spotPrice: 0.87
+      ]
+    ]
+    def context = [
+      capacity: [ desired: 5 ],
+      strategy: ''
+    ]
+
+    def instances = [
+    ]
+
+    then:
+    task.hasSucceeded(
+      new Stage<>(new Pipeline("orca"), "", "", context),
+      serverGroup, instances, null
+    )
+  }
+
   @Unroll
   void 'should return #result for #healthy instances when #description'() {
     when:


### PR DESCRIPTION
If spotPrice is set, there is no guarantee that the instances will come up immediately (especially if the price is too low). This is to stop the UI from hanging and say that the deployment is done when the launchConfig has been created.

Related to: https://github.com/spinnaker/deck/pull/4043 and https://github.com/spinnaker/clouddriver/pull/1833