### PR TITLE
Fixes restarting ACA task stages

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStage.groovy
@@ -62,7 +62,6 @@ class AcaTaskStage implements StageDefinitionBuilder, CancellableStage, Restarta
       stage.context.canary.remove("id")
       stage.context.canary.remove("launchDate")
       stage.context.canary.remove("endDate")
-      stage.context.canary.remove("canaryDeployments")
       stage.context.canary.remove("canaryResult")
       stage.context.canary.remove("status")
       stage.context.canary.remove("health")

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStage.groovy
@@ -30,6 +30,9 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import retrofit.RetrofitError
+import static org.springframework.http.HttpStatus.CONFLICT
+import static retrofit.RetrofitError.Kind.HTTP
 
 @Slf4j
 @Component
@@ -86,10 +89,18 @@ class AcaTaskStage implements StageDefinitionBuilder, CancellableStage, Restarta
 
   Map cancelCanary(Stage stage, String reason)  {
     if(stage?.context?.canary?.id) {
-      def cancelCanaryResults = mineService.cancelCanary(stage.context.canary.id as String, reason)
-      log.info("Canceled canary in mine (canaryId: ${stage.context.canary.id}, stageId: ${stage.id}, executionId: ${stage.execution.id}): ${reason}")
-      return cancelCanaryResults
+      try {
+        def cancelCanaryResults = mineService.cancelCanary(stage.context.canary.id as String, reason)
+        log.info("Canceled canary in mine (canaryId: ${stage.context.canary.id}, stageId: ${stage.id}, executionId: ${stage.execution.id}): ${reason}")
+        return cancelCanaryResults
+      } catch (RetrofitError e) {
+        if (e.kind == HTTP && e.response.status == CONFLICT.value()) {
+          log.info("Canary (canaryId: ${stage.context.canary.id}, stageId: ${stage.id}, executionId: ${stage.execution.id}) has already ended")
+          return [:]
+        } else {
+          throw e
+        }
+      }
     }
   }
-
 }

--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStageSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStageSpec.groovy
@@ -47,11 +47,13 @@ class AcaTaskStageSpec extends Specification {
     and: "preserve the canary config"
     stage.context.canary.canaryConfig == canary.canaryConfig
 
+    and: "the deployment details"
+    stage.context.canary.canaryDeployments == canary.canaryDeployments
+
     and: "clean up the canary"
     stage.context.canary.id == null
     stage.context.canary.launchDate == null
     stage.context.canary.endDate == null
-    stage.context.canary.canaryDeployments == null
     stage.context.canary.canaryResult == null
     stage.context.canary.status == null
     stage.context.canary.health == null
@@ -90,11 +92,13 @@ class AcaTaskStageSpec extends Specification {
     and: "preserve the canary config"
     stage.context.canary.canaryConfig == canary.canaryConfig
 
+    and: "the deployment details"
+    stage.context.canary.canaryDeployments == canary.canaryDeployments
+
     and: "clean up the canary"
     stage.context.canary.id == null
     stage.context.canary.launchDate == null
     stage.context.canary.endDate == null
-    stage.context.canary.canaryDeployments == null
     stage.context.canary.canaryResult == null
     stage.context.canary.status == null
     stage.context.canary.health == null


### PR DESCRIPTION
When an ACA task stage is restarted it attempts to cancel the previous canary. However, if enough time has passed the canary will have ended already. This case wasn't being handled. Also `canaryDeployments` got removed from context which makes sense for "full" canaries as they'll do a fresh deploy but not for ACA tasks.