### PR TITLE
feat(webhooks): support preconfig params

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -222,7 +222,8 @@ class OperationsController {
         type: it.type,
         waitForCompletion: it.waitForCompletion,
         preconfiguredProperties: it.preconfiguredProperties,
-        noUserConfigurableFields: it.noUserConfigurableFields()
+        noUserConfigurableFields: it.noUserConfigurableFields(),
+        parameters: it.parameters,
       ]
     }
   }

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -583,8 +583,8 @@ class OperationsControllerSpec extends Specification {
       createPreconfiguredWebhook("Webhook #2", "Description #2", "webhook_2")
     ]
     preconfiguredWebhooks == [
-      [label: "Webhook #1", description: "Description #1", type: "webhook_1", waitForCompletion: true, preconfiguredProperties: preconfiguredProperties, noUserConfigurableFields: true],
-      [label: "Webhook #2", description: "Description #2", type: "webhook_2", waitForCompletion: true, preconfiguredProperties: preconfiguredProperties, noUserConfigurableFields: true]
+      [label: "Webhook #1", description: "Description #1", type: "webhook_1", waitForCompletion: true, preconfiguredProperties: preconfiguredProperties, noUserConfigurableFields: true, parameters: null],
+      [label: "Webhook #2", description: "Description #2", type: "webhook_2", waitForCompletion: true, preconfiguredProperties: preconfiguredProperties, noUserConfigurableFields: true, parameters: null]
     ]
   }
 
@@ -596,7 +596,7 @@ class OperationsControllerSpec extends Specification {
       label: label, description: description, type: type,
       url: "a", customHeaders: customHeaders, method: HttpMethod.POST, payload: "b",
       waitForCompletion: true, statusUrlResolution: PreconfiguredWebhookProperties.StatusUrlResolution.webhookResponse,
-      statusUrlJsonPath: "c", statusJsonPath: "d", progressJsonPath: "e", successStatuses: "f", canceledStatuses: "g", terminalStatuses: "h"
+      statusUrlJsonPath: "c", statusJsonPath: "d", progressJsonPath: "e", successStatuses: "f", canceledStatuses: "g", terminalStatuses: "h", parameters: null
     )
   }
 }

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookProperties.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookProperties.groovy
@@ -26,7 +26,7 @@ import org.springframework.http.HttpMethod
 class PreconfiguredWebhookProperties {
 
   public static List<String> ALL_FIELDS = PreconfiguredWebhook.declaredFields.findAll {
-    !it.synthetic && !['props', 'enabled', 'label', 'description', 'type'].contains(it.name)
+    !it.synthetic && !['props', 'enabled', 'label', 'description', 'type', 'parameters', 'parameterValues'].contains(it.name)
   }.collect { it.name }
 
   List<PreconfiguredWebhook> preconfigured = []
@@ -37,10 +37,12 @@ class PreconfiguredWebhookProperties {
     String label
     String description
     String type
+    List<WebhookParameter> parameters
 
     // Stage configuration fields (all optional):
     String url
     Map<String, List<String>> customHeaders
+    Map<String, String> parameterValues
     HttpMethod method
     String payload
     Boolean waitForCompletion
@@ -51,6 +53,7 @@ class PreconfiguredWebhookProperties {
     String successStatuses
     String canceledStatuses
     String terminalStatuses
+
 
     List<String> getPreconfiguredProperties() {
       return ALL_FIELDS.findAll { this[it] != null }
@@ -64,6 +67,18 @@ class PreconfiguredWebhookProperties {
       } else {
         return ["url", "customHeaders", "method", "payload"].every { this[it] != null }
       }
+    }
+  }
+
+  static class WebhookParameter {
+    String name
+    String label
+    String defaultValue
+    String description
+    ParameterType type = ParameterType.string
+
+    static enum ParameterType {
+      string
     }
   }
 

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStage.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStage.groovy
@@ -32,7 +32,7 @@ class PreconfiguredWebhookStage extends WebhookStage {
   private WebhookService webhookService
 
   def fields = PreconfiguredWebhook.declaredFields.findAll {
-    !it.synthetic && !['props', 'enabled', 'label', 'description', 'type'].contains(it.name)
+    !it.synthetic && !['props', 'enabled', 'label', 'description', 'type', 'parameters'].contains(it.name)
   }.collect { it.name }
 
   @Override

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
@@ -56,7 +56,8 @@ class PreconfiguredWebhookStageSpec extends Specification {
       progressJsonPath: "e",
       successStatuses: "f",
       canceledStatuses: "g",
-      terminalStatuses: "h"
+      terminalStatuses: "h",
+      parameterValues: null
     ]
   }
 
@@ -74,7 +75,8 @@ class PreconfiguredWebhookStageSpec extends Specification {
       progressJsonPath: "e",
       successStatuses: "f",
       canceledStatuses: "g",
-      terminalStatuses: "h"
+      terminalStatuses: "h",
+      parameterValues: null
     ])
 
     when:
@@ -94,7 +96,8 @@ class PreconfiguredWebhookStageSpec extends Specification {
       progressJsonPath: "e",
       successStatuses: "f",
       canceledStatuses: "g",
-      terminalStatuses: "h"
+      terminalStatuses: "h",
+      parameterValues: null
     ]
   }
 


### PR DESCRIPTION
adds support for configuring predefined parameters as part of a
preconfigured webhook stage. this will allows admins to add options for
users to fill out. the values set by users can then be used in the other
options via SPEL. this is a really basic implementation and only
supports string types options.

spinnaker/spinnaker#2224

@robzienert @robfletcher @ajordens could some of you guys take a look at this. it's my first orca PR and _seems_ like it was easier than it should have been. i'm open to having a deeper conversation around it if need be. thanks!
