### PR TITLE
feat(artifacts): Use artifacts for Bake->Deploy GCE stages

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca.bakery.pipeline
 
-import javax.annotation.Nonnull
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.RestartableStage
 import com.netflix.spinnaker.orca.Task
@@ -27,10 +26,14 @@ import com.netflix.spinnaker.orca.bakery.tasks.MonitorBakeTask
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
+
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_BEFORE
 
 @Slf4j
@@ -50,6 +53,7 @@ class BakeStage implements StageDefinitionBuilder, RestartableStage {
         .withTask("createBake", CreateBakeTask)
         .withTask("monitorBake", MonitorBakeTask)
         .withTask("completedBake", CompletedBakeTask)
+        .withTask("bindProducedArtifacts", BindProducedArtifactsTask)
     }
   }
 

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
@@ -40,7 +40,11 @@ class CompletedBakeTask implements Task {
     def bakeStatus = stage.context.status as BakeStatus
     def bake = bakery.lookupBake(region, bakeStatus.resourceId).toBlocking().first()
     // This treatment of ami allows both the aws and gce bake results to be propagated.
-    def results = [ami: bake.ami ?: bake.imageName, imageId: bake.ami ?: bake.imageName, artifact: bake.artifact ?: new Artifact()]
+    def results = [
+      ami: bake.ami ?: bake.imageName,
+      imageId: bake.ami ?: bake.imageName,
+      artifacts: bake.artifact ? [bake.artifact] : []
+    ]
     /**
      * TODO:
      * It would be good to standardize on the key here. "imageId" works for all providers.

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
@@ -60,7 +60,7 @@ class CompletedBakeTaskSpec extends Specification {
     then:
     result.status == ExecutionStatus.SUCCEEDED
     result.context.ami == ami
-    result.context.artifact.reference == ami
+    result.context.artifacts[0].reference == ami
 
     where:
     region = "us-west-1"

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreator.groovy
@@ -62,8 +62,11 @@ class GoogleServerGroupCreator implements ServerGroupCreator, DeploymentDetailsA
     def stageContext = stage.getContext()
     String image
 
-    if (stageContext.containsKey("imageSource") && stageContext.get("imageSource") == "artifact") {
-      def artifactId = stageContext.get("imageArtifactId")
+    if (stageContext.imageSource == "artifact") {
+      def artifactId = stageContext.imageArtifactId
+      if (artifactId == null) {
+        throw new IllegalStateException("Image source was set to artifact but no artifact was specified.")
+      }
       def resolvedArtifact = artifactResolver.getBoundArtifactForId(stage, artifactId)
       image = resolvedArtifact.getName()
     } else {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreator.groovy
@@ -19,7 +19,9 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.providers.gce
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCreator
 import com.netflix.spinnaker.orca.kato.tasks.DeploymentDetailsAware
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver
 import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Slf4j
@@ -28,6 +30,9 @@ class GoogleServerGroupCreator implements ServerGroupCreator, DeploymentDetailsA
 
   boolean katoResultExpected = false
   String cloudProvider = "gce"
+
+  @Autowired
+  ArtifactResolver artifactResolver
 
   @Override
   List<Map> getOperations(Stage stage) {
@@ -44,19 +49,34 @@ class GoogleServerGroupCreator implements ServerGroupCreator, DeploymentDetailsA
       operation.credentials = operation.account
     }
 
-    withImageFromPrecedingStage(stage, null, cloudProvider) {
-      operation.image = operation.image ?: it.imageId
-    }
-
-    withImageFromDeploymentDetails(stage, null, cloudProvider) {
-      operation.image = operation.image ?: it.imageId
-    }
+    operation.image = getImage(stage)
 
     if (!operation.image) {
       throw new IllegalStateException("No image could be found in ${stage.context.region}.")
     }
 
     return [[(ServerGroupCreator.OPERATION): operation]]
+  }
+
+  private String getImage(Stage stage) {
+    def stageContext = stage.getContext()
+    String image
+
+    if (stageContext.containsKey("imageSource") && stageContext.get("imageSource") == "artifact") {
+      def artifactId = stageContext.get("imageArtifactId")
+      def resolvedArtifact = artifactResolver.getBoundArtifactForId(stage, artifactId)
+      image = resolvedArtifact.getName()
+    } else {
+      withImageFromPrecedingStage(stage, null, cloudProvider) {
+        image = image ?: it.imageId
+      }
+
+      withImageFromDeploymentDetails(stage, null, cloudProvider) {
+        image = image ?: it.imageId
+      }
+    }
+
+    return image
   }
 
   @Override

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreatorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreatorSpec.groovy
@@ -16,25 +16,30 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.gce
 
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver
 import com.netflix.spinnaker.orca.test.model.ExecutionBuilder
 import spock.lang.Specification
 
 class GoogleServerGroupCreatorSpec extends Specification {
 
+  ArtifactResolver artifactResolver = Mock(ArtifactResolver)
+
   def "should get operations"() {
     given:
-    def ctx = [
+    def basectx = [
       account          : "abc",
       region           : "north-pole",
       zone             : "north-pole-1",
       deploymentDetails: [[imageId: "testImageId", region: "north-pole"]],
-    ]
+    ].asImmutable()
+
+    when:
+    def ctx = [:] << basectx
     def stage = ExecutionBuilder.stage {
       context.putAll(ctx)
     }
-
-    when:
-    def ops = new GoogleServerGroupCreator().getOperations(stage)
+    def ops = new GoogleServerGroupCreator(artifactResolver: artifactResolver).getOperations(stage)
 
     then:
     ops == [
@@ -51,12 +56,13 @@ class GoogleServerGroupCreatorSpec extends Specification {
     ]
 
     when: "fallback to non-region matching image"
+    ctx = [:] << basectx
     ctx.region = "south-pole"
     ctx.zone = "south-pole-1"
     stage = ExecutionBuilder.stage {
       context.putAll(ctx)
     }
-    ops = new GoogleServerGroupCreator().getOperations(stage)
+    ops = new GoogleServerGroupCreator(artifactResolver: artifactResolver).getOperations(stage)
 
     then:
     ops == [
@@ -72,15 +78,44 @@ class GoogleServerGroupCreatorSpec extends Specification {
       ]
     ]
 
+    when: "use artifact when set as imageSource"
+    ctx = [:] << basectx
+    ctx.imageSource = "artifact"
+    stage = ExecutionBuilder.stage {
+      context.putAll(ctx)
+    }
+    artifactResolver.getBoundArtifactForId(*_) >> {
+      Artifact artifact = new Artifact();
+      artifact.setName("santaImage")
+      return artifact
+    }
+    ops = new GoogleServerGroupCreator(artifactResolver: artifactResolver).getOperations(stage)
+
+    then:
+    ops == [
+      [
+        "createServerGroup": [
+          imageSource      : "artifact",
+          account          : "abc",
+          credentials      : "abc",
+          image            : "santaImage",
+          region           : "north-pole",
+          zone             : "north-pole-1",
+          deploymentDetails: [[imageId: "testImageId", region: "north-pole"]],
+        ],
+      ]
+    ]
+
     when: "throw error if no image found"
+    ctx = [:] << basectx
     ctx.deploymentDetails = []
     stage = ExecutionBuilder.stage {
       context.putAll(ctx)
     }
-    new GoogleServerGroupCreator().getOperations(stage)
+    new GoogleServerGroupCreator(artifactResolver: artifactResolver).getOperations(stage)
 
     then:
     IllegalStateException ise = thrown()
-    ise.message == "No image could be found in south-pole."
+    ise.message == "No image could be found in north-pole."
   }
 }


### PR DESCRIPTION
Update the Bake stage to emit the baked image as an artifact, and the Deploy stage to optionally deploy an specified artifact instead of searching upstream for the most recent Bake or Find Artifact stage.