### PR TITLE
refactor(clouddriver): monitor clouddriver tasks every 5 seconds

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
@@ -57,7 +57,7 @@ class MonitorKatoTask implements RetryableTask {
     this.clock = clock
   }
 
-  long getBackoffPeriod() { 10000L }
+  long getBackoffPeriod() { 5000L }
 
   long getTimeout() { 3600000L }
 


### PR DESCRIPTION
This used to be 1 second; it was bumped to 10s back in February when we were seeing some performance issues.

Not sure what the appetite is for bumping it back up, or if we feel like there's much to be gained in task throughput.

@cfieber or @ajordens thoughts?