### PR TITLE
fix(pipeline_parsing) Protect against NPEs with trigger params.

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -154,11 +154,11 @@ class OperationsController {
       }
     }
 
-    if (pipeline.parameterConfig) {
-      if (!pipeline.trigger.parameters) {
-        pipeline.trigger.parameters = [:]
-      }
+    if (!pipeline.trigger.parameters) {
+      pipeline.trigger.parameters = [:]
+    }
 
+    if (pipeline.parameterConfig) {
       pipeline.parameterConfig.each {
         pipeline.trigger.parameters[it.name] = pipeline.trigger.parameters.containsKey(it.name) ? pipeline.trigger.parameters[it.name] : it.default
       }


### PR DESCRIPTION
Related to https://github.com/spinnaker/echo/pull/207

We noticed that pipelines that had triggers (like CRON or Jenkins triggers) were failing if they didn't also have parameters because of our change. This should fix that in a better way given that triggers are expected to have several null values.