### PR TITLE
Use StageContext consistently without breaking strategies

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AlertOnAccessMap.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/AlertOnAccessMap.java
@@ -46,21 +46,24 @@ public class AlertOnAccessMap<E extends Execution<E>> extends ForwardingMap<Stri
   @Override protected Map<String, Object> delegate() { return delegate; }
 
   @Override public Object get(@Nullable Object key) {
-    log.warn(
-      "Global context key \"{}\" accessed by {} {}[{}] \"{}\"",
-      key,
-      execution.getApplication(),
-      execution.getClass().getSimpleName(),
-      execution.getId(),
-      execution.getName()
-    );
-    Id counterId = registry
-      .createId("global.context.access")
-      .withTag("application", execution.getApplication())
-      .withTag("key", String.valueOf(key));
-    registry
-      .counter(counterId)
-      .increment();
-    return super.get(key);
+    Object value = super.get(key);
+    if (value != null) {
+      log.warn(
+        "Global context key \"{}\" accessed by {} {}[{}] \"{}\"",
+        key,
+        execution.getApplication(),
+        execution.getClass().getSimpleName(),
+        execution.getId(),
+        execution.getName()
+      );
+      Id counterId = registry
+        .createId("global.context.access")
+        .withTag("application", execution.getApplication())
+        .withTag("key", String.valueOf(key));
+      registry
+        .counter(counterId)
+        .increment();
+    }
+    return value;
   }
 }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -16,23 +16,16 @@
 
 package com.netflix.spinnaker.orca.pipeline.model;
 
+import java.io.Serializable;
+import java.util.*;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import com.netflix.spinnaker.security.User;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-
 import static com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED;
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionEngine.v3;
 import static java.util.Arrays.asList;
@@ -152,6 +145,7 @@ public abstract class Execution<T extends Execution<T>> implements Serializable 
 
   private final List<Stage<T>> stages = new ArrayList<>();
 
