### PR TITLE
feat(pipeline_template): Allow granular inheritance control on params, triggers, notifications

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplateMerge.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplateMerge.java
@@ -89,7 +89,13 @@ public class TemplateMerge {
       boolean updated = false;
       for (int i = 0; i < merged.size(); i++) {
         if (merged.get(i).getName().equals(bNode.getName())) {
-          merged.set(i, bNode);
+          if (bNode.isRemove()) {
+            merged.remove(i);
+          } else if (bNode.isMerge()) {
+            merged.set(i, (T) merged.get(i).merge(bNode));
+          } else {
+            merged.set(i, bNode);
+          }
           updated = true;
           break;
         }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/NamedContent.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/NamedContent.java
@@ -15,7 +15,10 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
-public interface NamedContent {
+public interface NamedContent<T extends NamedContent> {
 
   String getName();
+  boolean isRemove();
+  boolean isMerge();
+  T merge(T overlay);
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/NamedHashMap.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/NamedHashMap.java
@@ -17,9 +17,34 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
 import java.util.HashMap;
 
-public class NamedHashMap extends HashMap<String, Object> implements NamedContent {
+public class NamedHashMap extends HashMap<String, Object> implements NamedContent<NamedHashMap> {
+
+  public NamedHashMap() {
+  }
+
+  private NamedHashMap(NamedHashMap m) {
+    super(m);
+  }
 
   public String getName() {
     return String.valueOf(get("name"));
+  }
+
+  @Override
+  public boolean isRemove() {
+    return Boolean.parseBoolean(String.valueOf(getOrDefault("remove", "false")));
+  }
+
+  @Override
+  public boolean isMerge() {
+    return Boolean.parseBoolean(String.valueOf(getOrDefault("merge", "false")));
+  }
+
+  @Override
+  public NamedHashMap merge(NamedHashMap overlay) {
+    NamedHashMap m = new NamedHashMap(this);
+    m.putAll(overlay);
+    m.remove("merge");
+    return m;
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/PipelineTemplate.java
@@ -78,13 +78,15 @@ public class PipelineTemplate implements VersionedSchema {
     }
   }
 
-  public static class Variable implements NamedContent {
+  public static class Variable implements NamedContent<Variable>, Cloneable {
     private String name;
-    private String group = "General";
+    private String group;
     private String description;
-    private String type = "string";
+    private String type;
     private Object defaultValue;
     private String example;
+    private boolean merge = false;
+    private boolean remove = false;
 
     @Override
     public String getName() {
@@ -96,7 +98,7 @@ public class PipelineTemplate implements VersionedSchema {
     }
 
     public String getGroup() {
-      return group;
+      return Optional.ofNullable(group).orElse("General");
     }
 
     public void setGroup(String group) {
@@ -112,7 +114,7 @@ public class PipelineTemplate implements VersionedSchema {
     }
 
     public String getType() {
-      return type;
+      return Optional.ofNullable(type).orElse("string");
     }
 
     public void setType(String type) {
@@ -137,6 +139,43 @@ public class PipelineTemplate implements VersionedSchema {
 
     public void setExample(String example) {
       this.example = example;
+    }
+
+    public boolean isMerge() {
+      return merge;
+    }
+
+    public void setMerge(boolean merge) {
+      this.merge = merge;
+    }
+
+    public boolean isRemove() {
+      return remove;
+    }
+
+    public void setRemove(boolean remove) {
+      this.remove = remove;
+    }
+
+    @Override
+    public Variable merge(Variable overlay) {
+      Variable v;
+      try {
+        v = (Variable) this.clone();
+      } catch (CloneNotSupportedException e) {
+        throw new RuntimeException("Could not clone Variable", e);
+      }
+      if (overlay.group != null) { v.group = overlay.group; }
+      if (overlay.description != null) { v.description = overlay.description; }
+      if (overlay.type != null) { v.type = overlay.type; }
+      if (overlay.defaultValue != null) { v.defaultValue = overlay.defaultValue; }
+      if (overlay.example != null) { v.example = overlay.example; }
+      return v;
+    }
+
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+      return super.clone();
     }
   }
 

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplateMergeSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplateMergeSpec.groovy
@@ -44,6 +44,12 @@ class TemplateMergeSpec extends Specification {
         parameters: [
           new NamedHashMap().with {
             put('name', 'parameter1')
+            put('description', 'blah blah')
+            put('defaultValue', 'default')
+            return it
+          },
+          new NamedHashMap().with {
+            put('name', 'parameter2')
             return it
           }
         ],
@@ -74,6 +80,19 @@ class TemplateMergeSpec extends Specification {
             put('name', 'trigger2')
             return it
           }
+        ],
+        parameters: [
+          new NamedHashMap().with {
+            put('name', 'parameter1')
+            put('merge', true)
+            put('defaultValue', 'overridden')
+            return it
+          },
+          new NamedHashMap().with {
+            put('name', 'parameter2')
+            put('remove', true)
+            return it
+          }
         ]
       )
       stages = [
@@ -95,6 +114,8 @@ class TemplateMergeSpec extends Specification {
     result.variables.find { it.name == 'foo' }.defaultValue == 'overridden value'
     result.configuration.triggers*.name == ['trigger1', 'trigger2']
     result.configuration.parameters*.name == ['parameter1']
+    result.configuration.parameters*.description == ['blah blah']
+    result.configuration.parameters*.defaultValue == ['overridden']
     result.configuration.notifications*.name == ['notification1']
     result.stages*.id == ['s1', 's2', 's3']
     result.modules == null

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/parameterInheritance-config.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/parameterInheritance-config.yml
@@ -1,0 +1,13 @@
+---
+schema: "1"
+pipeline:
+  application: orca
+configuration:
+  inherit: ['parameters']
+  parameters:
+  - name: instances
+    default: 9000
+    merge: true
+  - name: toBeRemoved
+    remove: true
+stages: []

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/parameterInheritance-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/parameterInheritance-expected.json
@@ -1,0 +1,16 @@
+{
+  "id": "unknown",
+  "keepWaitingPipelines": false,
+  "limitConcurrent": true,
+  "application": "orca",
+  "name": "Unnamed Execution",
+  "stages": [],
+  "notifications": [],
+  "parameterConfig": [
+    {
+      "name": "instances",
+      "description": "Number of instances to start per region",
+      "default": 9000
+    }
+  ]
+}

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/parameterInheritance-template.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/parameterInheritance-template.yml
@@ -1,0 +1,14 @@
+---
+schema: "1"
+id: parameterInheritance
+metadata:
+  name: Granular parameter & config inheritance
+  description: Asserts that configs can modify inherited parameters, as well as remove unneeded ones.
+configuration:
+  parameters:
+  - name: instances
+    description: Number of instances to start per region
+    default: 3
+  - name: toBeRemoved
+    description: This parameter will be removed by the config
+stages: []


### PR DESCRIPTION
Internal teams would like the ability to have some level of control over how params, triggers and notifications are inherited. Adds two new flags, `remove` and `merge`, which are booleans and will control whether or not the config option is either removed from the final pipeline, or its values are merged into with the template values.

