### PR TITLE
fix(provider/kubernetes) - fixes exception when deploying with manual or container based trigger

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesContainerFinder.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesContainerFinder.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.kubernetes
 
+import com.netflix.spinnaker.orca.pipeline.model.DockerTrigger
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 
@@ -84,7 +85,8 @@ class KubernetesContainerFinder {
         if (stage.execution.type == PIPELINE) {
           def trigger = stage.execution.trigger
 
-          if (trigger?.account == container.imageDescription.account && trigger?.repository == container.imageDescription.repository) {
+
+          if ((trigger instanceof DockerTrigger && trigger.account == container.imageDescription.account && trigger.repository == container.imageDescription.repository) || (trigger?.otherProperties?.account == container.imageDescription.account && trigger?.otherProperties?.repository == container.imageDescription.repository)) {
             container.imageDescription.tag = trigger.tag
           }
         }


### PR DESCRIPTION
Due to the changes in moving orca triggers to classes vs maps it caused the exception below when deploying to Kubernetes and using a DockerTrigger or ManualTrigger when choosing a container to deploy

```
No such property: account for class: com.netflix.spinnaker.orca.pipeline.model.DockerTrigger\n\tat org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:53)\n\tat org.codehaus.groovy.runtime.callsite.GetEffectivePojoPropertySite.getProperty(GetEffectivePojoPropertySite.java:66)\n\tat org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGetProperty(AbstractCallSite.java:296)\n\tat org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGetPropertySafe(AbstractCallSite.java:410)\n\tat com.netflix.spinnaker.orca.clouddriver.tasks.providers.kubernetes.KubernetesContainerFinder$_populateFromStage_closure1.doCall(KubernetesContainerFinder.groovy:87)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)\n\tat groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)\n\tat org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:294)\n\tat groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1022)\n\tat groovy.lang.Closure.call(Closure.java:414)\n\tat org.codehaus.groovy.runtime.ConvertedClosure.invokeCustom(ConvertedClosure.java:54)\n\tat org.codehaus.groovy.runtime.ConversionHandler.invoke(ConversionHandler.java:124)\n\tat com.sun.proxy.$Proxy163.accept(Unknown Source)\n\tat java.util.ArrayList.forEach(ArrayList.java:1249)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```