### PR TITLE
fix(pipeline_template) Do not throw IllegalTemplateConfigurationException if empty inject object is passed with pipeline stage configuration

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigStageInjectionTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigStageInjectionTransform.java
@@ -76,7 +76,7 @@ public class ConfigStageInjectionTransform implements PipelineTemplateVisitor {
   private void expandStagePartials(PipelineTemplate pipelineTemplate) {
     List<StageDefinition> addStages = new ArrayList<>();
     List<StageDefinition> templateStages = pipelineTemplate.getStages();
-    
+
     // For each "partial" type stage in the graph, inject its internal stage graph into the main template, then
     // delete the "partial" type stages. Root-level partial stages will inherit the placeholder's dependsOn values,
     // and stages that had dependsOn references to the placeholder will be reassigned to partial leaf nodes.
@@ -141,7 +141,7 @@ public class ConfigStageInjectionTransform implements PipelineTemplateVisitor {
     );
 
     // Handle stage injections.
-    injectStages(pipelineTemplate.getStages(), pipelineTemplate.getStages());    
+    injectStages(pipelineTemplate.getStages(), pipelineTemplate.getStages());
     injectStages(templateConfiguration.getStages(), pipelineTemplate.getStages());
   }
 
@@ -207,7 +207,7 @@ public class ConfigStageInjectionTransform implements PipelineTemplateVisitor {
   private static void injectStages(List<StageDefinition> stages, List<StageDefinition> templateStages) {
     // Using a stream here can cause a ConcurrentModificationException.
     for (StageDefinition s : new ArrayList<>(stages)) {
-      if (s.getInject() == null) {
+      if (s.getInject() == null || !s.getInject().hasAny()) {
         continue;
       }
 
@@ -243,7 +243,7 @@ public class ConfigStageInjectionTransform implements PipelineTemplateVisitor {
   private static void injectFirst(StageDefinition stage, List<StageDefinition> allStages) {
     if (!allStages.isEmpty()) {
       allStages.forEach(s -> {
-        if(s.getRequisiteStageRefIds().isEmpty()) 
+        if(s.getRequisiteStageRefIds().isEmpty())
           s.getRequisiteStageRefIds().add(stage.getId());
       });
       allStages.add(0, stage);

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigStageInjectionTransformSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/ConfigStageInjectionTransformSpec.groovy
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform
 
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.IllegalTemplateConfigurationException
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PartialDefinition
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinition
@@ -258,6 +259,23 @@ class ConfigStageInjectionTransformSpec extends Specification {
     template.stages[2].dependsOn == ['s1.p2'] as Set
   }
 
+  def 'should ignore empty inject object'() {
+    given:
+    PipelineTemplate template = new PipelineTemplate(
+      stages: [
+        new StageDefinition(id: 's2', type: 'deploy'),
+        new StageDefinition(id: 's1', inject: [], type: 'findImageFromTags'),
+      ]
+    )
+
+    when:
+    new ConfigStageInjectionTransform(new TemplateConfiguration()).visitPipelineTemplate(template)
+
+    then:
+    notThrown(IllegalTemplateConfigurationException)
+    template.stages*.id == ['s1', 's2']
+  }
+
   def 'should inject and expand stage partials: first'() {
     given:
     PipelineTemplate template = new PipelineTemplate(
@@ -493,7 +511,7 @@ class ConfigStageInjectionTransformSpec extends Specification {
     requisiteStageIds('s1.p1', template.stages) == ['s2'] as Set
     requisiteStageIds('s1.p2', template.stages) == ['s1.p1'] as Set
   }
-  
+
   def 'should inject and expand stage partials: after last'() {
     given:
     PipelineTemplate template = new PipelineTemplate(
@@ -530,7 +548,7 @@ class ConfigStageInjectionTransformSpec extends Specification {
         )
       ]
     )
- 
+
     when:
     new ConfigStageInjectionTransform(
       new TemplateConfiguration(
@@ -589,7 +607,7 @@ class ConfigStageInjectionTransformSpec extends Specification {
         )
       ]
     )
-  
+
     when:
     new ConfigStageInjectionTransform(
       new TemplateConfiguration(

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-config.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-config.yml
@@ -1,0 +1,21 @@
+schema: "1"
+pipeline:
+  application: myApp
+  name: Stage dependsOn test
+  template:
+    source: dependsOn-template.yml
+stages:
+- id: configWait1
+  type: wait
+  dependsOn:
+  - wait2
+  inject: {}
+  config:
+    waitTime: 5
+- id: configWait2
+  type: wait
+  inject: {}
+  dependsOn:
+  - wait2
+  config:
+    waitTime: 5

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-expected.json
@@ -1,0 +1,51 @@
+{
+  "application": "myApp",
+  "name": "Stage dependsOn test",
+  "stages": [
+    {
+      "requisiteStageRefIds": [],
+      "name": "wait1",
+      "id": null,
+      "refId": "wait1",
+      "type": "wait",
+      "waitTime": 5
+    },
+    {
+      "requisiteStageRefIds": ["wait1"],
+      "name": "wait2",
+      "id": null,
+      "refId": "wait2",
+      "type": "wait",
+      "waitTime": 5
+    },
+    {
+      "requisiteStageRefIds": ["wait2"],
+      "name": "wait3",
+      "id": null,
+      "refId": "wait3",
+      "type": "wait",
+      "waitTime": 5
+    },
+    {
+      "requisiteStageRefIds": ["wait2"],
+      "name": "configWait2",
+      "id": null,
+      "refId": "configWait2",
+      "type": "wait",
+      "waitTime": 5
+    },
+    {
+      "requisiteStageRefIds": ["wait2"],
+      "name": "configWait1",
+      "id": null,
+      "refId": "configWait1",
+      "type": "wait",
+      "waitTime": 5
+    }
+  ],
+  "keepWaitingPipelines": false,
+  "limitConcurrent": true,
+  "notifications": [],
+  "parameterConfig": [],
+  "id": "unknown"
+}

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-template.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-template.yml
@@ -1,0 +1,26 @@
+schema: "1"
+id: simple
+metadata:
+  name: 'dependsOn test tempate'
+  description: 'dependsOn test tempate'
+configuration:
+  concurrentExecutions:
+    parallel: true
+    limitConcurrent: true
+stages:
+- id: wait1
+  type: wait
+  config:
+    waitTime: 5
+- id: wait2
+  type: wait
+  dependsOn:
+  - wait1
+  config:
+    waitTime: 5
+- id: wait3
+  type: wait
+  dependsOn:
+  - wait2
+  config:
+    waitTime: 5


### PR DESCRIPTION
I noticed that when I saved a pipeline configuration with `roer` the stage `dependsOn` data from the config was not being used to configure the pipeline.  Turns out `roer` will always send an empty `inject` object, which in-turn throws an `IllegalTemplateConfigurationException` from the `ConfigStageInjectionTransform` mutator.  This exception is thrown but the process of saving the pipeline continues - just without data from the pipeline config being applied to the pipeline.

This fix essentially continues with mutator processing if an empty `inject` object is present. 

I also added a dependsOn integration test to catch this issue in the future.

@robzienert 