### PR TITLE
fix(canary-v2): Use new /canary/{executionId} entry point.

### DIFF
--- a/orca-kayenta/src/main/groovy/com/netflix/spinnaker/orca/kayenta/KayentaService.groovy
+++ b/orca-kayenta/src/main/groovy/com/netflix/spinnaker/orca/kayenta/KayentaService.groovy
@@ -28,8 +28,9 @@ interface KayentaService {
              @Query("storageAccountName") String storageAccountName,
              @Body Map<String, String> canaryExecutionRequest)
 
-  @GET("/pipelines/{executionId}")
-  Execution getPipelineExecution(@Path("executionId") String executionId)
+  @GET("/canary/{canaryExecutionId}")
+  Map getCanaryResults(@Query("storageAccountName") String storageAccountName,
+                       @Path("canaryExecutionId") String canaryExecutionId)
 
   @PUT("/pipelines/{executionId}/cancel")
   Map cancelPipelineExecution(@Path("executionId") String executionId, @Body String ignored)

--- a/orca-kayenta/src/main/groovy/com/netflix/spinnaker/orca/kayenta/pipeline/KayentaCanaryStage.groovy
+++ b/orca-kayenta/src/main/groovy/com/netflix/spinnaker/orca/kayenta/pipeline/KayentaCanaryStage.groovy
@@ -50,6 +50,7 @@ class KayentaCanaryStage implements StageDefinitionBuilder {
     String metricsAccountName = canaryConfig.metricsAccountName
     String storageAccountName = canaryConfig.storageAccountName
     String canaryConfigId = canaryConfig.canaryConfigId
+    String scopeName = canaryConfig.scopeName
     String controlScope = canaryConfig.controlScope
     String controlRegion = canaryConfig.controlRegion
     String experimentScope = canaryConfig.experimentScope
@@ -107,6 +108,7 @@ class KayentaCanaryStage implements StageDefinitionBuilder {
         metricsAccountName: metricsAccountName,
         storageAccountName: storageAccountName,
         canaryConfigId: canaryConfigId,
+        scopeName: scopeName,
         controlScope: controlScope,
         controlRegion: controlRegion,
         experimentScope: experimentScope,

--- a/orca-kayenta/src/main/groovy/com/netflix/spinnaker/orca/kayenta/pipeline/RunCanaryPipelineStage.groovy
+++ b/orca-kayenta/src/main/groovy/com/netflix/spinnaker/orca/kayenta/pipeline/RunCanaryPipelineStage.groovy
@@ -53,12 +53,16 @@ class RunCanaryPipelineStage implements StageDefinitionBuilder, CancellableStage
     Map<String, Object> context = stage.getContext()
     String canaryPipelineExecutionId = (String)context.get("canaryPipelineExecutionId")
 
-    log.info("Cancelling stage (stageId: $stage.id: executionId: $stage.execution.id, canaryPipelineExecutionId: $canaryPipelineExecutionId, context: $stage.context)")
+    if (canaryPipelineExecutionId) {
+      log.info("Cancelling stage (stageId: $stage.id: executionId: $stage.execution.id, canaryPipelineExecutionId: $canaryPipelineExecutionId, context: $stage.context)")
 
-    try {
-      kayentaService.cancelPipelineExecution(canaryPipelineExecutionId, "")
-    } catch (Exception e) {
-      log.error("Failed to cancel stage (stageId: $stage.id, executionId: $stage.execution.id), e: $e.message", e)
+      try {
+        kayentaService.cancelPipelineExecution(canaryPipelineExecutionId, "")
+      } catch (Exception e) {
+        log.error("Failed to cancel stage (stageId: $stage.id, executionId: $stage.execution.id), e: $e.message", e)
+      }
+    } else {
+      log.info("Not cancelling stage (stageId: $stage.id: executionId: $stage.execution.id, context: $stage.context) since no canary pipeline execution id exists")
     }
 
     return new CancellableStage.Result(stage, [:])

--- a/orca-kayenta/src/main/groovy/com/netflix/spinnaker/orca/kayenta/tasks/RunKayentaCanaryTask.groovy
+++ b/orca-kayenta/src/main/groovy/com/netflix/spinnaker/orca/kayenta/tasks/RunKayentaCanaryTask.groovy
@@ -24,8 +24,6 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import retrofit.client.Response
-import retrofit.mime.TypedByteArray
 
 import javax.annotation.Nonnull
 
@@ -42,6 +40,7 @@ class RunKayentaCanaryTask implements Task {
     String metricsAccountName = (String)context.get("metricsAccountName")
     String storageAccountName = (String)context.get("storageAccountName")
     String canaryConfigId = (String)context.get("canaryConfigId")
+    String scopeName = (String)context.get("scopeName") ?: "default"
     String controlScope = (String)context.get("controlScope")
     String controlRegion = (String)context.get("controlRegion")
     String experimentScope = (String)context.get("experimentScope")
@@ -52,21 +51,25 @@ class RunKayentaCanaryTask implements Task {
     Map<String, String> extendedScopeParams = (Map<String, String>)context.get("extendedScopeParams")
     Map<String, String> scoreThresholds = (Map<String, String>)context.get("scoreThresholds")
     Map<String, String> canaryExecutionRequest = [
-      controlScope: [
-        scope: controlScope,
-        region: controlRegion,
-        start: startTimeIso,
-        end: endTimeIso,
-        step: step,
-        extendedScopeParams: extendedScopeParams
-      ],
-      experimentScope: [
-        scope: experimentScope,
-        region: experimentRegion,
-        start: startTimeIso,
-        end: endTimeIso,
-        step: step,
-        extendedScopeParams: extendedScopeParams
+      scopes: [
+        (scopeName): [
+          controlScope: [
+            scope: controlScope,
+            region: controlRegion,
+            start: startTimeIso,
+            end: endTimeIso,
+            step: step,
+            extendedScopeParams: extendedScopeParams
+          ],
+          experimentScope: [
+            scope: experimentScope,
+            region: experimentRegion,
+            start: startTimeIso,
+            end: endTimeIso,
+            step: step,
+            extendedScopeParams: extendedScopeParams
+          ]
+        ]
       ],
       thresholds: [
         pass: scoreThresholds?.pass,


### PR DESCRIPTION
Also add support for scope name and improve handling of exceptions and cancelations.