### PR TITLE
fix(queue): really cancel queued pipelines that were canceled

### DIFF
--- a/orca-queue/orca-queue.gradle
+++ b/orca-queue/orca-queue.gradle
@@ -25,6 +25,7 @@ dependencies {
   compile project(":orca-core")
   compile "org.threeten:threeten-extra:1.0"
   compile "org.funktionale:funktionale-partials:1.1"
+  compile spinnaker.dependency("logstashEncoder")
 
   testCompile "org.springframework.boot:spring-boot-test:${spinnaker.version('springBoot')}"
   testCompile project(":orca-test")


### PR DESCRIPTION
Looks like we were never canceling pipelines that were canceled while queued. This will not start a pipeline if it is in a canceled state.