### PR TITLE
chore(orca): Kotlin enhancements for Spring 1.5

### DIFF
--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisDeadMessageHandler.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/RedisDeadMessageHandler.kt
@@ -25,7 +25,7 @@ import redis.clients.util.Pool
 import java.time.Clock
 
 class RedisDeadMessageHandler(
-  val deadLetterQueueName: String,
+  deadLetterQueueName: String,
   private val pool: Pool<Jedis>,
   private val clock: Clock
 ) : DeadMessageHandler() {

--- a/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueIntegrationTest.kt
+++ b/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueIntegrationTest.kt
@@ -18,14 +18,14 @@ package com.netflix.spinnaker.orca.q.redis
 
 import com.netflix.spinnaker.config.RedisQueueConfiguration
 import com.netflix.spinnaker.orca.q.QueueIntegrationTest
+import com.netflix.spinnaker.orca.q.TestConfig
 import com.netflix.spinnaker.orca.q.memory.InMemoryQueue
 import com.netflix.spinnaker.orca.test.redis.EmbeddedRedisConfiguration
 import org.junit.runner.RunWith
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+import org.springframework.test.context.junit4.SpringRunner
 import redis.clients.jedis.Jedis
 import redis.clients.util.Pool
 
@@ -33,14 +33,21 @@ import redis.clients.util.Pool
  * This just runs [QueueIntegrationTest] with a [RedisQueue] instead of an
  * [InMemoryQueue].
  */
-@RunWith(SpringJUnit4ClassRunner::class)
-@ContextConfiguration(classes = arrayOf(
-  EmbeddedRedisConfiguration::class,
-  RedisQueueConfiguration::class,
-  RedisQueuePoolFixery::class
-))
+@RunWith(SpringRunner::class)
+@SpringBootTest(
+  classes = arrayOf(
+    EmbeddedRedisConfiguration::class,
+    RedisQueueConfiguration::class,
+    RedisQueuePoolFixery::class,
+    TestConfig::class
+  ),
+  properties = arrayOf(
+    "queue.retry.delay.ms=10",
+    "logging.level.root=ERROR",
+    "logging.level.org.springframework.test=ERROR",
+    "logging.level.com.netflix.spinnaker=FATAL"
+  ))
 class RedisQueueIntegrationTest : QueueIntegrationTest()
-
 
 
 @Configuration

--- a/orca-queue/orca-queue.gradle
+++ b/orca-queue/orca-queue.gradle
@@ -26,6 +26,7 @@ dependencies {
   compile "org.threeten:threeten-extra:1.0"
   compile "org.funktionale:funktionale-partials:1.1"
 
+  testCompile "org.springframework.boot:spring-boot-test:${spinnaker.version('springBoot')}"
   testCompile project(":orca-test")
 }
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/log/ExecutionLogListener.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/log/ExecutionLogListener.kt
@@ -16,13 +16,11 @@
 package com.netflix.spinnaker.orca.log
 
 import com.netflix.spinnaker.orca.events.*
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationListener
 import org.springframework.stereotype.Component
 
 @Component
-open class ExecutionLogListener
-@Autowired constructor(
+class ExecutionLogListener(
   private val executionLogRepository: ExecutionLogRepository,
   private val currentInstanceId: String
 ) : ApplicationListener<ExecutionEvent> {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueExecutionRunner.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueExecutionRunner.kt
@@ -19,10 +19,10 @@ package com.netflix.spinnaker.orca.q
 import com.netflix.spinnaker.orca.pipeline.ExecutionRunner
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.security.AuthenticatedRequest
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
-@Component open class QueueExecutionRunner @Autowired constructor(
+@Component
+class QueueExecutionRunner(
   private val queue: Queue
 ) : ExecutionRunner {
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueProcessor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueProcessor.kt
@@ -20,7 +20,6 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.discovery.DiscoveryActivated
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory.getLogger
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.util.concurrent.RejectedExecutionException
@@ -28,8 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.annotation.PostConstruct
 
 @Component
-open class QueueProcessor
-@Autowired constructor(
+class QueueProcessor(
   private val queue: Queue,
   private val queueExecutor: QueueExecutor,
   private val registry: Registry,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/ThreadPoolQueueExecutor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/ThreadPoolQueueExecutor.kt
@@ -16,14 +16,12 @@
 
 package com.netflix.spinnaker.orca.q
 
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.stereotype.Component
 
 @Component
-open class ThreadPoolQueueExecutor
-@Autowired constructor(
+class ThreadPoolQueueExecutor(
   @Qualifier("messageHandlerPool") override val executor: ThreadPoolTaskExecutor) : QueueExecutor {
   override fun hasCapacity(): Boolean = executor.threadPoolExecutor.activeCount < executor.threadPoolExecutor.maximumPoolSize
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
@@ -22,12 +22,10 @@ import com.netflix.spinnaker.orca.q.CancelExecution
 import com.netflix.spinnaker.orca.q.MessageHandler
 import com.netflix.spinnaker.orca.q.Queue
 import com.netflix.spinnaker.orca.q.ResumeStage
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-open class CancelExecutionHandler
-@Autowired constructor(
+class CancelExecutionHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository
 ) : MessageHandler<CancelExecution> {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandler.kt
@@ -22,14 +22,12 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.CancelStage
 import com.netflix.spinnaker.orca.q.MessageHandler
 import com.netflix.spinnaker.orca.q.Queue
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import java.util.concurrent.Executor
 
 @Component
-open class CancelStageHandler
-@Autowired constructor(
+class CancelStageHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   override val stageDefinitionBuilders: Collection<StageDefinitionBuilder>,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
@@ -24,15 +24,13 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.Duration
 
 @Component
-open class CompleteExecutionHandler
-@Autowired constructor(
+class CompleteExecutionHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   private val publisher: ApplicationEventPublisher,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -24,14 +24,12 @@ import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_BEFOR
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.Clock
 
 @Component
-open class CompleteStageHandler
-@Autowired constructor(
+class CompleteStageHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   private val publisher: ApplicationEventPublisher,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
@@ -21,14 +21,12 @@ import com.netflix.spinnaker.orca.events.TaskComplete
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.Clock
 
 @Component
-open class CompleteTaskHandler
-@Autowired constructor(
+class CompleteTaskHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   private val publisher: ApplicationEventPublisher,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandler.kt
@@ -23,12 +23,10 @@ import com.netflix.spinnaker.orca.q.InvalidExecutionId
 import com.netflix.spinnaker.orca.q.MessageHandler
 import com.netflix.spinnaker.orca.q.Queue
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-open class ConfigurationErrorHandler
-@Autowired constructor(
+class ConfigurationErrorHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository
 ) : MessageHandler<ConfigurationError> {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandler.kt
@@ -23,14 +23,12 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.time.Duration
 
 @Component
-open class ContinueParentStageHandler
-@Autowired constructor(
+class ContinueParentStageHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   @Value("\${queue.retry.delay.ms:5000}") retryDelayMs: Long

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/PauseStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/PauseStageHandler.kt
@@ -21,12 +21,10 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.MessageHandler
 import com.netflix.spinnaker.orca.q.PauseStage
 import com.netflix.spinnaker.orca.q.Queue
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-open class PauseStageHandler
-@Autowired constructor(
+class PauseStageHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository
 ) : MessageHandler<PauseStage> {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/PauseTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/PauseTaskHandler.kt
@@ -22,12 +22,10 @@ import com.netflix.spinnaker.orca.q.MessageHandler
 import com.netflix.spinnaker.orca.q.PauseStage
 import com.netflix.spinnaker.orca.q.PauseTask
 import com.netflix.spinnaker.orca.q.Queue
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-open class PauseTaskHandler
-@Autowired constructor(
+class PauseTaskHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository
 ) : MessageHandler<PauseTask> {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
@@ -25,13 +25,11 @@ import com.netflix.spinnaker.orca.q.MessageHandler
 import com.netflix.spinnaker.orca.q.Queue
 import com.netflix.spinnaker.orca.q.RestartStage
 import com.netflix.spinnaker.orca.q.StartStage
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import java.time.Clock
 
 @Component
-open class RestartStageHandler
-@Autowired constructor(
+class RestartStageHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   override val stageDefinitionBuilders: Collection<StageDefinitionBuilder>,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeExecutionHandler.kt
@@ -22,12 +22,10 @@ import com.netflix.spinnaker.orca.q.MessageHandler
 import com.netflix.spinnaker.orca.q.Queue
 import com.netflix.spinnaker.orca.q.ResumeExecution
 import com.netflix.spinnaker.orca.q.ResumeStage
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-open class ResumeExecutionHandler
-@Autowired constructor(
+class ResumeExecutionHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository
 ) : MessageHandler<ResumeExecution> {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeStageHandler.kt
@@ -23,12 +23,10 @@ import com.netflix.spinnaker.orca.q.MessageHandler
 import com.netflix.spinnaker.orca.q.Queue
 import com.netflix.spinnaker.orca.q.ResumeStage
 import com.netflix.spinnaker.orca.q.ResumeTask
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-open class ResumeStageHandler
-@Autowired constructor(
+class ResumeStageHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository
 ) : MessageHandler<ResumeStage> {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeTaskHandler.kt
@@ -24,12 +24,10 @@ import com.netflix.spinnaker.orca.q.MessageHandler
 import com.netflix.spinnaker.orca.q.Queue
 import com.netflix.spinnaker.orca.q.ResumeTask
 import com.netflix.spinnaker.orca.q.RunTask
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-open class ResumeTaskHandler
-@Autowired constructor(
+class ResumeTaskHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository
 ) : MessageHandler<ResumeTask> {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -36,7 +36,6 @@ import com.netflix.spinnaker.orca.time.toInstant
 import org.apache.commons.lang.time.DurationFormatUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory.getLogger
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import java.time.Clock
 import java.time.Duration
@@ -46,8 +45,7 @@ import java.time.temporal.TemporalAmount
 import java.util.concurrent.TimeUnit
 
 @Component
-open class RunTaskHandler
-@Autowired constructor(
+class RunTaskHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   override val stageNavigator: StageNavigator,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandler.kt
@@ -20,13 +20,11 @@ import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
 import com.netflix.spinnaker.orca.events.ExecutionStarted
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 
 @Component
-open class StartExecutionHandler
-@Autowired constructor(
+class StartExecutionHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   private val publisher: ApplicationEventPublisher

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
@@ -31,7 +31,6 @@ import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.q.*
 import com.netflix.spinnaker.orca.q.StartStage
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
@@ -39,8 +38,7 @@ import java.time.Clock
 import java.time.Duration
 
 @Component
-open class StartStageHandler
-@Autowired constructor(
+class StartStageHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   override val stageNavigator: StageNavigator,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandler.kt
@@ -24,14 +24,12 @@ import com.netflix.spinnaker.orca.q.MessageHandler
 import com.netflix.spinnaker.orca.q.Queue
 import com.netflix.spinnaker.orca.q.RunTask
 import com.netflix.spinnaker.orca.q.StartTask
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.Clock
 
 @Component
-open class StartTaskHandler
-@Autowired constructor(
+class StartTaskHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   private val publisher: ApplicationEventPublisher,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/TaskResultMonitor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/TaskResultMonitor.kt
@@ -18,13 +18,11 @@ package com.netflix.spinnaker.orca.q.metrics
 
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.events.TaskComplete
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationListener
 import org.springframework.stereotype.Component
 
 @Component
-open class TaskResultMonitor
-@Autowired constructor(private val registry: Registry)
+class TaskResultMonitor(private val registry: Registry)
   : ApplicationListener<TaskComplete> {
 
   private val id = registry.createId("orca.task.result")

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/TrafficShapingQueue.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/trafficshaping/TrafficShapingQueue.kt
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.orca.q.Queue
 import com.netflix.spinnaker.orca.q.QueueCallback
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Component
@@ -33,10 +32,11 @@ import java.time.temporal.TemporalAmount
  * TrafficShapingQueue provides a pluggable interface for manipulating queue polling behavior.
  */
 @ConditionalOnProperty("queue.trafficShaping.enabled")
-@Primary @Component open class TrafficShapingQueue
-@Autowired constructor(
-  val queueImpl: Queue,
-  val registry: Registry,
+@Primary
+@Component
+class TrafficShapingQueue(
+  private val queueImpl: Queue,
+  private val registry: Registry,
   interceptors: Collection<TrafficShapingInterceptor>
 ) : Queue, Closeable {
 
@@ -45,14 +45,14 @@ import java.time.temporal.TemporalAmount
   override val ackTimeout = queueImpl.ackTimeout
   override val deadMessageHandler: (Queue, Message) -> Unit = queueImpl.deadMessageHandler
 
-  val pollInterceptors = interceptors.filter { it.supports(InterceptorType.POLL) }.sortedBy { it.getPriority() }
-  val messageInterceptors = interceptors.filter { it.supports(InterceptorType.MESSAGE) }.sortedBy { it.getPriority() }
+  private val pollInterceptors = interceptors.filter { it.supports(InterceptorType.POLL) }.sortedBy { it.getPriority() }
+  private val messageInterceptors = interceptors.filter { it.supports(InterceptorType.MESSAGE) }.sortedBy { it.getPriority() }
 
-  val queueInterceptionsId: Id = registry.createId("queue.trafficShaping.queueInterceptions")
-  val messageInterceptionsId: Id = registry.createId("queue.trafficShaping.messageInterceptions")
+  private val queueInterceptionsId: Id = registry.createId("queue.trafficShaping.queueInterceptions")
+  private val messageInterceptionsId: Id = registry.createId("queue.trafficShaping.messageInterceptions")
 
   init {
-    log.info("Starting with interceptors: ${interceptors.sortedBy { it.getPriority() }.map { it.getName() }.joinToString()}")
+    log.info("Starting with interceptors: ${interceptors.sortedBy { it.getPriority() }.joinToString { it.getName() }}")
   }
 
   override fun poll(callback: QueueCallback) {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -47,23 +47,24 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+import org.springframework.test.context.junit4.SpringRunner
 import java.time.Duration
 import java.time.Instant.now
 import java.time.ZoneId
 
-@RunWith(SpringJUnit4ClassRunner::class)
-@ContextConfiguration(classes = arrayOf(TestConfig::class))
-@TestPropertySource(properties = arrayOf(
-  "queue.retry.delay.ms=10"
+@SpringBootTest(classes = arrayOf(TestConfig::class), properties = arrayOf(
+  "queue.retry.delay.ms=10",
+  "logging.level.root=ERROR",
+  "logging.level.org.springframework.test=ERROR",
+  "logging.level.com.netflix.spinnaker=FATAL"
 ))
+@RunWith(SpringRunner::class)
 open class QueueIntegrationTest {
 
   @Autowired lateinit var queue: Queue

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-apply plugin: 'spring-boot'
+apply plugin: 'org.springframework.boot'
 apply plugin: 'spinnaker.package'
 
 ext {


### PR DESCRIPTION
- No longer need to use `open` and `@Autowired constructor` on most `@Component` classes.
- Trying to quiet some of the logging from the queue integration tests.