### PR TITLE
feat(moniker): Use a cluster's moniker if available.

### DIFF
--- a/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca-clouddriver/orca-clouddriver.gradle
@@ -19,5 +19,6 @@ dependencies {
   compile project(":orca-retrofit")
   compile project(":orca-front50")
   compile project(":orca-bakery")
+  compile 'com.netflix.spinnaker.moniker:moniker:0.2.0'
   testCompile project(":orca-test")
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
@@ -101,9 +101,7 @@ abstract class AbstractWaitForClusterWideClouddriverTask extends AbstractCloudPr
       return TaskResult.SUCCEEDED
     }
 
-    def names = Names.parseName(clusterSelection.cluster)
-
-    Optional<Map> cluster = oortHelper.getCluster(names.app, clusterSelection.credentials, clusterSelection.cluster, clusterSelection.cloudProvider)
+    Optional<Map> cluster = oortHelper.getCluster(clusterSelection.getApplication(), clusterSelection.credentials, clusterSelection.cluster, clusterSelection.cloudProvider)
     if (!cluster.isPresent()) {
       return missingClusterResult(stage, clusterSelection)
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.cluster
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.OortService
@@ -48,13 +49,14 @@ class ClusterSizePreconditionTask extends AbstractCloudProviderAwareTask impleme
   @Canonical
   static class ComparisonConfig {
     String cluster
+    Moniker moniker
     String comparison = '=='
     int expected = 1
     String credentials
     Set<String> regions
 
     public String getApplication() {
-      Names.parseName(cluster)?.app
+      moniker?.app ?: Names.parseName(cluster)?.app
     }
 
     public Operator getOp() {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.cluster
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
@@ -80,6 +81,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
   @Canonical
   static class FindImageConfiguration {
     String cluster
+    Moniker moniker
     List<String> regions
     List<String> zones
     List<String> namespaces
@@ -89,7 +91,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
     String imageNamePattern
 
     String getApplication() {
-      Names.parseName(cluster).app
+      moniker?.app ?: Names.parseName(cluster).app
     }
 
     Set<Location> getRequiredLocations() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTaskSpec.groovy
@@ -23,10 +23,10 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.CreateServerG
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DisableServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideClouddriverTask.ClusterSelection
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideClouddriverTask.ClusterSelection
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -99,7 +99,7 @@ class AbstractClusterWideClouddriverTaskSpec extends Specification {
     given:
     def pipeline = new Pipeline("orca")
     def stage = new Stage<>(pipeline, DisableServerGroupStage.PIPELINE_CONFIG_TYPE, [
-        continueIfClusterNotFound: true
+      continueIfClusterNotFound: true
     ])
     def task = new AbstractClusterWideClouddriverTask() {
       @Override
@@ -123,7 +123,7 @@ class AbstractClusterWideClouddriverTaskSpec extends Specification {
     given:
     def pipeline = new Pipeline("orca")
     def stage = new Stage<>(pipeline, DisableServerGroupStage.PIPELINE_CONFIG_TYPE, [
-        continueIfClusterNotFound: true
+      continueIfClusterNotFound: true
     ])
     def task = new AbstractClusterWideClouddriverTask() {
       @Override
@@ -138,16 +138,17 @@ class AbstractClusterWideClouddriverTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    1 * oortHelper.getCluster(_, _, _, _) >> Optional.of([ serverGroups: [] ])
+    1 * oortHelper.getCluster(_, _, _, _) >> Optional.of([serverGroups: []])
     result == TaskResult.SUCCEEDED
 
   }
 
-  def 'cluster wide task should use moniker if available or else fallback on frigga'() {
+  @Unroll
+  'cluster with name "#cluster" and moniker "#moniker" should have application name "#expected"'() {
     given:
     def stage = new Stage<>(new Pipeline("orca"), 'clusterSelection', [
-      cluster    : cluster,
-      moniker    : moniker,
+      cluster: cluster,
+      moniker: moniker,
     ])
     when:
     ClusterSelection selection = stage.mapTo(ClusterSelection)
@@ -156,9 +157,9 @@ class AbstractClusterWideClouddriverTaskSpec extends Specification {
     selection.getApplication() == expected
 
     where:
-    cluster | moniker | expected
-    'clustername' | [ 'app': 'appname' ] | 'appname'
-    'app-stack' | null | 'app'
+    cluster       | moniker            | expected
+    'clustername' | ['app': 'appname'] | 'appname'
+    'app-stack'   | null               | 'app'
 
   }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTaskSpec.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Targe
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideClouddriverTask.ClusterSelection
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -139,6 +140,25 @@ class AbstractClusterWideClouddriverTaskSpec extends Specification {
     then:
     1 * oortHelper.getCluster(_, _, _, _) >> Optional.of([ serverGroups: [] ])
     result == TaskResult.SUCCEEDED
+
+  }
+
+  def 'cluster wide task should use moniker if available or else fallback on frigga'() {
+    given:
+    def stage = new Stage<>(new Pipeline("orca"), 'clusterSelection', [
+      cluster    : cluster,
+      moniker    : moniker,
+    ])
+    when:
+    ClusterSelection selection = stage.mapTo(ClusterSelection)
+
+    then:
+    selection.getApplication() == expected
+
+    where:
+    cluster | moniker | expected
+    'clustername' | [ 'app': 'appname' ] | 'appname'
+    'app-stack' | null | 'app'
 
   }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTaskSpec.groovy
@@ -120,6 +120,29 @@ class ClusterSizePreconditionTaskSpec extends Specification {
   }
 
 
+  def 'cluster precondition should use moniker if available or else fallback on frigga'() {
+    given:
+    def stage = new Stage<>(new Pipeline("orca"), 'checkCluster', [
+      context: [
+        cluster    : cluster,
+        moniker    : moniker,
+      ]
+    ])
+    when:
+    ClusterSizePreconditionTask.ComparisonConfig config = stage.mapTo("/context", ClusterSizePreconditionTask.ComparisonConfig)
+
+    then:
+    config.getApplication() == expected
+
+    where:
+    cluster | moniker | expected
+    'clustername' | [ 'app': 'appname' ] | 'appname'
+    'app-stack' | null | 'app'
+
+  }
+
+
+
   Map mkSg(String region) {
     [name: "foo-v${cnt.incrementAndGet()}".toString(), region: region]
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTaskSpec.groovy
@@ -120,12 +120,13 @@ class ClusterSizePreconditionTaskSpec extends Specification {
   }
 
 
-  def 'cluster precondition should use moniker if available or else fallback on frigga'() {
+  @Unroll
+  'cluster with name "#cluster" and moniker "#moniker" should have application name "#expected"'() {
     given:
     def stage = new Stage<>(new Pipeline("orca"), 'checkCluster', [
       context: [
-        cluster    : cluster,
-        moniker    : moniker,
+        cluster: cluster,
+        moniker: moniker,
       ]
     ])
     when:
@@ -135,12 +136,11 @@ class ClusterSizePreconditionTaskSpec extends Specification {
     config.getApplication() == expected
 
     where:
-    cluster | moniker | expected
-    'clustername' | [ 'app': 'appname' ] | 'appname'
-    'app-stack' | null | 'app'
+    cluster       | moniker            | expected
+    'clustername' | ['app': 'appname'] | 'appname'
+    'app-stack'   | null               | 'app'
 
   }
-
 
 
   Map mkSg(String region) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
@@ -398,4 +398,23 @@ class FindImageFromClusterTaskSpec extends Specification {
       }
       """.stripIndent()
   }
+
+  def 'find image from cluster should use moniker if available or else fallback on frigga'() {
+    given:
+    def stage = new Stage<>(new Pipeline("orca"), 'findImageFromCluster', [
+      cluster    : cluster,
+      moniker    : moniker,
+    ])
+    when:
+    FindImageFromClusterTask.FindImageConfiguration config = stage.mapTo(FindImageFromClusterTask.FindImageConfiguration)
+
+    then:
+    config.getApplication() == expected
+
+    where:
+    cluster | moniker | expected
+    'clustername' | [ 'app': 'appname' ] | 'appname'
+    'app-stack' | null | 'app'
+
+  }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
@@ -33,7 +33,7 @@ import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 class FindImageFromClusterTaskSpec extends Specification {
 
   @Subject
-      task = new FindImageFromClusterTask()
+    task = new FindImageFromClusterTask()
   OortService oortService = Mock(OortService)
 
   def setup() {
@@ -47,23 +47,23 @@ class FindImageFromClusterTaskSpec extends Specification {
     def pipe = pipeline {
       application = "contextAppName" // Should be ignored.
     }
-      def stage = new Stage<>(pipe, "findImage", [
-          cloudProvider    : "cloudProvider",
-          cluster          : "foo-test",
-          account          : "test",
-          selectionStrategy: "LARGEST",
-          onlyEnabled      : "false",
-          regions          : [location1.value, location2.value]
-      ])
+    def stage = new Stage<>(pipe, "findImage", [
+      cloudProvider    : "cloudProvider",
+      cluster          : "foo-test",
+      account          : "test",
+      selectionStrategy: "LARGEST",
+      onlyEnabled      : "false",
+      regions          : [location1.value, location2.value]
+    ])
 
     when:
-      def result = task.execute(stage)
+    def result = task.execute(stage)
 
     then:
-      1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location1.value,
-          "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse1
-      1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location2.value,
-          "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse2
+    1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location1.value,
+      "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse1
+    1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location2.value,
+      "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse2
     assertNorth result.outputs?.deploymentDetails?.find {
       it.region == "north"
     } as Map
@@ -72,28 +72,28 @@ class FindImageFromClusterTaskSpec extends Specification {
     } as Map
 
     where:
-      location1 = new Location(type: Location.Type.REGION, value: "north")
-      location2 = new Location(type: Location.Type.REGION, value: "south")
+    location1 = new Location(type: Location.Type.REGION, value: "north")
+    location2 = new Location(type: Location.Type.REGION, value: "south")
 
-      oortResponse1 = [
-        summaries: [[
-          serverGroupName:  "foo-test-v000",
-          imageId: "ami-012",
-          imageName: "ami-012-name",
-          image: [ imageId: "ami-012", name: "ami-012-name", foo: "bar" ],
-          buildInfo: [ job: "foo-build", buildNumber: 1 ]
-        ]]
-      ]
+    oortResponse1 = [
+      summaries: [[
+                    serverGroupName: "foo-test-v000",
+                    imageId        : "ami-012",
+                    imageName      : "ami-012-name",
+                    image          : [imageId: "ami-012", name: "ami-012-name", foo: "bar"],
+                    buildInfo      : [job: "foo-build", buildNumber: 1]
+                  ]]
+    ]
 
-      oortResponse2 = [
-        summaries: [[
-          serverGroupName:  "foo-test-v002",
-          imageId: "ami-234",
-          imageName: "ami-234-name",
-          image: [ imageId: "ami-234", name: "ami-234-name", foo: "baz" ],
-          buildInfo: [ job: "foo-build", buildNumber: 1 ]
-        ]]
-      ]
+    oortResponse2 = [
+      summaries: [[
+                    serverGroupName: "foo-test-v002",
+                    imageId        : "ami-234",
+                    imageName      : "ami-234-name",
+                    image          : [imageId: "ami-234", name: "ami-234-name", foo: "baz"],
+                    buildInfo      : [job: "foo-build", buildNumber: 1]
+                  ]]
+    ]
   }
 
   def "should be RUNNING if summary does not include imageId"() {
@@ -123,17 +123,17 @@ class FindImageFromClusterTaskSpec extends Specification {
 
     oortResponse1 = [
       summaries: [[
-                    serverGroupName:  "foo-test-v000",
-                    imageId: "ami-012",
-                    imageName: "ami-012-name",
-                    image: [ imageId: "ami-012", name: "ami-012-name", foo: "bar" ],
-                    buildInfo: [ job: "foo-build", buildNumber: 1 ]
+                    serverGroupName: "foo-test-v000",
+                    imageId        : "ami-012",
+                    imageName      : "ami-012-name",
+                    image          : [imageId: "ami-012", name: "ami-012-name", foo: "bar"],
+                    buildInfo      : [job: "foo-build", buildNumber: 1]
                   ]]
     ]
 
     oortResponse2 = [
       summaries: [[
-                    serverGroupName:  "foo-test-v002"
+                    serverGroupName: "foo-test-v002"
                   ]]
     ]
   }
@@ -181,12 +181,12 @@ class FindImageFromClusterTaskSpec extends Specification {
     }
     def stage = new Stage<>(pipe, "findImage", [
       resolveMissingLocations: true,
-      cloudProvider    : "cloudProvider",
-      cluster          : "foo-test",
-      account          : "test",
-      selectionStrategy: "LARGEST",
-      onlyEnabled      : "false",
-      regions          : [location1.value, location2.value]
+      cloudProvider          : "cloudProvider",
+      cluster                : "foo-test",
+      account                : "test",
+      selectionStrategy      : "LARGEST",
+      onlyEnabled            : "false",
+      regions                : [location1.value, location2.value]
     ])
 
     when:
@@ -213,12 +213,12 @@ class FindImageFromClusterTaskSpec extends Specification {
 
     oortResponse1 = [
       summaries: [[
-        serverGroupName: "foo-test-v000",
-        imageId        : "ami-012",
-        imageName      : "ami-012-name-ebs",
-        image          : [imageId: "ami-012", name: "ami-012-name-ebs", foo: "bar"],
-        buildInfo      : [job: "foo-build", buildNumber: 1]
-      ]]
+                    serverGroupName: "foo-test-v000",
+                    imageId        : "ami-012",
+                    imageName      : "ami-012-name-ebs",
+                    image          : [imageId: "ami-012", name: "ami-012-name-ebs", foo: "bar"],
+                    buildInfo      : [job: "foo-build", buildNumber: 1]
+                  ]]
     ]
 
     imageSearchResult = [
@@ -230,7 +230,7 @@ class FindImageFromClusterTaskSpec extends Specification {
       ],
       [
         imageName: "ami-012-name-ebs1",
-        amis : [
+        amis     : [
           "south": ["ami-234"]
         ]
       ]
@@ -244,12 +244,12 @@ class FindImageFromClusterTaskSpec extends Specification {
     }
     def stage = new Stage<>(pipe, "findImage", [
       resolveMissingLocations: true,
-      cloudProvider    : "cloudProvider",
-      cluster          : "foo-test",
-      account          : "test",
-      selectionStrategy: "LARGEST",
-      onlyEnabled      : "false",
-      regions          : [location1.value, location2.value]
+      cloudProvider          : "cloudProvider",
+      cluster                : "foo-test",
+      account                : "test",
+      selectionStrategy      : "LARGEST",
+      onlyEnabled            : "false",
+      regions                : [location1.value, location2.value]
     ])
 
     when:
@@ -276,11 +276,11 @@ class FindImageFromClusterTaskSpec extends Specification {
 
     oortResponse1 = [
       summaries: [[
-        serverGroupName: "foo-test-v000",
-        imageId        : "ami-012",
-        imageName      : "ami-012-name-ebs",
-        image          : [imageId: "ami-012", name: "ami-012-name-ebs", foo: "bar"]
-      ]]
+                    serverGroupName: "foo-test-v000",
+                    imageId        : "ami-012",
+                    imageName      : "ami-012-name-ebs",
+                    image          : [imageId: "ami-012", name: "ami-012-name-ebs", foo: "bar"]
+                  ]]
     ]
 
     imageSearchResult = [
@@ -292,7 +292,7 @@ class FindImageFromClusterTaskSpec extends Specification {
       ],
       [
         imageName: "ami-012-name-ebs1",
-        amis : [
+        amis     : [
           "south": ["ami-234"]
         ]
       ]
@@ -307,12 +307,12 @@ class FindImageFromClusterTaskSpec extends Specification {
     }
     def stage = new Stage<>(pipe, "findImage", [
       resolveMissingLocations: true,
-      cloudProvider    : "aws",
-      cluster          : "foo-test",
-      account          : "test",
-      selectionStrategy: "LARGEST",
-      onlyEnabled      : "false",
-      regions          : [location1.value, location2.value]
+      cloudProvider          : "aws",
+      cluster                : "foo-test",
+      account                : "test",
+      selectionStrategy      : "LARGEST",
+      onlyEnabled            : "false",
+      regions                : [location1.value, location2.value]
     ])
 
     when:
@@ -356,7 +356,7 @@ class FindImageFromClusterTaskSpec extends Specification {
       ],
       [
         imageName: "ami-012-name-ebs1",
-        amis : [
+        amis     : [
           "south": ["ami-234"]
         ]
       ]
@@ -367,30 +367,30 @@ class FindImageFromClusterTaskSpec extends Specification {
   def "should parse fail strategy error message"() {
     given:
     def stage = new Stage<>(new Pipeline("orca"), "whatever", [
-          cloudProvider    : "cloudProvider",
-          cluster          : "foo-test",
-          account          : "test",
-          selectionStrategy: "FAIL",
-          onlyEnabled      : "false",
-          zones          : [location.value]
-      ])
+      cloudProvider    : "cloudProvider",
+      cluster          : "foo-test",
+      account          : "test",
+      selectionStrategy: "FAIL",
+      onlyEnabled      : "false",
+      zones            : [location.value]
+    ])
 
-      Response response = new Response("http://oort", 404, "NOT_FOUND", [], new TypedString(oortResponse))
+    Response response = new Response("http://oort", 404, "NOT_FOUND", [], new TypedString(oortResponse))
 
     when:
     task.execute(stage)
 
     then:
-      1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location.value,
-          "FAIL", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> {
-        throw new RetrofitError(null, null, response, null, null, null, null)
-      }
-      IllegalStateException ise = thrown()
-      ise.message == "Multiple possible server groups present in ${location.value}".toString()
+    1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location.value,
+      "FAIL", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> {
+      throw new RetrofitError(null, null, response, null, null, null, null)
+    }
+    IllegalStateException ise = thrown()
+    ise.message == "Multiple possible server groups present in ${location.value}".toString()
 
     where:
-      location = new Location(type: Location.Type.ZONE, value: "north-pole-1a")
-      oortResponse = """\
+    location = new Location(type: Location.Type.ZONE, value: "north-pole-1a")
+    oortResponse = """\
       {
         "error" : "target.fail.strategy",
         "message" : "target.fail.strategy",
@@ -399,11 +399,12 @@ class FindImageFromClusterTaskSpec extends Specification {
       """.stripIndent()
   }
 
-  def 'find image from cluster should use moniker if available or else fallback on frigga'() {
+  @Unroll
+  'cluster with name "#cluster" and moniker "#moniker" should have application name "#expected"'() {
     given:
     def stage = new Stage<>(new Pipeline("orca"), 'findImageFromCluster', [
-      cluster    : cluster,
-      moniker    : moniker,
+      cluster: cluster,
+      moniker: moniker,
     ])
     when:
     FindImageFromClusterTask.FindImageConfiguration config = stage.mapTo(FindImageFromClusterTask.FindImageConfiguration)
@@ -412,9 +413,9 @@ class FindImageFromClusterTaskSpec extends Specification {
     config.getApplication() == expected
 
     where:
-    cluster | moniker | expected
-    'clustername' | [ 'app': 'appname' ] | 'appname'
-    'app-stack' | null | 'app'
+    cluster       | moniker            | expected
+    'clustername' | ['app': 'appname'] | 'appname'
+    'app-stack'   | null               | 'app'
 
   }
 }


### PR DESCRIPTION
Deducing the application name of a cluster is handled in two ways:
1. For newer pipeline configs: a moniker will be used to determine a cluster's application.
2. Older pipeline configs: since there isn't a moniker we need to fall back on frigga.

