### PR TITLE
chore(build): add debug flag to orca build

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ The tasks of a stage share a common context and can publish to a global context 
 For example a _bake_ stage publishes details of the image it creates which is then used by a _deploy_ stage.
 
 Orca persists a running execution to Redis.
+
+### Debugging
+
+To start the JVM in debug mode, set the Java system property `DEBUG=true`:
+```
+./gradlew -DDEBUG=true
+```
+
+The JVM will then listen for a debugger to be attached on port 8183.  The JVM will _not_ wait for the debugger
+to be attached before starting Orca; the relevant JVM arguments can seen and be modified as needed in `build.gradle`.

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,12 @@ allprojects {
       }
     }
   }
+
+  tasks.withType(JavaExec) {
+    if (System.getProperty('DEBUG', 'false') == 'true') {
+      jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8183'
+    }
+  }
 }
 subprojects {
   license {


### PR DESCRIPTION
Starting orca with ./gradlew -DDEBUG=true now causes the JVM to
listen on port 8183 for a remote debugger.