### PR TITLE
fix(queue): Only remove synthetic stages if there are replacements

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -158,7 +158,7 @@ class CompleteStageHandler(
       val onFailureStages = builder.onFailureStages(this)
       val alreadyPlanned = onFailureStages.any { previouslyPlannedAfterStageNames.contains(it.name) }
 
-      if (alreadyPlanned) {
+      if (alreadyPlanned || onFailureStages.isEmpty()) {
         return emptyList()
       }
 


### PR DESCRIPTION
Currently any non-started synthetic stage is removed from the graph
even if there are no `onFailure` stages to replace them.
