### PR TITLE
feat(aws): Support for pinning min=desired capacity on source server group

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/DeployStagePreProcessor.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/DeployStagePreProcessor.java
@@ -33,15 +33,19 @@ import java.util.Map;
 public interface DeployStagePreProcessor {
   boolean supports(Stage stage);
 
-  default List<StepDefinition> additionalSteps() {
+  default List<StepDefinition> additionalSteps(Stage stage) {
     return Collections.emptyList();
   }
 
-  default List<StageDefinition> beforeStageDefinitions() {
+  default List<StageDefinition> beforeStageDefinitions(Stage stage) {
     return Collections.emptyList();
   }
 
-  default List<StageDefinition> afterStageDefinitions() {
+  default List<StageDefinition> afterStageDefinitions(Stage stage) {
+    return Collections.emptyList();
+  }
+
+  default List<StageDefinition> onFailureStageDefinitions(Stage stage) {
     return Collections.emptyList();
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
@@ -57,8 +57,12 @@ abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask im
 
   abstract String getServerGroupAction()
 
-  Map getAdditionalStageOutputs(Stage stage, Map operation) {
-    [:]
+  Map<String, Object> getAdditionalContext(Stage stage, Map operation) {
+    return [:]
+  }
+
+  Map<String, Object> getAdditionalOutputs(Stage stage, Map operation) {
+    return [:]
   }
 
   TaskResult execute(Stage stage) {
@@ -93,7 +97,11 @@ abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask im
       ]
     }
 
-    new TaskResult(ExecutionStatus.SUCCEEDED, stageOutputs + getAdditionalStageOutputs(stage, operation))
+    new TaskResult(
+      ExecutionStatus.SUCCEEDED,
+      stageOutputs + getAdditionalContext(stage, operation),
+      getAdditionalOutputs(stage, operation)
+    )
   }
 
   Map convert(Stage stage) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeStrategy.groovy
@@ -46,6 +46,12 @@ interface ResizeStrategy {
   }
 
   @Canonical
+  static class CapacitySet {
+    Capacity original
+    Capacity target
+  }
+
+  @Canonical
   static class Capacity {
     Integer max
     Integer desired
@@ -75,5 +81,5 @@ interface ResizeStrategy {
   }
 
   boolean handles(ResizeAction resizeAction)
-  Capacity capacityForOperation(Stage stage, String account, String serverGroupName, String cloudProvider, Location location, OptionalConfiguration resizeConfig)
+  CapacitySet capacityForOperation(Stage stage, String account, String serverGroupName, String cloudProvider, Location location, OptionalConfiguration resizeConfig)
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeStrategySupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeStrategySupport.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kato.pipeline.support
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.RollingRedBlackStageData
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+
+public class ResizeStrategySupport {
+  static ResizeStrategy.Source getSource(TargetServerGroupResolver targetServerGroupResolver,
+                                         StageData stageData,
+                                         Map baseContext) {
+    if (stageData.source) {
+      return new ResizeStrategy.Source(
+        region: stageData.source.region,
+        serverGroupName: stageData.source.serverGroupName ?: stageData.source.asgName,
+        credentials: stageData.credentials ?: stageData.account,
+        cloudProvider: stageData.cloudProvider
+      )
+    }
+
+    // no source server group specified, lookup current server group
+    TargetServerGroup target = targetServerGroupResolver.resolve(
+      new Stage(null, null, null, baseContext + [target: TargetServerGroup.Params.Target.current_asg_dynamic])
+    )?.get(0)
+
+    if (!target) {
+      throw new IllegalStateException("No target server groups found (${baseContext})")
+    }
+
+    return new ResizeStrategy.Source(
+      region: target.getLocation().value,
+      serverGroupName: target.getName(),
+      credentials: stageData.credentials ?: stageData.account,
+      cloudProvider: stageData.cloudProvider
+    )
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToClusterResizeStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToClusterResizeStrategy.groovy
@@ -20,9 +20,6 @@ import com.netflix.frigga.Names
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
-import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.Capacity
-import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.OptionalConfiguration
-import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.ResizeAction
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -39,7 +36,12 @@ class ScaleToClusterResizeStrategy implements ResizeStrategy{
   }
 
   @Override
-  Capacity capacityForOperation(Stage stage, String account, String serverGroupName, String cloudProvider, Location location, OptionalConfiguration resizeConfig) {
+  CapacitySet capacityForOperation(Stage stage,
+                                   String account,
+                                   String serverGroupName,
+                                   String cloudProvider,
+                                   Location location,
+                                   OptionalConfiguration resizeConfig) {
     def names = Names.parseName(serverGroupName)
     def appName = stage?.context?.moniker?.app ?: names.app
     def clusterName = stage?.context?.moniker?.cluster ?:names.cluster
@@ -73,6 +75,6 @@ class ScaleToClusterResizeStrategy implements ResizeStrategy{
     capacity.desired = Math.max(capacity.min, capacity.desired)
     capacity.desired = Math.min(capacity.desired + increment, capacity.max)
 
-    return capacity
+    return new CapacitySet(null, capacity)
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleExactResizeStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleExactResizeStrategySpec.groovy
@@ -45,12 +45,13 @@ class ScaleExactResizeStrategySpec extends Specification {
     def cap = strategy.capacityForOperation(stage, account, serverGroupName, cloudProvider, location, resizeConfig)
 
     then:
-    cap == expected
+    cap.original == new Capacity(current)
+    cap.target == expected
     1 * oortHelper.getTargetServerGroup(account, serverGroupName, region, cloudProvider) >> targetServerGroup
     0 * _
 
     where:
-    specifiedCap                       | current                                      || expected
+    specifiedCap                       | current                      || expected
     [min: 0]                           | [min: 1, max: 1, desired: 1] || new Capacity(min: 0, max: 1, desired: 1)
     [max: 0]                           | [min: 1, max: 1, desired: 1] || new Capacity(min: 0, max: 0, desired: 0)
     [max: 1]                           | [min: 1, max: 1, desired: 1] || new Capacity(min: 1, max: 1, desired: 1)

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleRelativeResizeStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleRelativeResizeStrategySpec.groovy
@@ -35,7 +35,8 @@ class ScaleRelativeResizeStrategySpec extends Specification {
     def cap = strategy.capacityForOperation(stage, account, serverGroupName, cloudProvider, location, resizeConfig)
 
     then:
-    cap == expected
+    cap.original == original
+    cap.target == expected
     1 * oortHelper.getTargetServerGroup(account, serverGroupName, region, cloudProvider) >> targetServerGroup
     0 * _
 
@@ -51,8 +52,16 @@ class ScaleRelativeResizeStrategySpec extends Specification {
     "scaleNum" | "scale_down" | 6     || 4
     "scaleNum" | "scale_down" | 100   || 0
     serverGroupName = asgName()
-    targetServerGroup = Optional.of(new TargetServerGroup(name: serverGroupName, region: region, type: cloudProvider, capacity: [min: 10, max: 10, desired: 10]))
+    original = new ResizeStrategy.Capacity(10, 10, 10)
     expected = new ResizeStrategy.Capacity(want, want, want)
+    targetServerGroup = Optional.of(
+      new TargetServerGroup(
+        name: serverGroupName,
+        region: region,
+        type: cloudProvider,
+        capacity: [min: original.min, max: original.max, desired: original.desired]
+      )
+    )
     scalePct = method == 'scalePct' ? value : null
     scaleNum = method == 'scaleNum' ? value : null
     resizeConfig = cfg(direction, scalePct, scaleNum)

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToClusterResizeStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToClusterResizeStrategySpec.groovy
@@ -57,16 +57,17 @@ class ScaleToClusterResizeStrategySpec extends Specification {
     def cap = strategy.capacityForOperation(stage, account, serverGroupName, cloudProvider, location, resizeConfig)
 
     then:
-    cap == expectedCapacity
+    cap.original == null    // capacity bounds could come from multiple server groups -- no single source
+    cap.target == expectedCapacity
     1 * oortHelper.getCluster(application, account, clusterName, cloudProvider) >> cluster
     0 * _
 
     where:
-    serverGroups                                          | expectedCapacity
-    [mkSG()]                                              | new Capacity(0, 0, 0)
-    [mkSG(1)]                                             | new Capacity(1, 1, 1)
-    [mkSG(1), mkSG(1000, 1000, 1000, 'different-region')] | new Capacity(1, 1, 1)
-    [mkSG(0, 0, 10), mkSG(0, 1, 5), mkSG(5, 0, 9)]        | new Capacity(10, 5, 1)
+    serverGroups                                          || expectedCapacity
+    [mkSG()]                                              || new Capacity(0, 0, 0)
+    [mkSG(1)]                                             || new Capacity(1, 1, 1)
+    [mkSG(1), mkSG(1000, 1000, 1000, 'different-region')] || new Capacity(1, 1, 1)
+    [mkSG(0, 0, 10), mkSG(0, 1, 5), mkSG(5, 0, 9)]        || new Capacity(10, 5, 1)
 
     serverGroupName = asgName()
     resizeConfig = cfg()
@@ -81,16 +82,17 @@ class ScaleToClusterResizeStrategySpec extends Specification {
     def cap = strategy.capacityForOperation(stage, account, serverGroupName, cloudProvider, location, resizeConfig)
 
     then:
-    cap == expectedCapacity
+    cap.original == null    // capacity bounds could come from multiple server groups -- no single source
+    cap.target == expectedCapacity
     1 * oortHelper.getCluster(application, account, clusterName, cloudProvider) >> cluster
     0 * _
 
     where:
-    serverGroups                                   | scaleNum | scalePct | expectedCapacity
-    [mkSG()]                                       | 1        | null     | new Capacity(0, 0, 0)
-    [mkSG(1)]                                      | 1        | null     | new Capacity(1, 1, 1)
-    [mkSG(0, 0, 10), mkSG(0, 1, 5), mkSG(5, 0, 9)] | 1        | null     | new Capacity(10, 6, 1)
-    [mkSG(100, 0, 1000)]                           | null     | 1        | new Capacity(1000, 101, 0)
+    serverGroups                                   | scaleNum | scalePct || expectedCapacity
+    [mkSG()]                                       | 1        | null     || new Capacity(0, 0, 0)
+    [mkSG(1)]                                      | 1        | null     || new Capacity(1, 1, 1)
+    [mkSG(0, 0, 10), mkSG(0, 1, 5), mkSG(5, 0, 9)] | 1        | null     || new Capacity(10, 6, 1)
+    [mkSG(100, 0, 1000)]                           | null     | 1        || new Capacity(1000, 101, 0)
 
     resizeConfig = cfg(scalePct, scaleNum)
     cluster = Optional.of([serverGroups: serverGroups])

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToServerGroupResizeStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleToServerGroupResizeStrategySpec.groovy
@@ -100,9 +100,8 @@ class ScaleToServerGroupResizeStrategySpec extends Specification {
       ))
     }
 
-    capacity.min == expectedMin
-    capacity.desired == expectedDesired
-    capacity.max == expectedMax
+    capacity.original == new ResizeStrategy.Capacity(max: 3, min: 1, desired: 3)
+    capacity.target == new ResizeStrategy.Capacity(max: expectedMax, min: expectedMin, desired: expectedDesired)
 
     where:
     scalePct | pinCapacity | pinMinimumCapacity || expectedMin || expectedDesired || expectedMax

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitTask.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import static com.netflix.spinnaker.orca.ExecutionStatus.RUNNING;
 import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED;
+import static com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL;
 import static java.util.Collections.singletonMap;
 
 @Component

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.ExecutionStatus.*
 import com.netflix.spinnaker.orca.events.StageComplete
 import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
@@ -934,6 +935,8 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
       }
 
       on("receiving the message again") {
+        val onFailureStage = pipeline.stages.first { it.name.equals("onFailure1") }
+        onFailureStage.status = ExecutionStatus.SUCCEEDED
         subject.handle(message)
       }
 


### PR DESCRIPTION
This PR attempts to avoid unnecessary and problematic autoscale events
that occur as the total # of instances increase when a deploy is
happening.

As instance count increases, there is natural downward pressure
on the cluster resulting in the source server group being scaled down.

It is particularly bad for rolling red/black where the old server group
is not immediately disabled.

The expectation is that the source group will be returned to its
original unpinned capacity when the deploy completes (or fails!).
