### PR TITLE
feat(orca-core+queue): Add `errors` field to a Stage and wire from ExecutionHandler.Response

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskResult.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskResult.java
@@ -29,19 +29,37 @@ public final class TaskResult {
   private final ExecutionStatus status;
   private final ImmutableMap<String, ?> context;
   private final ImmutableMap<String, ?> outputs;
+  private final String error;
 
   public TaskResult(ExecutionStatus status) {
-    this(status, emptyMap(), emptyMap());
-  }
-
-  public TaskResult(ExecutionStatus status, Map<String, ?> context, Map<String, ?> outputs) {
-    this.status = status;
-    this.context = ImmutableMap.copyOf(context);
-    this.outputs = ImmutableMap.copyOf(outputs);
+    this(status, emptyMap(), emptyMap(), null);
   }
 
   public TaskResult(ExecutionStatus status, Map<String, ?> context) {
-    this(status, context, emptyMap());
+    this(status, context, emptyMap(), null);
+  }
+
+  public TaskResult(ExecutionStatus status, Map<String, ?> context, Map<String, ?> outputs) {
+    this(status, context, outputs, null);
+  }
+
+  public TaskResult(ExecutionStatus status, Map<String, ?> context, Map<String, ?> outputs, String error) {
+    this.status = status;
+    this.context = ImmutableMap.copyOf(context);
+    this.outputs = ImmutableMap.copyOf(outputs);
+    this.error = error;
+  }
+
+  public @Nonnull TaskResult withContext(@Nonnull Map<String, ?> context) {
+    return new TaskResult(this.status, context, this.outputs, this.error);
+  }
+
+  public @Nonnull TaskResult withOutputs(@Nonnull Map<String, ?> outputs) {
+    return new TaskResult(this.status, this.context, outputs, this.error);
+  }
+
+  public @Nonnull TaskResult withError(@Nonnull String error) {
+    return new TaskResult(this.status, this.context, this.outputs, error);
   }
 
   public @Nonnull ExecutionStatus getStatus() {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -197,6 +197,23 @@ public class Stage implements Serializable {
   }
 
   /**
+   * The execution status for this stage
+   */
+  private List<String> errors = new ArrayList<>();
+
+  public @Nonnull List<String> getErrors() {
+    return errors;
+  }
+
+  public void setErrors(@Nonnull List<String> errors) {
+    this.errors = new ArrayList<>(errors);
+  }
+
+  public void addErrors(@Nonnull List<String> errors) {
+    this.errors.addAll(errors);
+  }
+
+  /**
    * The context driving this stage. Provides inputs necessary to component steps
    */
   private Map<String, Object> context = new StageContext(this);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/AbstractRedisExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/AbstractRedisExecutionRepository.java
@@ -58,6 +58,9 @@ import static net.logstash.logback.argument.StructuredArguments.value;
 
 public abstract class AbstractRedisExecutionRepository implements ExecutionRepository {
 
+  private static final TypeReference<List<String>> LIST_OF_STRINGS =
+    new TypeReference<List<String>>() {
+    };
   private static final TypeReference<List<Task>> LIST_OF_TASKS =
     new TypeReference<List<Task>>() {
     };
@@ -499,6 +502,11 @@ public abstract class AbstractRedisExecutionRepository implements ExecutionRepos
         } else {
           stage.setOutputs(emptyMap());
         }
+        if (map.get(prefix + "errors") != null) {
+          stage.setErrors(mapper.readValue(map.get(prefix + "errors"), LIST_OF_STRINGS));
+        } else {
+          stage.setErrors(emptyList());
+        }
         if (map.get(prefix + "tasks") != null) {
           stage.setTasks(mapper.readValue(map.get(prefix + "tasks"), LIST_OF_TASKS));
         } else {
@@ -589,6 +597,7 @@ public abstract class AbstractRedisExecutionRepository implements ExecutionRepos
     try {
       map.put(prefix + "context", mapper.writeValueAsString(stage.getContext()));
       map.put(prefix + "outputs", mapper.writeValueAsString(stage.getOutputs()));
+      map.put(prefix + "errors", mapper.writeValueAsString(stage.getErrors()));
       map.put(prefix + "tasks", mapper.writeValueAsString(stage.getTasks()));
       map.put(prefix + "lastModified", (stage.getLastModified() != null ? mapper.writeValueAsString(stage.getLastModified()) : null));
     } catch (JsonProcessingException e) {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -150,6 +150,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
       stage {
         type = "one"
         context = [foo: "foo"]
+        errors = ["error: first", "error: second"]
       }
       stage {
         type = "two"
@@ -158,6 +159,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
       stage {
         type = "three"
         context = [baz: "baz"]
+        errors = []
       }
     }
     def application = pipeline.application
@@ -177,6 +179,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
       }
       stages.every {
         it.context == pipeline.namedStage(it.type).context
+        it.errors == pipeline.namedStage(it.type).errors
       }
     }
   }


### PR DESCRIPTION
This is an attempt to codify error messages for stage failures, instead of arbitrary fields in the context or outputs