### PR TITLE
tests(pipeline_templates): integrations tests and removing unique ID

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
@@ -66,7 +66,7 @@ class PipelineTemplatePreprocessor
           throw IrrecoverableConditionException(t)
         }
 
-        log.error("Unexpected error occurred while processing template: (requestId: {})", context.getRequestId(), t)
+        log.error("Unexpected error occurred while processing template: ", context.getRequest().getId(), t)
         errorHandler.recordThrowable(t)
         chain.clear()
       }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/handler/PipelineTemplateContext.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/handler/PipelineTemplateContext.kt
@@ -20,7 +20,6 @@ import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors
 import java.util.*
 
 interface PipelineTemplateContext {
-  fun getRequestId(): String
   fun getChain(): HandlerChain
   fun getErrors(): Errors
   fun getProcessedOutput(): MutableMap<String, Any>
@@ -35,8 +34,6 @@ class GlobalPipelineTemplateContext(
   private val chain: HandlerChain,
   private val request: TemplatedPipelineRequest
 ) : PipelineTemplateContext {
-
-  override fun getRequestId() = UUID.randomUUID().toString()
 
   private val errors = Errors()
   private val processedOutput = mutableMapOf<String, Any>()

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/handler/PipelineTemplateErrorHandler.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/handler/PipelineTemplateErrorHandler.kt
@@ -31,7 +31,6 @@ class PipelineTemplateErrorHandler : Handler {
 
     if (context.getErrors().hasErrors(context.getRequest().plan)) {
       context.getProcessedOutput().putAll(context.getErrors().toResponse())
-      context.getProcessedOutput().put("mptRequestId", context.getRequestId())
     }
   }
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateConfigurationSchemaValidator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/validator/V1TemplateConfigurationSchemaValidator.java
@@ -67,8 +67,6 @@ public class V1TemplateConfigurationSchemaValidator implements SchemaValidator<V
           .withSeverity(Severity.WARN));
       }
     });
