### PR TITLE
fix(front50): Avoid canceling an already canceled child pipeline

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
@@ -118,13 +118,14 @@ class RollingRedBlackStrategy implements Strategy, ApplicationContextAware {
         source        : source,
         targetLocation: cleanupConfig.location,
         scalePct      : p,
-        pinCapacity   : p < 100 // if p = 100, capacity should be unpinned
+        pinCapacity   : p < 100, // if p = 100, capacity should be unpinned,
+        useNameAsLabel: true     // hint to deck that it should _not_ override the name
       ]
 
       def resizeStage = newStage(
         stage.execution,
         resizeServerGroupStage.type,
-        "Grow to $p% Desired Size",
+        "Grow to $p% of Desired Size",
         resizeContext,
         stage,
         SyntheticStageOwner.STAGE_AFTER
@@ -182,6 +183,7 @@ class RollingRedBlackStrategy implements Strategy, ApplicationContextAware {
       ]
 
       def pipelineContext = [
+        application        : stageData.pipelineBeforeCleanup.application,
         pipelineApplication: stageData.pipelineBeforeCleanup.application,
         pipelineId         : stageData.pipelineBeforeCleanup.pipelineId,
         pipelineParameters : [

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.front50.tasks.StartPipelineTask;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Pipeline;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import com.netflix.spinnaker.orca.pipeline.model.Task;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
@@ -84,8 +85,11 @@ public class PipelineStage implements StageDefinitionBuilder, RestartableStage, 
         if (executionRepository == null) {
           log.error(format("Stage %s could not be canceled w/o front50 enabled. Please set 'front50.enabled: true' in your orca config.", readableStageDetails));
         } else {
-          // flag the child pipeline as canceled (actual cancellation will happen asynchronously)
-          executionRepository.cancel(executionId, "parent pipeline", null);
+          Pipeline childPipeline = executionRepository.retrievePipeline(executionId);
+          if (!childPipeline.isCanceled()) {
+            // flag the child pipeline as canceled (actual cancellation will happen asynchronously)
+            executionRepository.cancel(executionId, "parent pipeline", null);
+          }
         }
       }
     } catch (Exception e) {

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
@@ -108,13 +108,25 @@ class MonitorPipelineTaskSpec extends Specification {
 
     when:
     def result = task.execute(stage)
+    def exception = result.context.exception
 
     then:
-    result.context.exception == [details: [errors: [
-      "Exception in child pipeline stage (some child: a pipeline): Some error",
-      "Exception in child pipeline stage (some child: pipeline): Some other error",
-      "Exception in child pipeline stage (some child: deploy): task failed, no exception",
-      "Exception in child pipeline stage (some child: deploy): task had exception"
-    ]]]
+    exception == [
+      details: [
+        errors: [
+          "Exception in child pipeline stage (some child: a pipeline): Some error",
+          "Exception in child pipeline stage (some child: pipeline): Some other error",
+          "Exception in child pipeline stage (some child: deploy): task failed, no exception",
+          "Exception in child pipeline stage (some child: deploy): task had exception"
+        ]
+      ],
+      // source should reference the _first_ halted stage in the child pipeline
+      source: [
+        executionId: pipeline.id,
+        stageId: pipeline.stages[1].id,
+        stageName: "a pipeline",
+        stageIndex: 1
+      ]
+    ]
   }
 }


### PR DESCRIPTION
This PR also propagates some details about the particular stage that
failed such that `deck` can render an appropriate link.
