### PR TITLE
chore(oortService): expose /serverGroups endpoint

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -41,6 +41,11 @@ public class DelegatingOortService
   }
 
   @Override
+  public Response getServerGroups(String app) {
+    return getService().getServerGroups(app);
+  }
+
+  @Override
   public Response getServerGroup(String app, String account, String region, String serverGroup) {
     return getService().getServerGroup(app, account, region, serverGroup);
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -30,6 +30,9 @@ interface OortService {
                       @Path("cluster") String cluster,
                       @Path("cloudProvider") String cloudProvider)
 
+  @GET("/applications/{app}/serverGroups")
+  Response getServerGroups(@Path("app") String app)
+
   @GET("/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/serverGroups/{serverGroup}")
   Response getServerGroupFromCluster(@Path("app") String app,
                                      @Path("account") String account,


### PR DESCRIPTION
This is my favorite clouddriver endpoint and I am upset it's not already available in OortService.