### PR TITLE
feat(pipeline_template) Add strategyId tag to render ids by application and strategy name

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRenderer.java
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.filters.Frigg
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.filters.JsonFilter;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.tags.ModuleTag;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.tags.PipelineIdTag;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.tags.StrategyIdTag;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Error;
 import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors.Severity;
@@ -76,6 +77,7 @@ public class JinjaRenderer implements Renderer {
     jinja.setResourceLocator(new NoopResourceLocator());
     jinja.getGlobalContext().registerTag(new ModuleTag(this, pipelineTemplateObjectMapper));
     jinja.getGlobalContext().registerTag(new PipelineIdTag(front50Service));
+    jinja.getGlobalContext().registerTag(new StrategyIdTag(front50Service));
     if (jinjaTags != null) {
       jinjaTags.forEach(tag -> jinja.getGlobalContext().registerTag(tag));
     }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/StrategyIdTag.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/StrategyIdTag.java
@@ -1,0 +1,86 @@
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.tags;
+
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.lib.tag.Tag;
+import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.util.HelperStringTokenizer;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.validator.Errors;
+
+import java.util.*;
+
+public class StrategyIdTag implements Tag {
+  private static final String APPLICATION = "application";
+  private static final String NAME = "name";
+
+  private final Front50Service front50Service;
+
+  public StrategyIdTag(Front50Service front50Service) {
+    this.front50Service = front50Service;
+  }
+
+  @Override
+  public String getEndTagName() {
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return "strategyid";
+  }
+
+  @Override
+  public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+    List<String> helper = new HelperStringTokenizer(tagNode.getHelpers()).splitComma(true).allTokens();
+    if (helper.isEmpty()) {
+        throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'strategyId' expects at least a strategy name: " + helper, tagNode.getLineNumber());
+    }
+
+    Map<String, String> paramPairs = new HashMap<>();
+    helper.forEach(p -> {
+        String[] parts = p.split("=");
+        if (parts.length != 2) {
+            throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'strategyId' expects parameters to be in a 'key=value' format: " + helper, tagNode.getLineNumber());
+        }
+
+        paramPairs.put(parts[0], parts[1]);
+    });
+
+    Context context = interpreter.getContext();
+
+    String application = paramPairs.getOrDefault(APPLICATION, (String) context.get(APPLICATION)).replaceAll("^[\"\']|[\"\']$", "");
+    application = checkContext(application, context);
+
+    String name = paramPairs.get(NAME).replaceAll("^[\"\']|[\"\']$", "");
+    name = checkContext(name, context);
+
+    List<Map<String, Object>> strategies = Optional.ofNullable(front50Service.getStrategies(application)).orElse(Collections.emptyList());
+    Map<String, Object> result = findStrategy(strategies, application, name);
+    return (String) result.get("id");
+  }
+
+  private String checkContext(String param, Context context) {
+    Object var = context.get(param);
+
+    if (var != null) {
+        return (String) var;
+    }
+
+    return param;
+  }
+
+  private Map<String, Object> findStrategy(List<Map<String, Object>> strategies, String application, String strategyName) {
+    return strategies
+            .stream()
+            .filter(p -> p.get(NAME).equals(strategyName))
+            .findFirst()
+            .orElseThrow(
+                    () -> TemplateRenderException.fromError(
+                            new Errors.Error()
+                                    .withMessage(String.format("Failed to find strategyId ID with name '%s' in application '%s'", strategyName, application)
+                                    )));
+  }
+}

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/StrategyIdSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/StrategyIdSpec.groovy
@@ -1,0 +1,131 @@
+package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.tags
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.DefaultRenderContext
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderContext
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class StrategyIdSpec extends Specification {
+  ObjectMapper objectMapper = new ObjectMapper()
+  Front50Service front50Service = Mock(Front50Service)
+  Renderer renderer = new JinjaRenderer(objectMapper, front50Service, [])
+
+  @Subject
+  StrategyIdTag subject = new StrategyIdTag(front50Service)
+
+  @Unroll
+  def 'should render strategy id'() {
+    given:
+    front50Service.getStrategies('myApp') >>  [
+      [
+        name: 'Deploy and destroy server group',
+        id: '9595429f-afa0-4c34-852b-01a9a01967f9',
+        stages: []
+      ],
+      [
+        name: 'Important strategy',
+        id: '1685429e-beb1-4d35-963c-02b9a01977e1',
+        stages: []
+      ],
+      [
+        name: "Rob's great strategy",
+        id: '1685429e-beb1-4d35-963c-123456789012',
+        stages: []
+      ]
+    ]
+
+    expect:
+    renderer.render(
+      tag,
+      new DefaultRenderContext('myApp',null, [:])
+    ) == expectedId
+
+    where:
+    tag                                                                         || expectedId
+    '{% strategyId application=myApp name="Deploy and destroy server group" %}' || '9595429f-afa0-4c34-852b-01a9a01967f9'
+    "{% strategyId name='Important strategy' %}"                                || '1685429e-beb1-4d35-963c-02b9a01977e1'
+    '{% strategyId name="Rob\'s great strategy" %}'                             || '1685429e-beb1-4d35-963c-123456789012'
+  }
+
+  def 'should render strategy id from another app'() {
+    given:
+    front50Service.getStrategies('testApp') >>  [
+      [
+        name: 'Strategy in different app',
+        id: '1685429e-beb1-4d35-963c-02b9a01977e1',
+        stages: []
+      ]
+    ]
+
+    expect:
+    renderer.render(
+      tag,
+      new DefaultRenderContext('myApp',null, [:])
+    ) == expectedId
+
+    where:
+    tag                                                                     || expectedId
+    '{% strategyId application=testApp name="Strategy in different app" %}' || '1685429e-beb1-4d35-963c-02b9a01977e1'
+  }
+
+  def 'should render strategy id using variables defined in context'() {
+    given:
+    front50Service.getStrategies('myApp') >>  [
+      [
+        name: 'Deploy and destroy server group',
+        id: '9595429f-afa0-4c34-852b-01a9a01967f9',
+        stages: []
+      ]
+    ]
+
+    RenderContext context = new DefaultRenderContext('myApp', null, [:])
+    context.variables.put("pipelineName", "Deploy and destroy server group")
+    context.variables.put("applicationName", "myApp")
+
+    expect:
+    renderer.render('{% strategyId application=applicationName name=pipelineName %}', context) ==  '9595429f-afa0-4c34-852b-01a9a01967f9'
+  }
+
+  def 'should handle missing input params'() {
+    given: 'a strategyId tag with no app defined'
+    def applicationInContext = 'myApp'
+    def context = new DefaultRenderContext(applicationInContext, null, [:])
+
+    when:
+    renderer.render('{% strategyId name="Deploy and destroy server group" %}', context)
+
+    then: 'application should be inferred from context'
+    1 * front50Service.getStrategies(applicationInContext) >>  [
+      [
+        name: 'Deploy and destroy server group',
+        id: '9595429f-afa0-4c34-852b-01a9a01967f9',
+        stages: []
+      ]
+    ]
+
+    when: 'template is missing required fields (name)'
+    renderer.render('{% strategyId application=myApp %}', context)
+
+    then:
+    thrown(TemplateRenderException)
+
+    when: 'template is missing required fields (all)'
+    renderer.render('{% strategyId %}', context)
+
+    then:
+    thrown(TemplateRenderException)
+
+    when: 'no pipeline was not found from provided input'
+    renderer.render('{% strategyId name="Deploy and destroy server group" %}', context)
+
+    then:
+    1 * front50Service.getStrategies(applicationInContext) >>  []
+    thrown(TemplateRenderException)
+  }
+}


### PR DESCRIPTION
Modeled off PipelineIdTag.  It's the least obtrusive, though I could refactor both this and PipelineIdTag if we want to - let me know.

@robzienert 