### PR TITLE
fix(trafficguards): Fix Moniker usage in instance termination

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
@@ -67,7 +67,13 @@ public class TrafficGuard {
 
     instancesPerServerGroup.entrySet().forEach(entry -> {
       String serverGroupName = entry.getKey();
-      if (hasDisableLock(serverGroupMonikerFromStage, account, location)) {
+      Moniker moniker = serverGroupMonikerFromStage;
+      if (moniker.getApp() == null) {
+        // handle scenarios where the stage moniker is invalid (ie. stage had no server group details provided)
+        moniker = MonikerHelper.friggaToMoniker(serverGroupName);
+      }
+
+      if (hasDisableLock(moniker, account, location)) {
         Optional<TargetServerGroup> targetServerGroup = oortHelper.getTargetServerGroup(account, serverGroupName, location.getValue(), cloudProvider);
 
         targetServerGroup.ifPresent(serverGroup -> {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
@@ -257,7 +257,7 @@ class TrafficGuardSpec extends Specification {
     otherServerGroup.instances = [[name: "i-1", healthState: "Down"]]
 
     when:
-    trafficGuard.verifyInstanceTermination(null, moniker, ["i-1"], "test", location, "aws", "x")
+    trafficGuard.verifyInstanceTermination(null, MonikerHelper.friggaToMoniker(null), ["i-1"], "test", location, "aws", "x")
 
     then:
     thrown(IllegalStateException)


### PR DESCRIPTION
The instance termination task does not normally have a `serverGroupName`
explicitly specified.

Without such, the moniker used to check traffic guards is invalid.
