### PR TITLE
fix(web): Reverting needless method sig refactor from #1718

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -73,7 +73,7 @@ class OperationsController {
 
   @RequestMapping(value = "/orchestrate", method = RequestMethod.POST)
   Map<String, Object> orchestrate(@RequestBody Map pipeline, HttpServletResponse response) {
-    parsePipelineTrigger(executionRepository, buildService, pipelineTemplateService, pipeline)
+    parsePipelineTrigger(executionRepository, buildService, pipeline)
     Map trigger = pipeline.trigger
 
     boolean plan = pipeline.plan ?: false
@@ -113,7 +113,7 @@ class OperationsController {
     startPipeline(processedPipeline)
   }
 
-  private void parsePipelineTrigger(ExecutionRepository executionRepository, BuildService buildService, PipelineTemplateService pipelineTemplateService, Map pipeline) {
+  private void parsePipelineTrigger(ExecutionRepository executionRepository, BuildService buildService, Map pipeline) {
     if (!(pipeline.trigger instanceof Map)) {
       pipeline.trigger = [:]
       if (pipeline.plan && pipeline.type == "templatedPipeline") {


### PR DESCRIPTION
Was causing 500 errors because the method couldn't be found in other places in the Controller. Thanks, Groovy.

@spinnaker/netflix-reviewers @jervi FYI