### PR TITLE
feat(core): Allow a synthetic stage to override `stageTimeoutMs`

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -486,12 +486,22 @@ public class Stage implements Serializable {
     return topLevelStage;
   }
 
-  /**
-   * Returns the top-most stage timeout value if present.
-   */
-  @JsonIgnore public Optional<Long> getTopLevelTimeout() {
-    Stage topLevelStage = getTopLevelStage();
-    Object timeout = topLevelStage.getContext().get("stageTimeoutMs");
+  @JsonIgnore public Optional<Stage> getParentWithTimeout() {
+    Stage current = this;
+    Optional<Long> timeout = Optional.empty();
+
+    while (current != null && !timeout.isPresent()) {
+      timeout = current.getTimeout();
+      if (!timeout.isPresent()) {
+        current = current.getParent();
+      }
+    }
+
+    return timeout.isPresent() ? Optional.of(current) : Optional.empty();
+  }
+
+  @JsonIgnore public Optional<Long> getTimeout() {
+    Object timeout = getContext().get(STAGE_TIMEOUT_OVERRIDE_KEY);
     if (timeout instanceof Integer) {
       return Optional.of((Integer) timeout).map(Integer::longValue);
     } else if (timeout instanceof Long) {


### PR DESCRIPTION
```
def pipeline = pipeline {
  stage {
    id = "1"

    stage {
      id = "2"

      stage {
        id = "3"
      }
    }
  }
}
```

This PR allows a synthetic stage (#2 in ^^ example) to override the
`stageTimeoutMs` that will be used by a child synthetic stage (#3).

The current behavior has a synthetic stage only looking at it's root
top-level stage for `stageTimeoutMs`.

Will be used by spinnaker/orca#1944