+  @JsonManagedReference
   public @Nonnull List<Stage<T>> getStages() {
     return stages;
   }

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -175,7 +175,11 @@ public class Stage<T extends Execution<T>> implements Serializable {
   }
 
   public void setContext(@Nonnull Map<String, Object> context) {
-    this.context = context;
+    if (context instanceof StageContext) {
+      this.context = context;
+    } else {
+      this.context = new StageContext(this, context);
+    }
   }
 
   /**

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContext.java
@@ -16,23 +16,23 @@
 
 package com.netflix.spinnaker.orca.pipeline.model;
 
-import com.google.common.collect.ForwardingMap;
-
-import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import com.google.common.collect.ForwardingMap;
 
 public class StageContext extends ForwardingMap<String, Object> {
 
   private final Stage<?> stage;
-  private final Map<String, Object> delegate = new HashMap<>();
+  private final Map<String, Object> delegate;
 
   public StageContext(Stage<?> stage) {
+    this(stage, new HashMap<>());
+  }
+
+  public StageContext(Stage<?> stage, Map<String, Object> delegate) {
     this.stage = stage;
+    this.delegate = delegate;
   }
 
   @Override protected Map<String, Object> delegate() {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Execution
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
+import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
@@ -305,141 +306,139 @@ class ContextParameterProcessorSpec extends Specification {
   }
 
   def "is able to parse deployment details correctly from execution"() {
-
     given:
     def source = ['deployed': '${deployedServerGroups}']
-    def context = [execution: execution]
 
     when:
-    def result = contextParameterProcessor.process(source, context, true)
+    def result = contextParameterProcessor.process(source, [execution: execution], true)
 
     then:
     result.deployed.size == 2
-    result.deployed.serverGroup == ['flex-test-v043', 'flex-prestaging-v011']
-    result.deployed.region == ['us-east-1', 'us-west-1']
-    result.deployed[0].ami == 'ami-06362b6e'
+    result.deployed.serverGroup == ["flex-test-v043", "flex-prestaging-v011"]
+    result.deployed.region == ["us-east-1", "us-west-1"]
+    result.deployed.ami == ["ami-06362b6e", "ami-f759b7b3"]
 
     where:
-    execution = [
-      "context": [
-        "deploymentDetails": [
-          [
-            "ami"      : "ami-06362b6e",
-            "amiSuffix": "201505150627",
-            "baseLabel": "candidate",
-            "baseOs"   : "ubuntu",
-            "package"  : "flex",
-            "region"   : "us-east-1",
-            "storeType": "ebs",
-            "vmType"   : "pv"
-          ],
-          [
-            "ami"      : "ami-f759b7b3",
-            "amiSuffix": "201505150627",
-            "baseLabel": "candidate",
-            "baseOs"   : "ubuntu",
-            "package"  : "flex",
-            "region"   : "us-west-1",
-            "storeType": "ebs",
-            "vmType"   : "pv"
+    execution = pipeline {
+      stage {
+        type = "bake"
+        name = "Bake"
+        refId = "1"
+        status = SUCCEEDED
+        outputs.putAll(
+          deploymentDetails: [
+            [
+              ami      : "ami-06362b6e",
+              amiSuffix: "201505150627",
+              baseLabel: "candidate",
+              baseOs   : "ubuntu",
+              package  : "flex",
+              region   : "us-east-1",
+              storeType: "ebs",
+              vmType   : "pv"
+            ],
+            [
+              ami      : "ami-f759b7b3",
+              amiSuffix: "201505150627",
+              baseLabel: "candidate",
+              baseOs   : "ubuntu",
+              package  : "flex",
+              region   : "us-west-1",
+              storeType: "ebs",
+              vmType   : "pv"
+            ]
           ]
-        ]
-      ],
-      "stages" : [
-        [
-          "status"       : ExecutionStatus.SUCCEEDED,
-          "type"         : "deploy",
-          "name"         : "Deploy in us-east-1",
-          "context"      : [
-            "account"             : "test",
-            "application"         : "flex",
-            "availabilityZones"   : [
+        )
+      }
+      stage {
+        type = "deploy"
+        name = "Deploy"
+        refId = "2"
+        requisiteStageRefIds = ["1"]
+        status = SUCCEEDED
+        stage {
+          status = SUCCEEDED
+          type = "createServerGroup"
+          name = "Deploy in us-east-1"
+          context.putAll(
+            "account": "test",
+            "application": "flex",
+            "availabilityZones": [
               "us-east-1": [
                 "us-east-1c",
                 "us-east-1d",
                 "us-east-1e"
               ]
             ],
-            "capacity"            : [
+            "capacity": [
               "desired": 1,
               "max"    : 1,
               "min"    : 1
             ],
-            "deploy.account.name" : "test",
+            "deploy.account.name": "test",
             "deploy.server.groups": [
               "us-east-1": [
                 "flex-test-v043"
               ]
             ],
-            "stack"               : "test",
-            "strategy"            : "highlander",
-            "subnetType"          : "internal",
-            "suspendedProcesses"  : [],
-            "terminationPolicies" : [
+            "stack": "test",
+            "strategy": "highlander",
+            "subnetType": "internal",
+            "suspendedProcesses": [],
+            "terminationPolicies": [
               "Default"
-            ],
-            "type"                : "linearDeploy"
-          ],
-          "parentStageId": "dca27ddd-ce7d-42a0-a1db-5b43c6b2f0c7",
-        ],
-        [
-          "id"     : "dca27ddd-ce7d-42a0-a1db-5b43c6b2f0c7-2-destroyAsg",
-          "type"   : "destroyAsg",
-          "name"   : "destroyAsg",
-          "context": [
-          ]
-        ],
-        [
-          "id"           : "68ad3566-4857-4c76-839e-f4afc14410c5-1-Deployinuswest1",
-          "type"         : "deploy",
-          "name"         : "Deploy in us-west-1",
-          "startTime"    : 1431672074613,
-          "endTime"      : 1431672487124,
-          "status"       : ExecutionStatus.SUCCEEDED,
-          "context"      : [
-            "account"             : "prod",
-            "application"         : "flex",
-            "availabilityZones"   : [
+            ]
+          )
+        }
+        stage {
+          type = "destroyAsg"
+          name = "destroyAsg"
+        }
+        stage {
+          type = "createServerGroup"
+          name = "Deploy in us-west-1"
+          status = SUCCEEDED
+          context.putAll(
+            account: "prod",
+            application: "flex",
+            availabilityZones: [
               "us-west-1": [
                 "us-west-1a",
                 "us-west-1c"
               ]
             ],
-            "capacity"            : [
-              "desired": 1,
-              "max"    : 1,
-              "min"    : 1
+            capacity: [
+              desired: 1,
+              max    : 1,
+              min    : 1
             ],
-            "cooldown"            : 10,
-            "deploy.account.name" : "prod",
+            cooldown: 10,
+            "deploy.account.name": "prod",
             "deploy.server.groups": [
               "us-west-1": [
                 "flex-prestaging-v011"
               ]
             ],
-            "keyPair"             : "nf-prod-keypair-a",
-            "loadBalancers"       : [
+            keyPair: "nf-prod-keypair-a",
+            loadBalancers: [
               "flex-prestaging-frontend"
             ],
-            "provider"            : "aws",
-            "securityGroups"      : [
+            provider: "aws",
+            securityGroups: [
               "sg-d2c3dfbe",
               "sg-d3c3dfbf"
             ],
-            "stack"               : "prestaging",
-            "strategy"            : "highlander",
-            "subnetType"          : "internal",
-            "suspendedProcesses"  : [],
-            "terminationPolicies" : [
+            stack: "prestaging",
+            strategy: "highlander",
+            subnetType: "internal",
+            suspendedProcesses: [],
+            terminationPolicies: [
               "Default"
-            ],
-            "type"                : "linearDeploy"
-          ],
-          "parentStageId": "68ad3566-4857-4c76-839e-f4afc14410c5",
-          "scheduledTime": 0
-        ]
-      ]
-    ]
+            ]
+          )
+        }
+      }
+    }
   }
 
   def 'helper method to convert objects into json'() {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
@@ -49,7 +49,7 @@ interface ExpressionAware {
           }
         }
 
-        val result = processed[key] ?: execution.getContext()[key]
+        val result = processed[key]
 
         if (result is String && ContextParameterProcessor.containsExpression(result)) {
           val augmentedContext = processed.augmentContext(execution)

--- a/orca-test/src/main/groovy/com/netflix/spinnaker/orca/test/model/ExecutionBuilder.groovy
+++ b/orca-test/src/main/groovy/com/netflix/spinnaker/orca/test/model/ExecutionBuilder.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Orchestration
 import com.netflix.spinnaker.orca.pipeline.model.Pipeline
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.transform.CompileStatic
+import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_BEFORE
 import static groovy.lang.Closure.DELEGATE_FIRST
 import static java.lang.System.currentTimeMillis
 
@@ -80,6 +81,12 @@ class ExecutionBuilder {
     stage.execution = execution
     execution.stages << stage
 
+    def parentStage = findParentStage(builder)
+    if (parentStage) {
+      stage.parentStageId = parentStage.id
+      stage.syntheticStageOwner = STAGE_BEFORE
+    }
+
     builder.delegate = stage
     builder.resolveStrategy = DELEGATE_FIRST
     builder()
@@ -94,6 +101,19 @@ class ExecutionBuilder {
         return enclosingClosure.delegate as Pipeline
       } else {
         return findExecution(enclosingClosure)
+      }
+    } else {
+      return null
+    }
+  }
+
+  private static Stage<Pipeline> findParentStage(Closure closure) {
+    if (closure.owner instanceof Closure) {
+      def enclosingClosure = (closure.owner as Closure)
+      if (enclosingClosure.delegate instanceof Stage) {
+        return enclosingClosure.delegate as Stage
+      } else {
+        return findParentStage(enclosingClosure)
       }
     } else {
       return null


### PR DESCRIPTION
Restores commit f49653055f614cb38110e4e7924cedf923f0fdb5 and fixes the issue in parsing parent Pipeline from trigger that meant the `execution` back-ref was not set on stages.