### PR TITLE
fix(web): Enforce limit of pipelines when using previous redis conn

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/ProjectController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/ProjectController.groovy
@@ -71,7 +71,7 @@ class ProjectController {
       executionRepository.retrievePipelinesForPipelineConfigId(it, executionCriteria)
     }).subscribeOn(Schedulers.io()).toList().toBlocking().single().sort(startTimeOrId)
 
-    return allPipelines
+    return allPipelines.take(limit)
   }
 
   private static Closure startTimeOrId = { a, b ->


### PR DESCRIPTION
If we define a previous Redis connection, the task repository will get `n` executions from each redis. So, if you limit by 2, 4 results will be returned. This change will enforce that the limit is accurate on the way out, after sorting by start time.

cc @anotherchrisberry @emjburns 