### PR TITLE
fix(mahe): do not clean up properties that have been updated

### DIFF
--- a/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/MaheService.groovy
+++ b/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/MaheService.groovy
@@ -26,6 +26,9 @@ interface MaheService {
   @POST('/properties/upsert')
   Response upsertProperty(@Body Map property)
 
+  @GET('/properties/find')
+  Response findProperty(@QueryMap Map<String, String> property)
+
   @GET('/properties/prop')
   Response getPropertyById(@Query('propId') String propId, @Query('env') String env)
 


### PR DESCRIPTION
The current rollback functionality makes some potentially dangerous assumptions:
* it relies on the producer of the pipeline config to supply the relevant information about which properties are being created/updated. If the pipeline is configured incorrectly, or has out-of-date information when it runs, it could delete a property entirely on rollback, when it should have restored it to its previous state.
* property stages from a pipeline do not include the `originalProperties` field, so a rollback of the pipeline will always delete the property, which is not great if the property change was an upsert.

(Note: this is internal Netflix functionality - it is not used in open source)