### PR TITLE
feat(moniker): Pass moniker to cleanup stages.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies
 
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.AbstractCloudProviderAwareStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
@@ -153,10 +154,10 @@ abstract class AbstractDeployStrategyStage extends AbstractCloudProviderAwareSta
     return className
   }
 
-  @Immutable
   static class CleanupConfig {
     String account
     String cluster
+    Moniker moniker
     String cloudProvider
     Location location
 
@@ -166,6 +167,7 @@ abstract class AbstractDeployStrategyStage extends AbstractCloudProviderAwareSta
       new CleanupConfig(
         account: stageData.account,
         cluster: stageData.cluster,
+        moniker: stageData.moniker,
         cloudProvider: stageData.cloudProvider,
         location: loc
       )

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/CustomStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/CustomStrategy.groovy
@@ -46,6 +46,7 @@ class CustomStrategy implements Strategy, ApplicationContextAware {
       application                            : stage.context.application,
       credentials                            : cleanupConfig.account,
       cluster                                : cleanupConfig.cluster,
+      moniker                                : cleanupConfig.moniker,
       (cleanupConfig.location.singularType()): cleanupConfig.location.value,
       cloudProvider                          : cleanupConfig.cloudProvider,
       strategy                               : true,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/HighlanderStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/HighlanderStrategy.groovy
@@ -44,6 +44,7 @@ class HighlanderStrategy implements Strategy, ApplicationContextAware {
     Map shrinkContext = [
         (cleanupConfig.location.singularType()): cleanupConfig.location.value,
         cluster                                : cleanupConfig.cluster,
+        moniker                                : cleanupConfig.moniker,
         credentials                            : cleanupConfig.account,
         cloudProvider                          : cleanupConfig.cloudProvider,
         shrinkToSize                           : 1,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategy.groovy
@@ -59,6 +59,7 @@ class RedBlackStrategy implements Strategy, ApplicationContextAware {
       (cleanupConfig.location.singularType()): cleanupConfig.location.value,
       cluster                                : cleanupConfig.cluster,
       credentials                            : cleanupConfig.account,
+      moniker                                : cleanupConfig.moniker,
       cloudProvider                          : cleanupConfig.cloudProvider,
     ]
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
@@ -65,6 +65,7 @@ class RollingRedBlackStrategy implements Strategy, ApplicationContextAware {
     Map baseContext = [
       (cleanupConfig.location.singularType()): cleanupConfig.location.value,
       cluster                                : cleanupConfig.cluster,
+      moniker                                : cleanupConfig.moniker,
       credentials                            : cleanupConfig.account,
       cloudProvider                          : cleanupConfig.cloudProvider,
     ]

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategySpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies
 
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.DisableClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.ScaleDownClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.ShrinkClusterStage
@@ -32,10 +33,12 @@ class RedBlackStrategySpec extends Specification {
 
   def "should compose flow"() {
     given:
+      Moniker moniker = new Moniker(app: "unit", stack: "test");
       def ctx = [
           account          : "testAccount",
           application      : "unit",
           stack            : "tests",
+          moniker          : moniker,
           cloudProvider    : "aws",
           region           : "north",
           availabilityZones: [
@@ -60,6 +63,7 @@ class RedBlackStrategySpec extends Specification {
           credentials                   : "testAccount",
           cloudProvider                 : "aws",
           cluster                       : "unit-tests",
+          moniker                       : moniker,
           region                        : "north",
           remainingEnabledServerGroups  : 1,
           preferLargerOverNewer         : false,


### PR DESCRIPTION
Right now Deck will generate something like this when a user creates a new deploy stage in a pipeline:

```
{
  "clusters": [
    {
      "account": "aws-dev",
      "application": "nginx",
      "associatePublicIpAddress": true,
      "availabilityZones": {
        "us-west-2": [
          "us-west-2a"
        ]
      },
      "cloudProvider": "aws",
      "freeFormDetails": "",
      "instanceType": "t2.micro",
      "moniker": {
        "app": "nginx",
        "cluster": "nginx-cluster1",
        "detail": "",
        "stack": "cluster1"
      },
      "provider": "aws",
      "stack": "cluster1",
      "strategy": "redblack",
      "subnetType": "external (spinnaker)",
      "terminationPolicies": [
        "Default"
      ]
    }
  ],
  "name": "Deploy",
  "type": "deploy"
}
```

A deploy stage (redblack/highlander/rolling/etc) will generate several sub-stages. This PR will allow the cluster's moniker to be passed to the cleanup sub-stages (shrink/destroy/disable). Other methods require the moniker down stream (`AbstractClusterWideClouddriverTask.ClusterSelection.getApplication()` for example.)