### PR TITLE
chore(provider/kubernetes): de-capitalize cache refresh type

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
@@ -32,7 +32,7 @@ import java.util.Map;
 
 @Component
 public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTask implements Task {
-  private final static String REFRESH_TYPE = "Manifest";
+  private final static String REFRESH_TYPE = "manifest";
   public final static String TASK_NAME = "forceCacheRefresh";
 
   @Autowired


### PR DESCRIPTION
no change in behavior, the types are compared w/o case.
