### PR TITLE
feat(entitytags): Include previous server group image details

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
@@ -16,11 +16,17 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
 
+import com.netflix.frigga.Names;
+import com.netflix.spinnaker.orca.RetrySupport;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Orchestration;
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import retrofit.RetrofitError;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -29,13 +35,21 @@ import java.util.Map;
 
 @Component
 public class SpinnakerMetadataServerGroupTagGenerator implements ServerGroupEntityTagGenerator {
+  private final Logger log = LoggerFactory.getLogger(this.getClass());
+  private final OortService oortService;
+  private final RetrySupport retrySupport;
+
+  public SpinnakerMetadataServerGroupTagGenerator(OortService oortService, RetrySupport retrySupport) {
+    this.oortService = oortService;
+    this.retrySupport = retrySupport;
+  }
 
   @Override
   public Collection<Map<String, Object>> generateTags(Stage stage, String serverGroup, String account, String location, String cloudProvider) {
     Execution execution = stage.getExecution();
     Map context = stage.getContext();
 
-    Map<String, String> value = new HashMap<>();
+    Map<String, Object> value = new HashMap<>();
     value.put("stageId", stage.getId());
     value.put("executionId", execution.getId());
     value.put("executionType", execution.getClass().getSimpleName().toLowerCase());
@@ -59,6 +73,26 @@ public class SpinnakerMetadataServerGroupTagGenerator implements ServerGroupEnti
       value.put("comments", (String) context.get("comments"));
     }
 
+    String cluster = null;
+    try {
+      cluster = Names.parseName(serverGroup).getCluster();
+
+      Map<String, Object> previousServerGroup = getPreviousServerGroup(
+        execution.getApplication(),
+        account,
+        cluster,
+        cloudProvider,
+        location
+      );
+
+      if (previousServerGroup != null) {
+        value.put("previousServerGroup", previousServerGroup);
+      }
+    } catch (Exception e) {
+      // failure to populate `previousServerGroup` is not considered a fatal error that would cause this task to fail
+      log.error("Unable to determine ancestor image details for {}:{}:{}:{}", cloudProvider, account, location, cluster, e);
+    }
+
     Map<String, Object> tag = new HashMap<>();
     tag.put("name", "spinnaker:metadata");
     tag.put("value", value);
@@ -66,4 +100,39 @@ public class SpinnakerMetadataServerGroupTagGenerator implements ServerGroupEnti
     return Collections.singletonList(tag);
   }
 