-
-    // TODO rz - validate required variables are set and of the correct type
   }
 
   private static String location(String location) {

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-child.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-child.yml
@@ -1,0 +1,13 @@
+schema: "1"
+id: child-template
+source: example-root.yml   # Indicates that this template inherits from the root-template
+metadata:
+  name: Child template
+  description: A child template
+stages:
+- id: waitChild1
+  type: wait
+  dependsOn:
+  - wait1                   # Depending on a stage from the root-template
+  config:
+    waitTime: "{{ waitTime }}"  # Using a variable from the root-template

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-config.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-config.yml
@@ -1,0 +1,27 @@
+schema: "1"
+pipeline:
+  application: myApp
+  name: My super awesome pipeline
+  template:
+    source: example-template.yml
+  variables:
+    waitTime: 20
+    childWaitTime: 15
+configuration:
+  notifications:
+  - address: example@example.com
+    level: pipeline
+    name: email0
+    type: email
+    when:
+    - pipeline.failed
+  triggers: []
+stages:
+- id: finalWait
+  type: wait
+  dependsOn:
+  - waitChild1
+  - waitChild2
+  config:
+    waitTime: 10
+

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-expected.json
@@ -1,0 +1,51 @@
+{
+  "keepWaitingPipelines": false,
+  "limitConcurrent": true,
+  "application": "myApp",
+  "name": "My super awesome pipeline",
+  "stages": [
+    {
+      "requisiteStageRefIds": [],
+      "name": "wait1",
+      "id": null,
+      "refId": "wait1",
+      "type": "wait",
+      "waitTime": 20
+    },
+    {
+      "requisiteStageRefIds": ["wait1"],
+      "id": null,
+      "name": "waitChild2",
+      "refId": "waitChild2",
+      "type": "wait",
+      "waitTime": 15
+    },
+    {
+      "requisiteStageRefIds": ["wait1"],
+      "id": null,
+      "name": "waitChild1",
+      "refId": "waitChild1",
+      "type": "wait",
+      "waitTime": 20
+    },
+    {
+      "requisiteStageRefIds": ["waitChild2", "waitChild1"],
+      "id": null,
+      "name": "finalWait",
+      "refId": "finalWait",
+      "type": "wait",
+      "waitTime": 10
+    }
+  ],
+  "id": "unknown",
+  "notifications": [
+    {
+      "address": "example@example.com",
+      "level": "pipeline",
+      "name": "email0",
+      "when": ["pipeline.failed"],
+      "type": "email"
+    }
+  ],
+  "parameterConfig": []
+}

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-root.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-root.yml
@@ -1,0 +1,14 @@
+schema: "1"         # Schema must match for all
+id: root-template
+metadata:
+  name: Simple wait template
+  description: Extendable root template
+variables:          # Variables available to all that inherit
+- name: waitTime
+  description: The time a wait stage should pause
+  type: int
+stages:             # Stages available to all that inherit
+- id: wait1
+  type: wait
+  config:
+    waitTime: "{{ waitTime }}"  # Variables can be used anywhere

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-template.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-template.yml
@@ -1,0 +1,16 @@
+schema: "1"
+id: child-2-template
+source: example-child.yml
+variables:
+- name: childWaitTime
+  description: pause time for another wait
+metadata:
+  name: A Second Child template
+  description: A second child template
+stages:
+- id: waitChild2
+  type: wait
+  dependsOn:
+  - wait1
+  config:
+    waitTime: "{{ childWaitTime }}"

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-config.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-config.yml
@@ -1,0 +1,20 @@
+schema: "1"
+pipeline:
+  application: myApp
+  name: My super awesome pipeline
+  template:
+    source: exampleCombined-template.yml
+  variables:
+    waitTime: 20
+    childWaitTime: 15
+configuration:
+  notifications:
+  - address: example@example.com
+    level: pipeline
+    name: email0
+    type: email
+    when:
+    - pipeline.failed
+  triggers: []
+
+

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-expected.json
@@ -1,0 +1,51 @@
+{
+  "keepWaitingPipelines": false,
+  "limitConcurrent": true,
+  "application": "myApp",
+  "name": "My super awesome pipeline",
+  "stages": [
+    {
+      "requisiteStageRefIds": [],
+      "name": "wait1",
+      "id": null,
+      "refId": "wait1",
+      "type": "wait",
+      "waitTime": 20
+    },
+    {
+      "requisiteStageRefIds": ["wait1"],
+      "id": null,
+      "name": "waitChild2",
+      "refId": "waitChild2",
+      "type": "wait",
+      "waitTime": 15
+    },
+    {
+      "requisiteStageRefIds": ["wait1"],
+      "id": null,
+      "name": "waitChild1",
+      "refId": "waitChild1",
+      "type": "wait",
+      "waitTime": 20
+    },
+    {
+      "requisiteStageRefIds": ["waitChild2", "waitChild1"],
+      "id": null,
+      "name": "finalWait",
+      "refId": "finalWait",
+      "type": "wait",
+      "waitTime": 10
+    }
+  ],
+  "id": "unknown",
+  "notifications": [
+    {
+      "address": "example@example.com",
+      "level": "pipeline",
+      "name": "email0",
+      "when": ["pipeline.failed"],
+      "type": "email"
+    }
+  ],
+  "parameterConfig": []
+}

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-template.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-template.yml
@@ -1,0 +1,35 @@
+schema: "1"
+id: combined-template
+metadata:
+  name: Less simple wait template
+  description: A template with many waits
+variables:
+- name: waitTime
+  description: The time a wait stage should pause
+  type: int
+- name: childWaitTime
+  description: pause time for another wait
+stages:
+- id: wait1
+  type: wait
+  config:
+    waitTime: "{{ waitTime }}"
+- id: waitChild1
+  type: wait
+  dependsOn:
+  - wait1
+  config:
+    waitTime: "{{ waitTime }}"
+- id: waitChild2
+  type: wait
+  dependsOn:
+  - wait1
+  config:
+    waitTime: "{{ childWaitTime }}"
+- id: finalWait
+  type: wait
+  dependsOn:
+  - waitChild1
+  - waitChild2
+  config:
+    waitTime: 10

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/protect-config.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/protect-config.yml
@@ -1,0 +1,11 @@
+---
+schema: "1"
+pipeline:
+  application: orca
+stages:
+- id: wait2
+  type: wait
+  config:
+    waitTime: "{{ waitTime }}"
+  dependsOn:
+  - wait1

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/protect-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/protect-expected.json
@@ -1,0 +1,9 @@
+{
+  "errors": [
+    {
+      "severity": "FATAL",
+      "cause": "The template being used has marked itself as protected",
+      "message": "Modification of the stage graph (adding, removing, editing) is disallowed"
+    }
+  ]
+}

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/protect-template.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/protect-template.yml
@@ -1,0 +1,13 @@
+---
+schema: "1"
+id: simple
+protect: true
+metadata:
+  name: Barebones
+  description: The simplest template possible.
+stages:
+- id: wait1
+  type: wait
+  config:
+    waitTime: "{{ waitTime }}"
+

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/unsupportedVersion-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/unsupportedVersion-expected.json
@@ -2,7 +2,7 @@
   "errors": [
     {
       "severity": "FATAL",
-      "message": "config schema version is unsupported: expected '1', got '0.1'"
+      "message": "unexpected schema version '0.1'"
     }
   ]
 }


### PR DESCRIPTION
Removing `mptRequestId` in favor of defaulting to some structured logging that is being implemented.
Adding more complicated wait stage tests.

@robzienert PTAL