### PR TITLE
feat(core/executionWindows): add endpoint to get next time for an exe…

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindow.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindow.java
@@ -16,14 +16,14 @@
 
 package com.netflix.spinnaker.orca.pipeline;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.netflix.spinnaker.orca.RetryableTask;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask;
+import com.netflix.spinnaker.orca.pipeline.window.TimeWindowCalculator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
@@ -37,8 +37,6 @@ import java.util.concurrent.TimeUnit;
 import static com.netflix.spinnaker.orca.ExecutionStatus.*;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
-import static java.util.Calendar.*;
-import static java.util.Collections.singletonList;
 
 /**
  * A stage that suspends execution of pipeline if the current stage is restricted to run during a time window and
@@ -46,8 +44,6 @@ import static java.util.Collections.singletonList;
  */
 @Component
 public class RestrictExecutionDuringTimeWindow implements StageDefinitionBuilder {
-
-  private final Logger log = LoggerFactory.getLogger(getClass());
 
   public static final String TYPE = "restrictExecutionDuringTimeWindow";
 
@@ -118,8 +114,11 @@ public class RestrictExecutionDuringTimeWindow implements StageDefinitionBuilder
   }
 
   @Component
-  @VisibleForTesting
-  private static class SuspendExecutionDuringTimeWindowTask implements RetryableTask {
+  public static class SuspendExecutionDuringTimeWindowTask implements RetryableTask {
+
+    @Autowired
+    TimeWindowCalculator timeWindowCalculator;
+
     @Override public long getBackoffPeriod() {
       return TimeUnit.SECONDS.toMillis(30);
     }
@@ -128,21 +127,13 @@ public class RestrictExecutionDuringTimeWindow implements StageDefinitionBuilder
       return TimeUnit.DAYS.toMillis(7);
     }
 
-    private static final int DAY_START_HOUR = 0;
-    private static final int DAY_START_MIN = 0;
-    private static final int DAY_END_HOUR = 23;
-    private static final int DAY_END_MIN = 59;
-
     private final Logger log = LoggerFactory.getLogger(getClass());
-
-    @Value("${tasks.executionWindow.timezone:America/Los_Angeles}")
-    String timeZoneId;
 
     @Override public @Nonnull TaskResult execute(@Nonnull Stage stage) {
       Instant now = Instant.now();
       Instant scheduledTime;
       try {
-        scheduledTime = getTimeInWindow(stage, now);
+        scheduledTime = getTimeInWindowForStage(stage, now);
       } catch (Exception e) {
         return new TaskResult(TERMINAL, Collections.singletonMap("failureReason", "Exception occurred while calculating time window: " + e.getMessage()));
       }
@@ -156,257 +147,139 @@ public class RestrictExecutionDuringTimeWindow implements StageDefinitionBuilder
       }
     }
 
-    static class RestrictedExecutionWindowConfig {
-      private ExecutionWindowConfig restrictedExecutionWindow;
-
-      public ExecutionWindowConfig getRestrictedExecutionWindow() {
-        return restrictedExecutionWindow;
-      }
-
-      public void setRestrictedExecutionWindow(ExecutionWindowConfig restrictedExecutionWindow) {
-        this.restrictedExecutionWindow = restrictedExecutionWindow;
-      }
-    }
-
-    static class ExecutionWindowConfig {
-      private List<TimeWindowConfig> whitelist = new ArrayList<>();
-      private List<Integer> days = new ArrayList<>();
-
-      public List<TimeWindowConfig> getWhitelist() {
-        return whitelist;
-      }
-
-      public void setWhitelist(List<TimeWindowConfig> whitelist) {
-        this.whitelist = whitelist;
-      }
-
-      public List<Integer> getDays() {
-        return days;
-      }
-
-      public void setDays(List<Integer> days) {
-        this.days = days;
-      }
-
-      @Override public String toString() {
-        return format("[ whitelist: %s, days: %s ]", whitelist, days);
-      }
-    }
-
-    static class TimeWindowConfig {
-      private int startHour;
-      private int startMin;
-      private int endHour;
-      private int endMin;
-
-      public int getStartHour() {
-        return startHour;
-      }
-
-      public void setStartHour(int startHour) {
-        this.startHour = startHour;
-      }
-
-      public int getStartMin() {
-        return startMin;
-      }
-
-      public void setStartMin(int startMin) {
-        this.startMin = startMin;
-      }
-
-      public int getEndHour() {
-        return endHour;
-      }
-
-      public void setEndHour(int endHour) {
-        this.endHour = endHour;
-      }
-
-      public int getEndMin() {
-        return endMin;
-      }
-
-      public void setEndMin(int endMin) {
-        this.endMin = endMin;
-      }
-
-      @Override public String toString() {
-        return format("[ start: %d:%s, end: %d:%d ]", startHour, startMin, endHour, endMin);
-      }
-    }
-
     /**
      * Calculates a time which is within the whitelist of time windows allowed for execution
      *
      * @param stage
      * @param scheduledTime
-     * @return
+     * @return the next available time
      */
