### PR TITLE
feat(core): implement noop stage

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/NoopStage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/NoopStage.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline;
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NoopStage implements StageDefinitionBuilder {
+  @Override
+  public <T extends Execution<T>> void taskGraph(Stage<T> stage, TaskNode.Builder builder) {
+
+  }
+}


### PR DESCRIPTION
Allows users to submit ad-hoc tasks to provide traceability (via the Tasks view in Deck) of operations occurring outside Spinnaker that affect infrastructure components.