### PR TITLE
fix(pipelines): Fix templated pipelines not being triggered

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -81,7 +81,7 @@ class OperationsController {
   Map<String, Object> orchestrate(@RequestBody Map pipeline, HttpServletResponse response) {
     Exception pipelineError = null
     try {
-      parseAndValidatePipeline(pipeline)
+      pipeline = parseAndValidatePipeline(pipeline)
     } catch (Exception e) {
       pipelineError = e
     }
@@ -106,7 +106,7 @@ class OperationsController {
     }
   }
 
-  private void parseAndValidatePipeline(Map pipeline) {
+  private Map parseAndValidatePipeline(Map pipeline) {
     parsePipelineTrigger(executionRepository, buildService, pipeline)
 
     for (PipelinePreprocessor preprocessor : (pipelinePreprocessors ?: [])) {
@@ -128,6 +128,7 @@ class OperationsController {
     if (pipeline.errors != null) {
       throw new ValidationException("Pipeline template is invalid", pipeline.errors as List<Map<String, Object>>)
     }
+    return pipeline
   }
 
   private void parsePipelineTrigger(ExecutionRepository executionRepository, BuildService buildService, Map pipeline) {


### PR DESCRIPTION
This fixes a regression introduced in #1937. The preprocessors are not mutating `pipeline` inline, so we have to return the new, rendered pipeline back to caller.