### PR TITLE
fix(log): clarify null custom strategy error

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
@@ -50,7 +50,7 @@ class StartPipelineTask implements Task {
     Map<String, Object> pipelineConfig = pipelines.find { it.id == pipelineId }
 
     if (!pipelineConfig) {
-      throw new IllegalArgumentException("Unable to locate referenced pipeline $pipelineId.")
+      throw new IllegalArgumentException("The referenced ${isStrategy ? 'custom strategy' : 'pipeline'} cannot be located (${pipelineId}")
     }
 
     def parameters = stage.context.pipelineParameters ?: [:]


### PR DESCRIPTION
If deployment strategy == custom and the resulting strategy dropdown remains blank (as may happen if custom strategy was selected by accident) the resulting `Unable to located referenced pipeline null` error message doesn't make sense to users unfamiliar with custom strategy configuration.