+  Map<String, Object> getPreviousServerGroup(String application,
+                                             String account,
+                                             String cluster,
+                                             String cloudProvider,
+                                             String location) {
+    return retrySupport.retry(() -> {
+      try {
+        Map<String, Object> targetServerGroup = oortService.getServerGroupSummary(
+          application,
+          account,
+          cluster,
+          cloudProvider,
+          location,
+          "ANCESTOR",
+          "image",
+          "true"
+        );
+
+        Map<String, Object> previousServerGroup = new HashMap<>();
+        previousServerGroup.put("name", targetServerGroup.get("serverGroupName"));
+        previousServerGroup.put("imageName", targetServerGroup.get("imageName"));
+        previousServerGroup.put("imageId", targetServerGroup.get("imageId"));
+        previousServerGroup.put("cloudProvider", cloudProvider);
+
+        return previousServerGroup;
+      } catch (RetrofitError e) {
+        if (e.getKind() == RetrofitError.Kind.HTTP && e.getResponse().getStatus() == 404) {
+          // it's ok if the previous server group does not exist
+          return null;
+        }
+
+        throw e;
+      }
+    }, 12, 5000, false); // retry for up to one minute
+  }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGeneratorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGeneratorSpec.groovy
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
+
+import com.netflix.spinnaker.orca.RetrySupport
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import retrofit.RetrofitError
+import retrofit.client.Response
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.*
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.orchestration
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND
+
+class SpinnakerMetadataServerGroupTagGeneratorSpec extends Specification {
+  def oortService = Mock(OortService)
+  def retrySupport = Spy(RetrySupport) {
+    _ * sleep(_) >> { /* do nothing */ }
+  }
+
+  @Shared
+  def notFoundError = RetrofitError.httpError(
+    null,
+    new Response("http://google.com", HTTP_NOT_FOUND, "Not Found", [], null),
+    null,
+    null
+  )
+
+  @Unroll
+  def "should build spinnaker:metadata tag for pipeline"() {
+    given:
+    def tagGenerator = Spy(SpinnakerMetadataServerGroupTagGenerator, constructorArgs: [oortService, retrySupport]) {
+      1 * getPreviousServerGroup(_, _, _, _, _) >> { return previousServerGroup }
+    }
+
+    def pipeline = pipeline {
+      name = "my pipeline"
+      application = "application"
+      pipelineConfigId = "configId"
+      authentication = authenticatedUser ? new AuthenticationDetails(authenticatedUser) : null
+
+      stage {
+        type = "wait"
+        context = [comments: "this is a wait stage"]
+      }
+    }
+
+    when:
+    def tags = tagGenerator.generateTags(pipeline.stages[0], "application-v002", "account", "us-west-2", "aws")
+
+    then:
+    tags == [[
+               name : "spinnaker:metadata",
+               value: [
+                 executionId     : pipeline.id,
+                 pipelineConfigId: "configId",
+                 application     : "application",
+                 executionType   : "pipeline",
+                 description     : "my pipeline",
+                 stageId         : pipeline.stages[0].id,
+                 comments        : "this is a wait stage",
+               ] + (previousServerGroup ? [previousServerGroup: previousServerGroup] : [:])
+                 + (authenticatedUser ? [user: authenticatedUser] : [:])
+             ]]
+
+    where:
+    previousServerGroup                   | authenticatedUser || _
+    null                                  | null              || _    // metadata tag should NOT include `previousServerGroup`
+    null                                  | "username"        || _    // include user if non-null
+    [serverGroupName: "application-v001"] | null              || _
+  }
+
+  @Unroll
+  def "should build spinnaker:metadata tag for orchestration"() {
+    given:
+    def tagGenerator = Spy(SpinnakerMetadataServerGroupTagGenerator, constructorArgs: [oortService, retrySupport]) {
+      1 * getPreviousServerGroup(_, _, _, _, _) >> { return previousServerGroup }
+    }
+
+    def orchestration = orchestration {
+      name = "my orchestration"
+      application = "application"
+      authentication = authenticatedUser ? new AuthenticationDetails(authenticatedUser) : null
+      description = "this is my orchestration"
+
+      stages << new Stage<>(delegate, "wait")
+    }
+
+    when:
+    def tags = tagGenerator.generateTags(orchestration.stages[0], "application-v002", "account", "us-west-2", "aws")
+
+    then:
+    tags == [[
+               name : "spinnaker:metadata",
+               value: [
+                 executionId  : orchestration.id,
+                 application  : "application",
+                 executionType: "orchestration",
+                 description  : "this is my orchestration",
+                 stageId      : orchestration.stages[0].id,
+               ] + (previousServerGroup ? [previousServerGroup: previousServerGroup] : [:])
+                 + (authenticatedUser ? [user: authenticatedUser] : [:])
+             ]]
+
+    where:
+    previousServerGroup                   | authenticatedUser || _
+    null                                  | null              || _    // metadata tag should NOT include `previousServerGroup`
+    null                                  | "username"        || _    // include user if non-null
+    [serverGroupName: "application-v001"] | null              || _
+  }
+
+  def "should construct previous server group metadata when present"() {
+    given:
+    def tagGenerator = new SpinnakerMetadataServerGroupTagGenerator(oortService, retrySupport)
+
+    when: "previous server does exist"
+    def previousServerGroupMetadata = tagGenerator.getPreviousServerGroup(
+      "application", "account", "cluster", "aws", "us-west-2"
+    )
+
+    then: "metadata should be returned"
+    1 * oortService.getServerGroupSummary("application", "account", "cluster", "aws", "us-west-2", "ANCESTOR", "image", "true") >> {
+      return [
+        serverGroupName: "application-v001",
+        imageId        : "ami-1234567",
+        imageName      : "my_image"
+      ]
+    }
+    previousServerGroupMetadata == [
+      name         : "application-v001",
+      imageId      : "ami-1234567",
+      imageName    : "my_image",
+      cloudProvider: "aws"
+    ]
+
+    when: "previous server group does NOT exist"
+    previousServerGroupMetadata = tagGenerator.getPreviousServerGroup(
+      "application", "account", "cluster", "aws", "us-west-2"
+    )
+
+    then: "no metadata should be returned"
+    1 * oortService.getServerGroupSummary("application", "account", "cluster", "aws", "us-west-2", "ANCESTOR", "image", "true") >> {
+      throw notFoundError
+    }
+    previousServerGroupMetadata == null
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolverSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolverSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.kato.pipeline.support
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.RetrySupport
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
@@ -94,10 +95,14 @@ class SourceResolverSpec extends Specification {
     given:
     OortService oort = Mock(OortService)
     ObjectMapper mapper = new ObjectMapper()
+    RetrySupport retrySupport = Spy(RetrySupport) {
+      _ * sleep(_) >> { /* do nothing */ }
+    }
+
     SourceResolver resolver = new SourceResolver(
       oortService: oort,
       mapper: mapper,
-      resolver: new TargetServerGroupResolver(oortService: oort, mapper: mapper)
+      resolver: new TargetServerGroupResolver(oortService: oort, mapper: mapper, retrySupport: retrySupport)
     )
 
     when:

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/RetrySupport.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/RetrySupport.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca;
+
+import java.util.function.Supplier;
+
+public class RetrySupport {
+  public <T> T retry(Supplier<T> fn, int maxRetries, long retryBackoff, boolean exponential) {
+    int retries = 0;
+    while (true) {
+      try {
+        return fn.get();
+      } catch (Exception e) {
+        if (retries >= (maxRetries - 1)) {
+          throw e;
+        }
+
+        long timeout = !exponential ? retryBackoff : (long) Math.pow(2, retries) * retryBackoff;
+        sleep(timeout);
+
+        retries++;
+      }
+    }
+  }
+
+  /**
+   * Overridable by test cases to avoid Thread.sleep()
+   */
+  void sleep(long duration) {
+    try {
+      Thread.sleep(duration);
+    } catch (InterruptedException ignored) {
+    }
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.orca.RetrySupport;
 import com.netflix.spinnaker.orca.events.ExecutionEvent;
 import com.netflix.spinnaker.orca.events.ExecutionListenerAdapter;
 import com.netflix.spinnaker.orca.exceptions.DefaultExceptionHandler;
@@ -153,6 +154,11 @@ public class OrcaConfiguration {
   @ConditionalOnMissingBean(StageDefinitionBuilderFactory.class)
   public StageDefinitionBuilderFactory stageDefinitionBuilderFactory(Collection<StageDefinitionBuilder> stageDefinitionBuilders) {
     return new DefaultStageDefinitionBuilderFactory(stageDefinitionBuilders);
+  }
+
+  @Bean
+  public RetrySupport retrySupport() {
+    return new RetrySupport();
   }
 
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/RetrySupportSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/RetrySupportSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class RetrySupportSpec extends Specification {
+  @Unroll
+  def "should retry until success or #maxRetries attempts is reached"() {
+    given:
+    def retrySupport = Spy(RetrySupport) {
+      Math.min(maxRetries - 1, failures) * sleep(10000) >> { /* do nothing */ }
+    }
+
+    int attemptCounter = 0;
+
+    when:
+    def exceptionMessage
+    try {
+      retrySupport.retry({
+        if (attemptCounter++ < failures) {
+          throw new IllegalStateException("Failed after " + attemptCounter + " attempts");
+        }
+      }, maxRetries, 10000, false)
+    } catch (Exception e) {
+      exceptionMessage = e.message
+    }
+
+    then:
+    attemptCounter == expectedAttempts
+    exceptionMessage == expectedExceptionMessage
+
+    where:
+    failures || maxRetries || expectedAttempts || expectedExceptionMessage
+    3        || 10         || 4                || null
+    11       || 10         || 10               || "Failed after 10 attempts"
+  }
+
+  def "should sleep exponentially"() {
+    given:
+    def retrySupport = Spy(RetrySupport) {
+      1 * sleep(10000) >> { /* do nothing */ }
+      1 * sleep(20000) >> { /* do nothing */ }
+      1 * sleep(40000) >> { /* do nothing */ }
+      1 * sleep(80000) >> { /* do nothing */ }
+    }
+
+    int attemptCounter = 0;
+
+    when:
+    retrySupport.retry({
+      if (attemptCounter++ < failures) {
+        throw new IllegalStateException("Failed after " + attemptCounter + " attempts");
+      }
+    }, maxRetries, 10000, true)
+
+    then:
+    attemptCounter == expectedAttempts
+
+    where:
+    failures || maxRetries || expectedAttempts
+    4        || 10         || 5
+  }
+}


### PR DESCRIPTION
This will ultimately facilitate an orchestrated rollback even if the
previous server group no longer exists.

It relies on the entity tags feature being enabled (dependency on
elastic search and not enabled by default in `clouddriver` / `orca`).

This PR also introduces some common retry handling (see `RetrySupport`).
