### PR TITLE
chore(dependencies): Bump spinnaker-dependencies to 0.120.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
   group = "com.netflix.spinnaker.orca"
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.120.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.120.1'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
@@ -74,7 +74,7 @@ public class FindImageFromTagsTask extends AbstractCloudProviderAwareTask implem
   }
 
   private Artifact generateArtifactFrom(ImageFinder.ImageDetails imageDetails, String cloudProvider) {
-    Map<String, String> metadata = new HashMap<>();
+    Map<String, Object> metadata = new HashMap<>();
     try {
         ImageFinder.JenkinsDetails jenkinsDetails = imageDetails.getJenkins();
         metadata.put("build_info_url", jenkinsDetails.get("host"));


### PR DESCRIPTION
Should fix the Artifact.metadata serialization issue.
