### PR TITLE
feat(pipeline_template): Re-save dependent pipelines on template save

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/UpdatePipelineTemplateStage.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/UpdatePipelineTemplateStage.java
@@ -15,16 +15,41 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.pipeline;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.front50.pipeline.UpdatePipelineStage;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode.Builder;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner;
 import com.netflix.spinnaker.orca.pipelinetemplate.tasks.PlanTemplateDependentsTask;
 import com.netflix.spinnaker.orca.pipelinetemplate.tasks.UpdatePipelineTemplateTask;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 public class UpdatePipelineTemplateStage implements StageDefinitionBuilder {
+
+  @Autowired(required = false)
+  private Front50Service front50Service;
+
+  @Autowired
+  private ObjectMapper pipelineTemplateObjectMapper;
+
+  @Autowired
+  private UpdatePipelineStage updatePipelineStage;
 
   @Override
   public <T extends Execution<T>> void taskGraph(Stage<T> stage, Builder builder) {
@@ -34,5 +59,57 @@ public class UpdatePipelineTemplateStage implements StageDefinitionBuilder {
 
     builder
       .withTask("updatePipelineTemplate", UpdatePipelineTemplateTask.class);
+  }
+
+  @Nonnull
+  @Override
+  public <T extends Execution<T>> List<Stage<T>> aroundStages(@Nonnull Stage<T> stage) {
+    if (front50Service == null) {
+      return Collections.emptyList();
+    }
+
+    if (!stage.getContext().containsKey("pipelineTemplate")) {
+      throw new IllegalArgumentException("Missing required task parameter (pipelineTemplate)");
+    }
+
+    if (!(stage.getContext().get("pipelineTemplate") instanceof String)) {
+      throw new IllegalArgumentException("'pipelineTemplate' context key must be a base64-encoded string: Ensure you're on the most recent version of gate");
+    }
+
+    PipelineTemplate pipelineTemplate = stage.decodeBase64(
+      "/pipelineTemplate",
+      PipelineTemplate.class,
+      pipelineTemplateObjectMapper
+    );
+
+    List<Map<String, Object>> dependentPipelines = front50Service.getPipelineTemplateDependents(pipelineTemplate.getId(), true);
+
+    return dependentPipelines.stream()
+      .filter(pipeline -> {
+        // We only need to re-save pipelines that actually inherit configurations.
+        TemplateConfiguration config = pipelineTemplateObjectMapper.convertValue(pipeline.get("config"), TemplateConfiguration.class);
+        return !config.getConfiguration().getInherit().isEmpty();
+      })
+      .map(pipeline -> configureSavePipelineStage(stage, pipeline))
+      .collect(Collectors.toList());
+  }
+
+  private <T extends Execution<T>> Stage<T> configureSavePipelineStage(Stage<T> stage, Map<String, Object> pipeline) {
+    Map<String, Object> context = new HashMap<>();
+
+    try {
+      context.put("pipeline", Base64.getEncoder().encodeToString(pipelineTemplateObjectMapper.writeValueAsBytes(pipeline)));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(String.format("Failed converting pipeline to JSON: %s", pipeline.get("id")), e);
+    }
+
+    return StageDefinitionBuilder.newStage(
+      stage.getExecution(),
+      updatePipelineStage.getType(),
+      "updateDependentPipeline",
+      context,
+      stage,
+      SyntheticStageOwner.STAGE_AFTER
+    );
   }
 }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/UpdatePipelineTemplateStageSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/UpdatePipelineTemplateStageSpec.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.pipeline
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.pipeline.UpdatePipelineStage
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate.Configuration
+import spock.lang.Specification
+
+class UpdatePipelineTemplateStageSpec extends Specification {
+
+  def front50Service = Mock(Front50Service)
+  def stageBuilder = new UpdatePipelineTemplateStage()
+
+  def setup() {
+    stageBuilder.updatePipelineStage = new UpdatePipelineStage()
+    stageBuilder.pipelineTemplateObjectMapper = new ObjectMapper()
+    stageBuilder.front50Service = front50Service
+  }
+
+  def "should create synthetic save pipeline stages for each dependent pipeline"() {
+    setup:
+    def pipelineTemplate = new PipelineTemplate(
+      schema: "1",
+      id: 'myTemplate',
+      metadata: [
+        name: 'myTemplate'
+      ],
+      configuration: new Configuration(
+        triggers: [
+          [
+            name: 'myTrigger',
+            type: 'jenkins'
+          ]
+        ]
+      ),
+      variables: []
+    )
+
+    def pipeline1 = [
+      id: 'one',
+      config: [
+        configuration: [
+          inherit: ['triggers']
+        ]
+      ]
+    ]
+    def pipeline2 = [
+      id: 'two',
+      config: [
+        configuration: [
+          inherit: ['triggers']
+        ]
+      ]
+    ]
+    def pipeline3 = [
+      id: 'three',
+      config: [
+        configuration: [
+          inherit: []
+        ]
+      ]
+    ]
+
+    and:
+    def config = [pipelineTemplate: Base64.encoder.encodeToString(new ObjectMapper().writeValueAsString(pipelineTemplate).bytes)]
+    def stage = new Stage<>(new Pipeline("orca"), "updatePipelineTemplate", config)
+
+    when:
+    def syntheticStages = stageBuilder.aroundStages(stage)
+    def beforeStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_BEFORE }
+    def afterStages = syntheticStages.findAll { it.syntheticStageOwner == SyntheticStageOwner.STAGE_AFTER }
+
+    then:
+    1 * front50Service.getPipelineTemplateDependents("myTemplate", true) >> {
+      [pipeline1, pipeline2, pipeline3]
+    }
+
+    afterStages.size() == 2
+    afterStages*.name == ['updateDependentPipeline', 'updateDependentPipeline']
+    beforeStages.size() == 0
+  }
+}


### PR DESCRIPTION
Allows updates to templates that define triggers, params, notifications
or concurrency options to cascade changes to downstream pipelines.

We'll selectively re-save pipelines only if:

1. The template actually defines an inheritable config (triggers, params, notifications, concurrency options) **AND**
2. A pipeline explicitly defines that it wants to inherit any of these configs.

@danielpeach @ajordens @emjburns PTAL