### PR TITLE
feat(amazon): Ensure that server groups are unpinned when a deploy fails

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -106,4 +106,9 @@ public class DelegatingOortService
   public List<Map> getEntityTags(String cloudProvider, String entityType, String entityId, String account, String region) {
     return getService().getEntityTags(cloudProvider, entityType, entityId, account, region);
   }
+
+  @Override
+  public List<Map> getEntityTags(Map parameters) {
+    return getService().getEntityTags(parameters);
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -115,4 +115,7 @@ interface OortService {
                           @Query("entityId") String entityId,
                           @Query("account") String account,
                           @Query("region") String region)
+
+  @GET('/tags')
+  List<Map> getEntityTags(@QueryMap Map parameters)
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStage.groovy
@@ -17,12 +17,23 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws
 
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.orca.clouddriver.FeaturesService
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.pipeline.entitytags.DeleteEntityTagsStage
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+
+import javax.annotation.Nonnull
+
+import static com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.PinnedServerGroupTagGenerator.PINNED_CAPACITY_TAG
 
 /**
  * Ensure that external scaling policies do not adversely affect a server group as it is in the process of being deployed.
@@ -32,13 +43,81 @@ import org.springframework.stereotype.Component
  * - creating a new server group with min = desired ({@link CaptureSourceServerGroupCapacityTask})
  * - restoring min after the deploy has completed ({@link ApplySourceServerGroupCapacityTask})
  */
+@Slf4j
 @Component
 class ApplySourceServerGroupCapacityStage implements StageDefinitionBuilder {
+  @Autowired
+  private FeaturesService featuresService
+
+  @Autowired
+  DeleteEntityTagsStage deleteEntityTagsStage
+
+  @Autowired
+  OortService oortService
+
+  @Autowired
+  RetrySupport retrySupport
+
   @Override
   void taskGraph(Stage stage, TaskNode.Builder builder) {
     builder
       .withTask("restoreMinCapacity", ApplySourceServerGroupCapacityTask)
       .withTask("waitForCapacityMatch", MonitorKatoTask)
       .withTask("forceCacheRefresh", ServerGroupCacheForceRefreshTask)
+  }
+
+  @Override
+  List<Stage> afterStages(@Nonnull Stage stage) {
+    try {
+      def taggingEnabled = featuresService.isStageAvailable("upsertEntityTags")
+      if (!taggingEnabled) {
+        return []
+      }
+
+      def entityTags = fetchEntityTags(oortService, retrySupport, stage)?.get(0)
+      if (!entityTags) {
+        return []
+      }
+
+      return [
+        newStage(
+          stage.execution,
+          deleteEntityTagsStage.type,
+          "Cleanup Server Group Tags",
+          [
+            id  : entityTags.id,
+            tags: Collections.singletonList(PINNED_CAPACITY_TAG)
+          ],
+          stage,
+          SyntheticStageOwner.STAGE_AFTER
+        )
+      ]
+    } catch (Exception e) {
+      log.error(
+        "Unable to determine whether server group is pinned (serverGroup: {}, account: {}, region: {})",
+        stage.context.serverGroupName,
+        stage.context.credentials,
+        getRegion(stage),
+        e
+      )
+
+      // any false negatives (pinned server groups that were not detected) will be caught by the RestorePinnedServerGroupsAgent
+      return []
+    }
+  }
+
+  private static List<Map> fetchEntityTags(OortService oortService, RetrySupport retrySupport, Stage stage) {
+    retrySupport.retry({
+      return oortService.getEntityTags([
+        ("tag:${PINNED_CAPACITY_TAG}".toString()): "*",
+        entityId                                 : stage.context.serverGroupName,
+        account                                  : stage.context.credentials,
+        region                                   : getRegion(stage)
+      ])
+    }, 5, 2000, false)
+  }
+
+  private static String getRegion(Stage stage) {
+    return ((Map<String, Object>) stage.context."deploy.server.groups").keySet()?.getAt(0)
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPoller.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPoller.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pollers;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.notifications.AbstractPollingNotificationAgent;
+import com.netflix.spinnaker.orca.pipeline.ExecutionLauncher;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
+import groovy.util.logging.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+import redis.clients.jedis.Jedis;
+import redis.clients.util.Pool;
+import retrofit.client.Response;
+import rx.Observable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.PinnedServerGroupTagGenerator.PINNED_CAPACITY_TAG;
+
+@Slf4j
+@Component
+@ConditionalOnExpression(value = "${pollers.restorePinnedServerGroups.enabled:false}")
+class RestorePinnedServerGroupsPoller extends AbstractPollingNotificationAgent {
+  private static final Logger log = LoggerFactory.getLogger(RestorePinnedServerGroupsPoller.class);
+
+  private final ObjectMapper objectMapper;
+  private final OortService oortService;
+  private final RetrySupport retrySupport;
+  private final ExecutionLauncher executionLauncher;
+  private final ExecutionRepository executionRepository;
+
+  private final Counter errorsCounter;
+  private final Counter triggeredCounter;
+
+  @Autowired
+  public RestorePinnedServerGroupsPoller(@Qualifier("jedisPool") Pool<Jedis> jedisPool,
+                                         ObjectMapper objectMapper,
+                                         OortService oortService,
+                                         RetrySupport retrySupport,
+                                         Registry registry,
+                                         ExecutionLauncher executionLauncher,
+                                         ExecutionRepository executionRepository) {
+    super(jedisPool);
+
+    this.objectMapper = objectMapper;
+    this.oortService = oortService;
+    this.retrySupport = retrySupport;
+    this.executionLauncher = executionLauncher;
+    this.executionRepository = executionRepository;
+
+    this.errorsCounter = registry.counter("poller.restorePinnedServerGroups.errors");
+    this.triggeredCounter = registry.counter("poller.restorePinnedServerGroups.triggered");
+  }
+
+  @Override
+  protected long getPollingInterval() {
+    return TimeUnit.MINUTES.toSeconds(10);
+  }
+
+  @Override
+  protected String getNotificationType() {
+    return "restorePinnedServerGroups";
+  }
+
+  @Override
+  protected void startPolling() {
+    subscription = Observable
+      .timer(getPollingInterval(), TimeUnit.SECONDS, scheduler)
+      .repeat()
+      .filter(interval -> tryAcquireLock())
+      .subscribe(interval -> {
+        try {
+          poll();
+        } catch (Exception e) {
+          log.error("Error checking for pinned server groups", e);
+        }
+      });
+  }
+
+  void poll() {
+    log.info("Checking for pinned server groups");
+
+    List<PinnedServerGroupTag> pinnedServerGroupTags = fetchPinnedServerGroupTags();
+    log.info("Found {} pinned server groups", pinnedServerGroupTags.size());
+
+    if (pinnedServerGroupTags.isEmpty()) {
+      return;
+    }
+
+    pinnedServerGroupTags = pinnedServerGroupTags.stream()
+      .filter(this::hasCompletedExecution)
+      .collect(Collectors.toList());
+
+    log.info("Found {} pinned server groups with completed executions", pinnedServerGroupTags.size());
+
+    for (PinnedServerGroupTag pinnedServerGroupTag : pinnedServerGroupTags) {
+      try {
+        ServerGroup serverGroup = fetchServerGroup(
+          pinnedServerGroupTag.account,
+          pinnedServerGroupTag.location,
+          pinnedServerGroupTag.serverGroup
+        );
+
+        List<Map<String, Object>> jobs = new ArrayList<>();
+        jobs.add(buildDeleteEntityTagsOperation(pinnedServerGroupTag, serverGroup));
+
+        if (serverGroup.capacity.min.equals(pinnedServerGroupTag.pinnedCapacity.min)) {
+          jobs.add(0, buildResizeOperation(pinnedServerGroupTag, serverGroup));
+
+          // ensure that the tag cleanup comes after the resize operation has completed
+          jobs.get(1).put("requisiteStageRefIds", Collections.singletonList(jobs.get(0).get("refId")));
+        }
+
+        Map<String, Object> cleanupOperation = buildCleanupOperation(pinnedServerGroupTag, serverGroup, jobs);
+        log.info((String) cleanupOperation.get("name"));
+
+        // TODO-AJ Need to provide an authentication context such that resize operations in privileged accounts work!
+        executionLauncher.start(
+          Execution.ExecutionType.ORCHESTRATION,
+          objectMapper.writeValueAsString(cleanupOperation)
+        );
+
+        triggeredCounter.increment();
+      } catch (Exception e) {
+        log.error("Failed to unpin server group (serverGroup: {})", pinnedServerGroupTag.serverGroup, e);
+        errorsCounter.increment();
+      }
+    }
+  }
+
+  List<PinnedServerGroupTag> fetchPinnedServerGroupTags() {
+    List<EntityTags> allEntityTags = retrySupport.retry(() -> objectMapper.convertValue(
+      oortService.getEntityTags(ImmutableMap.<String, String>builder()
+        .put("tag:" + PINNED_CAPACITY_TAG, "*")
+        .put("entityType", "servergroup")
+        .build()
+      ),
+      new TypeReference<List<EntityTags>>() {
+      }
+    ), 15, 2000, false);
+
+    return allEntityTags.stream()
+      .map(e -> e.tags.stream()
+        .filter(t -> PINNED_CAPACITY_TAG.equalsIgnoreCase(t.name))
+        .map(t -> {
+          PinnedServerGroupTag pinnedServerGroupTag = objectMapper.convertValue(t.value, PinnedServerGroupTag.class);
+          pinnedServerGroupTag.entityTagsId = e.id;
+          return pinnedServerGroupTag;
+        })
+        .findFirst()
+        .orElse(null)
+      )
+      .filter(Objects::nonNull)
+      .collect(Collectors.toList());
+  }
+
+  boolean hasCompletedExecution(PinnedServerGroupTag pinnedServerGroupTag) {
+    try {
+      Execution execution = executionRepository.retrieve(
+        pinnedServerGroupTag.executionType, pinnedServerGroupTag.executionId
+      );
+
+      return execution.getStatus().isComplete();
+    } catch (ExecutionNotFoundException e) {
+      return true;
+    } catch (Exception e) {
+      log.warn("Unable to determine status of execution (executionId: {})", pinnedServerGroupTag.executionId, e);
+      errorsCounter.increment();
+      return false;
+    }
+  }
+
+  ServerGroup fetchServerGroup(String account, String region, String serverGroup) {
+    return retrySupport.retry(() -> {
+      try {
+        Response response = oortService.getServerGroup(account, region, serverGroup);
+        return objectMapper.readValue(response.getBody().in(), ServerGroup.class);
+      } catch (IOException e) {
+        throw new RuntimeException(
+          format(
+            "Unable to fetch server group (account: %s, region: %s, serverGroup: %s)", account, region, serverGroup
+          ),
+          e
+        );
+      }
+    }, 5, 2000, false);
+  }
+
+
+  private Map<String, Object> buildCleanupOperation(PinnedServerGroupTag pinnedServerGroupTag,
+                                                    ServerGroup serverGroup,
+                                                    List<Map<String, Object>> jobs) {
+    return ImmutableMap.<String, Object>builder()
+      .put("application", serverGroup.moniker.app)
+      .put(
+        "name",
+        format(
+          "Unpin Server Group: %s to %s/%s/%s",
+          pinnedServerGroupTag.serverGroup,
+          pinnedServerGroupTag.unpinnedCapacity.min,
+          serverGroup.capacity.desired,
+          serverGroup.capacity.max
+        )
+      )
+      .put("trigger", Collections.emptyMap())
+      .put("user", "Spinnaker")
+      .put("stages", jobs)
+      .build();
+  }
+
+  private Map<String, Object> buildDeleteEntityTagsOperation(PinnedServerGroupTag pinnedServerGroupTag, ServerGroup serverGroup) {
+    Map<String, Object> operation = new HashMap<>();
+
+    operation.put("application", serverGroup.moniker.app);
+    operation.put("type", "deleteEntityTags");
+    operation.put("id", pinnedServerGroupTag.entityTagsId);
+    operation.put("tags", Collections.singletonList(PINNED_CAPACITY_TAG));
+
+    return operation;
+  }
+
+  private Map<String, Object> buildResizeOperation(PinnedServerGroupTag pinnedServerGroupTag, ServerGroup serverGroup) {
+    return ImmutableMap.<String, Object>builder()
+      .put("refId", "1")
+      .put("asgName", pinnedServerGroupTag.serverGroup)
+      .put("serverGroupName", pinnedServerGroupTag.serverGroup)
+      .put("type", "resizeServerGroup")
+      .put("region", pinnedServerGroupTag.location)
+      .put("credentials", pinnedServerGroupTag.account)
+      .put("cloudProvider", pinnedServerGroupTag.cloudProvider)
+      .put("interestingHealthProviderNames", Collections.emptyList()) // no need to wait on health when only
+      .put("capacity", ImmutableMap.<String, Integer>builder()        // adjusting min capacity
+        .put("min", pinnedServerGroupTag.unpinnedCapacity.min)
+        .put("desired", serverGroup.capacity.desired)
+        .put("max", serverGroup.capacity.max)
+        .build()
+      )
+      .put("constraints", Collections.singletonMap("capacity", ImmutableMap.<String, Integer>builder()
+        .put("min", serverGroup.capacity.min)                         // ensure that the current capacity matches
+        .put("desired", serverGroup.capacity.desired)                 // expectations and has not changed since the
+        .put("max", serverGroup.capacity.max)                         // last caching cycle
+        .build())
+      )
+      .build();
+  }
+
+  private static class EntityTags {
+    public String id;
+    public List<Tag> tags;
+
+    private static class Tag {
+      public String name;
+      public Object value;
+    }
+  }
+
+  private static class PinnedServerGroupTag {
+    public String entityTagsId;
+    public String serverGroup;
+    public String account;
+    public String location;
+    public String cloudProvider;
+
+    public Execution.ExecutionType executionType;
+    public String executionId;
+    public String stageId;
+
+    public Capacity pinnedCapacity;
+    public Capacity unpinnedCapacity;
+  }
+
+  private static class ServerGroup {
+    public Capacity capacity;
+    public Moniker moniker;
+
+    private static class Moniker {
+      public String app;
+    }
+  }
+
+  private static class Capacity {
+    public Integer min;
+    public Integer desired;
+    public Integer max;
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/PinnedServerGroupTagGenerator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/PinnedServerGroupTagGenerator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Component
+public class PinnedServerGroupTagGenerator implements ServerGroupEntityTagGenerator {
+  public static final String PINNED_CAPACITY_TAG = "spinnaker:pinned_capacity";
+
+  @Override
+  public Collection<Map<String, Object>> generateTags(Stage stage,
+                                                      String serverGroup,
+                                                      String account,
+                                                      String location,
+                                                      String cloudProvider) {
+    StageData stageData = stage.mapTo(StageData.class);
+    if (stageData.capacity == null || stageData.sourceServerGroupCapacitySnapshot == null) {
+      return Collections.emptyList();
+    }
+
+    if (stageData.capacity.min.equals(stageData.sourceServerGroupCapacitySnapshot.min)) {
+      // min capacity was not actually pinned, no need to mark this server group as having a pinned capacity
+      return Collections.emptyList();
+    }
+
+    Map<String, Object> value = ImmutableMap.<String, Object>builder()
+      .put("serverGroup", serverGroup)
+      .put("account", account)
+      .put("location", location)
+      .put("cloudProvider", cloudProvider)
+      .put("executionId", stage.getExecution().getId())
+      .put("executionType", stage.getExecution().getType())
+      .put("stageId", stage.getId())
+      .put("pinnedCapacity", stageData.capacity.toMap())
+      .put("unpinnedCapacity", stageData.sourceServerGroupCapacitySnapshot.toMap())
+      .build();
+
+    return Collections.singletonList(
+      ImmutableMap.<String, Object>builder()
+        .put("name", PINNED_CAPACITY_TAG)
+        .put("value", value)
+        .build()
+    );
+  }
+
+  private static class StageData {
+    public Capacity capacity;
+    public Capacity sourceServerGroupCapacitySnapshot;
+
+    private static class Capacity {
+      public Integer min;
+      public Integer desired;
+      public Integer max;
+
+      Map<String, Integer> toMap() {
+        return ImmutableMap.<String, Integer>builder()
+          .put("min", min)
+          .put("desired", desired)
+          .put("max", max)
+          .build();
+      }
+    }
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStageSpec.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws
+
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.orca.clouddriver.FeaturesService
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.pipeline.entitytags.DeleteEntityTagsStage
+import spock.lang.Specification
+import spock.lang.Subject;
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class ApplySourceServerGroupCapacityStageSpec extends Specification {
+  def featuresService = Mock(FeaturesService)
+  def oortService = Mock(OortService)
+  def retrySupport = Spy(RetrySupport) {
+    _ * sleep(_) >> { /* do nothing */ }
+  }
+
+  def stage = stage {
+    context = [
+      serverGroupName       : "app-stack-details-v001",
+      credentials           : "test",
+      "deploy.server.groups": ["us-east-1": ["app-stack-details-v001"]]
+    ]
+  }
+
+  @Subject
+  def stageBuilder = new ApplySourceServerGroupCapacityStage(
+    featuresService: featuresService,
+    oortService: oortService,
+    retrySupport: retrySupport,
+    deleteEntityTagsStage: new DeleteEntityTagsStage()
+  )
+
+  def "should not generate any stages when 'upsertEntityTags' is not enabled"() {
+    when:
+    def afterStages = stageBuilder.afterStages(stage)
+
+    then:
+    1 * featuresService.isStageAvailable("upsertEntityTags") >> { return false }
+    0 * oortService.getEntityTags(_)
+
+    afterStages.isEmpty()
+  }
+
+  def "should not generate any stages when there are no entity tags"() {
+    when:
+    def afterStages = stageBuilder.afterStages(stage)
+
+    then:
+    1 * featuresService.isStageAvailable("upsertEntityTags") >> { return true }
+    1 * oortService.getEntityTags(_) >> { return [] }
+
+    afterStages.isEmpty()
+  }
+
+  def "should not generate any stages when an exception is raised"() {
+    when:
+    def afterStages = stageBuilder.afterStages(stage)
+
+    then:
+    notThrown(RuntimeException)
+
+    1 * featuresService.isStageAvailable("upsertEntityTags") >> { throw new RuntimeException("An Exception!") }
+    0 * oortService.getEntityTags(_)
+
+    afterStages.isEmpty()
+  }
+
+  def "should generate a delete entity tags stage when the server group has a `spinnaker:pinned_capacity` entity tag"() {
+    when:
+    def afterStages = stageBuilder.afterStages(stage)
+
+    then:
+    1 * featuresService.isStageAvailable("upsertEntityTags") >> { return true }
+    1 * oortService.getEntityTags([
+      "tag:spinnaker:pinned_capacity": "*",
+      "entityId"                     : "app-stack-details-v001",
+      "account"                      : "test",
+      "region"                       : "us-east-1"
+    ]) >> {
+      return [
+        [id: "my-entity-tags-id"]
+      ]
+    }
+
+    afterStages.size() == 1
+    afterStages[0].context == [
+      id  : "my-entity-tags-id",
+      tags: ["spinnaker:pinned_capacity"]
+    ]
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPollerSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPollerSpec.groovy
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pollers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.pipeline.ExecutionLauncher
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import redis.clients.util.Pool
+import spock.lang.Specification
+import spock.lang.Subject;
+
+class RestorePinnedServerGroupsPollerSpec extends Specification {
+  def jedisPool = Mock(Pool)
+  def objectMapper = new ObjectMapper()
+  def oortService = Mock(OortService)
+  def executionLauncher = Mock(ExecutionLauncher)
+  def executionRepository = Mock(ExecutionRepository)
+  def retrySupport = Spy(RetrySupport) {
+    _ * sleep(_) >> { /* do nothing */ }
+  }
+  def registry = Mock(Registry) {
+    createId(_) >> Mock(Id)
+    counter(_) >> Mock(Counter)
+  }
+
+  def pinnedServerGroupTag1 = new RestorePinnedServerGroupsPoller.PinnedServerGroupTag(
+    serverGroup: "app-stack-details-v001",
+    entityTagsId: "entity-tags-id-1",
+    account: "test",
+    location: "us-east-1",
+    cloudProvider: "aws",
+    executionType: Execution.ExecutionType.PIPELINE,
+    executionId: "execution-id-1",
+    pinnedCapacity: new RestorePinnedServerGroupsPoller.Capacity(min: 3, max: 5, desired: 3),
+    unpinnedCapacity: new RestorePinnedServerGroupsPoller.Capacity(min: 2, max: 5, desired: 3)
+  )
+
+  def pinnedServerGroupTag2 = new RestorePinnedServerGroupsPoller.PinnedServerGroupTag(
+    serverGroup: "app-stack-details-v002",
+    entityTagsId: "entity-tags-id-2",
+    account: "test",
+    location: "us-east-1",
+    cloudProvider: "aws",
+    executionType: Execution.ExecutionType.PIPELINE,
+    executionId: "execution-id-2",
+    pinnedCapacity: new RestorePinnedServerGroupsPoller.Capacity(min: 3, max: 5, desired: 3),
+    unpinnedCapacity: new RestorePinnedServerGroupsPoller.Capacity(min: 2, max: 5, desired: 3)
+  )
+
+  @Subject
+  def restorePinnedServerGroupsAgent = Spy(
+    RestorePinnedServerGroupsPoller,
+    constructorArgs: [
+      jedisPool, objectMapper, oortService, retrySupport, registry, executionLauncher, executionRepository
+    ]
+  )
+
+  def "should only unpin server group if corresponding execution is complete"() {
+    when:
+    restorePinnedServerGroupsAgent.poll()
+
+    then:
+    1 * restorePinnedServerGroupsAgent.fetchPinnedServerGroupTags() >> {
+      return [pinnedServerGroupTag1, pinnedServerGroupTag2]
+    }
+    1 * restorePinnedServerGroupsAgent.hasCompletedExecution(pinnedServerGroupTag1) >> { return true }
+    1 * restorePinnedServerGroupsAgent.hasCompletedExecution(pinnedServerGroupTag2) >> { return false }
+    1 * restorePinnedServerGroupsAgent.fetchServerGroup("test", "us-east-1", "app-stack-details-v001") >> {
+      return new RestorePinnedServerGroupsPoller.ServerGroup(
+        moniker: [app: "app"],
+        capacity: new RestorePinnedServerGroupsPoller.Capacity(min: 3, max: 5, desired: 3)
+      )
+    }
+    1 * executionLauncher.start(Execution.ExecutionType.ORCHESTRATION, { String configJson ->
+      def config = objectMapper.readValue(configJson, Map)
+      assert config.stages*.type == ["resizeServerGroup", "deleteEntityTags"]
+
+      return true
+    })
+  }
+
+  def "should only resize server group if current 'min' capacity matches pinned 'min' capacity"() {
+    given:
+    true
+
+    when:
+    restorePinnedServerGroupsAgent.poll()
+
+    then:
+    1 * restorePinnedServerGroupsAgent.fetchPinnedServerGroupTags() >> {
+      return [pinnedServerGroupTag1]
+    }
+    1 * restorePinnedServerGroupsAgent.hasCompletedExecution(pinnedServerGroupTag1) >> { return true }
+    1 * restorePinnedServerGroupsAgent.fetchServerGroup("test", "us-east-1", "app-stack-details-v001") >> {
+      return new RestorePinnedServerGroupsPoller.ServerGroup(
+        moniker: [app: "app"],
+        // current 'min' capacity no longer matches the pinned 'min' capacity, assume something else resized!
+        capacity: new RestorePinnedServerGroupsPoller.Capacity(min: 2, max: 5, desired: 3)
+      )
+    }
+    1 * executionLauncher.start(Execution.ExecutionType.ORCHESTRATION, { String configJson ->
+      def config = objectMapper.readValue(configJson, Map)
+
+      // no resize necessary!
+      assert config.stages*.type == ["deleteEntityTags"]
+
+      return true
+    })
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/PinnedServerGroupTagGeneratorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/PinnedServerGroupTagGeneratorSpec.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.PinnedServerGroupTagGenerator
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll;
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class PinnedServerGroupTagGeneratorSpec extends Specification {
+  @Subject
+  def pinnedServerGroupTagGenerator = new PinnedServerGroupTagGenerator()
+
+  @Unroll
+  def "should not generate a tag if pinned capacity (min) and original capacity (min) are the same"() {
+    given:
+    def stage = stage {
+      context = [
+        capacity                         : capacity,
+        sourceServerGroupCapacitySnapshot: sourceServerGroupCapacitySnapshot
+      ]
+    }
+
+    when:
+    def tags = pinnedServerGroupTagGenerator.generateTags(stage, "app-stack-details-v001", "test", "us-east-1", "aws")
+
+    then:
+    tags.isEmpty()
+
+    where:
+    capacity                     | sourceServerGroupCapacitySnapshot || _
+    [min: 2, max: 5, desired: 3] | null                              || _
+    null                         | [min: 2, max: 5, desired: 3]      || _
+    [min: 2, max: 5, desired: 3] | [min: 2, max: 5, desired: 3]      || _
+  }
+
+  def "should generate a tag when original 'min' capacity and pinned 'min' capacity differ"() {
+    given:
+    def stage = stage {
+      context = [
+        capacity                         : [min: 3, max: 5, desired: 3],
+        sourceServerGroupCapacitySnapshot: [min: 2, max: 5, desired: 3]
+      ]
+    }
+
+    when:
+    def tags = pinnedServerGroupTagGenerator.generateTags(stage, "app-stack-details-v001", "test", "us-east-1", "aws")
+
+    then:
+    tags == [
+      [
+        name : "spinnaker:pinned_capacity",
+        value: [
+          serverGroup: "app-stack-details-v001",
+          account: "test",
+          location: "us-east-1",
+          cloudProvider: "aws",
+          executionId: stage.execution.id,
+          executionType: stage.execution.type,
+          stageId: stage.id,
+          pinnedCapacity: [min: 3, max: 5, desired: 3],
+          unpinnedCapacity: [min: 2, max: 5, desired: 3]
+        ]
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
Spinnaker currently pins the minimum capacity on newly deployed server
groups (`min` = `desired`).

When the deploy completes, this capacity is unpinned and the `min` is
set to the `min` of the source server group.

_If_ the deploy does not complete successfully, the newly created server
group is never unpinned.

This PR introduces a new entity tag `spinnaker:pinned_capacity` that
records both the pinned and unpinned capacities. A background agent
periodically looks for server groups that remain pinned despite the
originating execution having completed.

There is no impact if entity tags are not enabled.
