### PR TITLE
feat(servergroup): allow ad-hoc entity tags on deployments

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForUpInstancesTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CloneServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
-import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupMetadataTagTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.AddServerGroupEntityTagsTask
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
@@ -58,7 +58,7 @@ class CloneServerGroupStage extends AbstractDeployStrategyStage {
 
     if (taggingEnabled) {
       tasks += [
-        new TaskNode.TaskDefinition("tagServerGroup", ServerGroupMetadataTagTask)
+        new TaskNode.TaskDefinition("tagServerGroup", AddServerGroupEntityTagsTask)
       ]
     }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForUpInstancesTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CreateServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
-import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupMetadataTagTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.AddServerGroupEntityTagsTask
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
@@ -50,7 +50,7 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage {
     ]
 
     if (taggingEnabled) {
-      tasks << TaskNode.task("tagServerGroup", ServerGroupMetadataTagTask)
+      tasks << TaskNode.task("tagServerGroup", AddServerGroupEntityTagsTask)
     }
 
     tasks << TaskNode.task("waitForUpInstances", WaitForUpInstancesTask)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTask.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
+
+import java.util.concurrent.TimeUnit
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+@Slf4j
+class AddServerGroupEntityTagsTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+  long backoffPeriod = TimeUnit.SECONDS.toMillis(5)
+  long timeout = TimeUnit.MINUTES.toMillis(5)
+
+  @Autowired
+  KatoService kato
+
+  @Autowired
+  Collection<ServerGroupEntityTagGenerator> tagGenerators
+
+  @Override
+  TaskResult execute(Stage stage) {
+    try {
+      List<Map> tagOperations = buildTagOperations(stage)
+      if (!tagOperations) {
+        return new TaskResult(ExecutionStatus.SKIPPED)
+      }
+      TaskId taskId = kato.requestOperations(tagOperations).toBlocking().first()
+      return new TaskResult(ExecutionStatus.SUCCEEDED, new HashMap<String, Object>() {
+        {
+          put("notification.type", "upsertentitytags")
+          put("kato.last.task.id", taskId)
+        }
+      })
+    } catch (Exception e) {
+      log.error("Failed to tag deployed server groups (stageId: ${stage.id}, executionId: ${stage.execution.id})", e)
+      return new TaskResult(ExecutionStatus.FAILED_CONTINUE)
+    }
+  }
+
+  private List<Map> buildTagOperations(Stage stage) {
+    def operations = []
+    ((StageData) stage.mapTo(StageData)).deployServerGroups.each { String region, Set<String> serverGroups ->
+      serverGroups.each { String serverGroup ->
+        Collection<Map<String, Object>> tags = tagGenerators ? tagGenerators.findResults { it.generateTags(stage) }.flatten() : []
+        if (!tags) {
+          return []
+        }
+        operations <<
+          [
+            "upsertEntityTags": [
+              tags     : tags,
+              entityRef: [
+                entityType   : "servergroup",
+                entityId     : serverGroup,
+                account      : getCredentials(stage),
+                region       : region,
+                cloudProvider: getCloudProvider(stage)
+              ]
+            ]
+          ]
+      }
+    }
+
+    return operations
+  }
+
+  static class StageData {
+    @JsonProperty("deploy.server.groups")
+    Map<String, Set<String>> deployServerGroups = [:]
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ContextBasedServerGroupEntityTagGenerator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ContextBasedServerGroupEntityTagGenerator.java
@@ -14,15 +14,24 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
 
-import groovy.util.logging.Slf4j
-import org.springframework.stereotype.Component
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
 
 @Component
-@Slf4j
-@Deprecated
-class ServerGroupMetadataTagTask extends AddServerGroupEntityTagsTask {
-  // TODO: Remove after 11/11/17 - only here to smooth over initial round of deployments
-  // Just use AddServerGroupEntityTagsTask
+public class ContextBasedServerGroupEntityTagGenerator implements ServerGroupEntityTagGenerator {
+
+  @Override
+  public List<Map<String, Object>> generateTags(Stage stage) {
+    Map context = stage.getContext();
+
+    if (context.containsKey("entityTags")) {
+      return (List<Map<String, Object>>) context.getOrDefault("entityTags", null);
+    }
+    return null;
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupEntityTagGenerator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupEntityTagGenerator.java
@@ -18,14 +18,15 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
 
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 
+import java.util.Collection;
 import java.util.Map;
 
 public interface ServerGroupEntityTagGenerator {
 
   /**
-   * Generates an entity tag (e.g. server group provenance metadata) to be applied to a server group after deployment
+   * Generates a collection of entity tags (e.g. server group provenance metadata) to be applied to a server group after deployment
    * @param stage the stage that performed the deployment
-   * @return a map representing a tag to send to Clouddriver
+   * @return a collection of maps representing tags to send to Clouddriver
    */
-  Map<String, Object> generateTag(Stage stage);
+  Collection<Map<String, Object>> generateTags(Stage stage);
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.orca.pipeline.model.Pipeline;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +31,7 @@ import java.util.Map;
 public class SpinnakerMetadataServerGroupTagGenerator implements ServerGroupEntityTagGenerator {
 
   @Override
-  public Map<String, Object> generateTag(Stage stage) {
+  public Collection<Map<String, Object>> generateTags(Stage stage) {
     Execution execution = stage.getExecution();
     Map context = stage.getContext();
 
@@ -61,7 +63,7 @@ public class SpinnakerMetadataServerGroupTagGenerator implements ServerGroupEnti
     tag.put("name", "spinnaker:metadata");
     tag.put("value", value);
 
-    return tag;
+    return Collections.singletonList(tag);
   }
 
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTaskSpec.groovy
@@ -28,14 +28,14 @@ import spock.lang.Unroll
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.orchestration
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 
-class ServerGroupMetadataTagTaskSpec extends Specification {
+class AddServerGroupEntityTagsTaskSpec extends Specification {
 
   KatoService katoService = Mock(KatoService)
 
   ServerGroupEntityTagGenerator tagGenerator = new SpinnakerMetadataServerGroupTagGenerator()
 
   @Subject
-  ServerGroupMetadataTagTask task = new ServerGroupMetadataTagTask(kato: katoService, tagGenerators: [tagGenerator])
+  AddServerGroupEntityTagsTask task = new AddServerGroupEntityTagsTask(kato: katoService, tagGenerators: [tagGenerator])
 
   List<Map> taggingOps = null
 
@@ -146,7 +146,7 @@ class ServerGroupMetadataTagTaskSpec extends Specification {
 
   void "skips tagging when no tag generators or generators do not produce any tags"() {
     given:
-    ServerGroupMetadataTagTask emptyTask = new ServerGroupMetadataTagTask(kato: katoService, tagGenerators: [])
+    AddServerGroupEntityTagsTask emptyTask = new AddServerGroupEntityTagsTask(kato: katoService, tagGenerators: [])
 
     when:
     def stage = new Stage<>(new Pipeline("orca"), "whatever", [


### PR DESCRIPTION
Allows a user to include an `entityTags` collection in the payload of a deploy operation, which will add those tags once the deploy completes.

**NOTE:** this is technically a breaking change - I have modified the `ServerGroupEntityTagGenerator` method signature to return a collection of tags instead of a single tag. Since this was just released a few weeks ago, and I don't know of anyone else using entity tags (much less writing their own custom generators), I'm reluctant to label it a breaking change. Will defer to the Orca owners on that.

@ajordens PTAL