### PR TITLE
fix(timeouts): some tasks inherit stage timeout override

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.orca.bakery.tasks
 
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.bakery.api.BakeStatus
 import com.netflix.spinnaker.orca.bakery.api.BakeryService
@@ -31,7 +31,7 @@ import retrofit.RetrofitError
 @Slf4j
 @Component
 @CompileStatic
-class MonitorBakeTask implements RetryableTask {
+class MonitorBakeTask implements OverridableTimeoutRetryableTask {
 
   long backoffPeriod = 30000
   long timeout = 3600000 // 1hr

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.cluster
 
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
@@ -30,7 +30,7 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
 @Slf4j
-abstract class AbstractWaitForClusterWideClouddriverTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+abstract class AbstractWaitForClusterWideClouddriverTask extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
   @Override
   public long getBackoffPeriod() { 10000 }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
@@ -34,7 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import retrofit.RetrofitError
 
 @Slf4j
-abstract class AbstractInstancesCheckTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+abstract class AbstractInstancesCheckTask extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
   long backoffPeriod = TimeUnit.SECONDS.toMillis(10)
   long timeout = TimeUnit.HOURS.toMillis(2)
   long serverGroupWaitTime = TimeUnit.MINUTES.toMillis(10)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTask.groovy
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.instance
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 
-abstract class AbstractWaitForInstanceHealthChangeTask implements RetryableTask {
+abstract class AbstractWaitForInstanceHealthChangeTask implements OverridableTimeoutRetryableTask {
   long backoffPeriod = 5000
   long timeout = 3600000
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForTerminatedInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForTerminatedInstancesTask.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.instance
 
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.pipeline.instance.TerminatingInstance
 import com.netflix.spinnaker.orca.clouddriver.pipeline.instance.TerminatingInstanceSupport
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component
 
 @Slf4j
 @Component
-class WaitForTerminatedInstancesTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+class WaitForTerminatedInstancesTask extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
 
   long backoffPeriod = 10000
   long timeout = 3600000

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/OverridableTimeoutRetryableTask.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/OverridableTimeoutRetryableTask.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2017 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.netflix.spinnaker.orca;
 
-package com.netflix.spinnaker.orca.q
+/**
+ *  A retryable task whose timeout is taken from the top level stage
+ *  if that value has been overridden.
+ *
+ *  These are typically wait/monitor stages
+ */
+public interface OverridableTimeoutRetryableTask extends RetryableTask {
 
-import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
-import com.netflix.spinnaker.orca.RetryableTask
-import com.netflix.spinnaker.orca.Task
-
-interface DummyTask : RetryableTask
-interface InvalidTask : Task
-interface DummyTimeoutOverrideTask : OverridableTimeoutRetryableTask
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.orca.front50.tasks
 
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component
 
 @Slf4j
 @Component
-class MonitorPipelineTask implements RetryableTask {
+class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
 
   @Autowired
   ExecutionRepository executionRepository

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.orca.igor.tasks
 
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.igor.BuildArtifactFilter
 import com.netflix.spinnaker.orca.igor.BuildService
@@ -30,7 +30,7 @@ import retrofit.RetrofitError
 
 @Slf4j
 @Component
-class MonitorJenkinsJobTask implements RetryableTask {
+class MonitorJenkinsJobTask implements OverridableTimeoutRetryableTask {
 
   long backoffPeriod = 10000
   long timeout = TimeUnit.HOURS.toMillis(2)

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorQueuedJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorQueuedJenkinsJobTask.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.orca.igor.tasks
 
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.igor.BuildService
 import com.netflix.spinnaker.orca.pipeline.model.Stage
@@ -29,7 +29,7 @@ import retrofit.RetrofitError
 
 @Slf4j
 @Component
-class MonitorQueuedJenkinsJobTask implements RetryableTask {
+class MonitorQueuedJenkinsJobTask implements OverridableTimeoutRetryableTask {
 
   long backoffPeriod = 10000
   long timeout = TimeUnit.HOURS.toMillis(2)

--- a/orca-kayenta/src/main/groovy/com/netflix/spinnaker/orca/kayenta/tasks/MonitorCanaryTask.groovy
+++ b/orca-kayenta/src/main/groovy/com/netflix/spinnaker/orca/kayenta/tasks/MonitorCanaryTask.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.orca.kayenta.tasks
 
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.kayenta.KayentaService
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit
 
 @Slf4j
 @Component
-class MonitorCanaryTask implements RetryableTask {
+class MonitorCanaryTask implements OverridableTimeoutRetryableTask {
 
   long backoffPeriod = 1000
   long timeout = TimeUnit.HOURS.toMillis(12)

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorAcaTaskTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorAcaTaskTask.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.orca.mine.tasks
 
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
 import com.netflix.spinnaker.orca.mine.MineService
@@ -30,7 +30,7 @@ import retrofit.RetrofitError
 
 @Component
 @Slf4j
-class MonitorAcaTaskTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+class MonitorAcaTaskTask extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
   long backoffPeriod = 10000
   long timeout = TimeUnit.DAYS.toMillis(2)
 

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorCanaryTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorCanaryTask.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.orca.mine.tasks
 
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
@@ -31,7 +31,7 @@ import retrofit.RetrofitError
 
 @Component
 @Slf4j
-class MonitorCanaryTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+class MonitorCanaryTask extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
   long backoffPeriod = TimeUnit.MINUTES.toMillis(1)
   long timeout = TimeUnit.DAYS.toMillis(2)
 


### PR DESCRIPTION
Added a new type of task `OverridableTimeoutRetryableTask` to indicate tasks (like waiting and monitoring) that want to have the same timeout value as the stage. This came about because the bake stage with an overridden timeout of 2.5 hours failed, because the `monitorBakeTask` has a default timeout value of 1h. 

With this change, some waiting/monitoring stages will not use their default timeout when there is an overridden timeout. I think I grabbed all the `tasks` that make sense, but PTAL @robzienert @robfletcher.

@jrsquared this (should) fix the bake issue.


