### PR TITLE
feat(polling): remove polling for waiting stages

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.orca.controllers
 
+import com.netflix.spinnaker.orca.pipeline.OrchestrationLauncher
+import com.netflix.spinnaker.orca.pipeline.model.Task
+
 import java.time.Clock
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.front50.Front50Service
@@ -262,6 +265,8 @@ class TaskController {
       stage.context["lastModifiedBy"] = AuthenticatedRequest.getSpinnakerUser().orElse("anonymous")
 
       executionRepository.storeStage(stage)
+
+      executionRunner.reschedule(pipeline)
     }
     pipeline
   }

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.orca.controllers
 
+import com.netflix.spinnaker.orca.pipeline.ExecutionRunner
+
 import java.time.Clock
 import java.time.Instant
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -45,6 +47,7 @@ class TaskControllerSpec extends Specification {
   def executionRepository = Mock(ExecutionRepository)
   def front50Service = Mock(Front50Service)
   def startTracker = Mock(PipelineStartTracker)
+  def executionRunner = Mock(ExecutionRunner)
 
   def clock = Clock.fixed(Instant.now(), UTC)
   int daysOfExecutionHistory = 14
@@ -57,6 +60,7 @@ class TaskControllerSpec extends Specification {
       new TaskController(
         front50Service: front50Service,
         executionRepository: executionRepository,
+        executionRunner: executionRunner,
         daysOfExecutionHistory: daysOfExecutionHistory,
         numberOfOldPipelineExecutionsToInclude: numberOfOldPipelineExecutionsToInclude,
         startTracker: startTracker,
@@ -293,6 +297,7 @@ class TaskControllerSpec extends Specification {
         judgmentStatus: "stop", value: "1", lastModifiedBy: "anonymous"
       ]
     } as Stage)
+    1 * executionRunner.reschedule(pipeline)
     0 * _
 
     and:


### PR DESCRIPTION
Removed polling for wait, manual judgment, and execution window stages.
Message sent to reevaluate the stage at the time it would complete or timeout.
A PATCH to /pipelines/{executionId}/stages/{stageId} triggers a reevaluation of the running tasks for the stage in question.
Dynamic backoffs also implemented in these tasks so that if the task is not finished at the expected time polling will resume on the old backoff schedule (in case of throttling or pausing, for example).

@robfletcher PTAL - specifically at how I'm using the messages and pushing to the queue. 