### PR TITLE
fix(queue): treat waiting pipelines queue as FIFO if keepWaitingPipel…

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarterListener.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/PipelineStarterListener.java
@@ -75,7 +75,10 @@ public class PipelineStarterListener implements ExecutionListener {
     if (execution.getPipelineConfigId() != null) {
       List<String> queuedPipelines = startTracker.getQueuedPipelines(execution.getPipelineConfigId());
       if (!queuedPipelines.isEmpty()) {
-        String nextPipelineId = queuedPipelines.get(0);
+        // pipelines are stored in a stack...
+        // if we are keeping waiting pipelines, take the oldest one; otherwise, take the most recent
+        int nextIndex = execution.isKeepWaitingPipelines() ? queuedPipelines.size() - 1 : 0;
+        String nextPipelineId = queuedPipelines.get(nextIndex);
         queuedPipelines.forEach(id -> {
           if (Objects.equals(id, nextPipelineId)) {
             Pipeline queuedExecution = executionRepository.retrievePipeline(id);


### PR DESCRIPTION
…ines

When `keepWaitingPipelines` is `true`, the expected behavior is Spinnaker will run all triggered executions. Users expect those pipelines to run in the order they were received.

If `keepWaitingPipelines` is `false`, the user expects Spinnaker to just take the most recently triggered execution and discard any previous ones that were enqueued.

@spinnaker/reviewers PTAL