### PR TITLE
fix(expressions): ensure parentExecution is an execution not a map

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.groovy
@@ -618,7 +618,13 @@ class JedisExecutionRepository implements ExecutionRepository {
       execution.paused = map.paused ? mapper.readValue(map.paused, Execution.PausedDetails) : null
       execution.keepWaitingPipelines = Boolean.parseBoolean(map.keepWaitingPipelines)
       execution.origin = map.origin
-      execution.trigger.putAll(map.trigger ? mapper.readValue(map.trigger, Map) : [:])
+      if (map.trigger) {
+        def trigger = mapper.readValue(map.trigger, Map)
+        if (trigger.containsKey("parentExecution")) {
+          trigger["parentExecution"] = mapper.convertValue(trigger["parentExecution"], Execution)
+        }
+        execution.trigger.putAll(trigger)
+      }
 
       try {
         execution.executionEngine = map.executionEngine == null ? DEFAULT_EXECUTION_ENGINE : Execution.ExecutionEngine.valueOf(map.executionEngine)

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -20,6 +20,7 @@ import java.util.concurrent.CountDownLatch
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionCriteria
 import com.netflix.spinnaker.orca.pipeline.persistence.jedis.JedisExecutionRepository
@@ -444,6 +445,20 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
 
     then:
     thrown(ExecutionNotFoundException)
+  }
+
+  def "parses the parent execution of a pipeline trigger"() {
+    given:
+    def execution = pipeline {
+      trigger["type"] = "pipeline"
+      trigger["parentExecution"] = pipeline()
+    }
+    repository.store(execution)
+
+    expect:
+    with(repository.retrieve(PIPELINE, execution.id)) {
+      trigger["parentExecution"] instanceof Execution
+    }
   }
 }
 


### PR DESCRIPTION
This means expressions that reference "context" will work.

I'd like to go further and make the whole trigger JSON parseable but this is a start.