### PR TITLE
refactor(tag-generator): include server group coordinates in generate…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTask.groovy
@@ -65,7 +65,11 @@ class AddServerGroupEntityTagsTask extends AbstractCloudProviderAwareTask implem
     def operations = []
     ((StageData) stage.mapTo(StageData)).deployServerGroups.each { String region, Set<String> serverGroups ->
       serverGroups.each { String serverGroup ->
-        Collection<Map<String, Object>> tags = tagGenerators ? tagGenerators.findResults { it.generateTags(stage) }.flatten() : []
+        Collection<Map<String, Object>> tags = tagGenerators ?
+          tagGenerators.findResults {
+            it.generateTags(stage, serverGroup, getCredentials(stage), region, getCloudProvider(stage))
+          }.flatten() :
+          []
         if (!tags) {
           return []
         }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ContextBasedServerGroupEntityTagGenerator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ContextBasedServerGroupEntityTagGenerator.java
@@ -26,7 +26,7 @@ import java.util.Map;
 public class ContextBasedServerGroupEntityTagGenerator implements ServerGroupEntityTagGenerator {
 
   @Override
-  public List<Map<String, Object>> generateTags(Stage stage) {
+  public List<Map<String, Object>> generateTags(Stage stage, String serverGroup, String account, String location, String cloudProvider) {
     Map context = stage.getContext();
 
     if (context.containsKey("entityTags")) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupEntityTagGenerator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupEntityTagGenerator.java
@@ -28,5 +28,5 @@ public interface ServerGroupEntityTagGenerator {
    * @param stage the stage that performed the deployment
    * @return a collection of maps representing tags to send to Clouddriver
    */
-  Collection<Map<String, Object>> generateTags(Stage stage);
+  Collection<Map<String, Object>> generateTags(Stage stage, String serverGroup, String account, String location, String cloudProvider);
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class SpinnakerMetadataServerGroupTagGenerator implements ServerGroupEntityTagGenerator {
 
   @Override
-  public Collection<Map<String, Object>> generateTags(Stage stage) {
+  public Collection<Map<String, Object>> generateTags(Stage stage, String serverGroup, String account, String location, String cloudProvider) {
     Execution execution = stage.getExecution();
     Map context = stage.getContext();
 


### PR DESCRIPTION
…Tags signature

May as well include these, since they're useful for determining whether to apply a tag based on a set of rules. This is the last change to this interface, I imagine.