### PR TITLE
fix(canary): gentle canary cleanup

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/MonitorCanaryStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/MonitorCanaryStage.groovy
@@ -18,15 +18,18 @@ package com.netflix.spinnaker.orca.mine.pipeline
 
 import com.netflix.spinnaker.orca.CancellableStage
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.mine.MineService
 import com.netflix.spinnaker.orca.mine.tasks.CleanupCanaryTask
 import com.netflix.spinnaker.orca.mine.tasks.CompleteCanaryTask
+import com.netflix.spinnaker.orca.mine.tasks.DisableCanaryTask
 import com.netflix.spinnaker.orca.mine.tasks.MonitorCanaryTask
 import com.netflix.spinnaker.orca.mine.tasks.RegisterCanaryTask
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -43,6 +46,13 @@ class MonitorCanaryStage implements StageDefinitionBuilder, CancellableStage {
     builder
       .withTask("registerCanary", RegisterCanaryTask)
       .withTask("monitorCanary", MonitorCanaryTask)
+      .withTask("disableCanaryCluster", DisableCanaryTask)
+      .withTask("monitorDisable", MonitorKatoTask)
+      .withTask("waitBeforeCleanup", WaitTask)
+      .withTask("disableBaselineCluster", DisableCanaryTask)
+      .withTask("monitorDisable", MonitorKatoTask)
+      .withTask("waitBeforeCleanup", WaitTask)
+      .withTask("forceCacheRefresh", ServerGroupCacheForceRefreshTask)
       .withTask("cleanupCanary", CleanupCanaryTask)
       .withTask("monitorCleanup", MonitorKatoTask)
       .withTask("completeCanary", CompleteCanaryTask)

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/DisableCanaryTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/DisableCanaryTask.groovy
@@ -1,0 +1,55 @@
+package com.netflix.spinnaker.orca.mine.tasks
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.mine.MineService
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import retrofit.RetrofitError
+import static com.netflix.spinnaker.orca.mine.pipeline.CanaryStage.DEFAULT_CLUSTER_DISABLE_WAIT_TIME
+
+@Component
+@Slf4j
+class DisableCanaryTask extends AbstractCloudProviderAwareTask implements Task {
+
+  @Autowired MineService mineService
+  @Autowired KatoService katoService
+
+  @Override
+  TaskResult execute(Stage stage) {
+
+    Integer waitTime = stage.context.clusterDisableWaitTime != null ? stage.context.clusterDisableWaitTime : DEFAULT_CLUSTER_DISABLE_WAIT_TIME
+
+    try {
+      def canary = mineService.getCanary(stage.context.canary.id)
+      if (canary.health?.health == 'UNHEALTHY') {
+        // If unhealthy, already disabled in MonitorCanaryTask
+        return TaskResult.SUCCEEDED
+      }
+    } catch (RetrofitError e) {
+      log.error("Exception occurred while getting canary status with id {} from mine, continuing with disable",
+        stage.context.canary.id, e)
+    }
+
+    def selector = stage.context.containsKey('disabledCluster') ? 'baselineCluster' : 'canaryCluster'
+    def ops = DeployedClustersUtil.toKatoAsgOperations('disableServerGroup', stage.context, selector)
+    def dSG = DeployedClustersUtil.getDeployServerGroups(stage.context)
+
+    log.info "Disabling ${selector} in ${stage.id} with ${ops}"
+    String cloudProvider = ops && !ops.empty ? ops.first()?.values().first()?.cloudProvider : getCloudProvider(stage) ?: 'aws'
+    def taskId = katoService.requestOperations(cloudProvider, ops).toBlocking().first()
+
+    stage.context.remove('waitTaskState')
+    return new TaskResult(ExecutionStatus.SUCCEEDED, [
+      'kato.last.task.id'    : taskId,
+      'deploy.server.groups' : dSG,
+      disabledCluster        : selector,
+      waitTime               : waitTime
+    ])
+  }
+}

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTask.groovy
@@ -58,8 +58,14 @@ class RegisterCanaryTask implements Task {
     def outputs = [
       canary              : canary,
       stageTimeoutMs      : getMonitorTimeout(canary),
-      deployedClusterPairs: deployStage.context.deployedClusterPairs
+      deployedClusterPairs: deployStage.context.deployedClusterPairs,
+      application         : c.application
     ]
+
+    if (deployStage.context.deployedClusterPairs[0]?.canaryCluster?.accountName) {
+      outputs.account = deployStage.context.deployedClusterPairs[0].canaryCluster.accountName
+    }
+
     return new TaskResult(ExecutionStatus.SUCCEEDED, outputs)
   }
 


### PR DESCRIPTION
When canaries finish successfully: disable canaryAsg + waitTask(2min) + disable baselineAsg + waitTask(2min) + cache refresh, then proceed with deletion of both canary and baseline as before.

This addresses issues resulting from both canary and baseline asg's getting force deleted (which deletes asg lifecycle hooks) with simultaneous instance terminations (which also bypasses lifecycle hooks) while still serving traffic.

When canaries are terminated early and CanaryStage.cancel() invoked, asg's are also disabled prior to deletion.