### PR TITLE
feat(moniker): Use moniker in DetermineHealthProvidersTask

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import com.netflix.frigga.Names;
+import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.RetryableTask;
 import com.netflix.spinnaker.orca.TaskResult;
@@ -97,7 +98,10 @@ public class DetermineHealthProvidersTask implements RetryableTask, CloudProvide
 
     try {
       String applicationName = (String) stage.getContext().get("application");
-      if (applicationName == null && stage.getContext().containsKey("serverGroupName")) {
+      Moniker moniker = (Moniker) stage.getContext().get("moniker");
+      if (applicationName == null && moniker != null && moniker.getApp() != null) {
+        applicationName = moniker.getApp();
+      } else if (applicationName == null && stage.getContext().containsKey("serverGroupName")) {
         applicationName = Names.parseName((String) stage.getContext().get("serverGroupName")).getApp();
       } else if (applicationName == null && stage.getContext().containsKey("asgName")) {
         applicationName = Names.parseName((String) stage.getContext().get("asgName")).getApp();


### PR DESCRIPTION
When application name can't be found in the context, try to use the moniker before frigga.