### PR TITLE
fix(moniker): Use the correct moniker when applying source server group

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.ResizeServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.AbstractServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
@@ -78,6 +79,12 @@ class ApplySourceServerGroupCapacityTask extends AbstractServerGroupTask {
       log.error("Unable to apply source server group capacity (executionId: ${stage.execution.id})", e)
       return null
     }
+  }
+
+  @Override
+  Moniker convertMoniker(Stage stage) {
+    // Used in AbstractServerGroupTask.execute() but not needed here.
+    return null;
   }
 
   /**


### PR DESCRIPTION
`ApplySourceServerGroupCapacityTask` overrides `convert()`. `convertMoniker()` also needs to be overridden. The moniker used when verifying the cluster should be the same as the server group in the operation.

Everything seems to be working just fine for AWS, but the k8s rollback stage is currently failing. There is a bigger problem that @lwander is working as to why k8s is using this stage that is in the aws provider.

@ajordens - Would you mind taking a look at this for me? This task seems to work a lot differently than the others that extend `AbstractServerGroupTask` and based on the blame you have the most experience with it.