### PR TITLE
feat(core): Add correlation ids to orchestrations

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -16,10 +16,6 @@
 
 package com.netflix.spinnaker.orca.pipeline;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
@@ -28,6 +24,12 @@ import com.netflix.spinnaker.orca.pipeline.model.Pipeline;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
 import static java.lang.Boolean.parseBoolean;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -51,6 +53,11 @@ public abstract class ExecutionLauncher<T extends Execution<T>> {
 
   public T start(String configJson) throws Exception {
     final T execution = parse(configJson);
+
+    final T existingExecution = checkForCorrelatedExecution(execution);
+    if (existingExecution != null) {
+      return existingExecution;
+    }
 
     checkRunnable(execution);
 
@@ -77,6 +84,12 @@ public abstract class ExecutionLauncher<T extends Execution<T>> {
       onExecutionStarted(execution);
     }
     return execution;
+  }
+
+  protected T checkForCorrelatedExecution(T execution) {
+    // Correlated executions currently only supported by Orchestrations. Just lazy, and a carrot to
+    // refactoring out distinction between Pipeline / Orchestration.
+    return null;
   }
 
   protected T handleStartupFailure(T execution, Throwable failure) {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -227,6 +227,12 @@ public abstract class Execution<T extends Execution<T>> implements Serializable 
     this.origin = origin;
   }
 
+  private final Map<String, Object> trigger = new HashMap<>();
+
+  public @Nonnull Map<String, Object> getTrigger() {
+    return trigger;
+  }
+
   @Nullable
   public Stage<T> namedStage(String type) {
     return stages

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Pipeline.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Pipeline.java
@@ -16,16 +16,17 @@
 
 package com.netflix.spinnaker.orca.pipeline.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spectator.api.Registry;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.netflix.spectator.api.Registry;
 
 public class Pipeline extends Execution<Pipeline> {
 
@@ -48,12 +49,6 @@ public class Pipeline extends Execution<Pipeline> {
 
   public void setPipelineConfigId(@Nullable String pipelineConfigId) {
     this.pipelineConfigId = pipelineConfigId;
-  }
-
-  private final Map<String, Object> trigger = new HashMap<>();
-
-  public @Nonnull Map<String, Object> getTrigger() {
-    return trigger;
   }
 
   private final List<Map<String, Object>> notifications = new ArrayList<>();

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -83,6 +83,9 @@ public interface ExecutionRepository {
   @Nonnull Observable<Orchestration> retrieveOrchestrationsForApplication(
     @Nonnull String application, @Nonnull ExecutionCriteria criteria);
 
+  @Nonnull Orchestration retrieveOrchestrationForCorrelationId(
+    @Nonnull String correlationId) throws ExecutionNotFoundException;
+
   class ExecutionCriteria {
     public int getLimit() {
       return limit;

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -443,6 +443,27 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     where:
     status << ExecutionStatus.values()
   }
+
+  def "should return task ref for currently running orchestration by correlation id"() {
+    given:
+    def execution = orchestration()
+    execution.trigger['correlationId'] = 'covfefe'
+    repository.store(execution)
+    repository.updateStatus(execution.id, RUNNING)
+
+    when:
+    def result = repository.retrieveOrchestrationForCorrelationId('covfefe')
+
+    then:
+    result.id == execution.id
+
+    when:
+    repository.updateStatus(execution.id, SUCCEEDED)
+    repository.retrieveOrchestrationForCorrelationId('covfefe')
+
+    then:
+    thrown(ExecutionNotFoundException)
+  }
 }
 
 class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<JedisExecutionRepository> {


### PR DESCRIPTION
Allows us to repeatedly send orchestrations with the same correlation id and only running a single one. Pre-req for keel.