-    @VisibleForTesting
-    private Instant getTimeInWindow(Stage stage, Instant scheduledTime) {
-      // Passing in the current date to allow unit testing
-      try {
-        RestrictedExecutionWindowConfig config = stage.mapTo(RestrictedExecutionWindowConfig.class);
-        List<TimeWindow> whitelistWindows = new ArrayList<>();
-        log.info("Calculating scheduled time for {}; {}", stage.getId(), config.restrictedExecutionWindow);
-        for (TimeWindowConfig timeWindow : config.restrictedExecutionWindow.whitelist) {
-          LocalTime start = LocalTime.of(timeWindow.startHour, timeWindow.startMin);
-          LocalTime end = LocalTime.of(timeWindow.endHour, timeWindow.endMin);
-
-          whitelistWindows.add(new TimeWindow(start, end));
-        }
-        return calculateScheduledTime(scheduledTime, whitelistWindows, config.restrictedExecutionWindow.days);
-
-      } catch (IncorrectTimeWindowsException ite) {
-        throw new RuntimeException("Incorrect time windows specified", ite);
-      }
+    public Instant getTimeInWindowForStage(Stage stage, Instant scheduledTime) {
+      ExecutionWindowConfig restrictedExecutionWindow = stage.mapTo(RestrictedExecutionWindowConfig.class).restrictedExecutionWindow;
+      log.info("Calculating scheduled time for {}; {}", stage.getId(), restrictedExecutionWindow);
+      return timeWindowCalculator.getTimeInWindow(restrictedExecutionWindow, scheduledTime);
     }
 
-    @VisibleForTesting
-    private Instant calculateScheduledTime(Instant scheduledTime, List<TimeWindow> whitelistWindows, List<Integer> whitelistDays) throws IncorrectTimeWindowsException {
-      return calculateScheduledTime(scheduledTime, whitelistWindows, whitelistDays, false);
+  }
+
+  public static class RestrictedExecutionWindowConfig {
+    private ExecutionWindowConfig restrictedExecutionWindow;
+
+    public ExecutionWindowConfig getRestrictedExecutionWindow() {
+      return restrictedExecutionWindow;
     }
 
-    private Instant calculateScheduledTime(Instant scheduledTime, List<TimeWindow> whitelistWindows, List<Integer> whitelistDays, boolean dayIncremented) throws IncorrectTimeWindowsException {
-      if ((whitelistWindows.isEmpty()) && !whitelistDays.isEmpty()) {
-        whitelistWindows = singletonList(new TimeWindow(LocalTime.of(0, 0), LocalTime.of(23, 59)));
-      }
-
-      boolean inWindow = false;
-      Collections.sort(whitelistWindows);
-      List<TimeWindow> normalized = normalizeTimeWindows(whitelistWindows);
-      Calendar calendar = Calendar.getInstance();
-      calendar.setTimeZone(TimeZone.getTimeZone(timeZoneId));
-      calendar.setTime(new Date(scheduledTime.toEpochMilli()));
-      boolean todayIsValid = true;
-
-      if (!whitelistDays.isEmpty()) {
-        int daysIncremented = 0;
-        while (daysIncremented < 7) {
-          boolean nextDayFound = false;
-          if (whitelistDays.contains(calendar.get(DAY_OF_WEEK))) {
-            nextDayFound = true;
-            todayIsValid = daysIncremented == 0;
-          }
-          if (nextDayFound) {
-            break;
-          }
-          calendar.add(DAY_OF_MONTH, 1);
-          resetToTomorrow(calendar);
-          daysIncremented++;
-        }
-      }
-      if (todayIsValid) {
-        for (TimeWindow timeWindow : normalized) {
-          LocalTime hourMin = LocalTime.of(calendar.get(HOUR_OF_DAY), calendar.get(MINUTE));
-          int index = timeWindow.indexOf(hourMin);
-          if (index == -1) {
-            calendar.set(HOUR_OF_DAY, timeWindow.start.getHour());
-            calendar.set(MINUTE, timeWindow.start.getMinute());
-            calendar.set(SECOND, 0);
-            inWindow = true;
-            break;
-          } else if (index == 0) {
-            inWindow = true;
-            break;
-          }
-        }
-      }
-
-      if (!inWindow) {
-        if (!dayIncremented) {
-          resetToTomorrow(calendar);
-          return calculateScheduledTime(calendar.getTime().toInstant(), whitelistWindows, whitelistDays, true);
-        } else {
-          throw new IncorrectTimeWindowsException("Couldn't calculate a suitable time within given time windows");
-        }
-      }
-
-      if (dayIncremented) {
-        calendar.add(DAY_OF_MONTH, 1);
-      }
-      return calendar.getTime().toInstant();
-    }
-
-    private static void resetToTomorrow(Calendar calendar) {
-      calendar.set(HOUR_OF_DAY, DAY_START_HOUR);
-      calendar.set(MINUTE, DAY_START_MIN);
-      calendar.set(SECOND, 0);
-    }
-
-    private static List<TimeWindow> normalizeTimeWindows(List<TimeWindow> timeWindows) {
-      List<TimeWindow> normalized = new ArrayList<>();
-      for (TimeWindow timeWindow : timeWindows) {
-        int startHour = timeWindow.start.getHour();
-        int startMin = timeWindow.start.getMinute();
-        int endHour = timeWindow.end.getHour();
-        int endMin = timeWindow.end.getMinute();
-
-        if (startHour > endHour) {
-          LocalTime start1 = LocalTime.of(startHour, startMin);
-          LocalTime end1 = LocalTime.of(DAY_END_HOUR, DAY_END_MIN);
-          normalized.add(new TimeWindow(start1, end1));
-
-          LocalTime start2 = LocalTime.of(DAY_START_HOUR, DAY_START_MIN);
-          LocalTime end2 = LocalTime.of(endHour, endMin);
-          normalized.add(new TimeWindow(start2, end2));
-
-        } else {
-          LocalTime start = LocalTime.of(startHour, startMin);
-          LocalTime end = LocalTime.of(endHour, endMin);
-          normalized.add(new TimeWindow(start, end));
-        }
-      }
-      Collections.sort(normalized);
-      return normalized;
-    }
-
-    @VisibleForTesting
-    private static class TimeWindow implements Comparable {
-      private final LocalTime start;
-      private final LocalTime end;
-
-      TimeWindow(LocalTime start, LocalTime end) {
-        this.start = start;
-        this.end = end;
-      }
-
-      @Override public int compareTo(Object o) {
-        TimeWindow rhs = (TimeWindow) o;
-        return this.start.compareTo(rhs.start);
-      }
-
-      int indexOf(LocalTime current) {
-        if (current.isBefore(this.start)) {
-          return -1;
-        } else if ((current.isAfter(this.start) || current.equals(this.start)) && (current.isBefore(this.end) || current.equals(this.end))) {
-          return 0;
-        } else {
-          return 1;
-        }
-      }
-
-      LocalTime getStart() {
-        return start;
-      }
-
-      LocalTime getEnd() {
-        return end;
-      }
-
-      private static
-      final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("HH:mm");
-
-      @Override public String toString() {
-        return format("{%s to %s}", start.format(FORMAT), end.format(FORMAT));
-      }
-    }
-
-    private static class IncorrectTimeWindowsException extends Exception {
-      IncorrectTimeWindowsException(String message) {
-        super(message);
-      }
+    public void setRestrictedExecutionWindow(ExecutionWindowConfig restrictedExecutionWindow) {
+      this.restrictedExecutionWindow = restrictedExecutionWindow;
     }
   }
+
+  public static class TimeWindowConfig {
+    private int startHour;
+    private int startMin;
+    private int endHour;
+    private int endMin;
+
+    public int getStartHour() {
+      return startHour;
+    }
+
+    public void setStartHour(int startHour) {
+      this.startHour = startHour;
+    }
+
+    public int getStartMin() {
+      return startMin;
+    }
+
+    public void setStartMin(int startMin) {
+      this.startMin = startMin;
+    }
+
+    public int getEndHour() {
+      return endHour;
+    }
+
+    public void setEndHour(int endHour) {
+      this.endHour = endHour;
+    }
+
+    public int getEndMin() {
+      return endMin;
+    }
+
+    public void setEndMin(int endMin) {
+      this.endMin = endMin;
+    }
+
+    @Override public String toString() {
+      return format("[ start: %d:%s, end: %d:%d ]", startHour, startMin, endHour, endMin);
+    }
+  }
+
+  public static class TimeWindow implements Comparable {
+    public final LocalTime start;
+    public final LocalTime end;
+
+    public TimeWindow(LocalTime start, LocalTime end) {
+      this.start = start;
+      this.end = end;
+    }
+
+    @Override public int compareTo(Object o) {
+      TimeWindow rhs = (TimeWindow) o;
+      return this.start.compareTo(rhs.start);
+    }
+
+    public int indexOf(LocalTime current) {
+      if (current.isBefore(this.start)) {
+        return -1;
+      } else if ((current.isAfter(this.start) || current.equals(this.start)) && (current.isBefore(this.end) || current.equals(this.end))) {
+        return 0;
+      } else {
+        return 1;
+      }
+    }
+
+    LocalTime getStart() {
+      return start;
+    }
+
+    LocalTime getEnd() {
+      return end;
+    }
+
+    private static
+    final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("HH:mm");
+
+    @Override public String toString() {
+      return format("{%s to %s}", start.format(FORMAT), end.format(FORMAT));
+    }
+  }
+
+  public static class ExecutionWindowConfig {
+    private List<TimeWindowConfig> whitelist = new ArrayList<>();
+    private List<Integer> days = new ArrayList<>();
+
+    public List<TimeWindowConfig> getWhitelist() {
+      return whitelist;
+    }
+
+    public void setWhitelist(List<TimeWindowConfig> whitelist) {
+      this.whitelist = whitelist;
+    }
+
+    public List<Integer> getDays() {
+      return days;
+    }
+
+    public void setDays(List<Integer> days) {
+      this.days = days;
+    }
+
+    @Override public String toString() {
+      return format("[ whitelist: %s, days: %s ]", whitelist, days);
+    }
+  }
+
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/window/TimeWindowCalculator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/window/TimeWindowCalculator.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.window;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWindow;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalTime;
+import java.util.*;
+
+import static java.util.Calendar.*;
+import static java.util.Calendar.SECOND;
+import static java.util.Collections.singletonList;
+
+@Component
+public class TimeWindowCalculator {
+
+  private static final int DAY_START_HOUR = 0;
+  private static final int DAY_START_MIN = 0;
+  private static final int DAY_END_HOUR = 23;
+  private static final int DAY_END_MIN = 59;
+
+  @Value("${tasks.executionWindow.timezone:America/Los_Angeles}")
+  private String timeZoneId;
+
+  public Instant getTimeInWindow(RestrictExecutionDuringTimeWindow.ExecutionWindowConfig restrictedExecutionWindow, Instant scheduledTime) {
+    // Passing in the current date to allow unit testing
+    try {
+      List<RestrictExecutionDuringTimeWindow.TimeWindow> whitelistWindows = new ArrayList<>();
+      for (RestrictExecutionDuringTimeWindow.TimeWindowConfig timeWindow : restrictedExecutionWindow.getWhitelist()) {
+        LocalTime start = LocalTime.of(timeWindow.getStartHour(), timeWindow.getStartMin());
+        LocalTime end = LocalTime.of(timeWindow.getEndHour(), timeWindow.getEndMin());
+
+        whitelistWindows.add(new RestrictExecutionDuringTimeWindow.TimeWindow(start, end));
+      }
+      return calculateScheduledTime(scheduledTime, whitelistWindows, restrictedExecutionWindow.getDays());
+
+    } catch (IncorrectTimeWindowsException ite) {
+      throw new RuntimeException("Incorrect time windows specified", ite);
+    }
+  }
+
+  @VisibleForTesting
+  private Instant calculateScheduledTime(Instant scheduledTime, List<RestrictExecutionDuringTimeWindow.TimeWindow> whitelistWindows, List<Integer> whitelistDays) throws IncorrectTimeWindowsException {
+    return calculateScheduledTime(scheduledTime, whitelistWindows, whitelistDays, false);
+  }
+
+  private Instant calculateScheduledTime(Instant scheduledTime, List<RestrictExecutionDuringTimeWindow.TimeWindow> whitelistWindows, List<Integer> whitelistDays, boolean dayIncremented) throws IncorrectTimeWindowsException {
+    if ((whitelistWindows.isEmpty()) && !whitelistDays.isEmpty()) {
+      whitelistWindows = singletonList(new RestrictExecutionDuringTimeWindow.TimeWindow(LocalTime.of(0, 0), LocalTime.of(23, 59)));
+    }
+
+    boolean inWindow = false;
+    Collections.sort(whitelistWindows);
+    List<RestrictExecutionDuringTimeWindow.TimeWindow> normalized = normalizeTimeWindows(whitelistWindows);
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTimeZone(TimeZone.getTimeZone(timeZoneId));
+    calendar.setTime(new Date(scheduledTime.toEpochMilli()));
+    boolean todayIsValid = true;
+
+    if (!whitelistDays.isEmpty()) {
+      int daysIncremented = 0;
+      while (daysIncremented < 7) {
+        boolean nextDayFound = false;
+        if (whitelistDays.contains(calendar.get(DAY_OF_WEEK))) {
+          nextDayFound = true;
+          todayIsValid = daysIncremented == 0;
+        }
+        if (nextDayFound) {
+          break;
+        }
+        calendar.add(DAY_OF_MONTH, 1);
+        resetToTomorrow(calendar);
+        daysIncremented++;
+      }
+    }
+    if (todayIsValid) {
+      for (RestrictExecutionDuringTimeWindow.TimeWindow timeWindow : normalized) {
+        LocalTime hourMin = LocalTime.of(calendar.get(HOUR_OF_DAY), calendar.get(MINUTE));
+        int index = timeWindow.indexOf(hourMin);
+        if (index == -1) {
+          calendar.set(HOUR_OF_DAY, timeWindow.start.getHour());
+          calendar.set(MINUTE, timeWindow.start.getMinute());
+          calendar.set(SECOND, 0);
+          inWindow = true;
+          break;
+        } else if (index == 0) {
+          inWindow = true;
+          break;
+        }
+      }
+    }
+
+    if (!inWindow) {
+      if (!dayIncremented) {
+        resetToTomorrow(calendar);
+        return calculateScheduledTime(calendar.getTime().toInstant(), whitelistWindows, whitelistDays, true);
+      } else {
+        throw new IncorrectTimeWindowsException("Couldn't calculate a suitable time within given time windows");
+      }
+    }
+
+    if (dayIncremented) {
+      calendar.add(DAY_OF_MONTH, 1);
+    }
+    return calendar.getTime().toInstant();
+  }
+
+  private static void resetToTomorrow(Calendar calendar) {
+    calendar.set(HOUR_OF_DAY, DAY_START_HOUR);
+    calendar.set(MINUTE, DAY_START_MIN);
+    calendar.set(SECOND, 0);
+  }
+
+  private static List<RestrictExecutionDuringTimeWindow.TimeWindow> normalizeTimeWindows(List<RestrictExecutionDuringTimeWindow.TimeWindow> timeWindows) {
+    List<RestrictExecutionDuringTimeWindow.TimeWindow> normalized = new ArrayList<>();
+    for (RestrictExecutionDuringTimeWindow.TimeWindow timeWindow : timeWindows) {
+      int startHour = timeWindow.start.getHour();
+      int startMin = timeWindow.start.getMinute();
+      int endHour = timeWindow.end.getHour();
+      int endMin = timeWindow.end.getMinute();
+
+      if (startHour > endHour) {
+        LocalTime start1 = LocalTime.of(startHour, startMin);
+        LocalTime end1 = LocalTime.of(DAY_END_HOUR, DAY_END_MIN);
+        normalized.add(new RestrictExecutionDuringTimeWindow.TimeWindow(start1, end1));
+
+        LocalTime start2 = LocalTime.of(DAY_START_HOUR, DAY_START_MIN);
+        LocalTime end2 = LocalTime.of(endHour, endMin);
+        normalized.add(new RestrictExecutionDuringTimeWindow.TimeWindow(start2, end2));
+
+      } else {
+        LocalTime start = LocalTime.of(startHour, startMin);
+        LocalTime end = LocalTime.of(endHour, endMin);
+        normalized.add(new RestrictExecutionDuringTimeWindow.TimeWindow(start, end));
+      }
+    }
+    Collections.sort(normalized);
+    return normalized;
+  }
+
+  public static class IncorrectTimeWindowsException extends Exception {
+    public IncorrectTimeWindowsException(String message) {
+      super(message);
+    }
+  }
+
+}

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TimeWindowController.java
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TimeWindowController.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.controllers;
+
+import com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWindow.ExecutionWindowConfig;
+import com.netflix.spinnaker.orca.pipeline.window.TimeWindowCalculator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+
+@RestController
+public class TimeWindowController {
+
+  @Autowired
+  private TimeWindowCalculator timeWindowCalculator;
+
+  @RequestMapping(value = "/timeWindow/nextAvailable", method = RequestMethod.POST)
+  public long getNextAvailableTimeWindow(@RequestBody ExecutionWindowConfig windowConfig) {
+    return timeWindowCalculator.getTimeInWindow(windowConfig, Instant.now()).toEpochMilli();
+  }
+
+}


### PR DESCRIPTION
…cution window

Exposes an endpoint to get the timestamp of the next available time for a given execution window, e.g.
```bash
curl 'http://orca-local/timeWindow/nextAvailable' 
  -H 'Content-Type: application/json;charset=UTF-8' 
  --data-binary '{ "whitelist": [ { "startMin": 0, "startHour": 18, "endMin": 0, "endHour": 20}]}' 
```
might return `1518660000965`

This looks like a lot more code changing than it is. It's almost entirely moving the time window calculations into its own class/component and un-nesting some of the internal static classes. I don't think we can un-nest anything else without breaking deserialization of running tasks.

Would appreciate feedback on the route (we'll need to expose it in Gate and would like to keep them consistent), as well as some confidence this won't break on running tasks.