### PR TITLE
fix(notifications): send correct notification type on pipeline events

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
@@ -62,7 +62,7 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
         echoService.recordEvent(
           details: [
             source     : "orca",
-            type       : "orca:${execution.getClass().simpleName.toLowerCase()}:starting".toString(),
+            type       : "orca:${execution.type}:starting".toString(),
             application: execution.application,
           ],
           content: [
@@ -90,7 +90,7 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
         echoService.recordEvent(
           details: [
             source     : "orca",
-            type       : "orca:${execution.getClass().simpleName.toLowerCase()}:${wasSuccessful ? "complete" : "failed"}".toString(),
+            type       : "orca:${execution.type}:${wasSuccessful ? "complete" : "failed"}".toString(),
             application: execution.application,
           ],
           content: [

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListenerSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListenerSpec.groovy
@@ -72,6 +72,23 @@ class EchoNotifyingExecutionListenerSpec extends Specification {
     notifications.set("email", [emailTasks])
   }
 
+  void "sends events with expected type to Echo"() {
+    given:
+    def pipeline = Execution.newPipeline("myapp")
+
+    when:
+    echoListener.beforeExecution(null, pipeline)
+
+    then:
+    1 * echoService.recordEvent({ it.details.type == "orca:pipeline:starting"})
+
+    when:
+    echoListener.afterExecution(null, pipeline, ExecutionStatus.SUCCEEDED, true)
+
+    then:
+    1 * echoService.recordEvent({ it.details.type == "orca:pipeline:complete"})
+  }
+
   void "adds notifications to pipeline on beforeExecution"() {
     given:
     def pipeline = Execution.newPipeline("myapp")


### PR DESCRIPTION
The class is always `Execution` now, so we need to use the `type`