### PR TITLE
fix(fastproperty): do not override context on monitor stage

### DIFF
--- a/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/MonitorPropertiesTask.groovy
+++ b/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/MonitorPropertiesTask.groovy
@@ -40,10 +40,6 @@ class MonitorPropertiesTask implements Task{
   TaskResult execute(Stage stage) {
 
     Map context = stage.context
-    if (stage.execution instanceof Pipeline) {
-      List<Map> overrides = ((Pipeline) stage.execution).trigger.stageOverrides ?: []
-      context = overrides.find { it.refId == stage.refId } ?: context
-    }
     log.info("MonitorPropertiesTask context: $context")
     List propertyIds = context.propertyIdList*.propertyId
     log.info("propertyIds: $propertyIds")


### PR DESCRIPTION
context is just used to get the property list, which is populated by the previous task - not the override