### PR TITLE
fix(rollback): Better support for automatic rollbacks on RRB deploys

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/Strategy.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/Strategy.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 public enum Strategy implements StrategyFlowComposer{
   RED_BLACK("redblack"),
+  ROLLING_RED_BLACK("rollingredblack"),
   HIGHLANDER("highlander"),
   ROLLING_PUSH("rollingpush"),
   CUSTOM("custom"),
@@ -34,7 +35,7 @@ public enum Strategy implements StrategyFlowComposer{
     this.key = key;
   }
 
-  static Strategy fromStrategy(String key) {
+  public static Strategy fromStrategy(String key) {
     if (key == null) {
       return NONE;
     }

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
@@ -64,7 +64,8 @@ val stageWithSyntheticOnFailure = object : StageDefinitionBuilder {
   }
 
   override fun onFailureStages(stage: Stage) = listOf(
-    newStage(stage.execution, singleTaskStage.type, "onFailure1", stage.context, stage, STAGE_AFTER)
+    newStage(stage.execution, singleTaskStage.type, "onFailure1", stage.context, stage, STAGE_AFTER),
+    newStage(stage.execution, singleTaskStage.type, "onFailure2", stage.context, stage, STAGE_AFTER)
   )
 }
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -165,8 +165,15 @@ class CompleteStageHandler(
       }
 
       val notStartedSynthetics = execution.stages.filter { it.parentStageId == id && it.status == NOT_STARTED}
+      val notStartedSyntheticRefIds = notStartedSynthetics.map { it.refId }
 
       builder.buildAfterStages(this, onFailureStages) { it: Stage ->
+        // Avoid having a NOT_STARTED synthetic stage as a prerequisite as it will be subsequently removed
+        // from the execution.
+        it.requisiteStageRefIds = it.requisiteStageRefIds.filter {
+          !notStartedSyntheticRefIds.contains(it)
+        }
+
         repository.addStage(it)
       }
 


### PR DESCRIPTION
This PR will correctly unpin the source server group when an RRB
deployment fails and is automatically rolled back.

The previous server group is guaranteed to exist so the automatic
rollback _only_ needs to disable the new server group.
