### PR TITLE
fix(front50): Keep front50 optional

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import org.springframework.stereotype.Component
+
 import static com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.newStage
 
 @Slf4j
@@ -47,7 +48,7 @@ class RollingRedBlackStrategy implements Strategy, ApplicationContextAware {
   @Autowired
   WaitStage waitStage
 
-  @Autowired
+  @Autowired(required = false)
   PipelineStage pipelineStage
 
   @Autowired
@@ -58,6 +59,10 @@ class RollingRedBlackStrategy implements Strategy, ApplicationContextAware {
 
   @Override
   <T extends Execution<T>> List<Stage<T>> composeFlow(Stage<T> stage) {
+    if (!pipelineStage) {
+      throw new IllegalStateException("Rolling red/black cannot be run without front50 enabled. Please set 'front50.enabled: true' in your orca config.")
+    }
+
     def stages = []
     def stageData = stage.mapTo(RollingRedBlackStageData)
     def cleanupConfig = AbstractDeployStrategyStage.CleanupConfig.fromStage(stage)

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.yaml.snakeyaml.Yaml;
 
 import java.util.List;
+import java.util.Optional;
 
 @ConditionalOnExpression("${pipelineTemplates.enabled:true}")
 @ComponentScan(
@@ -69,8 +70,8 @@ public class PipelineTemplateConfiguration {
   @Bean
   Renderer jinjaRenderer(RenderedValueConverter renderedValueConverter,
                          ObjectMapper pipelineTemplateObjectMapper,
-                         Front50Service front50Service) {
-    return new JinjaRenderer(renderedValueConverter, pipelineTemplateObjectMapper, front50Service, additionalJinjaTags);
+                         Optional<Front50Service> front50Service) {
+    return new JinjaRenderer(renderedValueConverter, pipelineTemplateObjectMapper, front50Service.orElse(null), additionalJinjaTags);
   }
 
   @Bean

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/Front50SchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/Front50SchemeLoader.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Component;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 
 @Component
 public class Front50SchemeLoader implements TemplateSchemeLoader {
@@ -32,8 +33,8 @@ public class Front50SchemeLoader implements TemplateSchemeLoader {
   private final ObjectMapper objectMapper;
 
   @Autowired
-  public Front50SchemeLoader(Front50Service front50Service, ObjectMapper pipelineTemplateObjectMapper) {
-    this.front50Service = front50Service;
+  public Front50SchemeLoader(Optional<Front50Service> front50Service, ObjectMapper pipelineTemplateObjectMapper) {
+    this.front50Service = front50Service.orElse(null);
     this.objectMapper = pipelineTemplateObjectMapper;
   }
 
@@ -45,6 +46,10 @@ public class Front50SchemeLoader implements TemplateSchemeLoader {
 
   @Override
   public PipelineTemplate load(URI uri) {
+    if (front50Service == null) {
+      throw new TemplateLoaderException("Cannot load templates without front50 enabled. Set 'front50.enabled: true' in your orca config.");
+    }
+
     String id = uri.getHost();
     try {
       Map<String, Object> pipelineTemplate = front50Service.getPipelineTemplate(id);

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/UpdatePipelineTemplateStage.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/pipeline/UpdatePipelineTemplateStage.java
@@ -48,7 +48,7 @@ public class UpdatePipelineTemplateStage implements StageDefinitionBuilder {
   @Autowired
   private ObjectMapper pipelineTemplateObjectMapper;
 
-  @Autowired
+  @Autowired(required = false)
   private UpdatePipelineStage updatePipelineStage;
 
   @Override

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
@@ -65,6 +65,11 @@ public class JinjaRenderer implements Renderer {
   }
 
   public JinjaRenderer(RenderedValueConverter renderedValueConverter, ObjectMapper pipelineTemplateObjectMapper, Front50Service front50Service, List<Tag> jinjaTags) {
+    if (front50Service == null) {
+      log.error("Pipeline templates require front50 to enabled. Set 'front50.enabled: true' in your orca config.");
+      return;
+    }
+
     this.renderedValueConverter = renderedValueConverter;
 
     jinja = new Jinjava(buildJinjavaConfig());

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/loader/Front50SchemeLoaderSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/loader/Front50SchemeLoaderSpec.groovy
@@ -28,7 +28,7 @@ class Front50SchemeLoaderSpec extends Specification {
   Front50Service front50Service = Mock()
 
   @Subject
-  def schemeLoader = new Front50SchemeLoader(front50Service, new ObjectMapper())
+  def schemeLoader = new Front50SchemeLoader(Optional.of(front50Service), new ObjectMapper())
 
   @Unroll
   void 'should support spinnaker scheme'() {


### PR DESCRIPTION
As we're trying to get our nightlies to pass we found that front50 has become required for orca again, breaking some halyard flows. 