### PR TITLE
fix(triggers): ensure canceling pipeline sends ExecutionComplete event

### DIFF
--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandlerTest.kt
@@ -16,10 +16,11 @@
 
 package com.netflix.spinnaker.orca.q.handler
 
-import com.netflix.spinnaker.orca.ExecutionStatus.PAUSED
-import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
+import com.netflix.spinnaker.orca.ExecutionStatus.*
+import com.netflix.spinnaker.orca.events.ExecutionComplete
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.*
+import com.netflix.spinnaker.spek.shouldEqual
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.given
@@ -27,17 +28,19 @@ import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.on
 import org.jetbrains.spek.api.lifecycle.CachingMode
 import org.jetbrains.spek.subject.SubjectSpek
+import org.springframework.context.ApplicationEventPublisher
 
 object CancelExecutionHandlerTest : SubjectSpek<CancelExecutionHandler>({
 
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
+  val publisher: ApplicationEventPublisher = mock()
 
   subject(CachingMode.GROUP) {
-    CancelExecutionHandler(queue, repository)
+    CancelExecutionHandler(queue, repository, publisher)
   }
 
-  fun resetMocks() = reset(queue, repository)
+  fun resetMocks() = reset(queue, repository, publisher)
 
   describe("cancelling an execution") {
     given("there are no paused stages") {
@@ -67,6 +70,14 @@ object CancelExecutionHandlerTest : SubjectSpek<CancelExecutionHandler>({
 
       it("it triggers a reevaluate") {
         verify(queue).push(RescheduleExecution(pipeline))
+      }
+
+      it("publishes an execution complete event") {
+        verify(publisher).publishEvent(check<ExecutionComplete> {
+          it.executionType shouldEqual pipeline.javaClass
+          it.executionId shouldEqual pipeline.id
+          it.status shouldEqual CANCELED
+        })
       }
 
       it("does not send any further messages") {


### PR DESCRIPTION
Tested locally by ensuring cancelling pipeline A triggered pipeline B with an on cancel trigger.