### PR TITLE
fix(cancel): cancel during wait stage

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
@@ -18,10 +18,7 @@ package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.ExecutionStatus.PAUSED
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
-import com.netflix.spinnaker.orca.q.CancelExecution
-import com.netflix.spinnaker.orca.q.MessageHandler
-import com.netflix.spinnaker.orca.q.Queue
-import com.netflix.spinnaker.orca.q.ResumeStage
+import com.netflix.spinnaker.orca.q.*
 import org.springframework.stereotype.Component
 
 @Component
@@ -43,6 +40,9 @@ class CancelExecutionHandler(
         .forEach { stage ->
           queue.push(ResumeStage(stage))
         }
+
+      // then, make sure those runTask messages get run right away
+      queue.push(RescheduleExecution(execution))
     }
   }
 }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandlerTest.kt
@@ -65,6 +65,10 @@ object CancelExecutionHandlerTest : SubjectSpek<CancelExecutionHandler>({
         verify(repository).cancel(pipeline.id, "fzlem@netflix.com", "because")
       }
 
+      it("it triggers a reevaluate") {
+        verify(queue).push(RescheduleExecution(pipeline))
+      }
+
       it("does not send any further messages") {
         verifyZeroInteractions(queue)
       }


### PR DESCRIPTION
Issue: if you cancel a pipeline during a wait stage/manual judgement stage the cancel won't propagate until the stage times out.

Fix: this adds a 'rescheduleExecution' message to the queue, which will make sure all running tasks are evaluated again right away, so that they cancel themselves.

@anotherchrisberry @robfletcher PTAL