### PR TITLE
fix(moniker): hotfix canary deploy stages

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
@@ -77,11 +77,13 @@ class DeployCanaryStage extends ParallelDeployStage implements CloudProviderAwar
     List<Map> canaryDeployments = defaultStageContext.clusterPairs
 
     return canaryDeployments.collect { Map canaryDeployment ->
-      def canary = canaryDeployment.canary
+      Map canary = canaryDeployment.canary
       canary.strategy = "highlander"
+      canary.remove('moniker')
 
-      def baseline = canaryDeployment.baseline
+      Map baseline = canaryDeployment.baseline
       baseline.strategy = "highlander"
+      baseline.remove('moniker')
       def baselineAmi = baselineAmis.find {
         it.region == (baseline.region ?: baseline.availabilityZones.keySet()[0])
       }


### PR DESCRIPTION
moniker objects are incorrect on canary deploy stages, this removes those objects for now pending a fix of the source problem
