### PR TITLE
fix(timeout): stage timeout overrides cumulative task durations

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -395,9 +395,9 @@ public class Stage<T extends Execution<T>> implements Serializable {
   }
 
   /**
-   * Returns the top-most stage timeout value if present.
+   * Returns the top-most stage.
    */
-  @JsonIgnore public Optional<Long> getTopLevelTimeout() {
+  @JsonIgnore public Stage<T> getTopLevelStage() {
     Stage<T> topLevelStage = this;
     while (topLevelStage.parentStageId != null) {
       String sid = topLevelStage.parentStageId;
@@ -408,6 +408,14 @@ public class Stage<T extends Execution<T>> implements Serializable {
         throw new IllegalStateException("Could not find stage by parentStageId (stage: " + topLevelStage.getId() + ", parentStageId:" + sid + ")");
       }
     }
+    return topLevelStage;
+  }
+
+  /**
+   * Returns the top-most stage timeout value if present.
+   */
+  @JsonIgnore public Optional<Long> getTopLevelTimeout() {
+    Stage<T> topLevelStage = getTopLevelStage();
     Object timeout = topLevelStage.getContext().get("stageTimeoutMs");
     if (timeout instanceof Integer) {
       return Optional.of((Integer) timeout).map(Long::new);


### PR DESCRIPTION
Previously overriding the stage timeout did not take into account the cumulative time the task were running/had run. This changes the stage timeout behavior so that when a user overrides the timeout, the stage times out after that value.

This change respects pausing the stage but NOT tasks getting throttled. If we want to take throttling time into account, we need to revisit the throttling strategy (as it's not easy to correctly calculate the stage throttle duration). Right now, we are assuming that users will enter pipeline timeout overrides have enough margin for throttling.

@ajordens @robfletcher @robzienert PTAL