### PR TITLE
feat(provider/kubernetes): support to orchestrate update and delete o…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RecreateUpdateStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RecreateUpdateStrategy.groovy
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2017 Cisco, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.ResizeServerGroupStage
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.DetermineTargetServerGroupStage
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver
+import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+import org.springframework.stereotype.Component
+
+import static com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.newStage
+
+@Slf4j
+@Component
+class RecreateUpdateStrategy implements Strategy, ApplicationContextAware {
+  final String name = "recreateupdate"
+
+  @Autowired
+  ResizeServerGroupStage resizeServerGroupStage
+
+  @Autowired
+  DetermineTargetServerGroupStage determineTargetServerGroupStage
+
+  @Autowired
+  TargetServerGroupResolver targetServerGroupResolver
+
+  @Override
+  List<Stage> composeFlow(Stage stage) {
+    def stages = []
+    def stageData = stage.mapTo(RecreateUpdateStrategyData)
+    def cleanupConfig = AbstractDeployStrategyStage.CleanupConfig.fromStage(stage)
+
+    Map baseContext = [
+      (cleanupConfig.location.singularType()): cleanupConfig.location.value,
+      cluster                                : cleanupConfig.cluster,
+      credentials                            : cleanupConfig.account,
+      cloudProvider                          : cleanupConfig.cloudProvider,
+    ]
+
+    stage.context.capacity = [
+      min    : 0,
+      max    : 0,
+      desired: 0
+    ]
+
+    def p = 0
+    def findContext = baseContext + [
+      target        : TargetServerGroup.Params.Target.current_asg_dynamic,
+      targetLocation: cleanupConfig.location,
+    ]
+
+    stages << newStage(
+      stage.execution,
+      determineTargetServerGroupStage.type,
+      "Determine Deployed Server Group",
+      findContext,
+      stage,
+      SyntheticStageOwner.STAGE_BEFORE
+    )
+
+    def source
+    try {
+      source = getSource(targetServerGroupResolver, stageData, baseContext)
+    } catch (Exception e) {
+      stages = []
+      return stages
+    }
+
+    def resizeContext = baseContext + [
+      target        : TargetServerGroup.Params.Target.current_asg_dynamic,
+      action        : ResizeStrategy.ResizeAction.scale_exact,
+      source        : source,
+      targetLocation: cleanupConfig.location,
+      kind          : stageData.kind,
+      capacity      : stage.context.capacity,
+      resizeType    : "exact",
+      scaleNum      : 0
+    ]
+
+    def resizeStage = newStage(
+      stage.execution,
+      resizeServerGroupStage.type,
+      "Scale down to $p% Desired Size(0)",
+      resizeContext,
+      stage,
+      SyntheticStageOwner.STAGE_BEFORE
+    )
+    stages << resizeStage
+
+    return stages
+  }
+
+  static ResizeStrategy.Source getSource(TargetServerGroupResolver targetServerGroupResolver,
+                                         RecreateUpdateStrategyData stageData,
+                                         Map baseContext) {
+    if (stageData.source) {
+      return new ResizeStrategy.Source(
+        region: stageData.source.region,
+        serverGroupName: stageData.source.serverGroupName ?: stageData.source.asgName,
+        credentials: stageData.credentials ?: stageData.account,
+        cloudProvider: stageData.cloudProvider
+      )
+    }
+
+    // no source server group specified, lookup current server group
+    TargetServerGroup target = targetServerGroupResolver.resolve(
+      new Stage(null, null, null, baseContext + [target: TargetServerGroup.Params.Target.current_asg_dynamic])
+    )?.get(0)
+
+    return new ResizeStrategy.Source(
+      region: target.getLocation().value,
+      serverGroupName: target.getName(),
+      credentials: stageData.credentials ?: stageData.account,
+      cloudProvider: stageData.cloudProvider
+    )
+  }
+  ApplicationContext applicationContext
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RecreateUpdateStrategyData.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RecreateUpdateStrategyData.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Cisco, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies
+
+import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
+
+class RecreateUpdateStrategyData extends StageData {
+  String kind
+  Map capacity
+  Integer targetSize
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DeployStrategyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DeployStrategyStage.groovy
@@ -210,6 +210,10 @@ abstract class DeployStrategyStage extends AbstractCloudProviderAwareStage {
     return stages
   }
 
+  protected List<Stage> composeRecreateUpdateFlow(Stage stage) {
+    return []
+  }
+
   protected List<Stage> composeCustomFlow(Stage stage) {
     def stages = []
     def cleanupConfig = determineClusterForCleanup(stage)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/Strategy.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/Strategy.java
@@ -25,6 +25,7 @@ public enum Strategy implements StrategyFlowComposer{
   RED_BLACK("redblack"),
   HIGHLANDER("highlander"),
   ROLLING_PUSH("rollingpush"),
+  RECREATE_UPDATE("recreateupdate"),
   CUSTOM("custom"),
   NONE("none");
 
@@ -49,7 +50,7 @@ public enum Strategy implements StrategyFlowComposer{
 
   @Override
   public boolean replacesBasicSteps() {
-    return this == ROLLING_PUSH || this == CUSTOM;
+    return this == ROLLING_PUSH || this == CUSTOM || this == RECREATE_UPDATE;
   }
 
   @Override
@@ -61,6 +62,8 @@ public enum Strategy implements StrategyFlowComposer{
         return builder.composeHighlanderFlow(stage);
       case ROLLING_PUSH:
         return builder.composeRollingPushFlow(stage);
+      case RECREATE_UPDATE:
+        return builder.composeRecreateUpdateFlow(stage);
       case CUSTOM:
         return builder.composeCustomFlow(stage);
     }


### PR DESCRIPTION
About this PR,

- orchestrate update strategies operation for statefulset and daemonset.
Add a new strategy (recreateupdate) for supporting OnDelete update in order to handle resize statefulset and daemonset pod(s) to 0 before update controller definition.
- orchestrate delete operation for statefulset and daemonset.
Remove this operation from original PR and leverage current orca task flow.  Disable server group logic, which is not applicable,  will be controlled in clouddriver.

Thanks.
…perations for new controllers.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
