### PR TITLE
fix(orca/canary): Don't presume array present

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTask.groovy
@@ -62,7 +62,7 @@ class RegisterCanaryTask implements Task {
       application         : c.application
     ]
 
-    if (deployStage.context.deployedClusterPairs[0]?.canaryCluster?.accountName) {
+    if (deployStage.context.deployedClusterPairs?.getAt(0)?.canaryCluster?.accountName) {
       outputs.account = deployStage.context.deployedClusterPairs[0].canaryCluster.accountName
     }
 


### PR DESCRIPTION
In at least one case of total canary stage failure, the deployedClusterPairs
context variable doesn't get set at all, resulting in a null value -- this
avoids the "Cannot invoke method getAt() on null object" error message
that results from trying to dereference the zero'th element in this case.


