### PR TITLE
fix(security): Prevent webhook users from spoofing authed user

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookService.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookService.groovy
@@ -30,6 +30,15 @@ import org.springframework.web.client.RestTemplate
 @Service
 class WebhookService {
 
+  // These headers create a security vulnerability.
+  static final List<String> headerBlacklist = [
+    "X-SPINNAKER-USER",
+    "X-SPINNAKER-ACCOUNT",
+    "X-SPINNAKER-USER-ORIGIN",
+    "X-SPINNAKER-REQUEST-ID",
+    "X-SPINNAKER-EXECUTION-ID"
+  ];
+
   @Autowired
   private RestTemplate restTemplate
 
@@ -60,6 +69,9 @@ class WebhookService {
   private static HttpHeaders buildHttpHeaders(Object customHeaders) {
     HttpHeaders headers = new HttpHeaders()
     customHeaders?.each { key, value ->
+      if (headerBlacklist.contains(key.toUpperCase())) {
+        return;
+      }
       if (value instanceof List<String>) {
         headers.put(key as String, value as List<String>)
       } else {


### PR DESCRIPTION
The webhook stage runs from Orca, so it has direct access to Clouddriver, Front50, etc. A user can create a request to, say, Clouddriver with a X-SPINNAKER-USER header of a user with sufficient permissions and effectively bypass all security checks.

This PR strips the X-SPINNAKER-USER and X-SPINNAKER-ACCOUNT headers before the request is created.

@ttomsu