### PR TITLE
fix(rollback): Propagate `interestingHealthProviderNames`

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollback.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollback.groovy
@@ -93,6 +93,11 @@ class PreviousImageRollback implements Rollback {
         useSourceCapacity: true
       ]
     ]
+
+    if (parentStageContext.containsKey("interestingHealthProviderNames")) {
+      cloneServerGroupContext.interestingHealthProviderNames = parentStageContext.interestingHealthProviderNames
+    }
+
     stages << newStage(
       parentStage.execution, cloneServerGroupStage.type, "clone", cloneServerGroupContext, parentStage, SyntheticStageOwner.STAGE_AFTER
     )

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollbackSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollbackSpec.groovy
@@ -111,6 +111,27 @@ class PreviousImageRollbackSpec extends Specification {
     null             | "image fetched from `spinnaker:metadata` entity tag" || "previous_image_from_entity_tags" || "previous_image_from_entity_tags_id"
   }
 
+  @Unroll
+  def "should include interestingHealthProviderNames in clone stage context when present in parent"() {
+    given:
+    rollback.imageName = "explicit_image"
+    stage.context.putAll(additionalContext)
+
+    when:
+    def allStages = rollback.buildStages(stage)
+
+    then:
+    allStages[0].context.containsKey("interestingHealthProviderNames") == hasInterestingHealthProviderNames
+
+    where:
+    additionalContext                            || hasInterestingHealthProviderNames
+    [:]                                          || false
+    [interestingHealthProviderNames: null]       || true
+    [interestingHealthProviderNames: ["Amazon"]] || true
+    [interestingHealthProviderNames: []]         || true
+
+  }
+
   def "should raise exception if multiple entity tags found"() {
     when:
     rollback.rollbackServerGroupName = "application-v002"


### PR DESCRIPTION
If `interestingHealthProviderNames` are specified on the parent stage
context, propagate them to the clone stage.
