### PR TITLE
chore(*): Wiring up kork redis/dynomite client factories

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/NetflixAWSConfiguration.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/NetflixAWSConfiguration.groovy
@@ -16,11 +16,15 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws
 
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForRequiredInstancesDownTask
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import redis.clients.jedis.Jedis
+import redis.clients.util.Pool
 
 @Configuration
 class NetflixAWSConfiguration {
@@ -31,5 +35,10 @@ class NetflixAWSConfiguration {
   @Bean
   Class<? extends Task> waitForAllInstancesDownOnDisableTaskType() {
     return useWaitForAllNetflixAWSInstancesDownTask ? WaitForAllNetflixAWSInstancesDownTask : WaitForRequiredInstancesDownTask
+  }
+
+  @Bean
+  RedisClientDelegate redisClientDelegate(Pool<Jedis> jedisPool) {
+    return new JedisClientDelegate("primaryDefault", jedisPool)
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/dynomite/DynomiteExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/dynomite/DynomiteExecutionRepository.java
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.orca.pipeline.persistence.dynomite;
 
 import com.netflix.dyno.jedis.DynoJedisPipeline;
-import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import com.netflix.spinnaker.kork.jedis.RedisClientSelector;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
@@ -63,27 +63,21 @@ public class DynomiteExecutionRepository extends AbstractRedisExecutionRepositor
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   public DynomiteExecutionRepository(
-    Registry registry,
-    @Qualifier("redisClientDelegate") RedisClientDelegate redisClientDelegate,
-    @Qualifier("previousRedisClientDelegate") Optional<RedisClientDelegate> previousRedisClientDelegate,
+    RedisClientSelector redisClientSelector,
     @Qualifier("queryAllScheduler") Scheduler queryAllScheduler,
     @Qualifier("queryByAppScheduler") Scheduler queryByAppScheduler,
     @Value("${chunkSize.executionRepository:75}") Integer threadPoolChunkSize
   ) {
-    super(registry, redisClientDelegate, previousRedisClientDelegate, queryAllScheduler, queryByAppScheduler, threadPoolChunkSize);
+    super(redisClientSelector, queryAllScheduler, queryByAppScheduler, threadPoolChunkSize);
   }
 
   public DynomiteExecutionRepository(
-    Registry registry,
-    RedisClientDelegate redisClientDelegate,
-    Optional<RedisClientDelegate> previousRedisClientDelegate,
+    RedisClientSelector redisClientSelector,
     Integer threadPoolSize,
     Integer threadPoolChunkSize
   ) {
     super(
-      registry,
-      redisClientDelegate,
-      previousRedisClientDelegate,
+      redisClientSelector,
       Schedulers.from(Executors.newFixedThreadPool(10)),
       Schedulers.from(Executors.newFixedThreadPool(threadPoolSize)),
       threadPoolChunkSize
@@ -267,5 +261,4 @@ public class DynomiteExecutionRepository extends AbstractRedisExecutionRepositor
   protected String orchestrationKey(String id) {
     return format("{%s:%s}", ORCHESTRATION, id);
   }
-
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepository.java
@@ -16,13 +16,8 @@
 
 package com.netflix.spinnaker.orca.pipeline.persistence.jedis;
 
-import java.util.*;
-import java.util.concurrent.Executors;
-import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-
-import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import com.netflix.spinnaker.kork.jedis.RedisClientSelector;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
@@ -38,6 +33,11 @@ import redis.clients.jedis.Response;
 import redis.clients.jedis.Transaction;
 import rx.Scheduler;
 import rx.schedulers.Schedulers;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.Maps.filterValues;
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION;
@@ -55,27 +55,21 @@ public class JedisExecutionRepository extends AbstractRedisExecutionRepository {
 
   @Autowired
   public JedisExecutionRepository(
-    Registry registry,
-    @Qualifier("redisClientDelegate") RedisClientDelegate redisClientDelegate,
-    @Qualifier("previousRedisClientDelegate") Optional<RedisClientDelegate> previousRedisClientDelegate,
+    RedisClientSelector redisClientSelector,
     @Qualifier("queryAllScheduler") Scheduler queryAllScheduler,
     @Qualifier("queryByAppScheduler") Scheduler queryByAppScheduler,
     @Value("${chunkSize.executionRepository:75}") Integer threadPoolChunkSize
   ) {
-    super(registry, redisClientDelegate, previousRedisClientDelegate, queryAllScheduler, queryByAppScheduler, threadPoolChunkSize);
+    super(redisClientSelector, queryAllScheduler, queryByAppScheduler, threadPoolChunkSize);
   }
 
   public JedisExecutionRepository(
-    Registry registry,
-    RedisClientDelegate redisClientDelegate,
-    Optional<RedisClientDelegate> previousRedisClientDelegate,
+    RedisClientSelector redisClientSelector,
     Integer threadPoolSize,
     Integer threadPoolChunkSize
   ) {
     super(
-      registry,
-      redisClientDelegate,
-      previousRedisClientDelegate,
+      redisClientSelector,
       Schedulers.from(Executors.newFixedThreadPool(10)),
       Schedulers.from(Executors.newFixedThreadPool(threadPoolSize)),
       threadPoolChunkSize

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -24,6 +24,8 @@ import com.netflix.spinnaker.assertj.assertSoftly
 import com.netflix.spinnaker.config.OrcaQueueConfiguration
 import com.netflix.spinnaker.config.QueueConfiguration
 import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.orca.ExecutionStatus.*
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.config.OrcaConfiguration
@@ -848,5 +850,8 @@ class TestConfig {
       deadMessageHandler = deadMessageHandler,
       publisher = publisher
     )
+
+  @Bean fun redisClientSelector(redisClientDelegates: List<RedisClientDelegate>) =
+    RedisClientSelector(redisClientDelegates)
 }
 

--- a/orca-test/src/main/java/com/netflix/spinnaker/orca/test/redis/EmbeddedRedisConfiguration.java
+++ b/orca-test/src/main/java/com/netflix/spinnaker/orca/test/redis/EmbeddedRedisConfiguration.java
@@ -23,6 +23,6 @@ public class EmbeddedRedisConfiguration {
   }
 
   @Bean public RedisClientDelegate redisClientDelegate(Pool<Jedis> jedisPool) {
-    return new JedisClientDelegate(jedisPool);
+    return new JedisClientDelegate("primaryDefault", jedisPool);
   }
 }


### PR DESCRIPTION
Depends on https://github.com/spinnaker/kork/pull/131 before anything will work.

Nothing particularly interesting going on here, but this is what it takes to update any of our services to kork Jedis / Dynomite.

I ran locally with the following config(-ish). `redis.connection` was wiring up the queue, and the execution repository writing into dynomite, reading previous executions from local.

```yaml
redis:
  connection: redis://localhost:6379
  clients:
    executionRepository:
      primary: 
        driver: dynomite
        config:
          applicationName: orca
          clusterName: dyno_spinnaker_staging
          forceUseStaticHosts: true
          connectionPool:
            maxConnsPerHost: 5
          hosts:
          - hostname: ip-1.1.1.1.us-west-2.compute.internal
            ipAddress: 1.1.1.1
      previous:
        driver: redis
        config:
          connection: redis://localhost:6379
```