### PR TITLE
Use fingerprint of message instead of id

### DIFF
--- a/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueTest.kt
+++ b/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueTest.kt
@@ -16,20 +16,11 @@
 
 package com.netflix.spinnaker.orca.q.redis
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
-import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.q.DeadMessageCallback
-import com.netflix.spinnaker.orca.q.Message
 import com.netflix.spinnaker.orca.q.QueueTest
-import com.netflix.spinnaker.orca.q.StartExecution
 import com.netflix.spinnaker.orca.q.metrics.MonitorableQueueTest
 import org.funktionale.partials.invoke
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.junit.Assert
 import org.springframework.context.ApplicationEvent
 import org.springframework.context.ApplicationEventPublisher
 import java.time.Clock
@@ -63,29 +54,3 @@ private val createQueue = { clock: Clock,
 private fun shutdownCallback() {
   redis?.destroy()
 }
-
-class ConvertToMessageSpec : Spek({
-  describe("should support deserializing a nested message") {
-    val objectMapper = ObjectMapper().apply {
-      registerModule(KotlinModule())
-    }
-
-    val message = StartExecution(Pipeline::class.java, "1", "foo")
-
-    it("is not nested") {
-      Assert.assertEquals(
-        message,
-        RedisQueue.convertToMessage(objectMapper.writeValueAsString(message), objectMapper)
-      )
-    }
-
-    it("is nested") {
-      Assert.assertEquals(
-        message,
-        RedisQueue.convertToMessage(objectMapper.writeValueAsString(Envelope(message)), objectMapper)
-      )
-    }
-  }
-})
-
-private data class Envelope(val payload: Message)

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/AtlasQueueMonitor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/AtlasQueueMonitor.kt
@@ -79,9 +79,6 @@ open class AtlasQueueMonitor
     registry.gauge("queue.orphaned.messages", this, {
       it.lastState.orphaned.toDouble()
     })
-    registry.gauge("queue.hash.drift", this, {
-      it.lastState.hashDrift.toDouble()
-    })
     registry.gauge("queue.last.poll.age", this, {
       Duration
         .between(it.lastQueuePoll, clock.instant())

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/MonitorableQueue.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/MonitorableQueue.kt
@@ -68,13 +68,5 @@ data class QueueState(
    * Some implementations may not have any way to implement this metric. It is
    * only intended for alerting leaks.
    */
-  val orphaned: Int = 0,
-  /**
-   * Difference between number of known message hashes and number of de-dupe
-   * hashes plus in-process messages.
-   *
-   * Some implementations may not have any way to implement this metric. It is
-   * only intended for alerting leaks.
-   */
-  val hashDrift: Int = 0
+  val orphaned: Int = 0
 )

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -454,7 +454,6 @@ open class QueueIntegrationTest {
 
     repository.retrievePipeline(pipeline.id).apply {
       status shouldEqual SUCCEEDED
-      println(stages.first().context)
       // resolved expressions should be persisted
       stages.first().context["expr"] shouldEqual true
       (stages.first().context["key"] as Map<String, Any>)["expr"] shouldEqual true


### PR DESCRIPTION
This makes de-dupe easier (no more indexes for hash values) and means we'll be able to re-prioritize existing messages efficiently (PR to follow).