### PR TITLE
More useful dry run

### DIFF
--- a/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/groovy/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -462,6 +462,17 @@ public class Stage implements Serializable {
   }
 
   /**
+   * Returns the parent of this stage or null if it is a top-level stage.
+   */
+  @JsonIgnore public @Nullable Stage getParent() {
+    if (parentStageId == null) {
+      return null;
+    } else {
+      return execution.stageById(parentStageId);
+    }
+  }
+
+  /**
    * Returns the top-most stage.
    */
   @JsonIgnore public Stage getTopLevelStage() {

--- a/orca-dry-run/orca-dry-run.gradle
+++ b/orca-dry-run/orca-dry-run.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
   compile project(":orca-core")
 
+  testCompile "org.assertj:assertj-core:3.9.0"
   testCompile "org.springframework.boot:spring-boot-test:${spinnaker.version('springBoot')}"
   testCompile project(":orca-test")
   testCompile project(":orca-queue-tck")

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunStage.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunStage.kt
@@ -20,12 +20,11 @@ import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.TaskNode.Builder
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import kotlin.reflect.KClass
 
 class DryRunStage(private val delegate: StageDefinitionBuilder) : StageDefinitionBuilder {
 
   override fun taskGraph(stage: Stage, builder: Builder) {
-    builder.withTask("dry run", DryRunTask::class)
+    builder.withTask<DryRunTask>("dry run")
   }
 
   override fun aroundStages(stage: Stage): List<Stage>
@@ -36,6 +35,6 @@ class DryRunStage(private val delegate: StageDefinitionBuilder) : StageDefinitio
 
   override fun getType() = delegate.type
 
-  private fun Builder.withTask(name: String, type: KClass<out Task>) =
-    withTask(name, type.java)
+  private inline fun <reified T : Task> Builder.withTask(name: String) =
+    withTask(name, T::class.java)
 }

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunTask.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunTask.kt
@@ -35,9 +35,8 @@ class DryRunTask : Task {
     }
 
   private fun Stage.triggerOutputs(): Map<String, Any> {
-    val parameters = execution.trigger["parameters"] as Map<String, Any>?
+    val outputs = execution.trigger["outputs"] as Map<String, Any>?
       ?: emptyMap()
-    val outputs = parameters["outputs"] as Map<String, Any>? ?: emptyMap()
     return outputs[refId] as Map<String, Any>? ?: emptyMap()
   }
 

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunTask.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunTask.kt
@@ -16,115 +16,30 @@
 
 package com.netflix.spinnaker.orca.dryrun
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature.WRITE_NULL_MAP_VALUES
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.ExecutionStatus.SKIPPED
-import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
+import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
-import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
-import com.netflix.spinnaker.orca.pipeline.model.Execution
-import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
 class DryRunTask : Task {
-  private val blacklistKeyPatterns =
-    setOf(
-      "amiSuffix",
-      "kato\\..*",
-      "spelEvaluator",
-      "stageDetails",
-      "useSourceCapacity"
-    )
-      .map(String::toRegex)
 
   override fun execute(stage: Stage): TaskResult =
-    stage
-      .execution
-      .let { execution ->
-        if (execution.type == PIPELINE) {
-          realStage(execution, stage)
-            .let { realStage ->
-              stage.evaluateStage(realStage)
-            }
-        } else {
-          log.error("Dry run is only supported for pipelines")
-          TaskResult(TERMINAL)
-        }
+    stage.triggerOutputs().let { outputs ->
+      stage.execution.also { execution ->
+        log.info("Dry run of ${execution.application} ${execution.name} ${execution.id} stage ${stage.type} ${stage.refId} outputting $outputs")
       }
-
-  private fun Stage.evaluateStage(realStage: Stage): TaskResult {
-    val dryRunResult = mutableMapOf<String, Any>()
-    var status: ExecutionStatus? = null
-
-    val diff = context.removeNulls().diffKeys(realStage.context.removeNulls())
-
-    if (diff.isNotEmpty()) {
-      dryRunResult["context"] = diff
-        .mapValues { (key, value) ->
-          "Expected \"${realStage.context[key]}\" but found \"$value\"."
-        }
-      status = TERMINAL
+      TaskResult(SUCCEEDED, emptyMap<String, Any>(), outputs)
     }
 
-    if (realStage.status == SKIPPED) {
-      dryRunResult["errors"] = listOf("Expected stage to be skipped.")
-      status = TERMINAL
-    }
-
-    return TaskResult(
-      status ?: realStage.status,
-      realStage.context + diff,
-      realStage.outputs + if (dryRunResult.isNotEmpty()) mapOf("dryRunResult" to dryRunResult) else emptyMap()
-    )
+  private fun Stage.triggerOutputs(): Map<String, Any> {
+    val parameters = execution.trigger["parameters"] as Map<String, Any>?
+      ?: emptyMap()
+    val outputs = parameters["outputs"] as Map<String, Any>? ?: emptyMap()
+    return outputs[refId] as Map<String, Any>? ?: emptyMap()
   }
-
-  private fun Map<String, *>.removeNulls() =
-    // this is a quick way to remove nested null values
-    mapper.writeValueAsString(this).let { json ->
-      mapper.readValue<Map<String, *>>(json)
-    }
-
-  private inline fun <reified T> ObjectMapper.readValue(src: String): T = readValue(src, T::class.java)
-
-  private fun Map<String, *>.diffKeys(other: Map<String, *>): Map<String, Any?> =
-    filterKeys { key ->
-      blacklistKeyPatterns.none(key::matches)
-    }
-      .filter { (key, value) ->
-        value != other[key]
-      }
-
-  private fun realStage(execution: Execution, stage: Stage): Stage {
-    return execution
-      .trigger["lastSuccessfulExecution"]
-      .let { realPipeline ->
-        when (realPipeline) {
-          is Execution -> realPipeline
-          is Map<*, *> -> mapper.convertValue(realPipeline)
-          else -> throw IllegalStateException("No triggering pipeline execution found")
-        }
-      }
-      .stageByRef(stage.refId)
-  }
-
-  private val mapper = OrcaObjectMapper
-    .newInstance()
-    .apply {
-      disable(WRITE_NULL_MAP_VALUES)
-      SimpleModule()
-        .addSerializer(RoundingFloatSerializer())
-        .addSerializer(RoundingDoubleSerializer())
-        .let(this::registerModule)
-    }
 
   private val log = LoggerFactory.getLogger(javaClass)
-
-  private inline fun <reified T> ObjectMapper.convertValue(fromValue: Any): T =
-    convertValue(fromValue, T::class.java)
 }

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/BakeOutputStub.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/BakeOutputStub.kt
@@ -47,8 +47,4 @@ class BakeOutputStub : OutputStub {
         }
       )
     }
-
-  @Suppress("UNCHECKED_CAST")
-  private val Stage.regions: List<String>
-    get() = context["regions"] as List<String>? ?: emptyList()
 }

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/BakeOutputStub.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/BakeOutputStub.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.dryrun.stub
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.stereotype.Component
+
+@Component
+class BakeOutputStub : OutputStub {
+
+  override fun supports(stageType: String) = stageType == "bake"
+
+  override fun outputs(stage: Stage) =
+    if (stage.parent?.type == "bake") {
+      emptyMap()
+    } else {
+      mapOf(
+        "deploymentDetails" to (stage.regions).map { region ->
+          randomHex(8).let { id ->
+            mapOf(
+              "ami" to "ami-$id",
+              "imageId" to "ami-$id",
+              "amiSuffix" to timestamp(),
+              "baseLabel" to "release",
+              "baseOs" to "trusty",
+              "storeType" to "ebs",
+              "vmType" to "hvm",
+              "region" to region,
+              "package" to stage.execution.application,
+              "cloudProvider" to "aws"
+            )
+          }
+        }
+      )
+    }
+
+  @Suppress("UNCHECKED_CAST")
+  private val Stage.regions: List<String>
+    get() = context["regions"] as List<String>? ?: emptyList()
+}

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/FindImageFromTagsOutputStub.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/FindImageFromTagsOutputStub.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.dryrun.stub
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.stereotype.Component
+
+@Component
+class FindImageFromTagsOutputStub : OutputStub {
+  override fun supports(stageType: String) = stageType == "findImageFromTags"
+
+  override fun outputs(stage: Stage): Map<String, Any> =
+    mapOf(
+      "deploymentDetails" to stage.regions.map { region ->
+        Pair(randomHex(8), randomNumeric(4)).let { (id, build) ->
+          mapOf(
+            "imageName" to "${stage.execution.application}-${randomNumeric(1)}.${randomNumeric(4)}.0-h${build}.${randomHex(7)}-x86_64-${timestamp()}-trusty-hvm-sriov-ebs",
+            "imageId" to "ami-$id",
+            "jenkins" to mapOf(
+              "number" to build,
+              "host" to "http://jenkins/",
+              "name" to "ami-$id"
+            ),
+            "ami" to "ami-$id",
+            "region" to region
+          )
+        }
+      }
+    )
+}

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/FindImageOutputStub.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/FindImageOutputStub.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.dryrun.stub
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.stereotype.Component
+
+@Component
+class FindImageOutputStub : OutputStub {
+  override fun supports(stageType: String) = stageType == "findImage"
+
+  override fun outputs(stage: Stage): Map<String, Any> = mapOf(
+    "deploymentDetails" to stage.regions.map { region ->
+      Pair(randomHex(8), randomNumeric(4)).let { (id, build) ->
+        val version = "${randomNumeric(1)}.${randomNumeric(4)}.0"
+        val image = "${stage.execution.application}-${version}-h${build}.${randomHex(7)}-x86_64-${timestamp()}-trusty-hvm-sriov-ebs"
+        mapOf(
+          "ami" to "ami-$id",
+          "imageId" to "ami-$id",
+          "imageName" to image,
+          "cloudProvider" to "aws",
+          "sourceServerGroup" to "${stage.context["cluster"]}-v${randomNumeric(3)}",
+          "region" to region,
+          "virtualizationType" to "hvm",
+          "blockDeviceMappings" to emptyList<Map<String, Any>>(),
+          "description" to "name=${stage.execution.application}, arch=x86_64, ancestor_name=trustybase-x86_64-${randomNumeric(10)}-ebs, ancestor_id=ami-${randomHex(8)}",
+          "enaSupport" to true,
+          "ownerId" to randomNumeric(12),
+          "creationDate" to "2017-11-29T21:30:42.000Z",
+          "imageLocation" to "${randomNumeric(12)}/${image}",
+          "rootDeviceType" to "ebs",
+          "tags" to emptyList<Map<String, Any>>(),
+          "public" to false,
+          "sriovNetSupport" to "simple",
+          "hypervisor" to "xen",
+          "name" to image,
+          "rootDeviceName" to "/dev/sda1",
+          "productCodes" to emptyList<Any>(),
+          "state" to "available",
+          "imageType" to "machine",
+          "architecture" to "x86_64",
+          "package_name" to stage.execution.application,
+          "version" to version,
+          "commit" to randomHex(7),
+          "jenkins" to mapOf(
+            "number" to build,
+            "host" to "http://jenkins/",
+            "name" to "ami-$id"
+          )
+        )
+      }
+    }
+  )
+}

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/OutputStub.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/OutputStub.kt
@@ -28,12 +28,15 @@ interface OutputStub {
   /**
    * Return `true` if a stage type is supported by this stub.
    */
-  fun supports(stageType: String): Boolean = false
+  fun supports(stageType: String): Boolean
 
   /**
    * Generate stub output. This can be based on things in the stage context if
    * necessary.
    */
-  fun outputs(stage: Stage): Map<String, Any> = emptyMap()
+  fun outputs(stage: Stage): Map<String, Any>
 
+  @Suppress("UNCHECKED_CAST")
+  val Stage.regions: List<String>
+    get() = context["regions"] as List<String>? ?: emptyList()
 }

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/OutputStub.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/OutputStub.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.dryrun.stub
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+
+/**
+ * Certain stages may benefit from outputting dummy data in order that they
+ * generate some kind of representative output. Implement this interface in that
+ * case.
+ */
+interface OutputStub {
+
+  /**
+   * Return `true` if a stage type is supported by this stub.
+   */
+  fun supports(stageType: String): Boolean = false
+
+  /**
+   * Generate stub output. This can be based on things in the stage context if
+   * necessary.
+   */
+  fun outputs(stage: Stage): Map<String, Any> = emptyMap()
+
+}

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/random.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/random.kt
@@ -31,3 +31,10 @@ internal fun randomHex(length: Int) = UUID
   .absoluteValue
   .toString(16)
   .substring(0 until minOf(length, 16))
+
+internal fun randomNumeric(length: Int) = UUID
+  .randomUUID()
+  .leastSignificantBits
+  .absoluteValue
+  .toString(10)
+  .substring(0 until minOf(length, 16))

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/random.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/stub/random.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.dryrun.stub
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.*
+import kotlin.math.absoluteValue
+
+internal fun timestamp(format: String = "yyyyMMddHHmmss") = DateTimeFormatter
+  .ofPattern(format)
+  .format(LocalDateTime.now())
+
+internal fun randomHex(length: Int) = UUID
+  .randomUUID()
+  .leastSignificantBits
+  .absoluteValue
+  .toString(16)
+  .substring(0 until minOf(length, 16))

--- a/orca-dry-run/src/test/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunTaskTest.kt
+++ b/orca-dry-run/src/test/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunTaskTest.kt
@@ -17,17 +17,22 @@
 package com.netflix.spinnaker.orca.dryrun
 
 import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.dryrun.stub.OutputStub
 import com.netflix.spinnaker.orca.q.pipeline
 import com.netflix.spinnaker.orca.q.stage
+import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
 
 object DryRunTaskTest : Spek({
 
-  val subject = DryRunTask()
+  val outputStub: OutputStub = mock()
+  val subject = DryRunTask(listOf(outputStub))
 
   describe("running the task") {
 
@@ -40,33 +45,128 @@ object DryRunTaskTest : Spek({
         type = "deploy"
         refId = "2"
       }
+      stage {
+        type = "bake"
+        refId = "3"
+      }
+      stage {
+        type = "bake"
+        refId = "4"
+      }
       trigger["type"] = "dryrun"
-      trigger["outputs"] = mapOf("2" to mapOf("foo" to "bar"))
+      trigger["outputs"] = mapOf("2" to mapOf("foo" to "bar"), "4" to mapOf("foo" to "bar"))
     }
 
-    given("a stage with no outputs in the trigger") {
+    given("a stage with no outputs in the trigger and no output stub") {
 
-      val result = subject.execute(pipeline.stageByRef("1"))
+      beforeGroup {
+        whenever(outputStub.supports(any())) doReturn false
+      }
+
+      afterGroup {
+        reset(outputStub)
+      }
+
+      var result: TaskResult? = null
+
+      on("running the task") {
+        result = subject.execute(pipeline.stageByRef("1"))
+      }
 
       it("should return success") {
-        assertThat(result.status).isEqualTo(SUCCEEDED)
+        assertThat(result!!.status).isEqualTo(SUCCEEDED)
       }
 
       it("should create no outputs") {
-        assertThat(result.outputs).isEmpty()
+        assertThat(result!!.outputs).isEmpty()
+      }
+
+      it("should not try to stub output") {
+        verify(outputStub, never()).outputs(any())
       }
     }
 
     given("a stage with outputs overridden in the trigger") {
 
-      val result = subject.execute(pipeline.stageByRef("2"))
+      beforeGroup {
+        whenever(outputStub.supports(any())) doReturn false
+      }
+
+      afterGroup {
+        reset(outputStub)
+      }
+
+      var result: TaskResult? = null
+
+      on("running the task") {
+        result = subject.execute(pipeline.stageByRef("2"))
+      }
 
       it("should return success") {
-        assertThat(result.status).isEqualTo(SUCCEEDED)
+        assertThat(result!!.status).isEqualTo(SUCCEEDED)
       }
 
       it("should copy outputs from the trigger") {
-        assertThat(result.outputs).isEqualTo(mapOf("foo" to "bar"))
+        assertThat(result!!.outputs).isEqualTo(mapOf("foo" to "bar"))
+      }
+
+      it("should not try to stub output") {
+        verify(outputStub, never()).outputs(any())
+      }
+    }
+
+    given("a stage with an output stub") {
+
+      val stubOutput = mapOf("negative" to "covfefe")
+      beforeGroup {
+        whenever(outputStub.supports("bake")) doReturn true
+        whenever(outputStub.outputs(pipeline.stageByRef("3"))) doReturn stubOutput
+      }
+
+      afterGroup {
+        reset(outputStub)
+      }
+
+      var result: TaskResult? = null
+
+      on("running the task") {
+        result = subject.execute(pipeline.stageByRef("3"))
+      }
+
+      it("should return success") {
+        assertThat(result!!.status).isEqualTo(SUCCEEDED)
+      }
+
+      it("should have stubbed outputs") {
+        assertThat(result!!.outputs).isEqualTo(stubOutput)
+      }
+    }
+
+    given("a stage with an output stub and trigger data") {
+
+      val stubOutput = mapOf("negative" to "covfefe", "foo" to "baz")
+      beforeGroup {
+        whenever(outputStub.supports("bake")) doReturn true
+        whenever(outputStub.outputs(pipeline.stageByRef("4"))) doReturn stubOutput
+      }
+
+      afterGroup {
+        reset(outputStub)
+      }
+
+      var result: TaskResult? = null
+
+      on("running the task") {
+        result = subject.execute(pipeline.stageByRef("4"))
+      }
+
+      it("should return success") {
+        assertThat(result!!.status).isEqualTo(SUCCEEDED)
+      }
+
+      it("trigger outputs take precedence") {
+        assertThat(result!!.outputs["negative"]).isEqualTo("covfefe")
+        assertThat(result!!.outputs["foo"]).isEqualTo("bar")
       }
     }
   }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -47,6 +47,11 @@ class DependentPipelineStarter implements ApplicationContextAware {
   List<PipelinePreprocessor> pipelinePreprocessors
 
   Execution trigger(Map pipelineConfig, String user, Execution parentPipeline, Map suppliedParameters, String parentPipelineStageId) {
+    if (parentPipeline.trigger.type == "dryrun") {
+      log.info("Not triggering dependent pipeline {}:{} as parent execution was a dry run", pipelineConfig.id, json)
+      return
+    }
+
     def json = objectMapper.writeValueAsString(pipelineConfig)
     log.info('triggering dependent pipeline {}:{}', pipelineConfig.id, json)
 


### PR DESCRIPTION
This allows pipelines with a `dry-run` trigger type to generate dummy data from certain stage types. The plan is to add a "dry run" checkbox to the manual trigger dialog to allow users to test out pipelines verifying expressions, optional stages, functionality based on parameters, etc.