### PR TITLE
chore(core): Consistency around `Millis` suffix on `task.*` values

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
@@ -34,7 +34,7 @@ abstract class AbstractWaitForClusterWideClouddriverTask extends AbstractCloudPr
   @Override
   public long getBackoffPeriod() { 10000 }
 
-  @Value('${tasks.waitForClusterTimeout:1800000}')
+  @Value('${tasks.waitForClusterTimeoutMillis:1800000}')
   public long defaultTimeout
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/WaitForUpsertedImageTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/WaitForUpsertedImageTagsTask.java
@@ -34,8 +34,8 @@ public class WaitForUpsertedImageTagsTask implements RetryableTask, CloudProvide
   @Autowired
   List<ImageTagger> imageTaggers;
 
-  @Value("${tasks.waitForUpsertedImageTagsTimeout:600}")
-  private long waitForUpsertedImageTagsTimeout;
+  @Value("${tasks.waitForUpsertedImageTagsTimeoutMillis:600000}")
+  private Long waitForUpsertedImageTagsTimeoutMillis;
 
   @Override
   public TaskResult execute(Stage stage) {
@@ -59,7 +59,7 @@ public class WaitForUpsertedImageTagsTask implements RetryableTask, CloudProvide
 
   @Override
   public long getTimeout() {
-    return TimeUnit.SECONDS.toMillis(this.waitForUpsertedImageTagsTimeout);
+    return this.waitForUpsertedImageTagsTimeoutMillis;
   }
 
   static class StageData {


### PR DESCRIPTION
We have a few situatations where task timeouts are overridable:

- tasks.waitForClusterTimeout (value is expected to be milliseconds)
- tasks.waitForUpsertedImageTagsTimeout (value is expected to be seconds)
- tasks.disableClusterMinTimeMillis (value is expected to be milliseconds)

The first two were added in the last 1-2 weeks, the latter was merged in
late November.

My preference would be to align around the suffix for these sort of
properties, even if it might mean a breaking change right now.
