### PR TITLE
feat(clouddriver): Support sharding read-only requests by `user`

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingClouddriverService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingClouddriverService.java
@@ -27,12 +27,13 @@ class DelegatingClouddriverService<T> {
   }
 
   T getService() {
-    SelectableService.Criteria criteria = new SelectableService.Criteria(null, null, null, null);
+    SelectableService.Criteria criteria = new SelectableService.Criteria(null, null, null, null, null);
 
     ExecutionContext executionContext = ExecutionContext.get();
     if (executionContext != null) {
       criteria = new SelectableService.Criteria(
         executionContext.getApplication(),
+        executionContext.getAuthenticatedUser(),
         executionContext.getExecutionType(),
         executionContext.getExecutionId(),
         executionContext.getOrigin()

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ByAuthenticatedUserServiceSelector.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/ByAuthenticatedUserServiceSelector.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class ByAuthenticatedUserServiceSelector implements ServiceSelector {
+  private final Object service;
+  private final int priority;
+  private final List<Pattern> userPatterns;
+
+  public ByAuthenticatedUserServiceSelector(Object service, Integer priority, Map<String, Object> config) {
+    this.service = service;
+    this.priority = priority;
+
+    Collection<String> users = new HashSet(
+      ((Map<String, String>) config.get("users")).values()
+    );
+    this.userPatterns = users.stream().map(Pattern::compile).collect(Collectors.toList());
+  }
+
+  @Override
+  public Object getService() {
+    return service;
+  }
+
+  @Override
+  public int getPriority() {
+    return priority;
+  }
+
+  @Override
+  public boolean supports(SelectableService.Criteria criteria) {
+    if (criteria.getAuthenticatedUser() == null) {
+      return false;
+    }
+
+    return userPatterns
+      .stream()
+      .anyMatch(userPattern -> userPattern.matcher(criteria.getAuthenticatedUser()).matches());
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/SelectableService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/SelectableService.java
@@ -41,19 +41,22 @@ public class SelectableService {
 
   public static class Criteria {
     private final String application;
+    private final String authenticatedUser;
     private final String executionType;
     private final String executionId;
     private final String origin;
 
-    public Criteria(String application, String executionType, String origin) {
-      this(application, executionType, null, origin);
+    public Criteria(String application, String authenticatedUser, String executionType, String origin) {
+      this(application, authenticatedUser, executionType, null, origin);
     }
 
     public Criteria(String application,
+                    String authenticatedUser,
                     String executionType,
                     String executionId,
                     String origin) {
       this.application = application;
+      this.authenticatedUser = authenticatedUser;
       this.executionType = executionType;
       this.executionId = executionId;
       this.origin = origin;
@@ -61,6 +64,10 @@ public class SelectableService {
 
     public String getApplication() {
       return application;
+    }
+
+    public String getAuthenticatedUser() {
+      return authenticatedUser;
     }
 
     public String getExecutionType() {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionContext.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/ExecutionContext.java
@@ -20,12 +20,14 @@ public class ExecutionContext {
   private static final ThreadLocal<ExecutionContext> threadLocal = new ThreadLocal<>();
 
   private final String application;
+  private final String authenticatedUser;
   private final String executionType;
   private final String executionId;
   private final String origin;
 
-  public ExecutionContext(String application, String executionType, String executionId, String origin) {
+  public ExecutionContext(String application, String authenticatedUser, String executionType, String executionId, String origin) {
     this.application = application;
+    this.authenticatedUser = authenticatedUser;
     this.executionType = executionType;
     this.executionId = executionId;
     this.origin = origin;
@@ -45,6 +47,10 @@ public class ExecutionContext {
 
   public String getApplication() {
     return application;
+  }
+
+  public String getAuthenticatedUser() {
+    return authenticatedUser;
   }
 
   public String getExecutionType() {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AuthenticationAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AuthenticationAware.kt
@@ -43,6 +43,7 @@ interface AuthenticationAware {
     try {
       ExecutionContext.set(ExecutionContext(
         getExecution().getApplication(),
+        currentUser.username,
         getExecution().javaClass.simpleName.toLowerCase(),
         getExecution().getId(),
         getExecution().getOrigin()


### PR DESCRIPTION
This allows you to serve all pipelines/orchestrations generated by a
particular user (or set of users) with a dedicated clouddriver
read replica.
