### PR TITLE
fix(clouddriver): Getting task from clouddriver master when timed out attempts to replicas

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestService.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver
 
+import com.netflix.spinnaker.orca.clouddriver.model.Task
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
 import retrofit.client.Response
 import retrofit.http.Body
@@ -57,4 +58,10 @@ interface KatoRestService {
                                       @Path("id") String id,
                                       @Path("fileName") String fileName)
 
+  /**
+   * This should _only_ be called if there is a problem retrieving the Task from CloudDriverTaskStatusService (ie. a
+   * clouddriver replica).
+   */
+  @GET("/task/{id}")
+  Task lookupTask(@Path("id") String id);
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
@@ -45,7 +45,11 @@ class KatoService {
     return Observable.from(cloudDriverTaskStatusService.listTasks())
   }
 
-  Observable<Task> lookupTask(String id) {
+  Observable<Task> lookupTask(String id, boolean skipReplica = false) {
+    if (skipReplica) {
+      return Observable.from(katoRestService.lookupTask(id))
+    }
+
     return Observable.from(cloudDriverTaskStatusService.lookupTask(id))
   }
 }


### PR DESCRIPTION
- keeping track if we have tried master
- added fx to look up task from master directly (KatoRestService)