### PR TITLE
feat(moniker): Use moniker in TrafficGuard.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -82,7 +82,7 @@ class TargetServerGroup {
     // serverGroup.moniker is a Map type, but Groovy is able to convert it to a Moniker type.
     return serverGroup.moniker
   }
-  
+
   Map toClouddriverOperationPayload(String account) {
     //TODO(cfieber) - add an endpoint on Clouddriver to do provider appropriate conversion of a TargetServerGroup
     def op = [

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support
 
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import groovy.transform.InheritConstructors
 import groovy.transform.ToString
 import groovy.util.logging.Slf4j
@@ -78,6 +79,7 @@ class TargetServerGroup {
    * Used in TrafficGuard, which is Java, which doesn't play nice with @Delegate
    */
   Moniker getMoniker() {
+    // serverGroup.moniker is a Map type, but Groovy is able to convert it to a Moniker type.
     return serverGroup.moniker
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -82,8 +82,7 @@ class TargetServerGroup {
     // serverGroup.moniker is a Map type, but Groovy is able to convert it to a Moniker type.
     return serverGroup.moniker
   }
-
-
+  
   Map toClouddriverOperationPayload(String account) {
     //TODO(cfieber) - add an endpoint on Clouddriver to do provider appropriate conversion of a TargetServerGroup
     def op = [

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -29,7 +29,8 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
  */
 class TargetServerGroup {
   // Delegates all Map interface calls to this object.
-  @Delegate private final Map<String, Object> serverGroup
+  @Delegate
+  private final Map<String, Object> serverGroup
 
   TargetServerGroup(Map<String, Object> serverGroupData) {
     if (serverGroupData.instances && serverGroupData.instances instanceof Collection) {
@@ -73,12 +74,21 @@ class TargetServerGroup {
     return (serverGroup.instances ?: []) as List<Map>
   }
 
+  /**
+   * Used in TrafficGuard, which is Java, which doesn't play nice with @Delegate
+   */
+  Moniker getMoniker() {
+    return serverGroup.moniker
+  }
+
+
   Map toClouddriverOperationPayload(String account) {
     //TODO(cfieber) - add an endpoint on Clouddriver to do provider appropriate conversion of a TargetServerGroup
     def op = [
       credentials    : account,
       accountName    : account,
       serverGroupName: serverGroup.name,
+      moniker        : serverGroup.moniker,
       asgName        : serverGroup.name,
       cloudProvider  : serverGroup.cloudProvider ?: serverGroup.type
     ]
@@ -173,19 +183,21 @@ class TargetServerGroup {
       /**
        * "Previous Server Group"
        */
-      ancestor_asg_dynamic,
+        ancestor_asg_dynamic,
       /**
        * "Oldest Server Group"
        */
-      oldest_asg_dynamic,
+        oldest_asg_dynamic,
       /**
        * "(Deprecated) Current Server Group"
        */
-      @Deprecated current_asg,
+        @Deprecated
+        current_asg,
       /**
        * "(Deprecated) Last Server Group"
        */
-      @Deprecated ancestor_asg,
+        @Deprecated
+        ancestor_asg,
 
       boolean isDynamic() {
         return this.name().endsWith("dynamic")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import groovy.transform.InheritConstructors
 import groovy.transform.ToString
@@ -79,8 +80,8 @@ class TargetServerGroup {
    * Used in TrafficGuard, which is Java, which doesn't play nice with @Delegate
    */
   Moniker getMoniker() {
-    // serverGroup.moniker is a Map type, but Groovy is able to convert it to a Moniker type.
-    return serverGroup.moniker
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.convertValue(serverGroup.moniker, Moniker);
   }
 
   Map toClouddriverOperationPayload(String account) {
@@ -89,7 +90,6 @@ class TargetServerGroup {
       credentials    : account,
       accountName    : account,
       serverGroupName: serverGroup.name,
-      moniker        : serverGroup.moniker,
       asgName        : serverGroup.name,
       cloudProvider  : serverGroup.cloudProvider ?: serverGroup.type
     ]

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import groovy.transform.InheritConstructors
 import groovy.transform.ToString
 import groovy.util.logging.Slf4j
@@ -30,6 +29,9 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
  * A TargetServerGroup is a ServerGroup that is dynamically resolved using a target like "current" or "oldest".
  */
 class TargetServerGroup {
+
+  final static ObjectMapper objectMapper = new ObjectMapper()
+
   // Delegates all Map interface calls to this object.
   @Delegate
   private final Map<String, Object> serverGroup
@@ -80,8 +82,7 @@ class TargetServerGroup {
    * Used in TrafficGuard, which is Java, which doesn't play nice with @Delegate
    */
   Moniker getMoniker() {
-    ObjectMapper objectMapper = new ObjectMapper();
-    return objectMapper.convertValue(serverGroup.moniker, Moniker);
+    return serverGroup?.moniker ? objectMapper.convertValue(serverGroup?.moniker, Moniker) : null
   }
 
   Map toClouddriverOperationPayload(String account) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/TerminateInstanceAndDecrementServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/TerminateInstanceAndDecrementServerGroupTask.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.instance.TerminatingInsta
 import com.netflix.spinnaker.orca.clouddriver.pipeline.instance.TerminatingInstanceSupport
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
@@ -53,6 +54,7 @@ class TerminateInstanceAndDecrementServerGroupTask extends AbstractCloudProvider
 
     trafficGuard.verifyInstanceTermination(
       serverGroupName,
+      MonikerHelper.monikerFromStage(stage, serverGroupName),
       [stage.context.instance] as List<String>,
       account,
       Location.region(stage.context.region as String),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/TerminateInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/TerminateInstancesTask.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.instance.TerminatingInsta
 import com.netflix.spinnaker.orca.clouddriver.pipeline.instance.TerminatingInstanceSupport
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
@@ -53,6 +54,7 @@ class TerminateInstancesTask extends AbstractCloudProviderAwareTask implements T
 
     trafficGuard.verifyInstanceTermination(
       serverGroupName,
+      MonikerHelper.monikerFromStage(stage, serverGroupName),
       stage.context.instanceIds as List<String>,
       account,
       Location.region(stage.context.region as String),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractBulkServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractBulkServerGroupTask.java
@@ -104,8 +104,10 @@ public abstract class AbstractBulkServerGroupTask extends AbstractCloudProviderA
     targetServerGroups.forEach( targetServerGroup -> {
       Map<String , Map> tmp = new HashMap<>();
       Map operation = targetServerGroup.toClouddriverOperationPayload(request.getCredentials());
-      Moniker moniker = targetServerGroup.getMoniker() == null ?
-        MonikerHelper.friggaToMoniker(targetServerGroup.getName()) : targetServerGroup.getMoniker();
+      Moniker moniker = targetServerGroup.getMoniker();
+      if (moniker == null) {
+        moniker = MonikerHelper.friggaToMoniker(targetServerGroup.getName());
+      }
       validateClusterStatus(operation, moniker);
       tmp.put(getClouddriverOperation(), operation);
       operations.add(tmp);

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractBulkServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractBulkServerGroupTask.java
@@ -47,7 +47,7 @@ public abstract class AbstractBulkServerGroupTask extends AbstractCloudProviderA
   @Autowired
   protected KatoService katoService;
 
-  abstract void validateClusterStatus(Map<String, Object> operation);
+  abstract void validateClusterStatus(Map<String, Object> operation, Moniker moniker);
 
   abstract String getClouddriverOperation();
 
@@ -104,8 +104,9 @@ public abstract class AbstractBulkServerGroupTask extends AbstractCloudProviderA
     targetServerGroups.forEach( targetServerGroup -> {
       Map<String , Map> tmp = new HashMap<>();
       Map operation = targetServerGroup.toClouddriverOperationPayload(request.getCredentials());
-
-      validateClusterStatus(operation);
+      Moniker moniker = targetServerGroup.getMoniker() == null ?
+        MonikerHelper.friggaToMoniker(targetServerGroup.getName()) : targetServerGroup.getMoniker();
+      validateClusterStatus(operation, moniker);
       tmp.put(getClouddriverOperation(), operation);
       operations.add(tmp);
     });

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
@@ -119,12 +119,11 @@ abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask im
   Moniker convertMoniker(Stage stage) {
     if (TargetServerGroup.isDynamicallyBound(stage)) {
       TargetServerGroup tsg = TargetServerGroupResolver.fromPreviousStage(stage);
-      return  tsg.getMoniker() == null ?  MonikerHelper.friggaToMoniker(tsg.getName()) : tsg.getMoniker();
-    } else {
-      String serverGroupName = (String) stage.context.serverGroupName;
-      String asgName = (String) stage.context.asgName;
-      return MonikerHelper.monikerFromStage(stage, serverGroupName == null ? asgName : serverGroupName);
+      return  tsg.getMoniker() == null ? MonikerHelper.friggaToMoniker(tsg.getName()) : tsg.getMoniker();
     }
+    String serverGroupName = (String) stage.context.serverGroupName;
+    String asgName = (String) stage.context.asgName;
+    return MonikerHelper.monikerFromStage(stage, asgName ?: serverGroupName);
   }
 
   /**

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
@@ -96,6 +97,7 @@ abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask im
       def tsg = TargetServerGroupResolver.fromPreviousStage(stage)
       operation.asgName = tsg.name
       operation.serverGroupName = tsg.name
+      operation.moniker = tsg.getMoniker()
 
       def location = tsg.getLocation()
       operation.deployServerGroupsRegion = tsg.region
@@ -138,5 +140,4 @@ abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask im
         operation.namespace ? new Location(Type.NAMESPACE, operation.namespace) :
           null
   }
-
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDestroyServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDestroyServerGroupTask.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
 
 import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -39,7 +40,7 @@ public class BulkDestroyServerGroupTask extends AbstractBulkServerGroupTask impl
   @Override
   void validateClusterStatus(Map<String, Object> operation) {
     trafficGuard.verifyTrafficRemoval((String) operation.get("serverGroupName"),
-      (Moniker) operation.get("moniker"),
+      MonikerHelper.monikerOrFrigga((Moniker) operation.get("moniker"), (String) operation.get("serverGroupName")),
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Destroying");

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDestroyServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDestroyServerGroupTask.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
 
 import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.RetryableTask;
-import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -38,9 +37,9 @@ public class BulkDestroyServerGroupTask extends AbstractBulkServerGroupTask impl
   }
 
   @Override
-  void validateClusterStatus(Map<String, Object> operation) {
+  void validateClusterStatus(Map<String, Object> operation, Moniker moniker) {
     trafficGuard.verifyTrafficRemoval((String) operation.get("serverGroupName"),
-      MonikerHelper.monikerOrFrigga((Moniker) operation.get("moniker"), (String) operation.get("serverGroupName")),
+      moniker,
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Destroying");

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDestroyServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDestroyServerGroupTask.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
 
+import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.RetryableTask;
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,7 @@ public class BulkDestroyServerGroupTask extends AbstractBulkServerGroupTask impl
   @Override
   void validateClusterStatus(Map<String, Object> operation) {
     trafficGuard.verifyTrafficRemoval((String) operation.get("serverGroupName"),
+      (Moniker) operation.get("moniker"),
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Destroying");

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDisableServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDisableServerGroupTask.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
 
+import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.RetryableTask;
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +38,7 @@ public class BulkDisableServerGroupTask extends AbstractBulkServerGroupTask impl
   @Override
   void validateClusterStatus(Map<String, Object> operation) {
     trafficGuard.verifyTrafficRemoval((String) operation.get("serverGroupName"),
+      (Moniker) operation.get("moniker"),
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Disabling");

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDisableServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDisableServerGroupTask.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
 
 import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.RetryableTask;
-import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -37,9 +36,9 @@ public class BulkDisableServerGroupTask extends AbstractBulkServerGroupTask impl
   }
 
   @Override
-  void validateClusterStatus(Map<String, Object> operation) {
+  void validateClusterStatus(Map<String, Object> operation, Moniker moniker) {
     trafficGuard.verifyTrafficRemoval((String) operation.get("serverGroupName"),
-      MonikerHelper.monikerOrFrigga((Moniker) operation.get("moniker"), (String) operation.get("serverGroupName")),
+      moniker,
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Disabling");

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDisableServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkDisableServerGroupTask.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
 
 import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -38,7 +39,7 @@ public class BulkDisableServerGroupTask extends AbstractBulkServerGroupTask impl
   @Override
   void validateClusterStatus(Map<String, Object> operation) {
     trafficGuard.verifyTrafficRemoval((String) operation.get("serverGroupName"),
-      (Moniker) operation.get("moniker"),
+      MonikerHelper.monikerOrFrigga((Moniker) operation.get("moniker"), (String) operation.get("serverGroupName")),
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Disabling");

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTask.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DestroyServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,6 +32,7 @@ class DestroyServerGroupTask extends AbstractServerGroupTask {
   @Override
   void validateClusterStatus(Map operation) {
     trafficGuard.verifyTrafficRemoval(operation.serverGroupName as String,
+      operation.moniker as Moniker,
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Destroying")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
 import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DestroyServerGroupStage
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -32,7 +33,7 @@ class DestroyServerGroupTask extends AbstractServerGroupTask {
   @Override
   void validateClusterStatus(Map operation) {
     trafficGuard.verifyTrafficRemoval(operation.serverGroupName as String,
-      operation.moniker as Moniker,
+      MonikerHelper.monikerOrFrigga(operation.moniker as Moniker, operation.serverGroupName as String),
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Destroying")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DestroyServerGroupTask.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
 import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DestroyServerGroupStage
-import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -31,9 +30,9 @@ class DestroyServerGroupTask extends AbstractServerGroupTask {
   TrafficGuard trafficGuard
 
   @Override
-  void validateClusterStatus(Map operation) {
+  void validateClusterStatus(Map operation, Moniker moniker) {
     trafficGuard.verifyTrafficRemoval(operation.serverGroupName as String,
-      MonikerHelper.monikerOrFrigga(operation.moniker as Moniker, operation.serverGroupName as String),
+      moniker,
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Destroying")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DisableServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DisableServerGroupTask.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DisableServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import org.springframework.beans.factory.annotation.Autowired
@@ -36,6 +37,7 @@ class DisableServerGroupTask extends AbstractServerGroupTask {
   @Override
   void validateClusterStatus(Map operation) {
     trafficGuard.verifyTrafficRemoval(operation.serverGroupName as String,
+      operation.moniker as Moniker,
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Disabling")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DisableServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DisableServerGroupTask.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
 import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DisableServerGroupStage
-import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -36,9 +35,9 @@ class DisableServerGroupTask extends AbstractServerGroupTask {
   String serverGroupAction = DisableServerGroupStage.PIPELINE_CONFIG_TYPE
 
   @Override
-  void validateClusterStatus(Map operation) {
+  void validateClusterStatus(Map operation, Moniker moniker) {
     trafficGuard.verifyTrafficRemoval(operation.serverGroupName as String,
-      MonikerHelper.monikerOrFrigga(operation.moniker as Moniker, operation.serverGroupName as String),
+      moniker,
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Disabling")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DisableServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/DisableServerGroupTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
 import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DisableServerGroupStage
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -37,7 +38,7 @@ class DisableServerGroupTask extends AbstractServerGroupTask {
   @Override
   void validateClusterStatus(Map operation) {
     trafficGuard.verifyTrafficRemoval(operation.serverGroupName as String,
-      operation.moniker as Moniker,
+      MonikerHelper.monikerOrFrigga(operation.moniker as Moniker, operation.serverGroupName as String),
       getCredentials(operation),
       getLocation(operation),
       getCloudProvider(operation), "Disabling")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ResizeServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ResizeServerGroupTask.groovy
@@ -20,7 +20,6 @@ import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.ResizeServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
-import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy
 import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.Capacity
@@ -65,10 +64,10 @@ class ResizeServerGroupTask extends AbstractServerGroupTask {
   }
 
   @Override
-  void validateClusterStatus(Map operation) {
+  void validateClusterStatus(Map operation, Moniker moniker) {
     if (operation.capacity.desired == 0) {
       trafficGuard.verifyTrafficRemoval(operation.serverGroupName as String,
-        MonikerHelper.monikerOrFrigga(operation.moniker as Moniker, operation.serverGroupName as String),
+        moniker,
         getCredentials(operation),
         getLocation(operation),
         getCloudProvider(operation), "Removal of all instances in ")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ResizeServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ResizeServerGroupTask.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.ResizeServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
@@ -66,6 +67,7 @@ class ResizeServerGroupTask extends AbstractServerGroupTask {
   void validateClusterStatus(Map operation) {
     if (operation.capacity.desired == 0) {
       trafficGuard.verifyTrafficRemoval(operation.serverGroupName as String,
+        operation.moniker as Moniker,
         getCredentials(operation),
         getLocation(operation),
         getCloudProvider(operation), "Removal of all instances in ")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ResizeServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ResizeServerGroupTask.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.ResizeServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy
 import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.Capacity
@@ -67,7 +68,7 @@ class ResizeServerGroupTask extends AbstractServerGroupTask {
   void validateClusterStatus(Map operation) {
     if (operation.capacity.desired == 0) {
       trafficGuard.verifyTrafficRemoval(operation.serverGroupName as String,
-        operation.moniker as Moniker,
+        MonikerHelper.monikerOrFrigga(operation.moniker as Moniker, operation.serverGroupName as String),
         getCredentials(operation),
         getLocation(operation),
         getCloudProvider(operation), "Removal of all instances in ")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/ClusterMatcher.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/ClusterMatcher.java
@@ -16,23 +16,21 @@
 
 package com.netflix.spinnaker.orca.clouddriver.utils;
 
-import com.netflix.frigga.Names;
+import com.netflix.spinnaker.moniker.Moniker;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ClusterMatcher {
 
-  public static ClusterMatchRule getMatchingRule(String account, String location, String clusterName, List<ClusterMatchRule> rules) {
+  public static ClusterMatchRule getMatchingRule(String account, String location, Moniker clusterMoniker, List<ClusterMatchRule> rules) {
     if (!Optional.ofNullable(rules).isPresent()) {
       return null;
     }
-    Names nameParts = Names.parseName(clusterName);
 
-    String stack = nameParts.getStack() == null ? "" : nameParts.getStack();
-    String detail = nameParts.getDetail() == null ? "" : nameParts.getDetail();
+    String stack = clusterMoniker.getStack() == null ? "" : clusterMoniker.getStack();
+    String detail = clusterMoniker.getDetail() == null ? "" : clusterMoniker.getDetail();
 
     List<ClusterMatchRule> candidates = rules.stream().filter(rule -> {
       String ruleAccount = rule.getAccount();

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.orca.clouddriver.utils;
 
 import com.netflix.frigga.Names;
 import com.netflix.spinnaker.moniker.Moniker;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import org.springframework.stereotype.Component;
 
@@ -62,15 +64,7 @@ public class MonikerHelper {
 
   static public Moniker monikerFromStage(Stage stage, String fallbackFriggaName) {
     Moniker moniker = monikerFromStage(stage);
-    return monikerOrFrigga(moniker, fallbackFriggaName);
-  }
-
-  static public Moniker monikerOrFrigga(Moniker moniker, String friggaName) {
-    if (moniker == null) {
-      return friggaToMoniker(friggaName);
-    } else {
-      return moniker;
-    }
+    return moniker == null ? friggaToMoniker(fallbackFriggaName) : moniker;
   }
 
   static public Moniker friggaToMoniker(String friggaName) {
@@ -83,4 +77,5 @@ public class MonikerHelper {
       .sequence(names.getSequence())
       .build();
   }
+
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
@@ -62,10 +62,7 @@ public class MonikerHelper {
 
   static public Moniker monikerFromStage(Stage stage, String fallbackFriggaName) {
     Moniker moniker = monikerFromStage(stage);
-    if (moniker == null) {
-      moniker = friggaToMoniker(fallbackFriggaName);
-    }
-    return moniker;
+    return monikerOrFrigga(moniker, fallbackFriggaName);
   }
 
   static public Moniker monikerOrFrigga(Moniker moniker, String friggaName) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
@@ -63,16 +63,29 @@ public class MonikerHelper {
   static public Moniker monikerFromStage(Stage stage, String fallbackFriggaName) {
     Moniker moniker = monikerFromStage(stage);
     if (moniker == null) {
-      Names names = Names.parseName(fallbackFriggaName);
-      return Moniker.builder()
-        .app(names.getApp())
-        .stack(names.getStack())
-        .detail(names.getDetail())
-        .cluster(names.getCluster())
-        .sequence(names.getSequence())
-        .build();
+      moniker = friggaToMoniker(fallbackFriggaName);
     }
     return moniker;
+  }
+
+  static public Moniker monikerOrFrigga(Moniker moniker, String friggaName) {
+    if (moniker == null) {
+      return friggaToMoniker(friggaName);
+    } else {
+      return moniker;
+    }
+  }
+
+
+  static public Moniker friggaToMoniker(String friggaName) {
+    Names names = Names.parseName(friggaName);
+    return Moniker.builder()
+      .app(names.getApp())
+      .stack(names.getStack())
+      .detail(names.getDetail())
+      .cluster(names.getCluster())
+      .sequence(names.getSequence())
+      .build();
   }
 
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
@@ -76,7 +76,6 @@ public class MonikerHelper {
     }
   }
 
-
   static public Moniker friggaToMoniker(String friggaName) {
     Names names = Names.parseName(friggaName);
     return Moniker.builder()
@@ -87,5 +86,4 @@ public class MonikerHelper {
       .sequence(names.getSequence())
       .build();
   }
-
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class MonikerHelper {
+
   public String getAppNameFromStage(Stage stage, String fallbackFriggaName) {
     Names names = Names.parseName(fallbackFriggaName);
     Moniker moniker = monikerFromStage(stage);
@@ -58,4 +59,20 @@ public class MonikerHelper {
       return null;
     }
   }
+
+  static public Moniker monikerFromStage(Stage stage, String fallbackFriggaName) {
+    Moniker moniker = monikerFromStage(stage);
+    if (moniker == null) {
+      Names names = Names.parseName(fallbackFriggaName);
+      return Moniker.builder()
+        .app(names.getApp())
+        .stack(names.getStack())
+        .detail(names.getDetail())
+        .cluster(names.getCluster())
+        .sequence(names.getSequence())
+        .build();
+    }
+    return moniker;
+  }
+
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
@@ -95,7 +95,7 @@ public class TrafficGuard {
       return;
     }
 
-    verifyOtherServerGroupsAreTakingTraffic(serverGroupName, serverGroupMoniker,location, account, cloudProvider, operationDescriptor);
+    verifyOtherServerGroupsAreTakingTraffic(serverGroupName, serverGroupMoniker, location, account, cloudProvider, operationDescriptor);
   }
 
   private void verifyOtherServerGroupsAreTakingTraffic(String serverGroupName, Moniker serverGroupMoniker, Location location, String account, String cloudProvider, String operationDescriptor) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
@@ -18,12 +18,11 @@ package com.netflix.spinnaker.orca.clouddriver.utils;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import com.netflix.frigga.Names;
+import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.front50.model.Application;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +46,7 @@ public class TrafficGuard {
   }
 
   public void verifyInstanceTermination(String serverGroupNameFromStage,
+                                        Moniker serverGroupMonikerFromStage,
                                         List<String> instanceIds,
                                         String account,
                                         Location location,
@@ -67,8 +67,7 @@ public class TrafficGuard {
 
     instancesPerServerGroup.entrySet().forEach(entry -> {
       String serverGroupName = entry.getKey();
-      Names names = Names.parseName(serverGroupName);
-      if (hasDisableLock(names.getCluster(), account, location)) {
+      if (hasDisableLock(serverGroupMonikerFromStage, account, location)) {
         Optional<TargetServerGroup> targetServerGroup = oortHelper.getTargetServerGroup(account, serverGroupName, location.getValue(), cloudProvider);
 
         targetServerGroup.ifPresent(serverGroup -> {
@@ -76,7 +75,7 @@ public class TrafficGuard {
           if (thisInstance.isPresent() && "Up".equals(thisInstance.get().get("healthState"))) {
             long otherActiveInstances = serverGroup.getInstances().stream().filter(i -> "Up".equals(i.get("healthState")) && !entry.getValue().contains(i.get("name"))).count();
             if (otherActiveInstances == 0) {
-              verifyOtherServerGroupsAreTakingTraffic(serverGroupName, location, account, cloudProvider, operationDescriptor);
+              verifyOtherServerGroupsAreTakingTraffic(serverGroupName, serverGroup.getMoniker(), location, account, cloudProvider, operationDescriptor);
             }
           }
         });
@@ -91,22 +90,19 @@ public class TrafficGuard {
     return Optional.ofNullable((String) instance.orElse(new HashMap<>()).get("serverGroup"));
   }
 
-  public void verifyTrafficRemoval(String serverGroupName, String account, Location location, String cloudProvider, String operationDescriptor) {
-    Names names = Names.parseName(serverGroupName);
-
-    if (!hasDisableLock(names.getCluster(), account, location)) {
+  public void verifyTrafficRemoval(String serverGroupName, Moniker serverGroupMoniker, String account, Location location, String cloudProvider, String operationDescriptor) {
+    if (!hasDisableLock(serverGroupMoniker, account, location)) {
       return;
     }
 
-    verifyOtherServerGroupsAreTakingTraffic(serverGroupName, location, account, cloudProvider, operationDescriptor);
+    verifyOtherServerGroupsAreTakingTraffic(serverGroupName, serverGroupMoniker,location, account, cloudProvider, operationDescriptor);
   }
 
-  private void verifyOtherServerGroupsAreTakingTraffic(String serverGroupName, Location location, String account, String cloudProvider, String operationDescriptor) {
-    Names names = Names.parseName(serverGroupName);
-    Optional<Map> cluster = oortHelper.getCluster(names.getApp(), account, names.getCluster(), cloudProvider);
+  private void verifyOtherServerGroupsAreTakingTraffic(String serverGroupName, Moniker serverGroupMoniker, Location location, String account, String cloudProvider, String operationDescriptor) {
+    Optional<Map> cluster = oortHelper.getCluster(serverGroupMoniker.getApp(), account, serverGroupMoniker.getCluster(), cloudProvider);
 
     if (!cluster.isPresent()) {
-      throw new IllegalStateException(format("Could not find cluster '%s' in %s/%s with traffic guard configured.", names.getCluster(), account, location.getValue()));
+      throw new IllegalStateException(format("Could not find cluster '%s' in %s/%s with traffic guard configured.", serverGroupMoniker.getCluster(), account, location.getValue()));
     }
     List<TargetServerGroup> targetServerGroups = ((List<Map<String, Object>>) cluster.get().get("serverGroups"))
       .stream()
@@ -120,19 +116,18 @@ public class TrafficGuard {
     );
     if (!otherEnabledServerGroupFound) {
       throw new IllegalStateException(format("This cluster ('%s' in %s/%s) has traffic guards enabled. " +
-        "%s %s would leave the cluster with no instances taking traffic.", names.getCluster(), account, location.getValue(), operationDescriptor, serverGroupName));
+        "%s %s would leave the cluster with no instances taking traffic.", serverGroupMoniker.getCluster(), account, location.getValue(), operationDescriptor, serverGroupName));
     }
   }
 
-  public boolean hasDisableLock(String cluster, String account, Location location) {
+  public boolean hasDisableLock(Moniker clusterMoniker, String account, Location location) {
     if (front50Service == null) {
       log.warn("Front50 has not been configured, no way to check disable lock. Fix this by setting front50.enabled: true");
       return false;
     }
-    Names names = Names.parseName(cluster);
     Application application;
     try {
-      application = front50Service.get(names.getApp());
+      application = front50Service.get(clusterMoniker.getApp());
     } catch (RetrofitError e) {
       if (e.getResponse() != null && e.getResponse().getStatus() == 404) {
         application = null;
@@ -147,6 +142,6 @@ public class TrafficGuard {
     List<ClusterMatchRule> rules = trafficGuards.stream().map(guard ->
       new ClusterMatchRule(guard.get("account"), guard.get("location"), guard.get("stack"), guard.get("detail"), 1)
     ).collect(Collectors.toList());
-    return ClusterMatcher.getMatchingRule(account, location.getValue(), cluster, rules) != null;
+    return ClusterMatcher.getMatchingRule(account, location.getValue(), clusterMoniker, rules) != null;
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DisableInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DisableInstancesTask.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 import com.netflix.spinnaker.orca.clouddriver.utils.HealthHelper
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
@@ -46,6 +47,7 @@ class DisableInstancesTask implements CloudProviderAware, Task {
 
     trafficGuard.verifyInstanceTermination(
       serverGroupName,
+      MonikerHelper.monikerFromStage(stage, serverGroupName),
       stage.context.instanceIds as List<String>,
       account,
       Location.region(stage.context.region as String),

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTaskSpec.groovy
@@ -101,7 +101,7 @@ class AbstractServerGroupTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-      1 * TargetServerGroupResolver.fromPreviousStage(stage) >> new TargetServerGroup(
+      2 * TargetServerGroupResolver.fromPreviousStage(stage) >> new TargetServerGroup(
         name: "foo-v001", region: "us-east-1"
       )
     result.context.asgName == "foo-v001"

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/ClusterMatcherSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/ClusterMatcherSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.utils
 
+import com.netflix.spinnaker.moniker.Moniker
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -25,11 +26,11 @@ class ClusterMatcherSpec extends Specification {
   String location = "us-east-1"
   String stack = "stack"
   String detail = "detail"
-  String clusterName = "myapp-stack-detail"
+  Moniker moniker = new Moniker(null, "myapp-stack-detail", detail, stack, null);
 
   void "returns null when no rules provided"() {
     expect:
-    ClusterMatcher.getMatchingRule(account, location, clusterName, null) == null
+    ClusterMatcher.getMatchingRule(account, location, moniker, null) == null
   }
 
   void "returns null when no rules match on account, location, or stack/detail"() {
@@ -39,7 +40,7 @@ class ClusterMatcherSpec extends Specification {
     ]
 
     expect:
-    ClusterMatcher.getMatchingRule("prod", location, clusterName, rules) == null
+    ClusterMatcher.getMatchingRule("prod", location, moniker, rules) == null
   }
 
   void "returns rule based on location if accounts are identical"() {
@@ -51,7 +52,7 @@ class ClusterMatcherSpec extends Specification {
     ]
 
     expect:
-    ClusterMatcher.getMatchingRule(account, location, clusterName, rules) == expected
+    ClusterMatcher.getMatchingRule(account, location, moniker, rules) == expected
   }
 
   void "returns rule based on stack if account and location are identical"() {
@@ -63,7 +64,7 @@ class ClusterMatcherSpec extends Specification {
     ]
 
     expect:
-    ClusterMatcher.getMatchingRule(account, location, clusterName, rules) == expected
+    ClusterMatcher.getMatchingRule(account, location, moniker, rules) == expected
   }
 
   void "returns rule based on detail if account, location, and stack are identical"() {
@@ -75,7 +76,7 @@ class ClusterMatcherSpec extends Specification {
     ]
 
     expect:
-    ClusterMatcher.getMatchingRule(account, location, clusterName, rules) == expected
+    ClusterMatcher.getMatchingRule(account, location, moniker, rules) == expected
   }
 
   void "returns rule based on priority if all other fields match"() {
@@ -87,7 +88,7 @@ class ClusterMatcherSpec extends Specification {
     ]
 
     expect:
-    ClusterMatcher.getMatchingRule(account, location, clusterName, rules) == expected
+    ClusterMatcher.getMatchingRule(account, location, moniker, rules) == expected
   }
 
   void "specific account takes priority over all other wildcard fields"() {
@@ -99,7 +100,7 @@ class ClusterMatcherSpec extends Specification {
     ]
 
     expect:
-    ClusterMatcher.getMatchingRule(account, location, clusterName, rules) == expected
+    ClusterMatcher.getMatchingRule(account, location, moniker, rules) == expected
   }
 
   void "specific location takes priority over wildcard stack, detail"() {
@@ -111,7 +112,7 @@ class ClusterMatcherSpec extends Specification {
     ]
 
     expect:
-    ClusterMatcher.getMatchingRule(account, location, clusterName, rules) == expected
+    ClusterMatcher.getMatchingRule(account, location, moniker, rules) == expected
   }
 
   void "specific stack takes priority over wildcard detail"() {
@@ -123,7 +124,7 @@ class ClusterMatcherSpec extends Specification {
     ]
 
     expect:
-    ClusterMatcher.getMatchingRule(account, location, clusterName, rules) == expected
+    ClusterMatcher.getMatchingRule(account, location, moniker, rules) == expected
   }
 
   void "specific detail takes priority over priority"() {
@@ -135,7 +136,7 @@ class ClusterMatcherSpec extends Specification {
     ]
 
     expect:
-    ClusterMatcher.getMatchingRule(account, location, clusterName, rules) == expected
+    ClusterMatcher.getMatchingRule(account, location, moniker, rules) == expected
   }
 
   void "handles clusters without account or details values"() {
@@ -146,7 +147,7 @@ class ClusterMatcherSpec extends Specification {
     ]
 
     expect:
-    ClusterMatcher.getMatchingRule(account, location, "myapp", rules) == expected
+    ClusterMatcher.getMatchingRule(account, location, new Moniker("myapp", null, null, null, null),rules) == expected
   }
 
   @Unroll
@@ -158,7 +159,7 @@ class ClusterMatcherSpec extends Specification {
     ]
 
     expect:
-    ClusterMatcher.getMatchingRule(account, location, "myapp", rules) == expected
+    ClusterMatcher.getMatchingRule(account, location, new Moniker("myapp", null, null, null, null), rules) == expected
 
     where:
     expected << [


### PR DESCRIPTION
This PR will remove the use of frigga from `TrafficGuard`.

### Flow:
First, `Map<String, Object> operation` is generated from a `Stage` object in `TargetServerGroup.toClouddriverOperationPayload()` and `AbstractServerGroupTask.convert()`. 
`Stage` object may or may not have a moniker. If it is an older pipeline config, then it will not have a moniker.
`operation` is used by `validateClusterStatus()` in 
  - `TerminateInstanceAndDecrementServerGroupTask.groovy`
  - `TerminateInstancesTask.groovy`
  - `BulkDestroyServerGroupTask.java`
  - `BulkDisableServerGroupTask.java`
  - `DestroyServerGroupTask.groovy`
  - `DisableServerGroupTask.groovy`
  - `ResizeServerGroupTask.groovy`

When calling `TrafficGuard.verifyTrafficRemoval()` a moniker is generated (via MonikerHelper and frigga) if one can't be found in the `operation`. Once we transition old pipeline configs to all use monikers, we can remove generating the moniker. In the case of the new k8s provider, a moniker is always expected to be present.

### Testing

To test, I made an app in Spinnaker and set Traffic Guards. Then I made a pipeline that tries to disable, resize, and destroy the guarded server group. Then I made a copy of the pipeline and removed the monikers. 

You can find the pipeline configurations here:
- https://github.com/Armory/spinnaker-test-pipelines/blob/master/json/trafficguard-moniker-test.json
- https://github.com/Armory/spinnaker-test-pipelines/blob/master/json/trafficguard-no-moniker-test.json

After running the pipelines, I got the expected results:

![Pipeline Execution History](https://cl.ly/2T153l1n0504/Image%202017-10-20%20at%202.53.07%20PM.png)

Note: These pipelines will be added to our internal test suite that runs against our installation of Spinnaker.