### PR TITLE
fix(web): Enforce limit on previous redis for app pipelines endpoint

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -322,7 +322,7 @@ class TaskController {
       executionRepository.retrievePipelinesForPipelineConfigId(it, executionCriteria)
     }).subscribeOn(Schedulers.io()).toList().toBlocking().single().sort(startTimeOrId)
 
-    return filterPipelinesByHistoryCutoff(allPipelines)
+    return filterPipelinesByHistoryCutoff(allPipelines).take(limit)
   }
 
   private List<Pipeline> filterPipelinesByHistoryCutoff(List<Pipeline> pipelines) {


### PR DESCRIPTION
Missed this endpoint on the PR from yesterday.