### PR TITLE
feat(pipeline_templates): Support jinja expressions in source field

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
@@ -133,7 +133,7 @@ public class PipelineTemplatePipelinePreprocessor implements PipelinePreprocesso
     }
 
     setTemplateSourceWithJinja(request);
-    List<PipelineTemplate> templates = templateLoader.load(templateConfiguration.getPipeline().getTemplate());
+    List<PipelineTemplate> templates = templateLoader.load(templateConfiguration.getPipeline().getTemplate(), getRenderContext(request));
 
     PipelineTemplate pipelineTemplate = TemplateMerge.merge(templates);
 
@@ -160,8 +160,14 @@ public class PipelineTemplatePipelinePreprocessor implements PipelinePreprocesso
   }
 
   private void setTemplateSourceWithJinja(TemplatedPipelineRequest request) {
-    RenderContext context = new DefaultRenderContext(request.getConfig().getPipeline().getApplication(), null, request.getTrigger());
-    request.getConfig().getPipeline().getTemplate().setSource(renderer.render(request.getConfig().getPipeline().getTemplate().getSource(), context ));
+    TemplateConfiguration.TemplateSource template = request.getConfig().getPipeline().getTemplate();
+    template.setSource(renderer.render(template.getSource(), getRenderContext(request)));
+  }
+
+  private DefaultRenderContext getRenderContext(TemplatedPipelineRequest request) {
+    DefaultRenderContext renderContext = new DefaultRenderContext(request.getConfig().getPipeline().getApplication(), request.getTemplate(), request.getTrigger());
+    request.getConfig().getPipeline().getVariables().forEach((key, value) -> renderContext.getVariables().putIfAbsent(key, value));
+    return renderContext;
   }
 
   private static class TemplatedPipelineRequest {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/FileTemplateSchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/FileTemplateSchemeLoader.java
@@ -46,7 +46,7 @@ public class FileTemplateSchemeLoader implements TemplateSchemeLoader {
   @Override
   public boolean supports(URI uri) {
     String scheme = uri.getScheme();
-    return scheme.equalsIgnoreCase("file") && (isJson(uri) || isYaml(uri));
+    return scheme != null && scheme.equalsIgnoreCase("file") && (isJson(uri) || isYaml(uri));
   }
 
   @Override

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateLoader.java
@@ -19,15 +19,19 @@ package com.netflix.spinnaker.orca.pipelinetemplate.loader;
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderContext;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import static java.lang.String.format;
@@ -35,36 +39,55 @@ import static java.lang.String.format;
 @Component
 public class TemplateLoader {
   private Collection<TemplateSchemeLoader> schemeLoaders;
+  private final Renderer renderer;
 
   @Autowired
-  public TemplateLoader(Collection<TemplateSchemeLoader> schemeLoaders) {
+  public TemplateLoader(Collection<TemplateSchemeLoader> schemeLoaders, Renderer renderer) {
     this.schemeLoaders = schemeLoaders;
+    this.renderer = renderer;
   }
 
   /**
    * @return a LIFO list of pipeline templates
    */
   public List<PipelineTemplate> load(TemplateConfiguration.TemplateSource template) {
+    return load(template, null);
+  }
+
+  /**
+   * @return a LIFO list of pipeline templates
+   */
+  public List<PipelineTemplate> load(TemplateConfiguration.TemplateSource template, @Nullable RenderContext renderContext) {
     List<PipelineTemplate> pipelineTemplates = new ArrayList<>();
 
-    PipelineTemplate pipelineTemplate = load(template.getSource());
+    // To support jinja expressions in the source field, we have to do some extra rendering here before loading the templates
+    PipelineTemplate pipelineTemplate = load(parseSource(template.getSource(), renderContext));
+    addNewVariablesToRenderContext(renderContext, pipelineTemplate);
     pipelineTemplates.add(0, pipelineTemplate);
 
     Set<String> seenTemplateSources = new HashSet<>();
     while (pipelineTemplate.getSource() != null) {
-      seenTemplateSources.add(pipelineTemplate.getSource());
-
-      pipelineTemplate = load(pipelineTemplate.getSource());
-      pipelineTemplates.add(0, pipelineTemplate);
-
-      if (seenTemplateSources.contains(pipelineTemplate.getSource())) {
+      String source = parseSource(pipelineTemplate.getSource(), renderContext);
+      if (seenTemplateSources.contains(source)) {
         throw new TemplateLoaderException(
-          format("Illegal cycle detected loading pipeline template '%s'", pipelineTemplate.getSource())
+          format("Illegal cycle detected loading pipeline template '%s'", source)
         );
       }
+      pipelineTemplate = load(source);
+      addNewVariablesToRenderContext(renderContext, pipelineTemplate);
+      seenTemplateSources.add(source);
+      pipelineTemplates.add(0, pipelineTemplate);
     }
 
     return pipelineTemplates;
+  }
+
+  private void addNewVariablesToRenderContext(@Nullable RenderContext renderContext, PipelineTemplate pipelineTemplate) {
+    if (pipelineTemplate.getVariables() != null && renderContext != null) {
+      pipelineTemplate.getVariables().stream()
+        .filter(Objects::nonNull)
+        .forEach(v -> renderContext.getVariables().putIfAbsent(v.getName(), v.getDefaultValue()));
+    }
   }
 
   private PipelineTemplate load(String source) {
@@ -81,5 +104,16 @@ public class TemplateLoader {
       .orElseThrow(() -> new TemplateLoaderException(format("No TemplateSchemeLoader found for '%s'", uri.getScheme())));
 
     return schemeLoader.load(uri);
+  }
+
+  private boolean sourceContainsExpression(String source) {
+    return source != null && (source.contains("{{") || source.contains("{%"));
+  }
+
+  private String parseSource(String source, @Nullable RenderContext renderContext) {
+    if (renderContext != null && sourceContainsExpression(source)) {
+      return renderer.render(source, renderContext);
+    }
+    return source;
   }
 }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateLoaderSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateLoaderSpec.groovy
@@ -16,17 +16,29 @@
 
 package com.netflix.spinnaker.orca.pipelinetemplate.loader
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.YamlRenderedValueConverter
+import org.yaml.snakeyaml.Yaml
 import spock.lang.Specification
 import spock.lang.Subject;
 
 class TemplateLoaderSpec extends Specification {
   def schemeLoader = Mock(TemplateSchemeLoader)
 
+  ObjectMapper objectMapper = new ObjectMapper()
+
+  Renderer renderer = new JinjaRenderer(
+    new YamlRenderedValueConverter(new Yaml()), objectMapper, Mock(Front50Service), []
+  )
+
   @Subject
-  def templateLoader = new TemplateLoader([schemeLoader])
+  def templateLoader = new TemplateLoader([schemeLoader], renderer)
 
   void "should return a LIFO list of pipeline templates"() {
     when:

--- a/orca-pipelinetemplate/src/test/resources/templates/jinja-child-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/jinja-child-001.yml
@@ -1,0 +1,16 @@
+schema: "1"
+id: jinjaChild
+source: '{{parent}}'
+
+variables:
+  - name: instructions
+    defaultValue: Is it done yet?
+
+stages:
+ - id: wait
+   type: wait
+   name: Wait
+   dependsOn:
+     - manualJudgment
+   config:
+     waitTime: '{{waitTime}}'

--- a/orca-pipelinetemplate/src/test/resources/templates/jinja-parent-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/jinja-parent-001.yml
@@ -1,0 +1,8 @@
+schema: "1"
+id: jinjaParent
+stages:
+ - id: manualJudgment
+   type: manualJudgment
+   name: Manual Judgement
+   config:
+     instructions: '{{instructions}}'


### PR DESCRIPTION
Add support for recursively supporting jinja expressions in the source field of DCD templates. Currently, only the top level template definition supports jinja in the source field.