### PR TITLE
refactor(metrics): more configurable metrics wiring for thread pools

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -18,11 +18,7 @@ package com.netflix.spinnaker.orca.config;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.orca.events.ExecutionEvent;
 import com.netflix.spinnaker.orca.events.ExecutionListenerAdapter;
@@ -54,10 +50,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import rx.Scheduler;
 import rx.schedulers.Schedulers;
-import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
@@ -66,7 +60,8 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
   "com.netflix.spinnaker.orca.pipeline",
   "com.netflix.spinnaker.orca.notifications.scheduling",
   "com.netflix.spinnaker.orca.deprecation",
-  "com.netflix.spinnaker.orca.pipeline.util"
+  "com.netflix.spinnaker.orca.pipeline.util",
+  "com.netflix.spinnaker.orca.telemetry"
 })
 @EnableConfigurationProperties
 public class OrcaConfiguration {
@@ -151,27 +146,5 @@ public class OrcaConfiguration {
   @Bean
   public ApplicationListener<ExecutionEvent> onCompleteMetricExecutionListenerAdapter(Registry registry, ExecutionRepository repository) {
     return new ExecutionListenerAdapter(new MetricsExecutionListener(registry), repository);
-  }
-
-  // TODO: this is a weird place to have this, feels like it should be a bean configurer or something
-  public static ThreadPoolTaskExecutor applyThreadPoolMetrics(Registry registry,
-                                                              ThreadPoolTaskExecutor executor,
-                                                              String threadPoolName) {
-    BiConsumer<String, Function<ThreadPoolExecutor, Integer>> createGauge =
-      (name, valueCallback) -> {
-        Id id = registry
-          .createId(format("threadpool.%s", name))
-          .withTag("id", threadPoolName);
-
-        registry.gauge(id, executor, ref -> valueCallback.apply(ref.getThreadPoolExecutor()));
-      };
-
-    createGauge.accept("activeCount", ThreadPoolExecutor::getActiveCount);
-    createGauge.accept("maximumPoolSize", ThreadPoolExecutor::getMaximumPoolSize);
-    createGauge.accept("corePoolSize", ThreadPoolExecutor::getCorePoolSize);
-    createGauge.accept("poolSize", ThreadPoolExecutor::getPoolSize);
-    createGauge.accept("blockingQueueSize", e -> e.getQueue().size());
-
-    return executor;
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisConfiguration.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.persistence.jedis;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
+
+@Configuration
+public class JedisConfiguration {
+
+  @Bean("QueryAll")
+  public ThreadPoolTaskExecutor queryAll() {
+    return newFixedThreadPool(10);
+  }
+
+  @Bean
+  public Scheduler queryAllScheduler(
+    @Qualifier("QueryAll") ThreadPoolTaskExecutor executor) {
+    return Schedulers.from(executor);
+  }
+
+  @Bean("QueryByApp")
+  public ThreadPoolTaskExecutor queryByApp(
+    @Value("${threadPool.executionRepository:150}") int threadPoolSize
+  ) {
+    return newFixedThreadPool(threadPoolSize);
+  }
+
+  @Bean
+  public Scheduler queryByAppScheduler(
+    @Qualifier("QueryByApp") ThreadPoolTaskExecutor executor) {
+    return Schedulers.from(executor);
+  }
+
+  private static ThreadPoolTaskExecutor newFixedThreadPool(int threadPoolSize) {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(threadPoolSize);
+    executor.setMaxPoolSize(threadPoolSize);
+    return executor;
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/telemetry/ThreadPoolMetricsPostProcessor.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/telemetry/ThreadPoolMetricsPostProcessor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.telemetry;
+
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+import static java.lang.String.format;
+
+@Component
+public class ThreadPoolMetricsPostProcessor implements BeanPostProcessor {
+
+  private final Registry registry;
+
+  @Autowired
+  public ThreadPoolMetricsPostProcessor(Registry registry) {this.registry = registry;}
+
+  @Override
+  public Object postProcessBeforeInitialization(Object bean, String beanName) {
+    if (bean instanceof ThreadPoolTaskExecutor) {
+      applyThreadPoolMetrics((ThreadPoolTaskExecutor) bean, beanName);
+    }
+    return bean;
+  }
+
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) {
+    return bean;
+  }
+
+  private void applyThreadPoolMetrics(ThreadPoolTaskExecutor executor,
+                                      String threadPoolName) {
+    BiConsumer<String, Function<ThreadPoolExecutor, Integer>> createGauge =
+      (name, fn) -> {
+        Id id = registry
+          .createId(format("threadpool.%s", name))
+          .withTag("id", threadPoolName);
+
+        registry.gauge(id, executor, ref -> fn.apply(ref.getThreadPoolExecutor()));
+      };
+
+    createGauge.accept("activeCount", ThreadPoolExecutor::getActiveCount);
+    createGauge.accept("maximumPoolSize", ThreadPoolExecutor::getMaximumPoolSize);
+    createGauge.accept("corePoolSize", ThreadPoolExecutor::getCorePoolSize);
+    createGauge.accept("poolSize", ThreadPoolExecutor::getPoolSize);
+    createGauge.accept("blockingQueueSize", e -> e.getQueue().size());
+  }
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/migrations/MultiRedisOrchestrationMigrationNotificationAgent.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/migrations/MultiRedisOrchestrationMigrationNotificationAgent.groovy
@@ -17,6 +17,9 @@
 
 package com.netflix.spinnaker.orca.front50.migrations
 
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.function.Function
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.ExecutionStatus
@@ -38,9 +41,6 @@ import redis.clients.jedis.Jedis
 import redis.clients.util.Pool
 import rx.Observable
 import rx.schedulers.Schedulers
-
-import java.util.concurrent.TimeUnit
-import java.util.function.Function
 
 @Slf4j
 @Component
@@ -68,9 +68,9 @@ class MultiRedisOrchestrationMigrationNotificationAgent extends AbstractPollingN
     this.jedisPool = jedisPool
     this.jedisPoolPrevious = jedisPoolPrevious
 
-    def queryAllScheduler = Schedulers.from(JedisExecutionRepository.newFixedThreadPool(registry, 1, "QueryAll"))
-    def queryByAppScheduler = Schedulers.from(JedisExecutionRepository.newFixedThreadPool(registry, 1, "QueryByApp"))
-    this.executionRepositoryPrevious = new JedisExecutionRepository(jedisPoolPrevious, Optional.empty(), queryAllScheduler, queryByAppScheduler, 75)
+    def queryAllScheduler = Schedulers.from(Executors.newFixedThreadPool(1))
+    def queryByAppScheduler = Schedulers.from(Executors.newFixedThreadPool(1))
+    this.executionRepositoryPrevious = new JedisExecutionRepository(registry, jedisPoolPrevious, Optional.empty(), queryAllScheduler, queryByAppScheduler, 75)
   }
 
   @Override


### PR DESCRIPTION
I've teased out the stuff applying metrics to thread pools so it just uses spring to do so. This was causing me some pain in pulling the queue library out.