### PR TITLE
feat(pipeline_template): Plan all dependent pipelines before updating a template

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -16,15 +16,23 @@
 
 package com.netflix.spinnaker.orca.pipeline.model;
 
-import java.io.Serializable;
-import java.util.*;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import com.netflix.spinnaker.security.User;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
 import static com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED;
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionEngine.v3;
 import static java.util.Arrays.asList;

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -79,6 +79,9 @@ interface Front50Service {
   @DELETE("/pipelineTemplates/{pipelineTemplateId}")
   Response deletePipelineTemplate(@Path("pipelineTemplateId") String pipelineTemplateId)
 
+  @GET("/pipelineTemplates/{pipelineTemplateId}/dependentPipelines")
+  List<Map<String, Object>> getPipelineTemplateDependents(@Path("pipelineTemplateId") String pipelineTemplateId, @Query("recursive") boolean recursive)
+
   @GET("/strategies")
   List<Map<String, Object>> getAllStrategies()
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/UpdatePipelineTemplateStage.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/UpdatePipelineTemplateStage.java
@@ -19,6 +19,7 @@ import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode.Builder;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipelinetemplate.tasks.PlanTemplateDependentsTask;
 import com.netflix.spinnaker.orca.pipelinetemplate.tasks.UpdatePipelineTemplateTask;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +28,10 @@ public class UpdatePipelineTemplateStage implements StageDefinitionBuilder {
 
   @Override
   public <T extends Execution<T>> void taskGraph(Stage<T> stage, Builder builder) {
+    if (!Boolean.valueOf(stage.getContext().getOrDefault("skipPlanDependents", "false").toString())) {
+      builder.withTask("planDependentPipelines", PlanTemplateDependentsTask.class);
+    }
+
     builder
       .withTask("updatePipelineTemplate", UpdatePipelineTemplateTask.class);
   }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/PlanTemplateDependentsTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/PlanTemplateDependentsTask.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipelinetemplate.PipelineTemplatePipelinePreprocessor;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Component
+public class PlanTemplateDependentsTask implements RetryableTask {
+
+  @Autowired(required = false)
+  private Front50Service front50Service;
+
+  @Autowired
+  private ObjectMapper pipelineTemplateObjectMapper;
+
+  @Autowired
+  private PipelineTemplatePipelinePreprocessor pipelineTemplatePipelinePreprocessor;
+
+  @Nonnull
+  @Override
+  public TaskResult execute(@Nonnull Stage stage) {
+    if (front50Service == null) {
+      throw new UnsupportedOperationException("Front50 is not enabled. Fix this by setting front50.enabled: true");
+    }
+
+    if (!stage.getContext().containsKey("pipelineTemplate")) {
+      throw new IllegalArgumentException("Missing required task parameter (pipelineTemplate)");
+    }
+
+    if (!(stage.getContext().get("pipelineTemplate") instanceof String)) {
+      throw new IllegalArgumentException("'pipelineTemplate' context key must be a base64-encoded string: Ensure you're on the most recent version of gate");
+    }
+
+    PipelineTemplate pipelineTemplate = (PipelineTemplate) stage.decodeBase64(
+      "/pipelineTemplate",
+      PipelineTemplate.class,
+      pipelineTemplateObjectMapper
+    );
+
+    List<Map<String, Object>> dependentPipelines = front50Service.getPipelineTemplateDependents(pipelineTemplate.getId(), false);
+
+    Map<String, Object> errorResponses = new HashMap<>();
+    for (Map<String, Object> dependentPipeline : dependentPipelines) {
+      Map<String, Object> request = new HashMap<>();
+      request.put("type", "templatedPipeline");
+      request.put("trigger", new HashMap<>());
+      request.put("config", dependentPipeline.get("config"));
+      request.put("template", pipelineTemplate);
+      request.put("plan", true);
+
+      Map<String, Object> response = pipelineTemplatePipelinePreprocessor.process(request);
+      if (response.containsKey("errors")) {
+        errorResponses.put((String) dependentPipeline.get("id"), response.get("errors"));
+      }
+    }
+
+    Map<String, Object> context = new HashMap<>();
+    context.put("notification.type", "plantemplatedependents");
+    context.put("pipelineTemplate.id", pipelineTemplate.getId());
+    context.put("pipelineTemplate.allDependentPipelines", dependentPipelines.stream().map(it -> it.get("id")).collect(Collectors.toList()));
+
+    if (!errorResponses.isEmpty()) {
+      context.put("pipelineTemplate.dependentErrors", errorResponses);
+    }
+
+    return new TaskResult(
+      errorResponses.isEmpty() ? ExecutionStatus.SUCCEEDED : ExecutionStatus.TERMINAL,
+      context,
+      Collections.emptyMap()
+    );
+  }
+
+  @Override
+  public long getBackoffPeriod() {
+    return 15000;
+  }
+
+  @Override
+  public long getTimeout() {
+    return TimeUnit.MINUTES.toMillis(10);
+  }
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/tasks/PlanTemplateDependentsTaskSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/tasks/PlanTemplateDependentsTaskSpec.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.tasks
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipelinetemplate.PipelineTemplatePipelinePreprocessor
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import spock.lang.Specification
+import spock.lang.Subject
+
+class PlanTemplateDependentsTaskSpec extends Specification {
+
+  Front50Service front50Service = Mock()
+
+  PipelineTemplatePipelinePreprocessor pipelinePreprocessor = Mock()
+
+  ObjectMapper objectMapper = new ObjectMapper()
+
+  @Subject
+  def task = new PlanTemplateDependentsTask(
+    front50Service: front50Service,
+    pipelineTemplateObjectMapper: objectMapper,
+    pipelineTemplatePipelinePreprocessor: pipelinePreprocessor
+  )
+
+  def 'should aggregate all failed pipeline plan errors'() {
+    given:
+    def pipelineTemplate = new PipelineTemplate(
+      schema: "1",
+      id: 'myTemplate',
+      metadata: [
+        name: 'myTemplate'
+      ],
+      variables: []
+    )
+
+    def pipeline1 = [
+      id: 'one',
+      config: [:]
+    ]
+    def pipeline2 = [
+      id: 'two',
+      config: [:]
+    ]
+
+    when:
+    def result = task.execute(new Stage<>(new Pipeline("orca"), "", [
+      pipelineTemplate: Base64.encoder.encodeToString(objectMapper.writeValueAsString(pipelineTemplate).bytes)
+    ]))
+
+    then:
+    noExceptionThrown()
+    1 * front50Service.getPipelineTemplateDependents('myTemplate', false) >> {
+      [pipeline1, pipeline2]
+    }
+    2 * pipelinePreprocessor.process(_) >> {
+      [
+        errors: [
+          [
+            severity: 'FATAL',
+            message: 'Some error'
+          ]
+        ]
+      ]
+    }
+    result.status == ExecutionStatus.TERMINAL
+    result.context['notification.type'] == 'plantemplatedependents'
+    result.context['pipelineTemplate.id'] == 'myTemplate'
+    result.context['pipelineTemplate.allDependentPipelines'] == ['one', 'two']
+    result.context['pipelineTemplate.dependentErrors'] == [
+      one: [
+        [
+          severity: 'FATAL',
+          message: 'Some error'
+        ]
+      ],
+      two: [
+        [
+          severity: 'FATAL',
+          message: 'Some error'
+        ]
+      ]
+    ]
+  }
+
+  Map<String, Object> buildProcessRequest(Map<String, Object> pipeline, PipelineTemplate template) {
+    return [
+      type: 'templatedPipeline',
+      trigger: [:],
+      config: pipeline.get("config"),
+      template: template,
+      plan: true
+    ]
+  }
+}


### PR DESCRIPTION
This change will now perform best-effort plans against all resolvable
dependents of a template. Pipelines that resolve their templates
dynamically will not be checked for compatibility while performing a
template save operation.

On a failure, the stage outputs look sorta like this:

```
{
  # ...
  "outputs": {
    "notification.type": "plantemplatedependents",
    "pipelineTemplate.allDependentPipelines": [
      "d8a7e9ad-93f2-4273-9873-6ea4674bafa1"
    ],
    "pipelineTemplate.dependentErrors": {
      "d8a7e9ad-93f2-4273-9873-6ea4674bafa1": [
        {
          "location": "configuration:stages.foo",
          "message": "Stage is missing type",
          "severity": "FATAL"
        },
        {
          "location": "configuration:stages.foo",
          "message": "Stage configuration is unset",
          "severity": "FATAL"
        },
        {
          "location": "configuration:stages.foo",
          "message": "A configuration-defined stage should have either dependsOn or an inject rule defined",
          "severity": "WARN"
        }
      ]
    },
    "pipelineTemplate.id": "wait-child"
  }
  # ...
}
```

My biggest concern with this change is the performance impact of templates that everyone under the sun inherits from. We don't have any like this yet, but I suspect it could become an issue in the future. That said, I think the safety this change provides is worth it.

@danielpeach @emjburns @ajordens @cfieber PTAL