### PR TITLE
fix(amazon): derive image regions when tagging from Clouddriver data

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageTagger.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonImageTagger.java
@@ -70,10 +70,11 @@ public class AmazonImageTagger extends ImageTagger implements CloudProviderAware
     List<Map<String, Map>> operations = new ArrayList<>();
 
     for (MatchedImage matchedImage : matchedImages) {
+      Collection<String> regions = matchedImage.amis.keySet();
       Image targetImage = new Image(
         matchedImage.imageName,
         defaultBakeAccount,
-        stageData.regions,
+        regions,
         tags
       );
       targetImages.add(targetImage);
@@ -96,7 +97,7 @@ public class AmazonImageTagger extends ImageTagger implements CloudProviderAware
       matchedImage.accounts.stream()
         .filter(account -> !account.equalsIgnoreCase(defaultBakeAccount))
         .forEach(account -> {
-          stageData.regions.forEach(region ->
+          regions.forEach(region ->
             operations.add(
               ImmutableMap.<String, Map>builder()
                 .put(ALLOW_LAUNCH_OPERATION, ImmutableMap.builder()


### PR DESCRIPTION
In a multi-region bake, we sometimes see a slight difference in the times the bakes start, which leads to different image names (usually off by a single digit on the timestamp).

The current implementation of the image tagger always gets all the regions from all the different AMIs, but does not consider which region each image comes from. This fixes that up.

I'm not sure if there are other repercussions or assumptions based on the `extraOutputs`, but this change should at least get us past this bug.