### PR TITLE
fix(spel): Support new return types in SpEL expressions

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/ReturnTypeRestrictor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/ReturnTypeRestrictor.java
@@ -16,10 +16,28 @@
 
 package com.netflix.spinnaker.orca.pipeline.expressions.whitelisting;
 
-import java.util.*;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.model.Trigger;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 public interface ReturnTypeRestrictor extends InstantiationTypeRestrictor {
   Set<Class<?>> allowedReturnTypes = Collections.unmodifiableSet(
@@ -41,6 +59,10 @@ public interface ReturnTypeRestrictor extends InstantiationTypeRestrictor {
         TreeSet.class,
         Execution.class,
         Stage.class,
+        Trigger.class,
+        JenkinsTrigger.BuildInfo.class,
+        JenkinsTrigger.JenkinsArtifact.class,
+        JenkinsTrigger.SourceControl.class,
         ExecutionStatus.class,
         Execution.AuthenticationDetails.class,
         Execution.PausedDetails.class


### PR DESCRIPTION
Make SpEL support the new strongly typed `Trigger`s and some other models. Gets rid of errors like this: `Failed to evaluate [expression] found getter for requested trigger but rejected due to return type interface com.netflix.spinnaker.orca.pipeline.model.Trigger`