### PR TITLE
fix(kubernetes/rollback) Pass cloudProvider to tasks so it doesn't default to aws (#1810)

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
@@ -118,8 +118,9 @@ class ExplicitRollback implements Rollback {
   Stage buildApplySourceServerGroupCapacityStage(Stage parentStage,
                                                  ResizeStrategy.Source source) {
     Map applySourceServerGroupCapacityContext = [
-      credentials: source.credentials,
-      target     : [
+      credentials  : source.credentials,
+      cloudProvider: source.cloudProvider,
+      target       : [
         asgName        : restoreServerGroupName,
         serverGroupName: restoreServerGroupName,
         region         : source.region,

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollbackSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollbackSpec.groovy
@@ -108,7 +108,8 @@ class ExplicitRollbackSpec extends Specification {
       serverGroupName: "servergroup-v002"
     ]
     afterStages[4].context == [
-      target     : [
+      cloudProvider: "aws",
+      target       : [
         asgName        : "servergroup-v001",
         serverGroupName: "servergroup-v001",
         region         : "us-west-1",


### PR DESCRIPTION
cherry-pick of https://github.com/spinnaker/orca/pull/1810 for 1.5.1