### PR TITLE
(DO NOT MERGE) feat(expressions): Expose getTargetServerGroup() as an expression fn

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -41,8 +41,8 @@ public class DelegatingOortService
   }
 
   @Override
-  public Response getServerGroups(String app) {
-    return getService().getServerGroups(app);
+  public Response getServerGroups(String app, boolean expand) {
+    return getService().getServerGroups(app, expand);
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -31,7 +31,7 @@ interface OortService {
                       @Path("cloudProvider") String cloudProvider)
 
   @GET("/applications/{app}/serverGroups")
-  Response getServerGroups(@Path("app") String app)
+  Response getServerGroups(@Path("app") String app, @Query("expand") boolean expand)
 
   @GET("/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/serverGroups/{serverGroup}")
   Response getServerGroupFromCluster(@Path("app") String app,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/expressions/CloudDriverExpressionFunctionProvider.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/expressions/CloudDriverExpressionFunctionProvider.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.expressions;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.clouddriver.MortService;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionFunctionProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Component
+public class CloudDriverExpressionFunctionProvider implements ExpressionFunctionProvider {
+  private static final AtomicReference<ObjectMapper> objectMapper = new AtomicReference<>();
+  private static final AtomicReference<OortService> oortService = new AtomicReference<>();
+  private static final AtomicReference<MortService> mortService = new AtomicReference<>();
+
+  @Autowired
+  public CloudDriverExpressionFunctionProvider(ObjectMapper objectMapper,
+                                               OortService oortService,
+                                               MortService mortService) {
+    CloudDriverExpressionFunctionProvider.objectMapper.set(objectMapper);
+    CloudDriverExpressionFunctionProvider.oortService.set(oortService);
+    CloudDriverExpressionFunctionProvider.mortService.set(mortService);
+  }
+
+  @Override
+  public String getNamespace() {
+    return "api_v1";
+  }
+
+  @Override
+  public Collection<FunctionDefinition> getFunctions() {
+    List<FunctionDefinition> functions = new ArrayList<>();
+    functions.add(new FunctionDefinition(
+      "echo", Collections.singletonList(new FunctionParameter(String.class, "value"))
+    ));
+    functions.add(new FunctionDefinition(
+      "getTargetServerGroup",
+      Arrays.asList(
+        new FunctionParameter(String.class, "application"),
+        new FunctionParameter(String.class, "account"),
+        new FunctionParameter(String.class, "cluster"),
+        new FunctionParameter(String.class, "cloudProvider"), // TODO-AJ this should be an optional parameter
+        new FunctionParameter(String.class, "scope", "Region, zone or namespace depending on cloud provider"),
+        new FunctionParameter(String.class, "target", "One of CURRENT, PREVIOUS, OLDEST, LARGEST")
+      )
+    ));
+
+    return functions;
+  }
+
+  static String echo(String parameter) {
+    return "Hello " + parameter;
+  }
+
+  static List<Map> getTargetServerGroup(String application,
+                                        String account,
+                                        String cluster,
+                                        String cloudProvider,
+                                        String scope,
+                                        String target) {
+    try {
+      Response response = oortService.get().getTargetServerGroup(application, account, cluster, cloudProvider, scope, target);
+      Map targetServerGroup = objectMapper.get().readValue(response.getBody().in(), new TypeReference<Map>() {
+      });
+      return Collections.singletonList(targetServerGroup);
+    } catch (Exception e) {
+      return Collections.emptyList();
+    }
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -17,7 +17,12 @@ package com.netflix.spinnaker.orca.config;
 
 import java.time.Clock;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.orca.events.ExecutionEvent;
@@ -32,6 +37,7 @@ import com.netflix.spinnaker.orca.listeners.MetricsExecutionListener;
 import com.netflix.spinnaker.orca.notifications.scheduling.SuspendedPipelinesNotificationHandler;
 import com.netflix.spinnaker.orca.pipeline.PipelineStartTracker;
 import com.netflix.spinnaker.orca.pipeline.PipelineStarterListener;
+import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionFunctionProvider;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.orca.pipeline.persistence.PipelineStack;
 import com.netflix.spinnaker.orca.pipeline.persistence.memory.InMemoryPipelineStack;
@@ -134,8 +140,13 @@ public class OrcaConfiguration {
 
   @Bean
   public ContextFunctionConfiguration contextFunctionConfiguration(UserConfiguredUrlRestrictions userConfiguredUrlRestrictions,
+                                                                   Optional<List<ExpressionFunctionProvider>> expressionFunctionProviders,
                                                                    @Value("${spelEvaluator:v1}") String spelEvaluator) {
-    return new ContextFunctionConfiguration(userConfiguredUrlRestrictions, spelEvaluator);
+    return new ContextFunctionConfiguration(
+      userConfiguredUrlRestrictions,
+      expressionFunctionProviders.orElse(Collections.emptyList()),
+      spelEvaluator
+    );
   }
 
   @Bean

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionFunctionProvider.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionFunctionProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.expressions;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface ExpressionFunctionProvider {
+  String getNamespace();
+  Collection<FunctionDefinition> getFunctions();
+
+  class FunctionDefinition {
+    private final String name;
+    private final List<FunctionParameter> parameters;
+
+    public FunctionDefinition(String name, List<FunctionParameter> parameters) {
+      this.name = name;
+      this.parameters = parameters;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public List<FunctionParameter> getParameters() {
+      return parameters;
+    }
+  }
+
+  class FunctionParameter {
+    private final Class type;
+    private final String name;
+    private final String description;
+
+    public FunctionParameter(Class type, String name) {
+      this(type, name, null);
+    }
+
+    public FunctionParameter(Class type, String name, String description) {
+      this.type = type;
+      this.name = name;
+      this.description = description;
+    }
+
+    public Class getType() {
+      return type;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
@@ -49,8 +49,13 @@ public class PipelineExpressionEvaluator extends ExpressionsSupport implements E
   }
 
   @Override
-  public Map<String, Object> evaluate(Map<String, Object> source, Object rootObject, ExpressionEvaluationSummary summary, boolean ignoreUnknownProperties) {
-    StandardEvaluationContext evaluationContext = newEvaluationContext(rootObject, ignoreUnknownProperties);
+  public Map<String, Object> evaluate(Map<String, Object> source,
+                                      Object rootObject,
+                                      ExpressionEvaluationSummary summary,
+                                      boolean ignoreUnknownProperties) {
+    StandardEvaluationContext evaluationContext = newEvaluationContext(
+      rootObject, ignoreUnknownProperties
+    );
     return new ExpressionTransform(parserContext, parser).transform(source, evaluationContext, summary);
   }
 

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.pipeline.util
 
 import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionEvaluationSummary
 import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionEvaluator
+import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionFunctionProvider
 import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Orchestration
@@ -355,13 +356,16 @@ class ContextParameterProcessor {
   }
 }
 
-
 class ContextFunctionConfiguration {
   final UserConfiguredUrlRestrictions urlRestrictions
+  final Collection<ExpressionFunctionProvider> expressionFunctionProviders;
   final String spelEvaluator
 
-  ContextFunctionConfiguration(UserConfiguredUrlRestrictions urlRestrictions, String spelEvaluator = V1) {
+  ContextFunctionConfiguration(UserConfiguredUrlRestrictions urlRestrictions,
+                               Collection<ExpressionFunctionProvider> expressionFunctionProviders = [],
+                               String spelEvaluator = V1) {
     this.urlRestrictions = urlRestrictions
+    this.expressionFunctionProviders = expressionFunctionProviders;
     this.spelEvaluator = spelEvaluator
   }
 


### PR DESCRIPTION
This proof of concept exposes an extension point through which custom
expression functions can be registered.

The provided example maps `OortService.getServerGroups()` to an
expression function such that the following precondition could be
written:

```
#api_v1_getServerGroups('my_app').?[
  accountName == 'my_account' &&
  cluster == 'my_cluster' &&
  image.imageId == 'ami-xxxxx'
].size() == 0
```

`getServerGroups()` is probably not the right granularity of API to
expose as it can be expensive for large applications.