### PR TITLE
feat(declarative): Scaffold declarative module POC

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -16,10 +16,6 @@
 
 package com.netflix.spinnaker.orca.pipeline;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
@@ -28,6 +24,12 @@ import com.netflix.spinnaker.orca.pipeline.model.Pipeline;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
 import static java.lang.Boolean.parseBoolean;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -50,8 +52,11 @@ public abstract class ExecutionLauncher<T extends Execution<T>> {
   }
 
   public T start(String configJson) throws Exception {
-    final T execution = parse(configJson);
+    final T execution = start(parse(configJson));
+    return persistAndStart(execution);
+  }
 
+  public T persistAndStart(T execution) throws Exception {
     checkRunnable(execution);
 
     persistExecution(execution);

--- a/orca-declarative/orca-declarative.gradle
+++ b/orca-declarative/orca-declarative.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply from: "$rootDir/gradle/kotlin.gradle"
+apply from: "$rootDir/gradle/spek.gradle"
+
+repositories {
+  jcenter()
+}
+
+dependencies {
+  compile project(":orca-core")
+  compile "com.fasterxml.jackson.module:jackson-module-kotlin:${spinnaker.version("jackson")}"
+  compile 'com.github.jonpeterson:jackson-module-model-versioning:1.2.2'
+}

--- a/orca-declarative/src/main/kotlin/com/netflix/spinnaker/config/DeclarativeConfiguration.kt
+++ b/orca-declarative/src/main/kotlin/com/netflix/spinnaker/config/DeclarativeConfiguration.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.github.jonpeterson.jackson.module.versioning.VersioningModule
+import com.netflix.spinnaker.orca.declarative.Intent
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.type.filter.AssignableTypeFilter
+import org.springframework.util.ClassUtils
+
+@Configuration
+@ConditionalOnProperty("declarative.enabled")
+@ComponentScan(basePackages = arrayOf(
+  "com.netflix.spinnaker.orca.declarative",
+  "com.netflix.spinnaker.orca.declarative.intents",
+  "com.netflix.spinnaker.orca.declarative.pipelines",
+  "com.netflix.spinnaker.orca.declarative.tasks"
+))
+open class DeclarativeConfiguration {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  @Bean
+  open fun declarativeObjectMapper(): ObjectMapper
+    = ObjectMapper().apply {
+        registerSubtypes(*findAllIntentSubtypes().toTypedArray())
+      }
+      .registerModule(KotlinModule())
+      .registerModule(VersioningModule())
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+
+  private fun findAllIntentSubtypes(): List<Class<*>> {
+    return ClassPathScanningCandidateComponentProvider(false).apply {
+      addIncludeFilter(AssignableTypeFilter(Intent::class.java))
+    }
+      .findCandidateComponents("com.netflix.spinnaker.orca.declarative.intents")
+      .map {
+        val cls = ClassUtils.resolveClassName(it.beanClassName, ClassUtils.getDefaultClassLoader())
+        log.info("Registering Intent: ${cls.simpleName}")
+        return@map cls
+      }
+  }
+
+}

--- a/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/Intent.kt
+++ b/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/Intent.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.declarative
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.github.jonpeterson.jackson.module.versioning.JsonSerializeToVersion
+import com.netflix.spinnaker.orca.pipeline.model.Orchestration
+
+/**
+ * An Intent represents a new, discrete desired state. An Intent can contain
+ * other Intents to be updated at the same time. They are responsible for taking
+ * user (or system) inputs via their Specification and converting them into one
+ * of two outputs:
+ *
+ * 1. Intents can be output as an IntentPlan, which will construct both a set of
+ *    resources that will be changing. An IntentPlan can either be used to return
+ *    to the user, or to be applied and optionally abort if expected output does
+ *    not match the plan.
+ * 2. Intents can output an Orchestration that will apply the desired state
+ *    immediately without first performing a plan.
+ *
+ * TODO rz - override flag?
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+abstract class Intent<S : IntentSpec>
+@JsonCreator constructor(
+  @JsonSerializeToVersion(defaultToSource = true) val schema: String,
+  val kind: String,
+  val spec: S
+) {
+
+  abstract fun plan(metadata: IntentMetadata): IntentPlan<S>
+  abstract fun apply(i: IntentPlan<S>, metadata: IntentMetadata): List<Orchestration>
+  abstract fun apply(metadata: IntentMetadata): List<Orchestration>
+}
+
+interface IntentSpec
+
+// Current API design: intentspecs can be nested: Allows plans to create checkpoints
+// parallel execution graphs
+interface IntentPlan<S : IntentSpec>
+

--- a/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/IntentInvocationWrapper.kt
+++ b/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/IntentInvocationWrapper.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.declarative
+
+import java.util.*
+
+/**
+ * IntentRequestWrapper is the expected data wrapper for invoking intents via an orchestration.
+ */
+data class IntentInvocationWrapper(
+  val schema: String,
+  val metadata: IntentMetadata,
+  val intents: List<Intent<*>>,
+  val plan: Boolean = false
+)
+
+// The data fields that must be set from the orchestration request that is called
+// to start the intent process.
+// TODO rz - Add trigger information?
+data class IntentMetadata(
+  // application defines which application this intent will be applied to, or
+  // which application is the ultimate "owner" of the state change, in the case
+  // of an Intent crossing application boundaries.
+  val application: String,
+  val origin: String
+) {
+  // id is used to track an intent over multiple task invocations.
+  val id = UUID.randomUUID().toString()
+}

--- a/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/IntentLauncher.kt
+++ b/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/IntentLauncher.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.declarative
+
+import com.netflix.spinnaker.orca.pipeline.OrchestrationLauncher
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Orchestration
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.time.Clock
+
+@Component
+class IntentLauncher
+@Autowired constructor(
+  private val orchestrationLauncher: OrchestrationLauncher,
+  private val clock: Clock
+) {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  fun launch(intent: Intent<*>, request: IntentInvocationWrapper): List<Orchestration> {
+    if (request.plan) {
+      // TODO rz - do
+      throw UnsupportedOperationException("planning is not supported")
+    }
+
+    return mutableListOf<Orchestration>().apply {
+      intent.apply(request.metadata).forEach {
+        log.info("Intent launching orchestration (intent: ${request.metadata.id}, orchestration: ${it.id})")
+
+        configureOrchestration(it, request.metadata.origin)
+        add(orchestrationLauncher.persistAndStart(it))
+      }
+    }
+  }
+
+  private fun configureOrchestration(orchestration: Orchestration, o: String) {
+    orchestration.apply {
+      executionEngine = Execution.ExecutionEngine.v3
+      buildTime = clock.millis()
+      authentication = Execution.AuthenticationDetails.build().orElse(Execution.AuthenticationDetails())
+      origin = o
+    }
+  }
+}

--- a/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/converter/ApplicationToCurrentConverter.kt
+++ b/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/converter/ApplicationToCurrentConverter.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.declarative.converter
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.github.jonpeterson.jackson.module.versioning.VersionedModelConverter
+
+class ApplicationToCurrentConverter : VersionedModelConverter {
+
+  override fun convert(modelData: ObjectNode?, modelVersion: String?, targetModelVersion: String?, nodeFactory: JsonNodeFactory?): ObjectNode {
+    throw UnsupportedOperationException("not implemented")
+  }
+}

--- a/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/converter/ChaosMonkeyToCurrentConverter.kt
+++ b/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/converter/ChaosMonkeyToCurrentConverter.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.declarative.converter
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.github.jonpeterson.jackson.module.versioning.VersionedModelConverter
+
+class ChaosMonkeyToCurrentConverter : VersionedModelConverter {
+  override fun convert(modelData: ObjectNode?, modelVersion: String?, targetModelVersion: String?, nodeFactory: JsonNodeFactory?): ObjectNode {
+    throw UnsupportedOperationException("not implemented")
+  }
+}
+

--- a/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/exceptions/DeclarativeException.kt
+++ b/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/exceptions/DeclarativeException.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.declarative.exceptions
+
+class DeclarativeException : RuntimeException {
+  constructor() : super()
+  constructor(message: String?) : super(message)
+  constructor(message: String?, cause: Throwable?) : super(message, cause)
+}

--- a/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/intents/ApplicationIntent.kt
+++ b/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/intents/ApplicationIntent.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.declarative.intents
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.github.jonpeterson.jackson.module.versioning.JsonVersionedModel
+import com.netflix.spinnaker.orca.declarative.Intent
+import com.netflix.spinnaker.orca.declarative.IntentMetadata
+import com.netflix.spinnaker.orca.declarative.IntentPlan
+import com.netflix.spinnaker.orca.declarative.IntentSpec
+import com.netflix.spinnaker.orca.declarative.converter.ApplicationToCurrentConverter
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.pipeline.model.Orchestration
+import java.time.LocalDateTime
+
+/**
+ * The ApplicationIntent is responsible for updating all application configuration preferences.
+ */
+@JsonTypeName("Application")
+@JsonVersionedModel(currentVersion = "1", toCurrentConverterClass = ApplicationToCurrentConverter::class, propertyName = "schema")
+class ApplicationIntent
+@JsonCreator constructor(spec: ApplicationSpec) : Intent<ApplicationSpec>(
+  kind = "Application",
+  schema = "1",
+  spec = spec
+) {
+  override fun plan(metadata: IntentMetadata): IntentPlan<ApplicationSpec> {
+    throw UnsupportedOperationException("not implemented")
+  }
+
+  override fun apply(i: IntentPlan<ApplicationSpec>, metadata: IntentMetadata): List<Orchestration> {
+    throw UnsupportedOperationException("not implemented")
+  }
+
+  // TODO rz - Use case applying multiple / embedded intents.
+  override fun apply(metadata: IntentMetadata)
+    = listOf(Orchestration(metadata.application).apply {
+      name = "Update application"
+      description = "Converging on external state intent"
+      isLimitConcurrent = true
+      isKeepWaitingPipelines = true
+      origin = metadata.origin
+      stages.add(StageDefinitionBuilder.newStage(
+        this,
+        "upsertApplication",
+        null,
+        spec.toUpsertApplicationContext(),
+        null,
+        null))
+    })
+}
+
+data class ApplicationSpec(
+  val name: String,
+  val description: String,
+  val type: String,
+  val email: String,
+  val updateTs: LocalDateTime,
+  val createTs: LocalDateTime,
+  val repoType: String,
+  val repoSlug: String,
+  val repoProjectKey: String,
+  val owner: String,
+  val enableRestartRunningExecutions: Boolean,
+  val accounts: Set<String>,
+  val appGroup: String,
+  val group: String,
+  val cloudProviders: Set<String>,
+  val requiredGroupMembership: Set<String>,
+  val pdApiKey: String,
+  val dataSources: ApplicationFeatures,
+  val chaosMonkey: ChaosMonkeySpec
+) : IntentSpec {
+  // TODO rz - This is pretty janky, backwards-compatibility with the rest of orca. Would prefer to use everywhere in time.
+  fun toUpsertApplicationContext() = mapOf<String, Any>(
+    "name" to name,
+    "description" to description,
+    "type" to type,
+    "email" to email,
+    "updateTs" to updateTs,
+    "createTs" to createTs,
+    "repoType" to repoType,
+    "repoSlug" to repoSlug,
+    "repoProjectKey" to repoProjectKey,
+    "owner" to owner,
+    "enableRestartRunningExecutions" to enableRestartRunningExecutions,
+    "accounts" to accounts,
+    "appGroup" to appGroup,
+    "group" to group,
+    "cloudProviders" to cloudProviders,
+    "requiredGroupMembership" to requiredGroupMembership,
+    "dataSources" to dataSources,
+    "pdApiKey" to pdApiKey
+    // TODO rz - finish
+  )
+}
+
+data class ApplicationFeatures(
+  val enabled: Set<String>,
+  val disabled: Set<String>
+)

--- a/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/intents/ChaosMonkeyIntent.kt
+++ b/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/intents/ChaosMonkeyIntent.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.declarative.intents
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.github.jonpeterson.jackson.module.versioning.JsonVersionedModel
+import com.netflix.spinnaker.orca.declarative.Intent
+import com.netflix.spinnaker.orca.declarative.IntentMetadata
+import com.netflix.spinnaker.orca.declarative.IntentPlan
+import com.netflix.spinnaker.orca.declarative.IntentSpec
+import com.netflix.spinnaker.orca.declarative.converter.ChaosMonkeyToCurrentConverter
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.pipeline.model.Orchestration
+
+@JsonTypeName("ChaosMonkey")
+@JsonVersionedModel(currentVersion = "1", toCurrentConverterClass = ChaosMonkeyToCurrentConverter::class, propertyName = "schema")
+class ChaosMonkeyIntent
+@JsonCreator constructor(spec: ChaosMonkeySpec) : Intent<ChaosMonkeySpec>(
+  kind = "ChaosMonkey",
+  schema = "1",
+  spec = spec
+) {
+
+  override fun plan(metadata: IntentMetadata): IntentPlan<ChaosMonkeySpec> {
+    throw UnsupportedOperationException("not implemented")
+  }
+
+  override fun apply(i: IntentPlan<ChaosMonkeySpec>, metadata: IntentMetadata): List<Orchestration> {
+    throw UnsupportedOperationException("not implemented")
+  }
+
+  override fun apply(metadata: IntentMetadata): List<Orchestration>
+    = listOf(Orchestration(metadata.application).apply {
+        name = "Update Chaos Monkey settings"
+        description = "Converging on external state intent"
+        isLimitConcurrent = true
+        isKeepWaitingPipelines = true
+        origin = metadata.origin
+        stages.add(StageDefinitionBuilder.newStage(
+          this,
+          "upsertApplication",
+          null,
+          mapOf(
+            "name" to metadata.application,
+            "chaosMonkey" to spec.toUpsertApplicationContext()
+          ),
+          null,
+          null))
+      })
+}
+
+data class ChaosMonkeySpec(
+  val enabled: Boolean,
+  val meanTimeBetweenKillsInWorkDays: Int,
+  val minTimeBetweenKillsInWorkDays: Int,
+  val grouping: String,
+  val regionsAreIndependent: Boolean,
+  val exceptions: List<ChaosMonkeyExceptionRule>
+) : IntentSpec {
+  // TODO rz - Should probably look into something like a base toMap() fun
+  fun toUpsertApplicationContext() = mapOf<String, Any>(
+    "enabled" to enabled,
+    "meanTimeBetweenKillsInWorkDays" to meanTimeBetweenKillsInWorkDays,
+    "minTimeBetweenKillsInWorkDays" to minTimeBetweenKillsInWorkDays,
+    "grouping" to grouping,
+    "regionsAreIndependent" to regionsAreIndependent,
+    "exceptions" to exceptions.map { it.toUpsertApplicationContext() }
+  )
+}
+
+data class ChaosMonkeyExceptionRule(
+  val region: String,
+  val account: String,
+  val detail: String,
+  val stack: String
+) {
+  fun toUpsertApplicationContext() = mapOf<String, Any>(
+    "region" to region,
+    "account" to account,
+    "detail" to detail,
+    "stack" to stack
+  )
+}

--- a/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/pipelines/InvokeIntentStage.kt
+++ b/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/pipelines/InvokeIntentStage.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.declarative.pipelines
+
+import com.netflix.spinnaker.orca.declarative.tasks.InvokeIntentTask
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.pipeline.TaskNode
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.stereotype.Component
+
+@Component
+class InvokeIntentStage : StageDefinitionBuilder {
+
+  override fun <T : Execution<T>?> taskGraph(stage: Stage<T>, builder: TaskNode.Builder) {
+    builder.withTask("invokeIntents", InvokeIntentTask::class.java)
+    // TODO rz - add monitor intents task
+  }
+}

--- a/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/tasks/InvokeIntentTask.kt
+++ b/orca-declarative/src/main/kotlin/com/netflix/spinnaker/orca/declarative/tasks/InvokeIntentTask.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.declarative.tasks
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.declarative.IntentInvocationWrapper
+import com.netflix.spinnaker.orca.declarative.IntentLauncher
+import com.netflix.spinnaker.orca.declarative.exceptions.DeclarativeException
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+
+@Component
+class InvokeIntentTask
+@Autowired constructor(
+  private val intentLauncher: IntentLauncher,
+  @Qualifier("declarativeObjectMapper") private val mapper: ObjectMapper
+): Task {
+
+  override fun execute(stage: Stage<out Execution<*>>): TaskResult {
+    if (!stage.getContext().containsKey("intent")) {
+      throw DeclarativeException("Missing 'intent' context key")
+    }
+
+    val wrapper = mapper.convertValue(stage.getContext()["intent"], IntentInvocationWrapper::class.java)
+
+    val executionIds = wrapper.intents
+      .map { intentLauncher.launch(it, wrapper) }
+      .flatten()
+      .map { it.id }
+
+    return TaskResult(ExecutionStatus.SUCCEEDED, mapOf<String, Any>(
+      "intentId" to wrapper.metadata.id,
+      "executionIds" to executionIds
+    ))
+  }
+}

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -47,6 +47,7 @@ dependencies {
   compile project(":orca-eureka")
   compile project(":orca-queue-redis")
   compile project(":orca-pipelinetemplate")
+  compile project(":orca-declarative")
 
   runtime spinnaker.dependency("kork")
   compile spinnaker.dependency('korkExceptions')

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,7 +35,8 @@ include "orca-extensionpoint",
   "orca-queue-redis",
   "orca-queue-sqs",
   "orca-pipelinetemplate",
-  "orca-validation"
+  "orca-validation",
+  "orca-declarative"
 
 if (!Boolean.parseBoolean(System.getProperty('skip.loadtest'))) {
   include "orca-loadtest"


### PR DESCRIPTION
Before I go down the rabbit hole of a real initial impl (and the tests to go with), I wanted to get some POC code out there for thoughts on approach.

Declarative intents are submitted as an orchestration. In this PR, I wired up an Intent that updates an app's Chaos Monkey config settings.

```json
{
  "application": "spindemo",
  "description": "testing declarative",
  "job": [
    {
      "type": "invokeIntent",
      "intent": {
        "schema": "1",
        "metadata": {
          "application": "spindemo",
          "origin": "api"
        },
        "intents": [
          {
            "kind": "ChaosMonkey",
            "schema": "1",
            "spec": {
              "enabled": true,
              "meanTimeBetweenKillsInWorkDays": 2,
              "minTimeBetweenKillsInWorkDays": 1,
              "grouping": "cluster",
              "regionsAreIndependent": true,
              "exceptions": []
            }
          }
        ]
      }
    }
  ]
}
```

When an intent orchestration is submitted, it will fanout orchestrations for each intent, so if 5 intents are submitted via `invokeIntent`, it will run 5 additional orchestrations. The top-level invocation orchestration returns succeeded if all fanned out orchestrations are successfully started, but it does not track completion. Not yet designed is concepts for running / resolving state conflict resolution, orchestration dependency resolution (will be necessary for submitting a security group and LB intent alongside each other, for example), etc.

Each Intent has its own schema version, which will allow us to iterate individual schemas. I'd like to introduce the ability to bring-your-own Intent implementation (allow us to have a Netflix-specific ApplicationIntent, for example, to supply our additional metadata). Each Intent also gets a Converter, which we could use to help users migrate their `.spinnaker` files.

cc @spinnaker/netflix-reviewers 