### PR TITLE
Keep fast property stuff out of global context

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-kotlinVersion=1.1.60
+kotlinVersion=1.2.0
 junitVersion=1.0.2
 jupiterVersion=5.0.2
 junitLegacyVersion=4.12.0

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -28,7 +28,7 @@ configurations.all {
 
 compileKotlin {
   kotlinOptions {
-    languageVersion = "1.1"
+    languageVersion = "1.2"
     jvmTarget = "1.8"
   }
 }

--- a/gradle/spek.gradle
+++ b/gradle/spek.gradle
@@ -25,8 +25,8 @@ dependencies {
   testCompile "org.junit.platform:junit-platform-runner:$junitVersion"
   testCompile "org.jetbrains.spek:spek-api:$spekVersion"
   testCompile "org.jetbrains.spek:spek-subject-extension:$spekVersion"
-  testCompile "com.nhaarman:mockito-kotlin:1.4.0"
-  testCompile "com.natpryce:hamkrest:1.4.0.0"
+  testCompile "com.nhaarman:mockito-kotlin:1.5.0"
+  testCompile "com.natpryce:hamkrest:1.4.2.2"
   testCompile "org.junit.jupiter:junit-jupiter-api:$jupiterVersion"
 
   testRuntime "org.junit.platform:junit-platform-launcher:$junitVersion"

--- a/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
+++ b/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTask.groovy
@@ -81,16 +81,13 @@ class CreatePropertiesTask implements Task {
       }
     }
 
-    boolean rollback = context.rollbackProperties
-
     def outputs = [
       propertyIdList: propertyIdList,
       originalProperties: originalProperties,
-      rollback: rollback,
       propertyAction: propertyAction,
     ]
 
-    return new TaskResult(SUCCEEDED, outputs, outputs)
+    return new TaskResult(SUCCEEDED, [rollbackProperties: context.rollbackProperties as boolean], outputs)
 
   }
 

--- a/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/MonitorPropertiesTask.groovy
+++ b/orca-mahe/src/main/groovy/com/netflix/spinnaker/orca/mahe/tasks/MonitorPropertiesTask.groovy
@@ -31,7 +31,7 @@ import retrofit.client.Response
 
 @Slf4j
 @Component
-class MonitorPropertiesTask implements Task{
+class MonitorPropertiesTask implements Task {
   @Autowired MaheService maheService
   @Autowired ObjectMapper mapper
 
@@ -57,18 +57,18 @@ class MonitorPropertiesTask implements Task{
           fetchedProperties << responseMap.property
         }
 
-      } catch (RetrofitError e ){
+      } catch (RetrofitError e) {
         log.error("Exception occurred while getting persisted property with id ${id} from mahe service", e)
-        return new TaskResult(ExecutionStatus.RUNNING, outputs)
+        return new TaskResult(ExecutionStatus.RUNNING, [:], outputs)
       }
     }
 
 
-    if(outputs.persistedProperties.size() == propertyIds.size()) {
-      return new TaskResult(ExecutionStatus.SUCCEEDED, outputs, outputs)
+    if (outputs.persistedProperties.size() == propertyIds.size()) {
+      return new TaskResult(ExecutionStatus.SUCCEEDED, [:], outputs)
     }
 
     log.info("create persited properties in progress: ${outputs}")
-    return new TaskResult(ExecutionStatus.RUNNING, outputs)
+    return new TaskResult(ExecutionStatus.RUNNING, [:], outputs)
   }
 }

