### PR TITLE
perf(clouddriver): skip cooldown on disable if no server groups disabled

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
@@ -54,8 +54,8 @@ class WaitForClusterDisableTask extends AbstractWaitForClusterWideClouddriverTas
     def taskResult = super.execute(stage)
 
     def duration = System.currentTimeMillis() - stage.startTime
-    if (taskResult.status == ExecutionStatus.SUCCEEDED && duration < MINIMUM_WAIT_TIME_MS) {
-      // wait at least MINIMUM_WAIT_TIME to account for any necessary connection draining to occur
+    if (stage.context['deploy.server.groups'] && taskResult.status == ExecutionStatus.SUCCEEDED && duration < MINIMUM_WAIT_TIME_MS) {
+      // wait at least MINIMUM_WAIT_TIME to account for any necessary connection draining to occur if there were actually server groups
       return new TaskResult(ExecutionStatus.RUNNING, taskResult.context, taskResult.outputs)
     }
 


### PR DESCRIPTION
If there are no connections to drain, don't wait 90 seconds before proceeding.

This speeds up shrink cluster operations that are essentially no-ops.