### PR TITLE
fix(triggers): derived properties of Jenkins triggers

### DIFF
--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -91,11 +91,11 @@ class CreateBakeTaskSpec extends Specification {
 
   @Shared
   def buildInfo = new BuildInfo(
-    "name", 0, null, [
+    "name", 0, "http://jenkins", [
     new JenkinsArtifact("hodor_1.1_all.deb", "."),
     new JenkinsArtifact("hodor-1.1.noarch.rpm", "."),
     new JenkinsArtifact("hodor.1.1.nupkg", ".")
-  ], [], "name#0", false, "SUCCESS"
+  ], [], false, "SUCCESS"
   )
 
   @Shared
@@ -105,7 +105,7 @@ class CreateBakeTaskSpec extends Specification {
       new JenkinsArtifact("hodor_1.1_all.deb", "."),
       new JenkinsArtifact("hodor-1.1.noarch.rpm", "."),
       new JenkinsArtifact("hodor.1.1.nupkg", ".")
-    ], [], "name#0", false, "SUCCESS"
+    ], [], false, "SUCCESS"
   )
 
   @Shared
@@ -115,7 +115,7 @@ class CreateBakeTaskSpec extends Specification {
       new JenkinsArtifact("hodor_1.1_all.deb", "."),
       new JenkinsArtifact("hodor-1.1.noarch.rpm", "."),
       new JenkinsArtifact("hodor.1.1.nupkg", ".")
-    ], [], "name#0", false, "SUCCESS"
+    ], [], false, "SUCCESS"
   )
 
   @Shared
@@ -127,7 +127,7 @@ class CreateBakeTaskSpec extends Specification {
       new JenkinsArtifact("hodor.1.1.nupkg", ".")
     ], [
     new SourceControl("refs/remotes/origin/master", "master", "f83a447f8d02a40fa84ec9d4d0dccd263d51782d")
-  ], "name#0", false, "SUCCESS"
+  ], false, "SUCCESS"
   )
 
   @Shared
@@ -140,7 +140,7 @@ class CreateBakeTaskSpec extends Specification {
     ], [
     new SourceControl("refs/remotes/origin/master", "master", "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"),
     new SourceControl("refs/remotes/origin/some-feature", "some-feature", "1234567f8d02a40fa84ec9d4d0dccd263d51782d")
-  ], "name#0", false, "SUCCESS"
+  ], false, "SUCCESS"
   )
 
   @Shared
@@ -153,16 +153,16 @@ class CreateBakeTaskSpec extends Specification {
     ], [
     new SourceControl("refs/remotes/origin/master", "master", "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"),
     new SourceControl("refs/remotes/origin/develop", "develop", "1234567f8d02a40fa84ec9d4d0dccd263d51782d")
-  ], "name#0", false, "SUCCESS"
+  ], false, "SUCCESS"
   )
 
   @Shared
   def buildInfoNoMatch = new BuildInfo(
-    "name", 0, null, [
+    "name", 0, "http://jenkins", [
     new JenkinsArtifact("hodornodor_1.1_all.deb", "."),
     new JenkinsArtifact("hodor-1.1.noarch.rpm", "."),
     new JenkinsArtifact("hodor.1.1.nupkg", ".")
-  ], [], "name#0", false, "SUCCESS"
+  ], [], false, "SUCCESS"
   )
 
   @Shared
