### PR TITLE
fix(gradle): Pin jedis version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@ junitVersion=1.0.0-M4
 jupiterVersion=5.0.0-M4
 junitLegacyVersion=4.12.0-M4
 spekVersion=1.1.2
-
+jedis.version=2.8.1


### PR DESCRIPTION
The spring boot upgrade is forcing 2.9.0, which we don't want.

