### PR TITLE
feat(get_commits): Display SCM changes in pipeline-triggered pipelines

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
@@ -92,6 +92,13 @@ class GetCommitsTask implements DiffTask {
 
       //figure out the new asg/ami/commit
       String targetAmi = getTargetAmi(stage.context, region)
+      if (!targetAmi) {
+        def parentPipeline = stage.execution.trigger?.parentExecution
+        while (!targetAmi && parentPipeline?.context) {
+          targetAmi = getTargetAmi(parentPipeline.context, region)
+          parentPipeline = parentPipeline.trigger?.parentExecution
+        }
+      }
 
       //get commits from igor
       sourceInfo = resolveInfoFromAmi(ancestorAmi, account, region)
@@ -203,7 +210,7 @@ class GetCommitsTask implements DiffTask {
     def globalAccount = front50Service.credentials.find { it.global }
     def applicationAccount = globalAccount?.name ?: account
     Application app = front50Service.get(application)
-    return [repoType : app?.details().repoType, projectKey : app?.details().repoProjectKey, repositorySlug : app?.details().repoSlug]
+    return [repoType : app?.details()?.repoType, projectKey : app?.details()?.repoProjectKey, repositorySlug : app?.details()?.repoSlug]
   }
 
   String getBuildFromAppVersion(String appVersion) {


### PR DESCRIPTION
The changes tab that displays SCM diff between deploys was not showing if the pipeline was triggered by another pipeline. Now it does.

![skjermbilde 2017-09-28 kl 12 41 30](https://user-images.githubusercontent.com/155558/30962586-adb22110-a44a-11e7-9c7e-47e82d917729.png)

![skjermbilde 2017-09-28 kl 12 41 51](https://user-images.githubusercontent.com/155558/30962587-add0671a-a44a-11e7-8ef1-421f48f230f6.png)