--- a/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTaskSpec.groovy
+++ b/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/CreatePropertiesTaskSpec.groovy
@@ -47,7 +47,7 @@ class CreatePropertiesTaskSpec extends Specification {
     def property = createProperty()
     def originalProperty = createProperty()
 
-    def stage = createPropertiesStage(pipeline, scope, property, originalProperty )
+    def stage = createPropertiesStage(pipeline, scope, property, originalProperty)
 
     when:
     List properties = task.assemblePersistedPropertyListFromContext(stage.context, stage.context.persistedProperties)
@@ -82,14 +82,14 @@ class CreatePropertiesTaskSpec extends Specification {
     def property = createProperty()
     def originalProperty = createProperty()
 
-    def stage = createPropertiesStage(pipeline, scope, property, originalProperty )
+    def stage = createPropertiesStage(pipeline, scope, property, originalProperty)
     stage.context.remove("originalProperties")
 
     when:
     def results = task.execute(stage)
 
     then:
-    1 * maheService.findProperty(_) >> new Response('', 200, 'OK', [], new TypedString(mapper.writeValueAsString([a:1])))
+    1 * maheService.findProperty(_) >> new Response('', 200, 'OK', [], new TypedString(mapper.writeValueAsString([a: 1])))
     1 * maheService.upsertProperty(_) >> { Map res ->
       def json = mapper.writeValueAsString([propertyId: 'propertyId'])
       new Response("http://mahe", 200, "OK", [], new TypedByteArray('application/json', json.bytes))
@@ -104,7 +104,7 @@ class CreatePropertiesTaskSpec extends Specification {
 
   def "prefer a stage override if present for context"() {
     given:
-    def trigger = [ stageOverrides: [] ]
+    def trigger = [stageOverrides: []]
     def pipeline = new PipelineBuilder("foo").withTrigger(trigger).build()
     def stageOverride = createPropertiesStage(pipeline, createScope(), createProperty("other"), null)
     stageOverride.context.refId = "a"
@@ -127,7 +127,7 @@ class CreatePropertiesTaskSpec extends Specification {
 
     then:
 
-    with(results.context) {
+    with(results.outputs) {
       propertyIdList.size() == 1
       propertyIdList.contains(propertyId: 'other')
     }
@@ -135,7 +135,7 @@ class CreatePropertiesTaskSpec extends Specification {
 
   def "should handle expressions in stage override"() {
     given: "an override property containing an expression"
-    def trigger = [ stageOverrides: [] ]
+    def trigger = [stageOverrides: []]
     def pipeline = new PipelineBuilder("foo").withTrigger(trigger).build()
     def stageOverride = createPropertiesStage(
       pipeline,
@@ -168,7 +168,7 @@ class CreatePropertiesTaskSpec extends Specification {
 
     then:
 
-    with(results.context) {
+    with(results.outputs) {
       propertyIdList.size() == 1
       propertyIdList.contains(propertyId: 'other')
     }
@@ -207,7 +207,7 @@ class CreatePropertiesTaskSpec extends Specification {
     def property = createProperty()
     def originalProperty = []
 
-    def stage = createPropertiesStage(pipeline, scope, property, originalProperty )
+    def stage = createPropertiesStage(pipeline, scope, property, originalProperty)
 
     when:
     List properties = task.assemblePersistedPropertyListFromContext(stage.context, stage.context.persistedProperties)
@@ -238,7 +238,7 @@ class CreatePropertiesTaskSpec extends Specification {
 
     then:
 
-    with(results.context) {
+    with(results.outputs) {
       propertyIdList.size() == 1
       propertyIdList.contains(propertyId: 'propertyId')
     }
@@ -258,13 +258,14 @@ class CreatePropertiesTaskSpec extends Specification {
     def results = task.execute(propertiesStage)
 
     then:
-    1 * maheService.deleteProperty(property.propertyId, 'delete', scope.env) >> { def res ->
-      def json = mapper.writeValueAsString([propertyId: 'propertyId'])
-      new Response("http://mahe", 200, "OK", [] , null)
+    1 * maheService.deleteProperty(property.propertyId, 'delete', scope.env) >> {
+      def res ->
+        def json = mapper.writeValueAsString([propertyId: 'propertyId'])
+        new Response("http://mahe", 200, "OK", [], null)
     }
 
     then: "deleting a fast property does not return a property ID"
-    with(results.context) {
+    with(results.outputs) {
       propertyIdList.size() == 0
     }
 
@@ -284,16 +285,16 @@ class CreatePropertiesTaskSpec extends Specification {
     def results = task.execute(propertiesStage)
 
     then:
-    1 * maheService.deleteProperty(property.propertyId, 'delete', scope.env) >> { def res ->
-      def json = mapper.writeValueAsString([error:  "com.netflix.fastproperty.api.model.PropertyNotFound : property null"])
-      new Response("http://mahe", 400, "OK", [], new TypedByteArray('application/json', json.bytes))
+    1 * maheService.deleteProperty(property.propertyId, 'delete', scope.env) >> {
+      def res ->
+        def json = mapper.writeValueAsString([error: "com.netflix.fastproperty.api.model.PropertyNotFound : property null"])
+        new Response("http://mahe", 400, "OK", [], new TypedByteArray('application/json', json.bytes))
     }
 
     then:
     thrown(IllegalStateException)
 
   }
-
 
   def "create multiple new persistent properties"() {
     given:
@@ -334,20 +335,19 @@ class CreatePropertiesTaskSpec extends Specification {
     }
 
     then:
-    with(results.context) {
+    with(results.outputs) {
       propertyIdList.size() == 2
       propertyIdList.contains(propertyId: "${properties[0].key}|${properties[0].value}".toString())
       propertyIdList.contains(propertyId: "${properties[1].key}|${properties[1].value}".toString())
     }
   }
 
-
   def createPropertiesStage(pipeline, scope, property, originalProperty) {
     def context = [
-      parentStageId: UUID.randomUUID().toString(),
+      parentStageId      : UUID.randomUUID().toString(),
       scope              : scope,
       persistedProperties: [property],
-      originalProperties: originalProperty ? [originalProperty] : null,
+      originalProperties : originalProperty ? [originalProperty] : null,
       email              : 'test@netflix.com',
       cmcTicket          : 'cmcTicket'
     ]

--- a/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/MonitorPropertiesTaskSpec.groovy
+++ b/orca-mahe/src/test/groovy/com/netflix/spinnaker/orca/mahe/tasks/MonitorPropertiesTaskSpec.groovy
@@ -69,9 +69,9 @@ class MonitorPropertiesTaskSpec extends Specification {
 
     then:
     result.status == SUCCEEDED
-    result.context.persistedProperties.size() == 1
+    result.outputs.persistedProperties.size() == 1
 
-    with(result.context.persistedProperties.first()) {
+    with(result.outputs.persistedProperties.first()) {
       propertyId == propId
       key == "foo"
       value == "bar"

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -217,8 +217,19 @@ class RunTaskHandler(
     } else return ZERO
   }
 
+  /**
+   * Keys that should never be added to global context. Eventually this will
+   * disappear along with global context itself.
+   */
+  private val blacklistGlobalKeys = setOf(
+    "stageTimeoutMs",
+    "propertyIdList",
+    "originalProperties",
+    "propertyAction"
+  )
+
   private fun Stage.processTaskOutput(result: TaskResult) {
-    val filteredOutputs = result.outputs.filterKeys { it != "stageTimeoutMs" }
+    val filteredOutputs = result.outputs.filterKeys { it !in blacklistGlobalKeys }
     if (result.context.isNotEmpty() || filteredOutputs.isNotEmpty()) {
       context.putAll(result.context)
       outputs.putAll(filteredOutputs)


### PR DESCRIPTION
The cleanup listener for fast properties would previously search for properties in global context (transitively because it checks each fast property stage) and could end up rolling back those it shouldn't. I've prevented any of the keys associated with fast properties from getting exported from stage outputs to global context. Also removed the duplication of the same data in context and outputs. This removes one of the main hits currently occurring on global context.