### PR TITLE
feat(moniker): Allow moniker field to pass through to StageData and TargetServerGroups

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -20,6 +20,7 @@ import groovy.transform.InheritConstructors
 import groovy.transform.ToString
 import groovy.util.logging.Slf4j
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 
@@ -195,6 +196,7 @@ class TargetServerGroup {
     // TODO(ttomsu): This feels dirty - consider structuring to enable an 'exact' Target that just specifies the exact
     // server group name to fetch?
     String serverGroupName
+    Moniker moniker
 
     // Alternatively to asgName, the combination of target and cluster can be used.
     Target target
@@ -205,11 +207,11 @@ class TargetServerGroup {
     String cloudProvider = "aws"
 
     String getApp() {
-      Names.parseName(serverGroupName ?: cluster)?.app
+      moniker?.app ?: Names.parseName(serverGroupName ?: cluster)?.app
     }
 
     String getCluster() {
-      cluster ?: Names.parseName(serverGroupName)?.cluster
+      moniker?.cluster ?: cluster ?: Names.parseName(serverGroupName)?.cluster
     }
 
     static Params fromStage(Stage stage) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageData.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageData.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.kato.pipeline.support
 
 import com.netflix.frigga.autoscaling.AutoScalingGroupNameBuilder
+import com.netflix.spinnaker.moniker.Moniker
 
 class StageData {
   String strategy
@@ -27,6 +28,7 @@ class StageData {
   String freeFormDetails
   String application
   String stack
+  Moniker moniker
   @Deprecated String providerType = "aws"
   String cloudProvider = "aws"
   boolean scaleDown
@@ -38,11 +40,15 @@ class StageData {
   long delayBeforeDisableSec
 
   String getCluster() {
-    def builder = new AutoScalingGroupNameBuilder()
-    builder.appName = application
-    builder.stack = stack
-    builder.detail = freeFormDetails
-    return builder.buildGroupName()
+    if (moniker?.cluster) {
+      return moniker.cluster
+    } else {
+      def builder = new AutoScalingGroupNameBuilder()
+      builder.appName = application
+      builder.stack = stack
+      builder.detail = freeFormDetails
+      return builder.buildGroupName()
+    }
   }
 
   String getAccount() {


### PR DESCRIPTION
Orca casts stage json into StageData and TargetServerGroup throughout the process of running certain stages. This PR will allow the moniker to be maintained.

The corresponding Deck change is still in progress, but Deck will add a moniker to the necessary stages. Here is an example of a deploy stage:

```
{
  "clusters": [
    {
      "account": "aws-dev",
      "application": "nginx",
      "associatePublicIpAddress": true,
      "availabilityZones": {
        "us-west-2": ["us-west-2a"]
      },
      "capacity": {
        "desired": 1,
        "max": 1,
        "min": 1
      },
      "cloudProvider": "aws",
      "cooldown": 10,
      "copySourceCustomBlockDeviceMappings": true,
      "freeFormDetails": "mydetail",
      "healthCheckGracePeriod": 600,
      "healthCheckType": "EC2",
      "instanceMonitoring": false,
      "instanceType": "t2.micro",
      "moniker": {
        "app": "nginx",
        "stack": "mystack",
        "detail": "mydetail",
        "cluster": "nginx-mydetail-mystack"
      },
      "provider": "aws",
      "stack": "mystack",
      "subnetType": "external (spinnaker)",
      "targetHealthyDeployPercentage": 100,
      "terminationPolicies": ["Default"],
      "useAmiBlockDeviceMappings": false
    }
  ],
  "name": "Deploy",
  "type": "deploy"
}
```