### PR TITLE
feat(manualJudgment): allow standard notification types for manual ju…

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
@@ -72,20 +72,20 @@ class ManualJudgmentStage implements StageDefinitionBuilder, RestartableStage, A
     @Override
     TaskResult execute(Stage stage) {
       StageData stageData = stage.mapTo(StageData)
-      NotificationState notificationState
+      String notificationState
       ExecutionStatus executionStatus
 
       switch (stageData.state) {
         case StageData.State.CONTINUE:
-          notificationState = NotificationState.manualJudgmentContinue
+          notificationState = "manualJudgmentContinue"
           executionStatus = ExecutionStatus.SUCCEEDED
           break
         case StageData.State.STOP:
-          notificationState = NotificationState.manualJudgmentStop
+          notificationState = "manualJudgmentStop"
           executionStatus = ExecutionStatus.TERMINAL
           break
         default:
-          notificationState = NotificationState.manualJudgment
+          notificationState = "manualJudgment"
           executionStatus = ExecutionStatus.RUNNING
           break
       }
@@ -95,12 +95,12 @@ class ManualJudgmentStage implements StageDefinitionBuilder, RestartableStage, A
       return new TaskResult(executionStatus, outputs)
     }
 
-    Map processNotifications(Stage stage, StageData stageData, NotificationState notificationState) {
+    Map processNotifications(Stage stage, StageData stageData, String notificationState) {
       if (echoService) {
         // sendNotifications will be true if using the new scheme for configuration notifications.
         // The new scheme matches the scheme used by the other stages.
         // If the deprecated scheme is in use, only the original 'awaiting judgment' notification is supported.
-        if (notificationState != NotificationState.manualJudgment && !stage.context.sendNotifications) {
+        if (notificationState != "manualJudgment" && !stage.context.sendNotifications) {
           return [:]
         }
 
@@ -117,12 +117,6 @@ class ManualJudgmentStage implements StageDefinitionBuilder, RestartableStage, A
         return [:]
       }
     }
-  }
-
-  static enum NotificationState {
-    manualJudgment,
-    manualJudgmentContinue,
-    manualJudgmentStop
   }
 
   static class StageData {
@@ -152,13 +146,13 @@ class ManualJudgmentStage implements StageDefinitionBuilder, RestartableStage, A
     String address
     String cc
     String type
-    List<NotificationState> when
-    Map<NotificationState, Map> message
+    List<String> when
+    Map<String, Map> message
 
-    Map<NotificationState, Date> lastNotifiedByNotificationState = [:]
+    Map<String, Date> lastNotifiedByNotificationState = [:]
     Long notifyEveryMs = -1
 
-    boolean shouldNotify(NotificationState notificationState, Date now = new Date()) {
+    boolean shouldNotify(String notificationState, Date now = new Date()) {
       // The new scheme for configuring notifications requires the use of the when list (just like the other stages).
       // If this list is present, but does not contain an entry for this particular notification state, do not notify.
       if (when && !when.contains(notificationState)) {
@@ -178,7 +172,7 @@ class ManualJudgmentStage implements StageDefinitionBuilder, RestartableStage, A
       return new Date(lastNotified.time + notifyEveryMs) <= now
     }
 
-    void notify(EchoService echoService, Stage stage, NotificationState notificationState) {
+    void notify(EchoService echoService, Stage stage, String notificationState) {
       echoService.create(new EchoService.Notification(
         notificationType: EchoService.Notification.Type.valueOf(type.toUpperCase()),
         to: address ? [address] : null,

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
@@ -62,7 +62,7 @@ class ManualJudgmentStageSpec extends Specification {
     then:
     result.status == ExecutionStatus.RUNNING
     result.context.notifications.findAll {
-      it.lastNotifiedByNotificationState[NotificationState.manualJudgment]
+      it.lastNotifiedByNotificationState["manualJudgment"]
     }*.type == ["email", "hipchat", "sms"]
   }
 
@@ -85,13 +85,13 @@ class ManualJudgmentStageSpec extends Specification {
     if (sent) result.context.notifications?.getAt(0)?.lastNotifiedByNotificationState?.containsKey(notificationState)
 
     where:
-    sendNotifications | notificationState                        | judgmentStatus | executionStatus           || sent
-    true              | NotificationState.manualJudgment         | null           | ExecutionStatus.RUNNING   || true
-    false             | NotificationState.manualJudgment         | null           | ExecutionStatus.RUNNING   || true
-    true              | NotificationState.manualJudgmentContinue | "continue"     | ExecutionStatus.SUCCEEDED || true
-    false             | NotificationState.manualJudgmentContinue | "continue"     | ExecutionStatus.SUCCEEDED || false
-    true              | NotificationState.manualJudgmentStop     | "stop"         | ExecutionStatus.TERMINAL  || true
-    false             | NotificationState.manualJudgmentStop     | "stop"         | ExecutionStatus.TERMINAL  || false
+    sendNotifications | notificationState        | judgmentStatus | executionStatus           || sent
+    true              | "manualJudgment"         | null           | ExecutionStatus.RUNNING   || true
+    false             | "manualJudgment"         | null           | ExecutionStatus.RUNNING   || true
+    true              | "manualJudgmentContinue" | "continue"     | ExecutionStatus.SUCCEEDED || true
+    false             | "manualJudgmentContinue" | "continue"     | ExecutionStatus.SUCCEEDED || false
+    true              | "manualJudgmentStop"     | "stop"         | ExecutionStatus.TERMINAL  || true
+    false             | "manualJudgmentStop"     | "stop"         | ExecutionStatus.TERMINAL  || false
   }
 
   @Unroll
@@ -100,18 +100,18 @@ class ManualJudgmentStageSpec extends Specification {
     notification.shouldNotify(notificationState, now) == shouldNotify
 
     where:
-    notification                                                                                  | notificationState                        | now             || shouldNotify
-    new Notification()                                                                            | NotificationState.manualJudgment         | new Date()      || true
+    notification                                                                  | notificationState        | now             || shouldNotify
+    new Notification()                                                            | "manualJudgment"         | new Date()      || true
     new Notification(
-      lastNotifiedByNotificationState: [(NotificationState.manualJudgment): new Date(1)])         | NotificationState.manualJudgment         | new Date()      || false
+      lastNotifiedByNotificationState: [("manualJudgment"): new Date(1)])         | "manualJudgment"         | new Date()      || false
     new Notification(
-      lastNotifiedByNotificationState: [(NotificationState.manualJudgment): new Date(1)])         | NotificationState.manualJudgmentContinue | new Date()      || true
+      lastNotifiedByNotificationState: [("manualJudgment"): new Date(1)])         | "manualJudgmentContinue" | new Date()      || true
     new Notification(
-      lastNotifiedByNotificationState: [(NotificationState.manualJudgment): new Date(1),
-                                        (NotificationState.manualJudgmentContinue): new Date(1)]) | NotificationState.manualJudgmentContinue | new Date()      || false
+      lastNotifiedByNotificationState: [("manualJudgment"): new Date(1),
+                                        ("manualJudgmentContinue"): new Date(1)]) | "manualJudgmentContinue" | new Date()      || false
     new Notification(
-      lastNotifiedByNotificationState: [(NotificationState.manualJudgment): new Date(1)],
-      notifyEveryMs: 60000)                                                                       | NotificationState.manualJudgment         | new Date(60001) || true
+      lastNotifiedByNotificationState: [("manualJudgment"): new Date(1)],
+      notifyEveryMs: 60000)                                                       | "manualJudgment"         | new Date(60001) || true
   }
 
   @Unroll
@@ -144,11 +144,7 @@ class ManualJudgmentStageSpec extends Specification {
     0 * _
 
     where:
-    notificationState << [
-                           NotificationState.manualJudgment,
-                           NotificationState.manualJudgmentContinue,
-                           NotificationState.manualJudgmentStop
-                         ]
+    notificationState << [ "manualJudgment", "manualJudgmentContinue", "manualJudgmentStop" ]
   }
 
   @Unroll


### PR DESCRIPTION
…dgment

Right now, Echo has custom templates to handle notification for manual judgment stage events, which are not easily overridden.

Rather than hack up the templates in Echo for manual judgment events, let's allow users to send standard stage notification configurations, which would let the user [customize the messages](https://github.com/spinnaker/echo/pull/189).

@duftler looks like you wrote a lot of the code around this enum I'm removing. WDYT?
