### PR TITLE
refactor(artifacts): Move artifact binding to orca-core

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.job
 
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
-import com.netflix.spinnaker.orca.clouddriver.tasks.artifacts.BindProducedArtifactsTask
+import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.job.RunJobTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.job.WaitOnJobCompletion
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
@@ -18,7 +18,7 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.manifest;
 
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
-import com.netflix.spinnaker.orca.clouddriver.tasks.artifacts.BindProducedArtifactsTask;
+import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestForceCacheRefreshTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.PromoteManifestKatoOutputsTask;

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/artifacts/BindProducedArtifactsTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/artifacts/BindProducedArtifactsTask.java
@@ -15,7 +15,7 @@
  *
  */
 
-package com.netflix.spinnaker.orca.clouddriver.tasks.artifacts;
+package com.netflix.spinnaker.orca.pipeline.tasks.artifacts;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
In order to use the artifact binding functionality in the image bakery,
we'll need this functionality to be available in orca-core so it can
be called from orca-bakery.