### PR TITLE
feat(core): AFTER_STAGE stages can now be planned post task completion

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/RollbackClusterStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/RollbackClusterStage.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.cluster;
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.RollbackServerGroupStage;
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.DetermineRollbackCandidatesTask;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.newStage;
+
+@Component
+public class RollbackClusterStage implements StageDefinitionBuilder {
+  public static final String PIPELINE_CONFIG_TYPE = "rollbackCluster";
+
+  private final RollbackServerGroupStage rollbackServerGroupStage;
+
+  @Autowired
+  public RollbackClusterStage(RollbackServerGroupStage rollbackServerGroupStage) {
+    this.rollbackServerGroupStage = rollbackServerGroupStage;
+  }
+
+  @Override
+  public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
+    builder
+      .withTask("determineRollbackCandidates", DetermineRollbackCandidatesTask.class);
+  }
+
+  @Nonnull
+  @Override
+  public List<Stage> afterStages(@Nonnull Stage stage) {
+    StageData stageData = stage.mapTo(StageData.class);
+
+    List<Stage> stages = new ArrayList<>();
+    for (String region : stageData.regions) {
+      Map<String, Object> context = new HashMap<>();
+      context.put(
+        "rollbackType",
+        ((Map) stage.getOutputs().get("rollbackTypes")).get(region)
+      );
+      context.put(
+        "rollbackContext",
+        ((Map) stage.getOutputs().get("rollbackContexts")).get(region)
+      );
+      context.put("type", rollbackServerGroupStage.getType());
+      context.put("region", region);
+      context.put("credentials", stageData.account);
+      context.put("cloudProvider", stageData.cloudProvider);
+
+      stages.add(
+        newStage(
+          stage.getExecution(),
+          rollbackServerGroupStage.getType(),
+          "Rollback " + region,
+          context,
+          stage,
+          SyntheticStageOwner.STAGE_AFTER
+        )
+      );
+    }
+
+    // TODO-AJ Consider wait stages between regions
+
+    return stages;
+  }
+
+  static class StageData {
+    public String account;
+    public String cloudProvider;
+
+    public List<String> regions;
+
+    public Long waitTimeBetweenRegions;
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.cluster;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.moniker.Moniker;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class DetermineRollbackCandidatesTask extends AbstractCloudProviderAwareTask implements RetryableTask {
+  private static final Logger logger = LoggerFactory.getLogger(DetermineRollbackCandidatesTask.class);
+
+  private final ObjectMapper objectMapper;
+  private final RetrySupport retrySupport;
+  private final OortService oortService;
+
+  @Autowired
+  public DetermineRollbackCandidatesTask(ObjectMapper objectMapper,
+                                         RetrySupport retrySupport,
+                                         OortService oortService) {
+    this.objectMapper = objectMapper;
+    this.retrySupport = retrySupport;
+    this.oortService = oortService;
+  }
+
+  @Override
+  public long getBackoffPeriod() {
+    return TimeUnit.SECONDS.toMillis(15);
+  }
+
+  @Override
+  public long getTimeout() {
+    return TimeUnit.MINUTES.toMillis(5);
+  }
+
+  @Nonnull
+  @Override
+  public TaskResult execute(@Nonnull Stage stage) {
+    Map<String, String> rollbackTypes = new HashMap<>();
+    Map<String, Map> rollbackContexts = new HashMap<>();
+
+    StageData stageData = stage.mapTo(StageData.class);
+    Map<String, Object> cluster;
+
+    try {
+      cluster = retrySupport.retry(() -> fetchCluster(
+        stageData.moniker.getApp(),
+        stageData.account,
+        stageData.moniker.getCluster(),
+        stageData.cloudProvider
+      ), 5, 1000, false);
+    } catch(Exception e) {
+      logger.warn(
+        "Failed to fetch cluster, retrying! (application: {}, account: {}, cluster: {}, cloudProvider: {})",
+        stageData.moniker.getApp(),
+        stageData.account,
+        stageData.moniker.getCluster(),
+        stageData.cloudProvider,
+        e
+      );
+      return new TaskResult(ExecutionStatus.RUNNING);
+    }
+
+    List<Map<String, Object>> serverGroups = (List<Map<String, Object>>) cluster.get("serverGroups");
+    serverGroups.sort(Comparator.comparing((Map o) -> ((Long) o.get("createdTime"))).reversed());
+
+    for (String region : stageData.regions) {
+      Map<String, Object> newestServerGroupInRegion = serverGroups
+        .stream()
+        .filter(s -> region.equalsIgnoreCase((String) s.get("region")))
+        .findFirst()
+        .orElse(null);
+
+      if (newestServerGroupInRegion != null) {
+        rollbackTypes.put(region, "PREVIOUS_IMAGE");
+        rollbackContexts.put(
+          region,
+          ImmutableMap.builder()
+            .put("rollbackServerGroupName", newestServerGroupInRegion.get("name"))
+            .put("targetHealthyRollbackPercentage", 100)
+            .build()
+        );
+      }
+    }
+
+    return new TaskResult(
+      ExecutionStatus.SUCCEEDED,
+      Collections.emptyMap(),
+      ImmutableMap.<String, Object>builder()
+        .put("rollbackTypes", rollbackTypes)
+        .put("rollbackContexts", rollbackContexts)
+        .build()
+    );
+  }
+
+  private Map<String, Object> fetchCluster(String application,
+                                           String account,
+                                           String cluster,
+                                           String cloudProvider) {
+    try {
+      Response response = oortService.getCluster(application, account, cluster, cloudProvider);
+      return (Map<String, Object>) objectMapper.readValue(response.getBody().in(), Map.class);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static class StageData {
+    public String account;
+    public String cloudProvider;
+
+    public Moniker moniker;
+    public List<String> regions;
+  }
+}

--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
@@ -50,6 +50,10 @@ public interface StageDefinitionBuilder {
     return emptyList();
   }
 
+  default @Nonnull List<Stage> afterStages(@Nonnull Stage stage) {
+    return emptyList();
+  }
+
   /**
    * @return the stage type this builder handles.
    */

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.ExecutionStatus.*
 import com.netflix.spinnaker.orca.events.StageComplete
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
+import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.q.*
@@ -31,13 +33,31 @@ class CompleteStageHandler(
   override val repository: ExecutionRepository,
   private val publisher: ApplicationEventPublisher,
   private val clock: Clock,
-  override val contextParameterProcessor: ContextParameterProcessor
-) : MessageHandler<CompleteStage>, ExpressionAware {
+  override val contextParameterProcessor: ContextParameterProcessor,
+  override val stageDefinitionBuilderFactory: StageDefinitionBuilderFactory
+) : MessageHandler<CompleteStage>, StageBuilderAware, ExpressionAware {
 
   override fun handle(message: CompleteStage) {
     message.withStage { stage ->
       if (stage.status in setOf(RUNNING, NOT_STARTED)) {
         val status = stage.determineStatus()
+        if (status.isComplete && !status.isHalt) {
+          // check to see if this stage has any unplanned synthetic after stages
+          var afterStages = stage.firstAfterStages()
+          if (afterStages.isEmpty()) {
+            stage.planAfterStages()
+
+            afterStages = stage.firstAfterStages()
+            if (afterStages.isNotEmpty()) {
+              afterStages.forEach {
+                queue.push(StartStage(message, it.id))
+              }
+
+              return@withStage
+            }
+          }
+        }
+
         stage.status = status
         stage.endTime = clock.millis()
         stage.includeExpressionEvaluationSummary()
@@ -61,4 +81,22 @@ class CompleteStageHandler(
   }
 
   override val messageType = CompleteStage::class.java
+
+  /**
+   * Plan any outstanding synthetic after stages.
+   */
+  private fun Stage.planAfterStages() {
+    var hasPlannedStages = false
+
+    builder().let { builder ->
+      builder.buildAfterStages(this, builder.afterStages(this)) { it: Stage ->
+        repository.addStage(it)
+        hasPlannedStages = true
+      }
+    }
+
+    if (hasPlannedStages) {
+      this.execution = repository.retrieve(this.execution.type, this.execution.id)
+    }
+  }
 }


### PR DESCRIPTION
This allows for interesting scenarios where a stage could have a `Task`
responsible for building the context that is subsequently used to build
a dynamic set of synthetic stages.

Currently this logic must reside entirely in `aroundStages()` and you
lose the ability to arbitrarily retry with backoff's, etc. that normal
`Task` execution provides.
