### PR TITLE
feat(tasks) - adds configuration property to waitForCluster timeouts

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
@@ -27,14 +27,20 @@ import groovy.transform.Canonical
 import groovy.transform.ToString
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 
 @Slf4j
 abstract class AbstractWaitForClusterWideClouddriverTask extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
   @Override
   public long getBackoffPeriod() { 10000 }
 
+  @Value('${tasks.waitForClusterTimeout:1800000}')
+  public long defaultTimeout
+
   @Override
-  public long getTimeout() { 1800000 }
+  public long getTimeout() {
+    return this.defaultTimeout
+  }
 
   @Autowired
   OortHelper oortHelper


### PR DESCRIPTION
Adds a configuration property to allow for longer timeouts for WaitForCluster tasks.   The default is 30 minutes.

Example of having a timeout of 60 minutes:
```
tasks:
  waitForClusterTimeout: 3600000
```