### PR TITLE
fix(pipeline_template): Respect UI-configured concurrency options

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessor.java
@@ -117,7 +117,7 @@ public class PipelineTemplatePipelinePreprocessor implements PipelinePreprocesso
     graphMutator.mutate(template);
 
     ExecutionGenerator executionGenerator = new V1SchemaExecutionGenerator();
-    Map<String, Object> generatedPipeline = executionGenerator.generate(template, templateConfiguration, (String) pipeline.get("id"));
+    Map<String, Object> generatedPipeline = executionGenerator.generate(template, templateConfiguration, request);
 
     return generatedPipeline;
   }
@@ -162,57 +162,5 @@ public class PipelineTemplatePipelinePreprocessor implements PipelinePreprocesso
   private void setTemplateSourceWithJinja(TemplatedPipelineRequest request) {
     RenderContext context = new DefaultRenderContext(request.getConfig().getPipeline().getApplication(), null, request.getTrigger());
     request.getConfig().getPipeline().getTemplate().setSource(renderer.render(request.getConfig().getPipeline().getTemplate().getSource(), context ));
-  }
-
-  private static class TemplatedPipelineRequest {
-    String type;
-    Map<String, Object> trigger;
-    TemplateConfiguration config;
-    PipelineTemplate template;
-    Boolean plan = false;
-
-    public boolean isTemplatedPipelineRequest() {
-      return "templatedPipeline".equals(type);
-    }
-
-    public String getType() {
-      return type;
-    }
-
-    public void setType(String type) {
-      this.type = type;
-    }
-
-    public TemplateConfiguration getConfig() {
-      return config;
-    }
-
-    public void setConfig(TemplateConfiguration config) {
-      this.config = config;
-    }
-
-    public Map<String, Object> getTrigger() {
-      return trigger;
-    }
-
-    public void setTrigger(Map<String, Object> trigger) {
-      this.trigger = trigger;
-    }
-
-    public PipelineTemplate getTemplate() {
-      return template;
-    }
-
-    public void setTemplate(PipelineTemplate template) {
-      this.template = template;
-    }
-
-    public Boolean getPlan() {
-      return plan;
-    }
-
-    public void setPlan(Boolean plan) {
-      this.plan = plan;
-    }
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequest.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate;
+
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
+
+import java.util.Map;
+
+public class TemplatedPipelineRequest {
+  String id;
+  String type;
+  Map<String, Object> trigger;
+  TemplateConfiguration config;
+  PipelineTemplate template;
+  Boolean plan = false;
+  boolean limitConcurrent = true;
+  boolean keepWaitingPipelines = false;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public boolean isTemplatedPipelineRequest() {
+    return "templatedPipeline".equals(type);
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public TemplateConfiguration getConfig() {
+    return config;
+  }
+
+  public void setConfig(TemplateConfiguration config) {
+    this.config = config;
+  }
+
+  public Map<String, Object> getTrigger() {
+    return trigger;
+  }
+
+  public void setTrigger(Map<String, Object> trigger) {
+    this.trigger = trigger;
+  }
+
+  public PipelineTemplate getTemplate() {
+    return template;
+  }
+
+  public void setTemplate(PipelineTemplate template) {
+    this.template = template;
+  }
+
+  public Boolean getPlan() {
+    return plan;
+  }
+
+  public void setPlan(Boolean plan) {
+    this.plan = plan;
+  }
+
+  public boolean isLimitConcurrent() {
+    return limitConcurrent;
+  }
+
+  public boolean isKeepWaitingPipelines() {
+    return keepWaitingPipelines;
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/generator/ExecutionGenerator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/generator/ExecutionGenerator.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.generator;
 
+import com.netflix.spinnaker.orca.pipelinetemplate.TemplatedPipelineRequest;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
 
@@ -22,5 +23,5 @@ import java.util.Map;
 
 public interface ExecutionGenerator {
 
-  Map<String, Object> generate(PipelineTemplate template, TemplateConfiguration configuration, String id);
+  Map<String, Object> generate(PipelineTemplate template, TemplateConfiguration configuration, TemplatedPipelineRequest request);
 }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.orca.pipelinetemplate.loader.TemplateLoader
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinition
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.DefaultRenderContext
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderUtil
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer
@@ -35,6 +34,7 @@ import org.yaml.snakeyaml.Yaml
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
+
 import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals
 
 class PipelineTemplatePipelinePreprocessorSpec extends Specification {
@@ -317,6 +317,33 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
 
     then:
     result.stages*.group == ['my group of stages: wowow waiting', 'my group of stages: wowow waiting']
+  }
+
+  def "should respect request-defined concurrency options if configuration does not define them"() {
+    given:
+    def pipeline = [
+      type: 'templatedPipeline',
+      config: [
+        schema: '1',
+        pipeline: [
+          application: 'myapp'
+        ]
+      ],
+      template: [
+        schema: '1',
+        id: 'myTemplate',
+        configuration: [:],
+        stages: []
+      ],
+      plan: true,
+      limitConcurrent: false
+    ]
+
+    when:
+    def result = subject.process(pipeline)
+
+    then:
+    result.limitConcurrent == false
   }
 
   Map<String, Object> createTemplateRequest(String templatePath, Map<String, Object> variables = [:], List<Map<String, Object>> stages = [], boolean plan = false) {

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGeneratorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGeneratorSpec.groovy
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema
 
+import com.netflix.spinnaker.orca.pipelinetemplate.TemplatedPipelineRequest
 import com.netflix.spinnaker.orca.pipelinetemplate.generator.ExecutionGenerator
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.NamedHashMap
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
@@ -44,7 +45,7 @@ class V1SchemaExecutionGeneratorSpec extends Specification {
     )
 
     when:
-    def result = subject.generate(template, configuration, "124")
+    def result = subject.generate(template, configuration, new TemplatedPipelineRequest(id: "124"))
 
     then:
     noExceptionThrown()
@@ -69,7 +70,7 @@ class V1SchemaExecutionGeneratorSpec extends Specification {
     )
 
     when:
-    def result = subject.generate(template, configuration, pipelineId)
+    def result = subject.generate(template, configuration, new TemplatedPipelineRequest(id: pipelineId))
 
     then:
     result.id == expectedId
@@ -102,7 +103,7 @@ class V1SchemaExecutionGeneratorSpec extends Specification {
     )
 
     when:
-    def result = subject.generate(template, configuration, "pipelineConfigId")
+    def result = subject.generate(template, configuration, new TemplatedPipelineRequest(id: "pipelineConfigId"))
 
     then:
     result.notifications*.address == addresses


### PR DESCRIPTION
When concurrency options are configured on a templated pipeline via the UI, they weren't being respected. This allows a pass-through, preferring any configuration that's been setup via the template configuration, then using the UI value if undefined.