### PR TITLE
chore(restarts): remove redundant logic from stage restart methods

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
@@ -15,7 +15,6 @@
  */
 package com.netflix.spinnaker.orca.front50.pipeline;
 
-import java.util.List;
 import com.netflix.spinnaker.orca.CancellableStage;
 import com.netflix.spinnaker.orca.RestartableStage;
 import com.netflix.spinnaker.orca.front50.tasks.MonitorPipelineTask;
@@ -24,13 +23,11 @@ import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
-import com.netflix.spinnaker.orca.pipeline.model.Task;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import static com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED;
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
@@ -57,19 +54,9 @@ public class PipelineStage implements StageDefinitionBuilder, RestartableStage, 
 
   @Override
   public void prepareStageForRestart(Stage stage) {
-    stage.setStartTime(null);
-    stage.setEndTime(null);
-
     stage.getContext().remove("status");
     stage.getContext().remove("executionName");
     stage.getContext().remove("executionId");
-
-    List<Task> tasks = stage.getTasks();
-    tasks.forEach(task -> {
-      task.setStartTime(null);
-      task.setEndTime(null);
-      task.setStatus(NOT_STARTED);
-    });
   }
 
   @Override

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/JenkinsStage.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/JenkinsStage.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.orca.igor.pipeline
 
 import com.netflix.spinnaker.orca.CancellableStage
-import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.RestartableStage
 import com.netflix.spinnaker.orca.igor.tasks.MonitorJenkinsJobTask
 import com.netflix.spinnaker.orca.igor.tasks.MonitorQueuedJenkinsJobTask
@@ -26,7 +25,6 @@ import com.netflix.spinnaker.orca.igor.tasks.StopJenkinsJobTask
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.pipeline.model.Task
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -49,21 +47,12 @@ public class JenkinsStage implements StageDefinitionBuilder, RestartableStage, C
 
   @Override
   void prepareStageForRestart(Stage stage) {
-    stage.startTime = null
-    stage.endTime = null
-
     if (stage.context.buildInfo) {
       if (!stage.context.restartDetails) stage.context.restartDetails = [:]
       stage.context.restartDetails["previousBuildInfo"] = stage.context.buildInfo
     }
     stage.context.remove("buildInfo")
     stage.context.remove("buildNumber")
-
-    stage.tasks.each { Task task ->
-      task.startTime = null
-      task.endTime = null
-      task.status = ExecutionStatus.NOT_STARTED
-    }
   }
 
   @Override

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/ScriptStage.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/ScriptStage.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca.igor.pipeline
 
-import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.RestartableStage
 import com.netflix.spinnaker.orca.igor.tasks.MonitorJenkinsJobTask
 import com.netflix.spinnaker.orca.igor.tasks.MonitorQueuedJenkinsJobTask
@@ -24,7 +23,6 @@ import com.netflix.spinnaker.orca.igor.tasks.StartScriptTask
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.pipeline.model.Task
 import groovy.transform.CompileStatic
 import org.springframework.stereotype.Component
 
@@ -45,20 +43,11 @@ class ScriptStage implements StageDefinitionBuilder, RestartableStage {
 
   @Override
   void prepareStageForRestart(Stage stage) {
-    stage.startTime = null
-    stage.endTime = null
-
     if (stage.context.buildInfo) {
       if (!stage.context.restartDetails) stage.context.restartDetails = [:]
       stage.context.restartDetails["previousBuildInfo"] = stage.context.buildInfo
     }
     stage.context.remove("buildInfo")
     stage.context.remove("buildNumber")
-
-    stage.tasks.each { Task task ->
-      task.startTime = null
-      task.endTime = null
-      task.status = ExecutionStatus.NOT_STARTED
-    }
   }
 }

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStage.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.orca.mine.pipeline
 
 import com.netflix.spinnaker.orca.CancellableStage
-import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.RestartableStage
 import com.netflix.spinnaker.orca.mine.MineService
 import com.netflix.spinnaker.orca.mine.tasks.CompleteCanaryTask
@@ -49,9 +48,6 @@ class AcaTaskStage implements StageDefinitionBuilder, CancellableStage, Restarta
 
   @Override
   void prepareStageForRestart(Stage stage) {
-    stage.startTime = null
-    stage.endTime = null
-
     if (stage.context.canary) {
       def previousCanary = stage.context.canary.clone()
       if (!stage.context.restartDetails) stage.context.restartDetails = [:]
@@ -64,16 +60,6 @@ class AcaTaskStage implements StageDefinitionBuilder, CancellableStage, Restarta
       stage.context.canary.remove("canaryResult")
       stage.context.canary.remove("status")
       stage.context.canary.remove("health")
-
-      //Canceling the canary marks the stage as CANCELED preventing it from restarting.
-      stage.setStatus(ExecutionStatus.NOT_STARTED)
-    }
-
-
-    stage.tasks.each { task ->
-      task.startTime = null
-      task.endTime = null
-      task.status = ExecutionStatus.NOT_STARTED
     }
   }
 

--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStageSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/AcaTaskStageSpec.groovy
@@ -59,16 +59,8 @@ class AcaTaskStageSpec extends Specification {
     stage.context.canary.health == null
     stage.status == ExecutionStatus.NOT_STARTED
 
-    and: "reset the tasks"
-    stage.tasks.each { task ->
-      assert task.startTime == null
-      assert task.endTime == null
-      assert task.status == ExecutionStatus.NOT_STARTED
-    }
-
     and: "the canary should be cancelled"
     1 * mineService.cancelCanary(_, _)
-
   }
 
   def "restart aca task should not cancel off the original canary if there is no canary id and clean up the stage context"() {
@@ -104,16 +96,8 @@ class AcaTaskStageSpec extends Specification {
     stage.context.canary.health == null
     stage.status == ExecutionStatus.NOT_STARTED
 
-    and: "reset the tasks"
-    stage.tasks.each { task ->
-      assert task.startTime == null
-      assert task.endTime == null
-      assert task.status == ExecutionStatus.NOT_STARTED
-    }
-
     and: "the canceled call of the canary should not be called"
     0 * mineService.cancelCanary(_, _)
-
   }
 
   def createCanary(String id) {


### PR DESCRIPTION
Resetting start/end time, status, and tasks is handled from the place `prepareStageForRestart` is called so there's no need for implementations of that method do such things.
