### PR TITLE
fix(echo): send different phase in notification when stage is skipped

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
@@ -82,7 +82,10 @@ class EchoNotifyingStageListener implements StageListener {
     // STOPPED stages are "successful" because they allow the pipeline to
     // proceed but they are still failures in terms of the stage and should
     // send failure notifications
-    if (stage.status in [SUCCEEDED, SKIPPED]) {
+    if (stage.status == SKIPPED) {
+      log.debug("***** $stage.execution.id Echo stage $stage.name skipped v2")
+      recordEvent('stage', 'skipped', stage)
+    } else if (stage.status == SUCCEEDED) {
       log.debug("***** $stage.execution.id Echo stage $stage.name complete v2")
       recordEvent('stage', 'complete', stage)
     } else {


### PR DESCRIPTION
Right now, if a stage is skipped, we still send a message to echo indicating it succeeded. This is really confusing if there are notifications configured.

I'm proposing we send a different, more accurate status, so we do not lose the ability to track the events, but also do not send inaccurate notifications.