### PR TITLE
feat(rollback): Support for automatic rollback when a deployment fails

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
@@ -16,24 +16,37 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.FeaturesService
+import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.RollbackClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForUpInstancesTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CreateServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.AddServerGroupEntityTagsTask
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import javax.annotation.Nonnull
+import java.util.concurrent.TimeUnit
+
+@Slf4j
 @Component
 class CreateServerGroupStage extends AbstractDeployStrategyStage {
   public static final String PIPELINE_CONFIG_TYPE = "createServerGroup"
 
   @Autowired
   private FeaturesService featuresService
+
+  @Autowired
+  private RollbackClusterStage rollbackClusterStage
 
   CreateServerGroupStage() {
     super(PIPELINE_CONFIG_TYPE)
@@ -57,5 +70,72 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage {
     tasks << TaskNode.task("forceCacheRefresh", ServerGroupCacheForceRefreshTask)
 
     return tasks
+  }
+
+  @Override
+  List<Stage> onFailureStages(@Nonnull Stage stage) {
+    def stageData = stage.mapTo(StageData)
+
+    if (!stageData.rollback?.onFailure) {
+      // rollback on failure is not enabled
+      return []
+    }
+
+    if (!stageData.getServerGroup()) {
+      // did not get far enough to create a new server group
+      log.warn("No server group was created, skipping rollback! (executionId: ${stage.execution.id}, stageId: ${stage.id})")
+
+      return []
+    }
+
+    return [
+      newStage(
+        stage.execution,
+        rollbackClusterStage.type,
+        "Rollback ${stageData.getCluster()}",
+        [
+          "credentials"   : stageData.getCredentials(),
+          "cloudProvider" : stageData.getCloudProvider(),
+          "regions"       : [stageData.getRegion()],
+          "serverGroup"   : stageData.getServerGroup(),
+          "stageTimeoutMs": TimeUnit.MINUTES.toMillis(30) // timebox a rollback to 30 minutes
+        ],
+        stage,
+        SyntheticStageOwner.STAGE_AFTER
+      )
+    ]
+  }
+
+  private static class StageData {
+    String application
+    String account
+    String credentials
+    String cloudProvider
+    Moniker moniker
+
+    Rollback rollback
+
+    @JsonProperty("deploy.server.groups")
+    Map<String, List<String>> deployedServerGroups = [:]
+
+    String getCredentials() {
+      return account ?: credentials
+    }
+
+    String getRegion() {
+      return deployedServerGroups?.keySet()?.getAt(0)
+    }
+
+    String getServerGroup() {
+      return deployedServerGroups.values().flatten().getAt(0)
+    }
+
+    String getCluster() {
+      return moniker?.cluster ?: MonikerHelper.friggaToMoniker(getServerGroup()).cluster
+    }
+  }
+
+  private static class Rollback {
+    Boolean onFailure
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
@@ -64,7 +64,10 @@ class ExplicitRollback implements Rollback {
       parentStage.execution, enableServerGroupStage.type, "enable", enableServerGroupContext, parentStage, SyntheticStageOwner.STAGE_AFTER
     )
 
-    stages << buildCaptureSourceServerGroupCapacityStage(parentStage, parentStage.mapTo(ResizeStrategy.Source))
+    if (!parentStage.getContext().containsKey("sourceServerGroupCapacitySnapshot")) {
+      // capacity has been previously captured (likely as part of a failed deploy), no need to do again!
+      stages << buildCaptureSourceServerGroupCapacityStage(parentStage, parentStage.mapTo(ResizeStrategy.Source))
+    }
 
     Map resizeServerGroupContext = new HashMap(parentStage.context) + [
       action                       : ResizeStrategy.ResizeAction.scale_to_server_group.toString(),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollback.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollback.groovy
@@ -89,7 +89,7 @@ class PreviousImageRollback implements Rollback {
       region                       : parentStageContext.region,
       credentials                  : parentStageContext.credentials,
       cloudProvider                : parentStageContext.cloudProvider,
-      source: [
+      source                       : [
         asgName          : rollbackServerGroupName,
         serverGroupName  : rollbackServerGroupName,
         account          : parentStageContext.credentials,
@@ -98,6 +98,11 @@ class PreviousImageRollback implements Rollback {
         useSourceCapacity: true
       ]
     ]
+
+    if (parentStageContext.containsKey("sourceServerGroupCapacitySnapshot")) {
+      cloneServerGroupContext.source.useSourceCapacity = false
+      cloneServerGroupContext.capacity = parentStageContext.sourceServerGroupCapacitySnapshot
+    }
 
     if (parentStageContext.containsKey("interestingHealthProviderNames")) {
       cloneServerGroupContext.interestingHealthProviderNames = parentStageContext.interestingHealthProviderNames

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/RollbackClusterStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/RollbackClusterStageSpec.groovy
@@ -19,7 +19,8 @@ package com.netflix.spinnaker.orca.clouddriver.pipeline.cluster
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.RollbackServerGroupStage
 import com.netflix.spinnaker.orca.pipeline.WaitStage
 import spock.lang.Specification
-import spock.lang.Subject;
+import spock.lang.Subject
+import spock.lang.Unroll;
 
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
@@ -76,5 +77,24 @@ class RollbackClusterStageSpec extends Specification {
     then:
     afterStages*.type == ["rollbackServerGroup"]
     afterStages*.context.region == ["us-east-1"]
+  }
+
+  @Unroll
+  def "should propagate 'interestingHealthProviderNames' and 'sourceServerGroupCapacitySnapshot' to child rollback stage"() {
+    given:
+    def stage = (stageContext == null) ? null : stage { context = stageContext }
+
+    expect:
+    RollbackClusterStage.propagateParentStageContext(stage) == expectedPropagations
+
+    where:
+    stageContext                                                       || expectedPropagations
+    null                                                               || [:]
+    [:]                                                                || [:]
+    [foo: "bar"]                                                       || [:]
+    [interestingHealthProviderNames: null]                             || [interestingHealthProviderNames: null]            // do not care if value is null
+    [interestingHealthProviderNames: ["Amazon"]]                       || [interestingHealthProviderNames: ["Amazon"]]
+    [sourceServerGroupCapacitySnapshot: null]                          || [sourceServerGroupCapacitySnapshot: null]         // do not care if value is null
+    [sourceServerGroupCapacitySnapshot: [min: 0, max: 10, desired: 5]] || [sourceServerGroupCapacitySnapshot: [min: 0, max: 10, desired: 5]]
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.RollbackClusterStage
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import java.util.concurrent.TimeUnit
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class CreateServerGroupStageSpec extends Specification {
+  @Subject
+  def createServerGroupStage = new CreateServerGroupStage(
+    rollbackClusterStage: new RollbackClusterStage(null, null)
+  )
+
+  @Unroll
+  def "should build RollbackStage when 'rollbackOnFailure' is enabled"() {
+    given:
+    def stage = stage {
+      context = [
+        "deploy.server.groups": deployServerGroups,
+        "application"         : "myapplication",
+        "account"             : "test",
+        "cloudProvider"       : "aws"
+      ]
+    }
+
+    if (shouldRollbackOnFailure) {
+      stage.context.rollback = [
+        onFailure: true
+      ]
+    }
+
+    when:
+    def onFailureStageContexts = createServerGroupStage.onFailureStages(stage)*.getContext()
+
+    then:
+    onFailureStageContexts == expectedOnFailureStageContexts
+
+    where:
+    shouldRollbackOnFailure | deployServerGroups                          || expectedOnFailureStageContexts
+    false                   | null                                        || []
+    true                    | null                                        || []
+    false                   | ["us-west-1": ["myapplication-stack-v001"]] || []
+    true                    | ["us-west-1": ["myapplication-stack-v001"]] || [
+      [
+        regions       : ["us-west-1"],
+        serverGroup   : "myapplication-stack-v001",
+        credentials   : "test",
+        cloudProvider : "aws",
+        stageTimeoutMs: TimeUnit.MINUTES.toMillis(30)
+      ]
+    ]
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
@@ -54,6 +54,10 @@ public interface StageDefinitionBuilder {
     return emptyList();
   }
 
+  default @Nonnull List<Stage> onFailureStages(@Nonnull Stage stage) {
+    return emptyList();
+  }
+
   /**
    * @return the stage type this builder handles.
    */

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
@@ -57,6 +57,17 @@ val stageWithSyntheticBefore = object : StageDefinitionBuilder {
   )
 }
 
+val stageWithSyntheticOnFailure = object : StageDefinitionBuilder {
+  override fun getType() = "stageWithSyntheticOnFailure"
+  override fun taskGraph(stage: Stage, builder: Builder) {
+    builder.withTask("dummy", DummyTask::class.java)
+  }
+
+  override fun onFailureStages(stage: Stage) = listOf(
+    newStage(stage.execution, singleTaskStage.type, "onFailure1", stage.context, stage, STAGE_AFTER)
+  )
+}
+
 val stageWithSyntheticBeforeAndNoTasks = object : StageDefinitionBuilder {
   override fun getType() = "stageWithSyntheticBeforeAndNoTasks"
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/Executions.kt
@@ -100,6 +100,9 @@ fun Stage.syntheticStages(): List<Stage> =
 fun Stage.beforeStages(): List<Stage> =
   syntheticStages().filter { it.syntheticStageOwner == STAGE_BEFORE }
 
+fun Stage.afterStages(): List<Stage> =
+  syntheticStages().filter { it.syntheticStageOwner == STAGE_AFTER }
+
 fun Stage.allBeforeStagesComplete(): Boolean =
   beforeStages().all { it.status in listOf(SUCCEEDED, FAILED_CONTINUE, SKIPPED) }
 


### PR DESCRIPTION
This PR injects a `RollbackCluster` stage if a particular cluster
deployment has automatic rollback enabled.

Automatic rollback can be enabled by adding the following to a deploy
stage:

```
      "rollback": {
        "onFailure": true
      }
```