### PR TITLE
Deployment details no longer accessed from global context

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
@@ -151,10 +151,14 @@ trait DeploymentDetailsAware {
     def deploymentDetails = (stage.context.deploymentDetails ?: []) as List<Map>
 
     if (!deploymentDetails) {
-      // If no deployment details were found in the stage context, check the global context of each pipeline up the tree.
+      // If no deployment details were found in the stage context, check outputs of each stage of each pipeline up the tree.
       List<Execution> pipelineExecutions = getPipelineExecutions(stage.execution)
 
-      deploymentDetails = pipelineExecutions?.findResult { it?.context?.deploymentDetails }
+      deploymentDetails = pipelineExecutions.findResult { execution ->
+        execution.stages.findResult {
+          it.outputs.deploymentDetails
+        }
+      }
     }
 
     if (deploymentDetails) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
@@ -147,14 +147,17 @@ class CreateServerGroupTaskSpec extends Specification {
     KatoService katoService = Mock(KatoService)
     MortService mortService = Mock(MortService)
     def deployRegion = "us-east-1"
-    def parentGlobalContext = [
+    def parentDeploymentDetails = [
       deploymentDetails: [
         ["imageId": "parent-ami", "ami": "parent-ami", "region": deployRegion]
       ]
     ]
     def parentPipeline = pipeline {
       name = "parent"
-      context.putAll(parentGlobalContext)
+      stage {
+        type = "someStage"
+        outputs.putAll(parentDeploymentDetails)
+      }
     }
 
     def childPipeline = pipeline {
@@ -206,7 +209,7 @@ class CreateServerGroupTaskSpec extends Specification {
     KatoService katoService = Mock(KatoService)
     MortService mortService = Mock(MortService)
     def deployRegion = "us-east-1"
-    def grandparentGlobalContext = [
+    def grandparentDeploymentDetails = [
       deploymentDetails: [
         ["imageId": "grandparent-ami", "ami": "grandparent-ami", "region": deployRegion]
       ]
@@ -216,8 +219,10 @@ class CreateServerGroupTaskSpec extends Specification {
       isPipeline     : true,
       parentExecution: mapper.convertValue(pipeline {
         name = "grandparent"
-        context = grandparentGlobalContext
-        stage { type = "someStage1" }
+        stage {
+          type = "someStage1"
+          outputs.putAll(grandparentDeploymentDetails)
+        }
         stage { type = "someStage2" }
       }, Map)
     ]
@@ -398,14 +403,17 @@ class CreateServerGroupTaskSpec extends Specification {
     KatoService katoService = Mock(KatoService)
     MortService mortService = Mock(MortService)
     def deployRegion = "us-east-1"
-    def parentGlobalContext = [
+    def parentDeploymentDetails = [
       deploymentDetails: [
         ["imageId": "parent-ami", "ami": "parent-ami", "region": deployRegion]
       ]
     ]
     def parentPipeline = pipeline {
       name = "parent"
-      context = parentGlobalContext
+      stage {
+        type = "someStage"
+        outputs.putAll(parentDeploymentDetails)
+      }
     }
 
     def pipelineStage = buildStageForPipeline(parentPipeline, "pipeline")

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -34,6 +34,7 @@ import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toMap;
 
 public class Execution implements Serializable {
 
@@ -147,15 +148,18 @@ public class Execution implements Serializable {
     this.keepWaitingPipelines = keepWaitingPipelines;
   }
 
-  private Map<String, Object> context = new HashMap<>();
-
   @Deprecated
+  @JsonIgnore
   public @Nonnull Map<String, Object> getContext() {
-    return context;
-  }
-
-  public void setContext(@Nonnull Map<String, Object> context) {
-    this.context = context;
+    return Stage.topologicalSort(stages)
+      .map(Stage::getOutputs)
+      .map(Map::entrySet)
+      .flatMap(Collection::stream)
+      .collect(toMap(
+        Map.Entry::getKey,
+        Map.Entry::getValue,
+        (o, o2) -> o2
+      ));
   }
 
   private final List<Stage> stages = new ArrayList<>();

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.groovy
@@ -30,7 +30,6 @@ class PipelineBuilder {
 
   PipelineBuilder(String application, Registry registry) {
     this(application)
-    pipeline.context = new AlertOnAccessMap(pipeline, registry)
   }
 
   PipelineBuilder(String application) {

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.groovy
@@ -120,12 +120,6 @@ class PipelineBuilder {
     return this
   }
 
-  PipelineBuilder withGlobalContext(Map<String, Object> context) {
-    pipeline.context.clear()
-    pipeline.context.putAll(context)
-    return this
-  }
-
   PipelineBuilder withStatus(ExecutionStatus executionStatus) {
     pipeline.status = executionStatus
     return this

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -24,8 +24,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
-import com.netflix.spinnaker.orca.pipeline.model.*
+import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner
+import com.netflix.spinnaker.orca.pipeline.model.Task
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionCriteria
@@ -603,7 +606,6 @@ class JedisExecutionRepository implements ExecutionRepository {
       }
 
       def execution = new Execution(type, id, map.application)
-      execution.context = new AlertOnAccessMap<>(execution, registry, map.context ? mapper.readValue(map.context, Map) : [:])
       execution.canceled = Boolean.parseBoolean(map.canceled)
       execution.canceledBy = map.canceledBy
       execution.cancellationReason = map.cancellationReason

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.groovy
@@ -55,7 +55,6 @@ class PackageInfo {
   public Map findTargetPackage(boolean allowMissingPackageInstallation) {
     Map requestMap = [:]
     // copy the context since we may modify it in createAugmentedRequest
-    requestMap.putAll(stage.execution.context)
     requestMap.putAll(stage.context)
 
     if (stage.execution.type == PIPELINE) {
@@ -110,8 +109,8 @@ class PackageInfo {
     // There might not be a request.package so we look for the package name from either the buildInfo or trigger
     //
     String reqPkg = request.package ?:
-                    buildArtifacts?.first()?.fileName?.split(versionDelimiter)?.first() ?:
-                      triggerArtifacts?.first()?.fileName?.split(versionDelimiter)?.first()
+      buildArtifacts?.first()?.fileName?.split(versionDelimiter)?.first() ?:
+        triggerArtifacts?.first()?.fileName?.split(versionDelimiter)?.first()
 
     List<String> requestPackages = reqPkg.split(" ")
 
@@ -176,7 +175,7 @@ class PackageInfo {
   }
 
   @CompileDynamic
-  Map getArtifactSourceBuildInfo(Map trigger){
+  Map getArtifactSourceBuildInfo(Map trigger) {
     if (trigger?.buildInfo?.artifacts) {
       return trigger.buildInfo
     }
@@ -194,7 +193,8 @@ class PackageInfo {
   @CompileDynamic
   private String extractPackageVersion(Map artifact, String filePrefix, String fileExtension) {
     String version = artifact.fileName.substring(artifact.fileName.indexOf(filePrefix) + filePrefix.length(), artifact.fileName.lastIndexOf(fileExtension))
-    if (version.contains(versionDelimiter)) { // further strip in case of _all is in the file name
+    if (version.contains(versionDelimiter)) {
+      // further strip in case of _all is in the file name
       version = version.substring(0, version.indexOf(versionDelimiter))
     }
     return version
@@ -224,14 +224,16 @@ class PackageInfo {
     }
   }
 
-  private static Map findBuildInfoInUpstreamStage(Stage currentStage, Pattern packageFilePattern) {
+  private
+  static Map findBuildInfoInUpstreamStage(Stage currentStage, Pattern packageFilePattern) {
     def upstreamStage = currentStage.ancestors().find {
-      artifactMatch(it.context.buildInfo?.artifacts as List<Map<String, String>>, packageFilePattern)
+      artifactMatch(it.outputs.buildInfo?.artifacts as List<Map<String, String>>, packageFilePattern)
     }
-    return upstreamStage ? upstreamStage.context.buildInfo as Map : null
+    return upstreamStage ? upstreamStage.outputs.buildInfo as Map : null
   }
 
-  private static boolean artifactMatch(List<Map<String, String>> artifacts, Pattern pattern) {
+  private
+  static boolean artifactMatch(List<Map<String, String>> artifacts, Pattern pattern) {
     artifacts?.find {
       Map artifact -> pattern.matcher(artifact.get('fileName') as String ?: "").matches()
     }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContextSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageContextSpec.groovy
@@ -24,11 +24,6 @@ import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 class StageContextSpec extends Specification {
 
   def pipeline = pipeline {
-    context.foo = "global-foo"
-    context.bar = "global-bar"
-    context.baz = "global-baz"
-    context.qux = "global-qux"
-    context.fnord = "global-fnord"
     stage {
       refId = "1"
       outputs.foo = "root-foo"

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageSpec.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.model
+
+import spock.lang.Specification
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+import static java.util.stream.Collectors.toList
+
+class StageSpec extends Specification {
+
+  def "DAG_ORDER sorts stages with direct relationships"() {
+    given:
+    def pipeline = pipeline {
+      stage {
+        refId = "1"
+      }
+      stage {
+        refId = "2"
+        requisiteStageRefIds = ["1"]
+      }
+      stage {
+        refId = "3"
+        requisiteStageRefIds = ["2"]
+      }
+    }
+
+    expect:
+    with(Stage.topologicalSort(pipeline.stages).collect(toList())) {
+      refId == ["1", "2", "3"]
+    }
+  }
+
+  def "DAG_ORDER sorts stages with fork join topology"() {
+    given:
+    def pipeline = pipeline {
+      stage {
+        refId = "1"
+      }
+      stage {
+        refId = "2"
+        requisiteStageRefIds = ["1"]
+      }
+      stage {
+        refId = "3"
+        requisiteStageRefIds = ["1"]
+      }
+      stage {
+        refId = "4"
+        requisiteStageRefIds = ["2", "3"]
+      }
+    }
+
+    expect:
+    with(Stage.topologicalSort(pipeline.stages).collect(toList())) {
+      refId.first() == "1"
+      refId.last() == "4"
+    }
+  }
+
+  def "DAG_ORDER sorts stages with isolated branches"() {
+    given:
+    def pipeline = pipeline {
+      stage {
+        refId = "1"
+      }
+      stage {
+        refId = "2"
+        requisiteStageRefIds = ["1"]
+      }
+      stage {
+        refId = "3"
+      }
+      stage {
+        refId = "4"
+        requisiteStageRefIds = ["3"]
+      }
+    }
+
+    expect:
+    with(Stage.topologicalSort(pipeline.stages).collect(toList())) {
+      "1" in refId[0..1]
+      "3" in refId[0..1]
+      "2" in refId[2..3]
+      "4" in refId[2..3]
+    }
+  }
+
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -49,22 +49,6 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
 
   abstract T createExecutionRepository()
 
-  def "can update an execution's context"() {
-    given:
-    repository.store(execution)
-
-    when:
-    repository.storeExecutionContext(execution.id, ["value": execution.class.simpleName])
-    def storedExecution = repository.retrieve(execution.type, execution.id)
-
-    then:
-    storedExecution.id == execution.id
-    storedExecution.context == ["value": storedExecution.class.simpleName]
-
-    where:
-    execution << [pipeline(), orchestration()]
-  }
-
   def "can retrieve pipelines by status"() {
     given:
     def runningExecution = pipeline {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
@@ -24,6 +24,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 import static com.netflix.spinnaker.orca.pipeline.util.PackageType.DEB
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
 class PackageInfoSpec extends Specification {
 
@@ -77,32 +78,30 @@ class PackageInfoSpec extends Specification {
   @Unroll
   def "If no artifacts in current build info, find from first ancestor that does"() {
     given:
-    def pipeline = Execution.newPipeline("orca")
-    def ancestorStages = inputFileNames.collect {
-      new Stage(
-        execution: pipeline,
-        refId: it,
-        context: [
-          buildInfo: [
+    def pipeline = pipeline {
+      inputFileNames.eachWithIndex { name, i ->
+        stage {
+          refId = "$i"
+          outputs["buildInfo"] = [
             artifacts: [
-              [fileName: "${it}.deb"],
-              [fileName: "${it}.war"],
+              [fileName: "${name}.deb"],
+              [fileName: "${name}.war"],
               [fileName: "build.properties"]
             ],
             url      : "http://localhost",
             name     : "testBuildName",
             number   : "1"
           ]
-        ]
-      )
+        }
+      }
+      stage {
+        refId = "${inputFileNames.size()}"
+        context["package"] = "testPackageName"
+        requisiteStageRefIds = inputFileNames.indices*.toString()
+      }
     }
-    Stage quipStage = new Stage(pipeline, "type", "name", [buildInfo: [name: "someName"], package: "testPackageName"]).with {
-      it.requisiteStageRefIds = ancestorStages.refId
-      return it
-    }
-    (ancestorStages + [quipStage]).each {
-      pipeline.stages << it
-    }
+
+    def quipStage = pipeline.stages.last()
 
     PackageInfo packageInfo =
       new PackageInfo(quipStage, DEB.packageType, DEB.versionDelimiter, true, false, new ObjectMapper())
@@ -214,12 +213,19 @@ class PackageInfoSpec extends Specification {
 
   def "findTargetPackage: bake execution with only a package set and jenkins stage artifacts"() {
     given:
-    Stage bakeStage = new Stage()
-    def pipeline = Execution.newPipeline("orca")
-    pipeline.context << [buildInfo: [artifacts: [[fileName: "api_1.1.1-h02.sha123_all.deb"]]]]
-    bakeStage.execution = pipeline
-    bakeStage.context = [package: 'api']
-
+    def pipeline = pipeline {
+      stage {
+        refId = "1"
+        type = "jenkins"
+        outputs["buildInfo"] = [artifacts: [[fileName: "api_1.1.1-h02.sha123_all.deb"]]]
+      }
+      stage {
+        refId = "2"
+        requisiteStageRefIds = ["1"]
+        context["package"] = "api"
+      }
+    }
+    def bakeStage = pipeline.stageByRef("2")
 
     PackageType packageType = DEB
     ObjectMapper objectMapper = new ObjectMapper()
@@ -254,11 +260,19 @@ class PackageInfoSpec extends Specification {
 
   def "findTargetPackage: stage execution instance of Pipeline with no trigger"() {
     given:
-    Stage quipStage = new Stage()
-    def pipeline = Execution.newPipeline("orca")
-    pipeline.context << [buildInfo: [artifacts: [[fileName: "api_1.1.1-h01.sha123_all.deb"]]]]
-    quipStage.execution = pipeline
-    quipStage.context = [package: 'api']
+    def pipeline = pipeline {
+      stage {
+        refId = "1"
+        type = "jenkins"
+        outputs["buildInfo"] = [artifacts: [[fileName: "api_1.1.1-h01.sha123_all.deb"]]]
+      }
+      stage {
+        refId = "2"
+        requisiteStageRefIds = ["1"]
+        context["package"] = "api"
+      }
+    }
+    def quipStage = pipeline.stageByRef("2")
 
     PackageType packageType = DEB
     ObjectMapper objectMapper = new ObjectMapper()
@@ -274,11 +288,19 @@ class PackageInfoSpec extends Specification {
   @Unroll
   def "findTargetPackage: matched packages are always allowed"() {
     given:
-    Stage quipStage = new Stage()
-    def pipeline = Execution.newPipeline("orca")
-    pipeline.context << [buildInfo: [artifacts: [[fileName: "api_1.1.1-h01.sha123_all.deb"]]]]
-    quipStage.execution = pipeline
-    quipStage.context = ['package': "api"]
+    def pipeline = pipeline {
+      stage {
+        refId = "1"
+        type = "jenkins"
+        outputs["buildInfo"] = [artifacts: [[fileName: "api_1.1.1-h01.sha123_all.deb"]]]
+      }
+      stage {
+        refId = "2"
+        requisiteStageRefIds = ["1"]
+        context["package"] = "api"
+      }
+    }
+    def quipStage = pipeline.stageByRef("2")
 
     PackageType packageType = DEB
     ObjectMapper objectMapper = new ObjectMapper()
@@ -299,11 +321,14 @@ class PackageInfoSpec extends Specification {
   @Unroll
   def "findTargetPackage: allowing unmatched packages is guarded by the allowMissingPackageInstallation flag"() {
     given:
-    Stage quipStage = new Stage()
-    def pipeline = Execution.newPipeline("orca")
-    pipeline.context << [buildInfo: [artifacts: [[fileName: "api_1.1.1-h01.sha123_all.deb"]]]]
-    quipStage.execution = pipeline
-    quipStage.context = ['package': "another_package"]
+    def pipeline = pipeline {
+      trigger["buildInfo"] = [artifacts: [[fileName: "api_1.1.1-h01.sha123_all.deb"]]]
+      stage {
+        refId = "1"
+        context["package"] = "another_package"
+      }
+    }
+    def quipStage = pipeline.stageByRef("1")
 
     PackageType packageType = DEB
     ObjectMapper objectMapper = new ObjectMapper()
@@ -326,7 +351,7 @@ class PackageInfoSpec extends Specification {
     where:
     allowMissingPackageInstallation || expectedException || expectedMessage
     true                            || false             || null
-    false                           || true              || "Unable to find deployable artifact starting with [another_package_] and ending with .deb in [[fileName:api_1.1.1-h01.sha123_all.deb]] and null. Make sure your deb package file name complies with the naming convention: name_version-release_arch."
+    false                           || true              || "Unable to find deployable artifact starting with [another_package_] and ending with .deb in null and [[fileName:api_1.1.1-h01.sha123_all.deb]]. Make sure your deb package file name complies with the naming convention: name_version-release_arch."
   }
 
   def "findTargetPackage: stage execution instance of Pipeline with trigger and no buildInfo"() {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
@@ -242,7 +242,6 @@ class PackageInfoSpec extends Specification {
     given:
     Stage bakeStage = new Stage()
     def pipeline = Execution.newPipeline("orca")
-    pipeline.context << [buildInfo: [artifacts: [[fileName: "api_1.1.1-h03.sha123_all.deb"]]]]
     bakeStage.execution = pipeline
     bakeStage.context = [package: '']
 

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
@@ -642,8 +642,8 @@ class GetCommitsTaskSpec extends Specification {
     def contextMap = [application: app, account: account,
       source     : [asgName: serverGroup, region: region, account: account], "deploy.server.groups": ["us-west-1": [targetServerGroup]], "kato.tasks" : katoMap]
 
-    parentPipeline.context = [deploymentDetails: [[imageId: "ami-foo", ami: "amiFooName", region: "us-east-1"], [imageId: targetImage, ami: targetImageName, region: region]]]
     def parentStage = setupGetCommits(contextMap, account, app, sourceImage, targetImage, region, cluster, serverGroup, 1, 1, parentPipeline)
+    parentStage.outputs = [deploymentDetails: [[imageId: "ami-foo", ami: "amiFooName", region: "us-east-1"], [imageId: targetImage, ami: targetImageName, region: region]]]
     def childStage = new Stage(childPipeline, "stash", [application: app, account: account, source: [asgName: serverGroup, region: region, account: account], "deploy.server.groups": ["us-west-1": [targetServerGroup]], "kato.tasks" : katoMap])
 
     parentPipeline.stages << parentStage

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
@@ -180,7 +180,7 @@ class DeployCanaryStage extends ParallelDeployStage implements CloudProviderAwar
             }
           }
           if (!cluster.amiName) {
-            def ami = deployStage.execution.context.deploymentDetails.find {
+            def ami = deployStage.outputs.deploymentDetails.find {
               it.region == region
             }
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -224,7 +224,9 @@ class RunTaskHandler(
   private val blacklistGlobalKeys = setOf(
     "propertyIdList",
     "originalProperties",
-    "propertyAction"
+    "propertyAction",
+    "propertyAction",
+    "deploymentDetails"
   )
 
   private fun Stage.processTaskOutput(result: TaskResult) {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -478,7 +478,6 @@ open class QueueIntegrationTest {
   fun `can resolve expressions in stage contexts`() {
     val pipeline = pipeline {
       application = "spinnaker"
-      context["global"] = "foo"
       stage {
         refId = "1"
         type = "dummy"
@@ -491,7 +490,6 @@ open class QueueIntegrationTest {
       }
     }
     repository.store(pipeline)
-    repository.storeExecutionContext(pipeline.id, pipeline.context)
 
     whenever(dummyTask.timeout) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult(SUCCEEDED, mapOf("output" to "foo"))


### PR DESCRIPTION
This ensures deployment details are retrieved from upstream stages, trigger or parent pipeline without using global context