### PR TITLE
fix(provider/amazon): restore finding imageId from trigger properties

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
@@ -108,6 +108,9 @@ class AmazonServerGroupCreator implements ServerGroupCreator, DeploymentDetailsA
           if (!operation.imageId && trigger.parameters.imageName) {
             operation.imageId = trigger.parameters.imageName
           }
+          if (!operation.imageId && trigger.properties && trigger.properties.imageName) {
+            operation.imageId = trigger.properties.imageName
+          }
         }
       }
     }


### PR DESCRIPTION
Restores a block of code from https://github.com/spinnaker/orca/pull/1254 that was removed during a refactor.