### PR TITLE
feat(timeout) Add configurable timeout to wait for upserted image tag task

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/WaitForUpsertedImageTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/WaitForUpsertedImageTagsTask.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.orca.RetryableTask;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -32,6 +33,9 @@ import org.springframework.stereotype.Component;
 public class WaitForUpsertedImageTagsTask implements RetryableTask, CloudProviderAware {
   @Autowired
   List<ImageTagger> imageTaggers;
+
+  @Value("${tasks.waitForUpsertedImageTagsTimeout:600}")
+  private long waitForUpsertedImageTagsTimeout;
 
   @Override
   public TaskResult execute(Stage stage) {
@@ -55,7 +59,7 @@ public class WaitForUpsertedImageTagsTask implements RetryableTask, CloudProvide
 
   @Override
   public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(10);
+    return TimeUnit.SECONDS.toMillis(this.waitForUpsertedImageTagsTimeout);
   }
 
   static class StageData {


### PR DESCRIPTION
We have lots of amis indexed in our AWS account and sometimes it takes more than 10 minutes to fetch the status of the tag operation.

![image](https://user-images.githubusercontent.com/4490611/34117919-7f5c7a0a-e41d-11e7-89c7-5c35dc4c486d.png)

With this PR we want to mitigate the issue while we find a way to clean-up old amis.