### PR TITLE
feat(web) disabling front50 refresh when orca fetches pipeline

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -49,6 +49,9 @@ interface Front50Service {
   @GET("/pipelines/{applicationName}")
   List<Map<String, Object>> getPipelines(@Path("applicationName") String applicationName)
 
+  @GET("/pipelines/{applicationName}")
+  List<Map<String, Object>> getPipelines(@Path("applicationName") String applicationName, @Query("refresh") boolean refresh)
+
   @POST("/pipelines")
   Response savePipeline(@Body Map pipeline)
 

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/EnabledPipelineValidator.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/EnabledPipelineValidator.java
@@ -46,7 +46,7 @@ public class EnabledPipelineValidator implements PipelineValidator {
     if (front50Service == null) {
       throw new UnsupportedOperationException("Front50 not enabled, no way to validate pipeline. Fix this by setting front50.enabled: true");
     }
-    List<Map<String, Object>> pipelines = isStrategy(pipeline) ? front50Service.getStrategies(pipeline.getApplication()) : front50Service.getPipelines(pipeline.getApplication());
+    List<Map<String, Object>> pipelines = isStrategy(pipeline) ? front50Service.getStrategies(pipeline.getApplication()) : front50Service.getPipelines(pipeline.getApplication(), false);
     pipelines
       .stream()
       .filter(it -> it.get("id").equals(pipeline.getPipelineConfigId()))

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
@@ -46,7 +46,7 @@ class StartPipelineTask implements Task {
     String pipelineId = stage.context.pipelineId ?: stage.context.pipeline
     Boolean isStrategy = stage.context.pipelineParameters?.strategy ?: false
 
-    List<Map<String, Object>> pipelines = isStrategy ? front50Service.getStrategies(application) : front50Service.getPipelines(application)
+    List<Map<String, Object>> pipelines = isStrategy ? front50Service.getStrategies(application) : front50Service.getPipelines(application, false)
     Map<String, Object> pipelineConfig = pipelines.find { it.id == pipelineId }
 
     if (!pipelineConfig) {

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/pipeline/EnabledPipelineValidatorSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/pipeline/EnabledPipelineValidatorSpec.groovy
@@ -30,7 +30,7 @@ class EnabledPipelineValidatorSpec extends Specification {
 
   def "allows one-off pipeline to run"() {
     given:
-    front50Service.getPipelines(execution.application) >> []
+    front50Service.getPipelines(execution.application, false) >> []
 
     when:
     validator.checkRunnable(execution)
@@ -47,7 +47,7 @@ class EnabledPipelineValidatorSpec extends Specification {
 
   def "allows enabled pipeline to run"() {
     given:
-    front50Service.getPipelines(execution.application) >> [
+    front50Service.getPipelines(execution.application, false) >> [
       [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: false]
     ]
 
@@ -66,7 +66,7 @@ class EnabledPipelineValidatorSpec extends Specification {
 
   def "prevents disabled pipeline from running"() {
     given:
-    front50Service.getPipelines(execution.application) >> [
+    front50Service.getPipelines(execution.application, false) >> [
       [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: true]
     ]
 
@@ -125,7 +125,7 @@ class EnabledPipelineValidatorSpec extends Specification {
 
   def "doesn't choke on non-boolean strategy value"() {
     given:
-    front50Service.getPipelines(execution.application) >> [
+    front50Service.getPipelines(execution.application, false) >> [
       [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: false]
     ]
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/PipelineIdTag.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/PipelineIdTag.java
@@ -66,7 +66,7 @@ public class PipelineIdTag implements Tag {
       throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'pipelineId' is missing required fields: " + helper, tagNode.getLineNumber());
     }
 
-    List<Map<String, Object>> pipelines = Optional.ofNullable(front50Service.getPipelines(application)).orElse(Collections.emptyList());
+    List<Map<String, Object>> pipelines = Optional.ofNullable(front50Service.getPipelines(application, false)).orElse(Collections.emptyList());
 
     Map<String, Object> result = pipelines
       .stream()

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/PipelineIdTagSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/PipelineIdTagSpec.groovy
@@ -37,7 +37,7 @@ class PipelineIdTagSpec extends Specification {
   @Unroll
   def 'should render pipeline id'() {
     given:
-    front50Service.getPipelines('myApp') >>  [
+    front50Service.getPipelines('myApp', false) >>  [
       [
         name: 'Bake and Tag',
         application: 'myApp',
@@ -86,7 +86,7 @@ class PipelineIdTagSpec extends Specification {
     renderer.render('{% pipelineId name="Bake and Tag" %}', context)
 
     then: 'application should be inferred from context'
-    1 * front50Service.getPipelines(applicationInContext) >>  [
+    1 * front50Service.getPipelines(applicationInContext, false) >>  [
       [
         name: 'Bake and Tag',
         application: 'myApp',
@@ -111,7 +111,7 @@ class PipelineIdTagSpec extends Specification {
     renderer.render('{% pipelineId name="Bake and Tag" %}', context)
 
     then:
-    1 * front50Service.getPipelines(applicationInContext) >>  []
+    1 * front50Service.getPipelines(applicationInContext, false) >>  []
     thrown(TemplateRenderException)
   }
 }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -314,7 +314,7 @@ class TaskController {
       statuses: (statuses.split(",") as Collection)
     )
 
-    def pipelineConfigIds = front50Service.getPipelines(application)*.id as List<String>
+    def pipelineConfigIds = front50Service.getPipelines(application, false)*.id as List<String>
     def strategyConfigIds = front50Service.getStrategies(application)*.id as List<String>
     def allIds = pipelineConfigIds + strategyConfigIds
 

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -209,7 +209,7 @@ class TaskControllerSpec extends Specification {
         pipelineConfigId = config.pipelineConfigId
       }
     })
-    front50Service.getPipelines(app) >> [[id: "1"], [id: "2"]]
+    front50Service.getPipelines(app, false) >> [[id: "1"], [id: "2"]]
     front50Service.getStrategies(app) >> []
 
     when:


### PR DESCRIPTION
This should prevent orca from triggering a front50 refresh when fetching pipelines. This call can be slow, so we want to pull the cached version from front50 (no more than a minute old). 

@ajordens PTAL