### PR TITLE
fix(pipelines): Improve pipeline error reporting

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -92,6 +92,22 @@ public class ExecutionLauncher {
     return execution;
   }
 
+  /**
+   * Log that an execution failed; useful if a pipeline failed validation and we want to persist the
+   * failure to the execution history but don't actually want to attempt to run the execution.
+   *
+   * @param t the exception that was thrown during pipeline validation
+   */
+  public Execution logFailedExecution(ExecutionType type, String configJson, Throwable t) throws Exception {
+    final Execution execution = parse(type, configJson);
+
+    persistExecution(execution);
+
+    handleStartupFailure(execution, t);
+
+    return execution;
+  }
+
   private void checkRunnable(Execution execution) {
     if (execution.getType() == PIPELINE) {
       pipelineValidator.ifPresent(it -> it.checkRunnable(execution));

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -96,14 +96,14 @@ public class ExecutionLauncher {
    * Log that an execution failed; useful if a pipeline failed validation and we want to persist the
    * failure to the execution history but don't actually want to attempt to run the execution.
    *
-   * @param t the exception that was thrown during pipeline validation
+   * @param e the exception that was thrown during pipeline validation
    */
-  public Execution logFailedExecution(ExecutionType type, String configJson, Throwable t) throws Exception {
+  public Execution fail(ExecutionType type, String configJson, Exception e) throws Exception {
     final Execution execution = parse(type, configJson);
 
     persistExecution(execution);
 
-    handleStartupFailure(execution, t);
+    handleStartupFailure(execution, e);
 
     return execution;
   }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -77,15 +77,45 @@ class OperationsController {
 
   @RequestMapping(value = "/orchestrate", method = RequestMethod.POST)
   Map<String, Object> orchestrate(@RequestBody Map pipeline, HttpServletResponse response) {
-    parsePipelineTrigger(executionRepository, buildService, pipeline)
-    Trigger trigger = objectMapper.convertValue(pipeline.trigger, Trigger)
-
-    boolean plan = pipeline.plan ?: false
-    for (PipelinePreprocessor preprocessor : (pipelinePreprocessors ?: [])) {
-      pipeline = preprocessor.process(pipeline)
+    if (pipeline.plan) {
+      parseAndValidatePipeline(pipeline)
+      log.info('Not starting pipeline (plan: true): {}', value("pipelineId", pipeline.id))
+      return pipeline
     }
 
-    pipeline.trigger = trigger
+    Throwable pipelineError = null
+    try {
+      parseAndValidatePipeline(pipeline)
+    } catch (Throwable t) {
+      pipelineError = t
+    }
+
+    def augmentedContext = [trigger: pipeline.trigger]
+    def processedPipeline = contextParameterProcessor.process(pipeline, augmentedContext, false)
+
+    if (pipelineError == null) {
+      startPipeline(processedPipeline)
+    } else {
+      markPipelineFailed(processedPipeline, pipelineError)
+      throw pipelineError
+    }
+  }
+
+  private void parseAndValidatePipeline(Map pipeline) {
+    try {
+      parsePipelineTrigger(executionRepository, buildService, pipeline)
+
+      for (PipelinePreprocessor preprocessor : (pipelinePreprocessors ?: [])) {
+        pipeline = preprocessor.process(pipeline)
+      }
+    } catch (Throwable t) {
+      throw t
+    } finally {
+      // Even if an exception is thrown above, we need to convert pipeline.trigger to
+      // a Trigger object, as the code to log the error to the execution history is
+      // expecting this.
+      pipeline.trigger = objectMapper.convertValue(pipeline.trigger, Trigger)
+    }
 
     def json = objectMapper.writeValueAsString(pipeline)
     log.info('received pipeline {}:{}', value("pipelineId", pipeline.id), json)
@@ -99,22 +129,9 @@ class OperationsController {
       convertLinearToParallel(pipeline)
     }
 
-    if (plan) {
-      log.info('not starting pipeline (plan: true): {}', value("pipelineId", pipeline.id))
-      if (pipeline.errors != null) {
-        throw new ValidationException("Pipeline template is invalid", pipeline.errors as List<Map<String, Object>>)
-      }
-      return pipeline
-    }
-
-    def augmentedContext = [trigger: pipeline.trigger]
-    def processedPipeline = contextParameterProcessor.process(pipeline, augmentedContext, false)
-
     if (pipeline.errors != null) {
       throw new ValidationException("Pipeline template is invalid", pipeline.errors as List<Map<String, Object>>)
     }
-
-    startPipeline(processedPipeline)
   }
 
   private void parsePipelineTrigger(ExecutionRepository executionRepository, BuildService buildService, Map pipeline) {
@@ -247,6 +264,16 @@ class OperationsController {
     log.info('requested pipeline: {}', json)
 
     def pipeline = executionLauncher.start(PIPELINE, json)
+
+    [ref: "/pipelines/${pipeline.id}".toString()]
+  }
+
+  private Map<String, String> markPipelineFailed(Map config, Throwable t) {
+    injectPipelineOrigin(config)
+    def json = objectMapper.writeValueAsString(config)
+    log.info('requested pipeline: {}', json)
+
+    def pipeline = executionLauncher.logFailedExecution(PIPELINE, json, t)
 
     [ref: "/pipelines/${pipeline.id}".toString()]
   }

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.controllers
 
 import javax.servlet.http.HttpServletResponse
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
+import com.netflix.spinnaker.kork.web.exceptions.ValidationException
 import com.netflix.spinnaker.orca.igor.BuildArtifactFilter
 import com.netflix.spinnaker.orca.igor.BuildService
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
@@ -46,6 +47,7 @@ import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static java.lang.String.format
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 
 class OperationsControllerSpec extends Specification {
@@ -60,7 +62,7 @@ class OperationsControllerSpec extends Specification {
   def executionRepository = Mock(ExecutionRepository)
   def pipelineTemplateService = Mock(PipelineTemplateService)
   def webhookService = Mock(WebhookService)
-  def artifactResolver = new ArtifactResolver(mapper, executionRepository)
+  def artifactResolver = Mock(ArtifactResolver)
 
   def env = new MockEnvironment()
   def buildArtifactFilter = new BuildArtifactFilter(environment: env)
@@ -548,6 +550,56 @@ class OperationsControllerSpec extends Specification {
       throw new ExecutionNotFoundException("Not found")
     }
     0 * executionLauncher.start(*_)
+  }
+
+  def "should log and re-throw validation error for non-templated pipeline"() {
+    given:
+    def pipelineConfig = [
+      type: PIPELINE,
+      errors: [
+        'things broke': 'because of the way it is'
+      ]
+    ]
+    def response = Mock(HttpServletResponse)
+    Execution startedPipeline = null
+    executionLauncher.logFailedExecution(*_) >> { ExecutionType type, String json, Throwable t ->
+      startedPipeline = mapper.readValue(json, Execution)
+      startedPipeline.id = UUID.randomUUID().toString()
+      startedPipeline
+    }
+
+    when:
+    controller.orchestrate(pipelineConfig, response)
+
+    then:
+    thrown(ValidationException)
+    0 * executionLauncher.start(*_)
+
+  }
+
+  def "should log and re-throw missing artifact error"() {
+    given:
+    def pipelineConfig = [
+      type: PIPELINE
+    ]
+    def response = Mock(HttpServletResponse)
+    artifactResolver.resolveArtifacts(*_) >> { Map pipeline ->
+      throw new IllegalStateException(format("Unmatched expected artifact could not be resolved."))
+    }
+    Execution startedPipeline = null
+    executionLauncher.logFailedExecution(*_) >> { ExecutionType type, String json, Throwable t ->
+      startedPipeline = mapper.readValue(json, Execution)
+      startedPipeline.id = UUID.randomUUID().toString()
+      startedPipeline
+    }
+
+    when:
+    controller.orchestrate(pipelineConfig, response)
+
+    then:
+    thrown(IllegalStateException)
+    0 * executionLauncher.start(*_)
+
   }
 
   def "should return empty list if webhook stage is not enabled"() {

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -562,7 +562,7 @@ class OperationsControllerSpec extends Specification {
     ]
     def response = Mock(HttpServletResponse)
     Execution startedPipeline = null
-    executionLauncher.logFailedExecution(*_) >> { ExecutionType type, String json, Throwable t ->
+    executionLauncher.fail(*_) >> { ExecutionType type, String json, Throwable t ->
       startedPipeline = mapper.readValue(json, Execution)
       startedPipeline.id = UUID.randomUUID().toString()
       startedPipeline
@@ -587,7 +587,7 @@ class OperationsControllerSpec extends Specification {
       throw new IllegalStateException(format("Unmatched expected artifact could not be resolved."))
     }
     Execution startedPipeline = null
-    executionLauncher.logFailedExecution(*_) >> { ExecutionType type, String json, Throwable t ->
+    executionLauncher.fail(*_) >> { ExecutionType type, String json, Throwable t ->
       startedPipeline = mapper.readValue(json, Execution)
       startedPipeline.id = UUID.randomUUID().toString()
       startedPipeline


### PR DESCRIPTION
When a pipeline fails validation, due to its being disabled, having
an invalid template, or being missing an artifact, log a failed execution
to the execution history instead of only generating an error in the
logs.