### PR TITLE
feat(helm): Add Helm ServerGroup tasks creator

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/helm/HelmServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/helm/HelmServerGroupCreator.groovy
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.helm
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCreator
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
+import org.springframework.stereotype.Component
+
+@Slf4j
+@Component
+class HelmServerGroupCreator implements ServerGroupCreator {
+
+  boolean katoResultExpected = false
+  String cloudProvider = "helm"
+
+  @Override
+  List<Map> getOperations(Stage stage) {
+    def operation = [:]
+
+    if (stage.context.containsKey("cluster")) {
+      operation.putAll(stage.context.cluster as Map)
+    } else {
+      operation.putAll(stage.context)
+    }
+
+    return [[(OPERATION): operation]]
+  }
+
+  @Override
+  Optional<String> getHealthProviderName() {
+    return Optional.empty()
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTaskSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.AmazonServerGroupCreator
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.dcos.DcosServerGroupCreator
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.gce.GoogleServerGroupCreator
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.helm.HelmServerGroupCreator
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.kubernetes.KubernetesServerGroupCreator
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.titus.TitusServerGroupCreator
 import com.netflix.spinnaker.orca.front50.Front50Service
@@ -38,7 +39,8 @@ class DetermineHealthProvidersTaskSpec extends Specification {
   def task = new DetermineHealthProvidersTask(
     new Optional<Front50Service>(front50Service),
     [],
-    [new KubernetesServerGroupCreator(), new AmazonServerGroupCreator(), new GoogleServerGroupCreator(), new TitusServerGroupCreator(), new DcosServerGroupCreator()]
+    [new KubernetesServerGroupCreator(), new AmazonServerGroupCreator(), new GoogleServerGroupCreator(), new TitusServerGroupCreator(), new DcosServerGroupCreator(),
+     new HelmServerGroupCreator()]
   )
 
   @Unroll


### PR DESCRIPTION
Add Helm ServerGroup tasks creator

This patch adds support creation of server groups using Helm clouddriver.
