### PR TITLE
feat(moniker): Use moniker for app name over frigga in flex

### DIFF
--- a/orca-flex/orca-flex.gradle
+++ b/orca-flex/orca-flex.gradle
@@ -16,6 +16,7 @@
 
 dependencies {
   compile spinnaker.dependency('frigga')
+  compile 'com.netflix.spinnaker.moniker:moniker:0.2.0'
   compile project(":orca-retrofit")
   testCompile project(":orca-test")
 }

--- a/orca-flex/src/main/groovy/com/netflix/spinnaker/orca/flex/tasks/AbstractElasticIpTask.groovy
+++ b/orca-flex/src/main/groovy/com/netflix/spinnaker/orca/flex/tasks/AbstractElasticIpTask.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.flex.tasks
 
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
@@ -49,11 +50,12 @@ abstract class AbstractElasticIpTask implements Task {
   static class StageData {
     String account
     String cluster
+    Moniker moniker
     String region
     ElasticIpRequest elasticIp
 
     String getApplication() {
-      return cluster ? Names.parseName(cluster).app : null
+      return moniker ? moniker.getApp() : cluster ? Names.parseName(cluster).app : null
     }
   }
 }


### PR DESCRIPTION
Similar to the other PRs for monikers, first try to use the moniker from the stage (which is added by deck). Then fall back on frigga.