### PR TITLE
fix(orca/log): Append to log instead of overwrite

### DIFF
--- a/orca-web/etc/init/orca.conf
+++ b/orca-web/etc/init/orca.conf
@@ -9,4 +9,4 @@ expect fork
 
 stop on stopping spinnaker
 
-exec /opt/orca/bin/orca 2>&1 > /var/log/spinnaker/orca/orca.log &
+exec /opt/orca/bin/orca 2>&1 >> /var/log/spinnaker/orca/orca.log &


### PR DESCRIPTION
Changing to appending to the log file so logs will correctly rotate.  This prevents large amounts of null data at the start of a rotated log file.