@@ -237,7 +237,10 @@ class CreateBakeTaskSpec extends Specification {
     given:
     bakeConfig.buildInfo = contextInfo
     def pipelineWithTrigger = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], triggerInfo, null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      if (triggerInfo != null) {
+        trigger.buildInfo = triggerInfo
+      }
       stage {
         type = "bake"
         context = bakeConfig
@@ -273,7 +276,10 @@ class CreateBakeTaskSpec extends Specification {
     given:
     bakeConfig.buildInfo = contextInfo
     def pipelineWithTrigger = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], triggerInfo, null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      if (triggerInfo != null) {
+        trigger.buildInfo = triggerInfo
+      }
       stage {
         type = "bake"
         context = bakeConfig
@@ -307,7 +313,8 @@ class CreateBakeTaskSpec extends Specification {
       ]
     ]
     def pipelineWithTrigger = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], buildInfo, null, null, null)
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, null, null)
+      trigger.buildInfo = buildInfo
       stage {
         type = "bake"
         context = bakeConfig
@@ -357,7 +364,10 @@ class CreateBakeTaskSpec extends Specification {
     given:
     bakeConfig.buildInfo = contextInfo
     def pipelineWithTrigger = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], triggerInfo, null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      if (triggerInfo != null) {
+        trigger.buildInfo = triggerInfo
+      }
       stage {
         type = "bake"
         context = bakeConfig
@@ -392,7 +402,10 @@ class CreateBakeTaskSpec extends Specification {
     given:
     bakeConfig.buildInfo = contextInfo
     def pipelineWithTrigger = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], triggerInfo, null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      if (triggerInfo != null) {
+        trigger.buildInfo = triggerInfo
+      }
       stage {
         type = "bake"
         context = bakeConfig
@@ -425,7 +438,10 @@ class CreateBakeTaskSpec extends Specification {
     given:
     bakeConfig.buildInfo = contextInfo
     def pipelineWithTrigger = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], triggerInfo, null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      if (triggerInfo != null) {
+        trigger.buildInfo = triggerInfo
+      }
       stage {
         type = "bake"
         context = mapper.convertValue(bakeConfig, Map)
@@ -458,7 +474,10 @@ class CreateBakeTaskSpec extends Specification {
     given:
     bakeConfig.buildInfo = mapper.convertValue(contextInfo, Map)
     def pipelineWithTrigger = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], triggerInfo, null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      if (triggerInfo != null) {
+        trigger.buildInfo = triggerInfo
+      }
       stage {
         type = "bake"
         context = mapper.convertValue(bakeConfig, Map)
@@ -491,7 +510,10 @@ class CreateBakeTaskSpec extends Specification {
     given:
     bakeConfig.buildInfo = contextInfo
     def pipelineWithTrigger = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], triggerInfo, null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      if (triggerInfo != null) {
+        trigger.buildInfo = triggerInfo
+      }
       stage {
         type = "bake"
         context = bakeConfig
@@ -526,7 +548,10 @@ class CreateBakeTaskSpec extends Specification {
     given:
     bakeConfig.buildInfo = contextInfo
     def pipelineWithTrigger = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], triggerInfo, null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      if (triggerInfo != null) {
+        trigger.buildInfo = triggerInfo
+      }
       stage {
         type = "bake"
         context = bakeConfig
@@ -564,7 +589,10 @@ class CreateBakeTaskSpec extends Specification {
     given:
     bakeConfig.buildInfo = contextInfo
     def pipelineWithTrigger = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], triggerInfo, null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      if (triggerInfo != null) {
+        trigger.buildInfo = triggerInfo
+      }
       stage {
         type = "bake"
         context = bakeConfig
@@ -601,7 +629,10 @@ class CreateBakeTaskSpec extends Specification {
     given:
     bakeConfig.buildInfo = contextInfo
     def pipelineWithTrigger = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], triggerInfo, null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      if (triggerInfo != null) {
+        trigger.buildInfo = triggerInfo
+      }
       stage {
         type = "bake"
         context = bakeConfig

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStageSpec.groovy
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.orca.pipeline.model.PipelineTrigger
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import spock.lang.Specification
 import spock.lang.Unroll
-
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
@@ -31,9 +30,7 @@ class ParallelDeployStageSpec extends Specification {
   def "should build contexts corresponding to cluster configuration(s)"() {
     given:
     def pipeline = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], new JenkinsTrigger.BuildInfo(
-        "job", 1, "http://url", [], [], "job", false, "result"
-      ), "user@example.com", [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, "user@example.com", [:], [])
       application = "orca"
     }
     def bakeStage = new Stage(pipeline, "deploy", "Deploy!", stageContext)
@@ -60,9 +57,7 @@ class ParallelDeployStageSpec extends Specification {
   def "pipeline strategy should #data.scenario"() {
     given:
     def parentPipeline = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], new JenkinsTrigger.BuildInfo(
-        "job", 1, "http://url", [], [], "job", false, "result"
-      ), "user@example.com", [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, "user@example.com", [:], [])
       application = "orca"
       stage {
         name = "parent stage"

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/JenkinsTrigger.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/JenkinsTrigger.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 
 @JsonTypeName("jenkins")
 public class JenkinsTrigger extends Trigger {
@@ -33,8 +35,9 @@ public class JenkinsTrigger extends Trigger {
   private final String job;
   private final int buildNumber;
   private final String propertyFile;
-  private final Map<String, Object> properties;
-  private final BuildInfo buildInfo;
+
+  private Map<String, Object> properties;
+  private BuildInfo buildInfo;
 
   @JsonCreator
   public JenkinsTrigger(
@@ -42,8 +45,6 @@ public class JenkinsTrigger extends Trigger {
     @JsonProperty("job") @Nonnull String job,
     @JsonProperty("buildNumber") int buildNumber,
     @JsonProperty("propertyFile") @Nullable String propertyFile,
-    @JsonProperty("properties") @Nonnull Map<String, Object> properties,
-    @JsonProperty("buildInfo") @Nonnull BuildInfo buildInfo,
     @JsonProperty("user") @Nullable String user,
     @JsonProperty("parameters") @Nullable Map<String, Object> parameters,
     @JsonProperty("artifacts") @Nullable List<Artifact> artifacts
@@ -53,8 +54,6 @@ public class JenkinsTrigger extends Trigger {
     this.job = job;
     this.buildNumber = buildNumber;
     this.propertyFile = propertyFile;
-    this.properties = properties;
-    this.buildInfo = buildInfo;
   }
 
   public @Nonnull String getMaster() {
@@ -73,12 +72,22 @@ public class JenkinsTrigger extends Trigger {
     return propertyFile;
   }
 
-  public Map<String, Object> getProperties() {
-    return properties;
+  @JsonProperty("properties")
+  public @Nonnull Map<String, Object> getProperties() {
+    return properties == null ? emptyMap() : properties;
   }
 
-  public @Nonnull BuildInfo getBuildInfo() {
+  public void setProperties(Map<String, Object> properties) {
+    this.properties = properties;
+  }
+
+  @JsonProperty("buildInfo")
+  public @Nullable BuildInfo getBuildInfo() {
     return buildInfo;
+  }
+
+  public void setBuildInfo(@Nonnull BuildInfo buildInfo) {
+    this.buildInfo = buildInfo;
   }
 
   @Override public boolean equals(Object o) {
@@ -87,12 +96,11 @@ public class JenkinsTrigger extends Trigger {
     return buildNumber == that.buildNumber &&
       Objects.equals(master, that.master) &&
       Objects.equals(job, that.job) &&
-      Objects.equals(propertyFile, that.propertyFile) &&
-      Objects.equals(buildInfo, that.buildInfo);
+      Objects.equals(propertyFile, that.propertyFile);
   }
 
   @Override public int hashCode() {
-    return Objects.hash(super.hashCode(), master, job, buildNumber, propertyFile, buildInfo);
+    return Objects.hash(super.hashCode(), master, job, buildNumber, propertyFile);
   }
 
   @Override public String toString() {
@@ -112,7 +120,6 @@ public class JenkinsTrigger extends Trigger {
     private final String url;
     private final List<JenkinsArtifact> artifacts;
     private final List<SourceControl> scm;
-    private final String fullDisplayName;
     private final boolean building;
     private final String result;
 
@@ -121,18 +128,16 @@ public class JenkinsTrigger extends Trigger {
       @JsonProperty("name") @Nonnull String name,
       @JsonProperty("number") int number,
       @JsonProperty("url") @Nonnull String url,
-      @JsonProperty("artifacts") @Nonnull List<JenkinsArtifact> artifacts,
-      @JsonProperty("scm") @Nonnull List<SourceControl> scm,
-      @JsonProperty("fullDisplayName") @Nonnull String fullDisplayName,
+      @JsonProperty("artifacts") @Nullable List<JenkinsArtifact> artifacts,
+      @JsonProperty("scm") @Nullable List<SourceControl> scm,
       @JsonProperty("building") boolean building,
       @JsonProperty("result") @Nullable String result
     ) {
       this.name = name;
       this.number = number;
       this.url = url;
-      this.artifacts = artifacts;
-      this.scm = scm;
-      this.fullDisplayName = fullDisplayName;
+      this.artifacts = artifacts == null ? emptyList() : artifacts;
+      this.scm = scm == null ? emptyList() : scm;
       this.building = building;
       this.result = result;
     }
@@ -158,7 +163,7 @@ public class JenkinsTrigger extends Trigger {
     }
 
     public @Nonnull String getFullDisplayName() {
-      return fullDisplayName;
+      return name + " #" + number;
     }
 
     public boolean isBuilding() {
@@ -179,12 +184,11 @@ public class JenkinsTrigger extends Trigger {
         Objects.equals(url, buildInfo.url) &&
         Objects.equals(artifacts, buildInfo.artifacts) &&
         Objects.equals(scm, buildInfo.scm) &&
-        Objects.equals(fullDisplayName, buildInfo.fullDisplayName) &&
         Objects.equals(result, buildInfo.result);
     }
 
     @Override public int hashCode() {
-      return Objects.hash(name, number, url, artifacts, scm, fullDisplayName, building, result);
+      return Objects.hash(name, number, url, artifacts, scm, building, result);
     }
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/ManualTrigger.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/ManualTrigger.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import static java.util.Collections.emptyList;
 
 @JsonTypeName("manual")
 public class ManualTrigger extends Trigger {
@@ -37,12 +38,13 @@ public class ManualTrigger extends Trigger {
     @Nullable @JsonProperty("correlationId") String correlationId,
     @Nonnull @JsonProperty("user") String user,
     @Nonnull @JsonProperty("parameters") Map<String, Object> parameters,
-    @Nonnull @JsonProperty("notifications") List<Map<String, Object>> notifications,
+    @Nullable @JsonProperty("notifications")
+      List<Map<String, Object>> notifications,
     @Nullable @JsonProperty("artifacts") List<Artifact> artifacts
   ) {
     super(user, parameters, artifacts);
     this.correlationId = correlationId;
-    this.notifications = notifications;
+    this.notifications = notifications == null ? emptyList() : notifications;
   }
 
   public @Nonnull List<Map<String, Object>> getNotifications() {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/TravisTrigger.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/TravisTrigger.java
@@ -33,12 +33,10 @@ public class TravisTrigger extends JenkinsTrigger {
     @JsonProperty("job") @Nonnull String job,
     @JsonProperty("buildNumber") int buildNumber,
     @JsonProperty("propertyFile") @Nullable String propertyFile,
-    @JsonProperty("properties") @Nonnull Map<String, Object> properties,
-    @JsonProperty("buildInfo") @Nonnull BuildInfo buildInfo,
     @JsonProperty("user") @Nullable String user,
     @JsonProperty("parameters") @Nullable Map<String, Object> parameters,
     @JsonProperty("artifacts") @Nullable List<Artifact> artifacts
   ) {
-    super(master, job, buildNumber, propertyFile, properties, buildInfo, user, parameters, artifacts);
+    super(master, job, buildNumber, propertyFile, user, parameters, artifacts);
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractor.java
@@ -45,7 +45,11 @@ public class BuildDetailExtractor {
 
   @Deprecated
   public boolean tryToExtractBuildDetails(Map<String, Object> buildInfo, Map<String, Object> request) {
-    return tryToExtractBuildDetails(mapper.convertValue(buildInfo, BuildInfo.class), request);
+    try {
+      return tryToExtractBuildDetails(mapper.convertValue(buildInfo, BuildInfo.class), request);
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
   }
 
   //Legacy Details extractor for Jenkins. It parses the url to fill the request build parameters

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator.ExpressionEvaluationVersion.V2;
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE;
+import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 /**
@@ -101,7 +102,7 @@ public class ContextParameterProcessor {
 
     context.put("scmInfo", Optional.ofNullable((BuildInfo) context.get("buildInfo")).map(BuildInfo::getScm).orElse(null));
     if (context.get("scmInfo") == null && trigger instanceof JenkinsTrigger) {
-      context.put("scmInfo", ((JenkinsTrigger) trigger).getBuildInfo().getScm());
+      context.put("scmInfo", Optional.ofNullable(((JenkinsTrigger) trigger).getBuildInfo()).map(BuildInfo::getScm).orElse(emptyList()));
     }
     if (context.get("scmInfo") != null && ((List) context.get("scmInfo")).size() >= 2) {
       List<SourceControl> scmInfos = (List<SourceControl>) context.get("scmInfo");

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineSpec.groovy
@@ -31,7 +31,7 @@ class PipelineSpec extends Specification {
 
   @Subject
     pipeline = pipeline {
-      trigger = new JenkinsTrigger("master", "SPINNAKER-build-job", 1, null, [:], null, null, null, null);
+      trigger = new JenkinsTrigger("master", "SPINNAKER-build-job", 1, null, null, null, null);
       stage { type = "stage1" }
       stage { type = "stage2" }
       stage { type = "stage3" }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -33,8 +33,6 @@ import static com.netflix.spinnaker.orca.ExecutionStatus.*
 import static com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.newStage
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
-import static com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.BuildInfo
-import static com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.JenkinsArtifact
 import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_AFTER
 import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_BEFORE
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.*
@@ -134,7 +132,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     def pipeline = pipeline {
       application = "orca"
       name = "dummy-pipeline"
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], new BuildInfo("name", 1, null, [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], null, false, "SUCCESS"), null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
       stage {
         type = "one"
         context = [foo: "foo"]

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractorSpec.groovy
@@ -54,10 +54,10 @@ class BuildDetailExtractorSpec extends Specification {
     result == expectedResult
 
     where:
-    buildInfo                                                                                 | result | expectedResult
-    ["url": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/"]        | [:]    | ["job": "SPINNAKER-package-echo", "buildNumber": "69", "buildInfoUrl": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/", "buildHost": "http://spinnaker.jenkis.test.netflix.net/"]
-    ["url": "http://spinnaker.jenkis.test.netflix.net/job/folderSPINNAKER/job/SPINNAKER/69/"] | [:]    | ["job": "folderSPINNAKER/job/SPINNAKER", "buildNumber": "69", "buildInfoUrl": "http://spinnaker.jenkis.test.netflix.net/job/folderSPINNAKER/job/SPINNAKER/69/", "buildHost": "http://spinnaker.jenkis.test.netflix.net/"]
-    ["url": "http://jenkins.com/job/folder/job/job name/123"]                                 | [:]    | ["job": "folder/job/job name", "buildNumber": "123", "buildInfoUrl": "http://jenkins.com/job/folder/job/job name/123", "buildHost": "http://jenkins.com/"]
+    buildInfo                                                                                                          | result | expectedResult
+    [name: "SPINNAKER-package-echo", "url": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/"] | [:]    | ["job": "SPINNAKER-package-echo", "buildNumber": "69", "buildInfoUrl": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/", "buildHost": "http://spinnaker.jenkis.test.netflix.net/"]
+    [name: "SPINNAKER", "url": "http://spinnaker.jenkis.test.netflix.net/job/folderSPINNAKER/job/SPINNAKER/69/"]       | [:]    | ["job": "folderSPINNAKER/job/SPINNAKER", "buildNumber": "69", "buildInfoUrl": "http://spinnaker.jenkis.test.netflix.net/job/folderSPINNAKER/job/SPINNAKER/69/", "buildHost": "http://spinnaker.jenkis.test.netflix.net/"]
+    [name: "job name", "url": "http://jenkins.com/job/folder/job/job name/123"]                                        | [:]    | ["job": "folder/job/job name", "buildNumber": "123", "buildInfoUrl": "http://jenkins.com/job/folder/job/job name/123", "buildHost": "http://jenkins.com/"]
   }
 
   @Unroll
@@ -70,11 +70,11 @@ class BuildDetailExtractorSpec extends Specification {
     result == expectedResult
 
     where:
-    buildInfo                                                                                               | result | expectedResult
-    ["name": "SPINNAKER", "url": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/"] | [:]    | ["job": "SPINNAKER-package-echo", "buildNumber": "69", "buildInfoUrl": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/", "buildHost": "http://spinnaker.jenkis.test.netflix.net/"]
-    ["name": "compose/SPINNAKER", "number": "9001", "url": null]                                            | [:]    | [:]
-    ["number": "9001"]                                                                                      | [:]    | [:]
-    [:]                                                                                                     | [:]    | [:]
-    null                                                                                                    | [:]    | [:]
+    buildInfo                                                                                           | result | expectedResult
+    [name: "SPINNAKER", url: "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/"] | [:]    | ["job": "SPINNAKER-package-echo", "buildNumber": "69", "buildInfoUrl": "http://spinnaker.jenkis.test.netflix.net/job/SPINNAKER-package-echo/69/", "buildHost": "http://spinnaker.jenkis.test.netflix.net/"]
+    [name: "compose/SPINNAKER", number: "9001", url: null]                                              | [:]    | [:]
+    [number: "9001", artifacts: [], scm: []]                                                            | [:]    | [:]
+    [:]                                                                                                 | [:]    | [:]
+    null                                                                                                | [:]    | [:]
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
@@ -279,8 +279,9 @@ class ContextParameterProcessorSpec extends Specification {
 
   @Unroll
   def "correctly compute scmInfo attribute"() {
-
     given:
+    context.trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [], scm, false, "SUCCESS")
+
     def source = ['branch': '${scmInfo.branch}']
 
     when:
@@ -303,8 +304,6 @@ class ContextParameterProcessorSpec extends Specification {
         "job",
         1,
         null,
-        [:],
-        new BuildInfo("name", 1, null, [], scm, "name", false, "SUCCESS"),
         "user",
         [:],
         []

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
@@ -62,7 +62,8 @@ class PackageInfoSpec extends Specification {
 
     given:
     def execution = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], new BuildInfo("name", 1, null, [new JenkinsArtifact("testFileName", ".")], [], null, false, "SUCCESS"), null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("testFileName", ".")], [], false, "SUCCESS")
       stage {
         context = [buildInfo: [name: "someName"], package: "testPackageName"]
       }
@@ -90,13 +91,14 @@ class PackageInfoSpec extends Specification {
           refId = "$i"
           outputs["buildInfo"] = [
             artifacts: [
-              [fileName: "${name}.deb".toString()],
-              [fileName: "${name}.war".toString()],
-              [fileName: "build.properties"]
+              [fileName: "${name}.deb".toString(), relativePath: "."],
+              [fileName: "${name}.war".toString(), relativePath: "."],
+              [fileName: "build.properties", relativePath: "."]
             ],
             url      : "http://localhost",
             name     : "testBuildName",
-            number   : "1"
+            number   : "1",
+            scm      : []
           ]
         }
       }
@@ -215,7 +217,14 @@ class PackageInfoSpec extends Specification {
       stage {
         refId = "1"
         type = "jenkins"
-        outputs["buildInfo"] = [artifacts: [[fileName: "api_1.1.1-h02.sha123_all.deb"]]]
+        outputs["buildInfo"] = [
+          url      : "http://jenkins",
+          master   : "master",
+          name     : "job",
+          number   : 1,
+          artifacts: [[fileName: "api_1.1.1-h02.sha123_all.deb", relativePath: "."]],
+          scm      : []
+        ]
       }
       stage {
         refId = "2"
@@ -264,7 +273,14 @@ class PackageInfoSpec extends Specification {
       stage {
         refId = "1"
         type = "jenkins"
-        outputs["buildInfo"] = [artifacts: [[fileName: "api_1.1.1-h01.sha123_all.deb"]]]
+        outputs["buildInfo"] = [
+          url      : "http://jenkins",
+          master   : "master",
+          name     : "job",
+          number   : 1,
+          artifacts: [[fileName: "api_1.1.1-h01.sha123_all.deb", relativePath: "."]],
+          scm      : []
+        ]
       }
       stage {
         refId = "2"
@@ -292,7 +308,14 @@ class PackageInfoSpec extends Specification {
       stage {
         refId = "1"
         type = "jenkins"
-        outputs["buildInfo"] = [artifacts: [[fileName: "api_1.1.1-h01.sha123_all.deb"]]]
+        outputs["buildInfo"] = [
+          url      : "http://jenkins",
+          master   : "master",
+          name     : "job",
+          number   : 1,
+          artifacts: [[fileName: "api_1.1.1-h01.sha123_all.deb", relativePath: "."]],
+          scm      : []
+        ]
       }
       stage {
         refId = "2"
@@ -322,7 +345,8 @@ class PackageInfoSpec extends Specification {
   def "findTargetPackage: allowing unmatched packages is guarded by the allowMissingPackageInstallation flag"() {
     given:
     def pipeline = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], new BuildInfo("name", 1, null, [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], null, false, "SUCCESS"), null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], false, "SUCCESS")
       stage {
         refId = "1"
         context["package"] = "another_package"
@@ -357,7 +381,8 @@ class PackageInfoSpec extends Specification {
   def "findTargetPackage: stage execution instance of Pipeline with trigger and no buildInfo"() {
     given:
     def pipeline = pipeline {
-      trigger = new JenkinsTrigger("master", "job", 1, null, [:], new BuildInfo("name", 1, null, [new JenkinsArtifact("api_2.2.2-h02.sha321_all.deb", ".")], [], null, false, "SUCCESS"), null, [:], [])
+      trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+      trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_2.2.2-h02.sha321_all.deb", ".")], [], false, "SUCCESS")
       stage {
         context = [package: 'api']
       }
@@ -442,9 +467,13 @@ class PackageInfoSpec extends Specification {
     packageVersion = "1.1.1-h01.sha123"
     pipelineTrigger << [
       new PipelineTrigger(ExecutionBuilder.pipeline {
-        trigger = new JenkinsTrigger("master", "job", 1, null, [:], new BuildInfo("name", 1, null, [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], null, false, "SUCCESS"), null, [:], [])
+        trigger = new JenkinsTrigger("master", "job", 1, null, null, [:], [])
+        trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], false, "SUCCESS")
       }, [:]),
-      new JenkinsTrigger("master", "job", 1, null, [:], new BuildInfo("name", 1, null, [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], null, false, "SUCCESS"), null, [:], [])
+      new JenkinsTrigger("master", "job", 1, null, null, [:], []).with {
+        it.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], false, "SUCCESS")
+        it
+      }
     ]
   }
 }

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -140,7 +140,7 @@ class OperationsControllerSpec extends Specification {
         buildNumber: buildNumber
       ]
     ]
-    buildInfo = [result: "SUCCESS"]
+    buildInfo = [name: job, number: buildNumber, result: "SUCCESS", url: "http://jenkins"]
   }
 
   def "should not get pipeline execution details from trigger if provided"() {
@@ -230,9 +230,9 @@ class OperationsControllerSpec extends Specification {
 
     where:
     requestedPipeline = [
-      id: "54321",
-      plan: true,
-      type: "templatedPipeline",
+      id         : "54321",
+      plan       : true,
+      type       : "templatedPipeline",
       executionId: "12345"
     ]
   }
@@ -281,7 +281,7 @@ class OperationsControllerSpec extends Specification {
         user       : triggerUser
       ]
     ]
-    buildInfo = [result: "SUCCESS"]
+    buildInfo = [name: job, number: buildNumber, result: "SUCCESS", url: "http://jenkins"]
 
   }
 
@@ -293,7 +293,7 @@ class OperationsControllerSpec extends Specification {
       startedPipeline.id = UUID.randomUUID().toString()
       startedPipeline
     }
-    buildService.getBuild(buildNumber, master, job) >> [result: "SUCCESS"]
+    buildService.getBuild(buildNumber, master, job) >> [name: job, number: buildNumber, result: "SUCCESS", url: "http://jenkins"]
     buildService.getPropertyFile(buildNumber, propertyFile, master, job) >> propertyFileContent
 
     when:
@@ -332,7 +332,9 @@ class OperationsControllerSpec extends Specification {
     Map requestedPipeline = [
       trigger: [
         type      : "jenkins",
-        buildInfo : [:],
+        master    : "master",
+        job       : "jon",
+        number    : 1,
         properties: [
           key1        : 'val1',
           key2        : 'val2',
@@ -360,7 +362,7 @@ class OperationsControllerSpec extends Specification {
 
     Map requestedPipeline = [
       trigger: [
-        type: "manual",
+        type      : "manual",
         parameters: [
           key1: 'value1',
           key2: 'value2'
@@ -500,15 +502,15 @@ class OperationsControllerSpec extends Specification {
         user       : 'foo'
       ]
     ]
-    buildInfo = [result: "SUCCESS", artifacts: [
-      [fileName: 'foo1.deb'],
-      [fileName: 'foo2.rpm'],
-      [fileName: 'foo3.properties'],
-      [fileName: 'foo4.yml'],
-      [fileName: 'foo5.json'],
-      [fileName: 'foo6.xml'],
-      [fileName: 'foo7.txt'],
-      [fileName: 'foo8.nupkg'],
+    buildInfo = [name: job, number: buildNumber, url: "http://jenkins", result: "SUCCESS", artifacts: [
+      [fileName: 'foo1.deb', relativePath: "."],
+      [fileName: 'foo2.rpm', relativePath: "."],
+      [fileName: 'foo3.properties', relativePath: "."],
+      [fileName: 'foo4.yml', relativePath: "."],
+      [fileName: 'foo5.json', relativePath: "."],
+      [fileName: 'foo6.xml', relativePath: "."],
+      [fileName: 'foo7.txt', relativePath: "."],
+      [fileName: 'foo8.nupkg', relativePath: "."],
     ]]
   }
 
@@ -528,10 +530,10 @@ class OperationsControllerSpec extends Specification {
   def "should throw validation exception when templated pipeline contains errors"() {
     given:
     def pipelineConfig = [
-      plan  : true,
-      type  : "templatedPipeline",
+      plan       : true,
+      type       : "templatedPipeline",
       executionId: "12345",
-      errors: [
+      errors     : [
         'things broke': 'because of the way it is'
       ]
     ]
@@ -542,7 +544,9 @@ class OperationsControllerSpec extends Specification {
 
     then:
     thrown(InvalidRequestException)
-    1 * pipelineTemplateService.retrievePipelineOrNewestExecution("12345", null) >> { throw new ExecutionNotFoundException("Not found") }
+    1 * pipelineTemplateService.retrievePipelineOrNewestExecution("12345", null) >> {
+      throw new ExecutionNotFoundException("Not found")
+    }
     0 * executionLauncher.start(*_)
   }
 


### PR DESCRIPTION
- buildInfo and properties are looked up from the Jenkins master not sent with the trigger
- fixed tests broken in IntelliJ when non-null annotation checks compiled in
- any `@Nonnull` list or map accepts null on the constructor and defaults the value
