### PR TITLE
fix(rollback): Guard against entity tags not being enabled

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/FeaturesService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/FeaturesService.java
@@ -21,11 +21,18 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class FeaturesService {
+  private final FeaturesRestService featuresRestService;
 
   @Autowired
-  private FeaturesRestService featuresRestService;
+  public FeaturesService(FeaturesRestService featuresRestService) {
+    this.featuresRestService = featuresRestService;
+  }
 
   public boolean isStageAvailable(String stageType) {
     return featuresRestService.getStages().stream().anyMatch(s -> s.enabled && stageType.equals(s.name));
+  }
+
+  public boolean areEntityTagsAvailable() {
+    return isStageAvailable("upsertEntityTags");
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStage.groovy
@@ -69,7 +69,7 @@ class ApplySourceServerGroupCapacityStage implements StageDefinitionBuilder {
   @Override
   List<Stage> afterStages(@Nonnull Stage stage) {
     try {
-      def taggingEnabled = featuresService.isStageAvailable("upsertEntityTags")
+      def taggingEnabled = featuresService.areEntityTagsAvailable()
       if (!taggingEnabled) {
         return []
       }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
@@ -48,7 +48,7 @@ class CloneServerGroupStage extends AbstractDeployStrategyStage {
 
   @Override
   protected List<TaskNode.TaskDefinition> basicTasks(Stage stage) {
-    def taggingEnabled = featuresService.isStageAvailable("upsertEntityTags")
+    def taggingEnabled = featuresService.areEntityTagsAvailable()
 
     def tasks = [
       new TaskNode.TaskDefinition("cloneServerGroup", CloneServerGroupTask),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
@@ -54,7 +54,7 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage {
 
   @Override
   protected List<TaskNode.TaskDefinition> basicTasks(Stage stage) {
-    def taggingEnabled = featuresService.isStageAvailable("upsertEntityTags")
+    def taggingEnabled = featuresService.areEntityTagsAvailable()
 
     def tasks = [
       TaskNode.task("createServerGroup", CreateServerGroupTask),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollback.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollback.groovy
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.orca.clouddriver.FeaturesService
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.CloneServerGroupStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
@@ -47,11 +48,15 @@ class PreviousImageRollback implements Rollback {
 
   @Autowired
   @JsonIgnore
+  FeaturesService featuresService
+
+  @Autowired
+  @JsonIgnore
   RetrySupport retrySupport
 
   @Override
   List<Stage> buildStages(Stage parentStage) {
-    def previousImageRollbackSupport = new PreviousImageRollbackSupport(objectMapper, oortService, retrySupport)
+    def previousImageRollbackSupport = new PreviousImageRollbackSupport(objectMapper, oortService, featuresService, retrySupport)
     def stages = []
 
     def parentStageContext = parentStage.context

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.RetryableTask;
 import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.FeaturesService;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.RollbackServerGroupStage;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.rollback.PreviousImageRollbackSupport;
@@ -71,17 +72,22 @@ public class DetermineRollbackCandidatesTask extends AbstractCloudProviderAwareT
   private final ObjectMapper objectMapper;
   private final RetrySupport retrySupport;
   private final OortService oortService;
+  private final FeaturesService featuresService;
   private final PreviousImageRollbackSupport previousImageRollbackSupport;
 
   @Autowired
   public DetermineRollbackCandidatesTask(ObjectMapper objectMapper,
                                          RetrySupport retrySupport,
-                                         OortService oortService) {
+                                         OortService oortService,
+                                         FeaturesService featuresService) {
     this.objectMapper = objectMapper;
     this.retrySupport = retrySupport;
     this.oortService = oortService;
+    this.featuresService = featuresService;
 
-    this.previousImageRollbackSupport = new PreviousImageRollbackSupport(objectMapper, oortService, retrySupport);
+    this.previousImageRollbackSupport = new PreviousImageRollbackSupport(
+      objectMapper, oortService, featuresService, retrySupport
+    );
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/RollingPushStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/RollingPushStage.java
@@ -46,7 +46,7 @@ public class RollingPushStage implements StageDefinitionBuilder {
 
   @Override
   public void taskGraph(Stage stage, TaskNode.Builder builder) {
-    boolean taggingEnabled = featuresService.isStageAvailable("upsertEntityTags");
+    boolean taggingEnabled = featuresService.areEntityTagsAvailable();
     builder
       .withTask("captureParentInterestingHealthProviderNames", CaptureParentInterestingHealthProviderNamesTask.class)
       .withTask("determineTerminationCandidates", DetermineTerminationCandidatesTask.class)

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStageSpec.groovy
@@ -53,7 +53,7 @@ class ApplySourceServerGroupCapacityStageSpec extends Specification {
     def afterStages = stageBuilder.afterStages(stage)
 
     then:
-    1 * featuresService.isStageAvailable("upsertEntityTags") >> { return false }
+    1 * featuresService.areEntityTagsAvailable() >> { return false }
     0 * oortService.getEntityTags(_)
 
     afterStages.isEmpty()
@@ -64,7 +64,7 @@ class ApplySourceServerGroupCapacityStageSpec extends Specification {
     def afterStages = stageBuilder.afterStages(stage)
 
     then:
-    1 * featuresService.isStageAvailable("upsertEntityTags") >> { return true }
+    1 * featuresService.areEntityTagsAvailable() >> { return true }
     1 * oortService.getEntityTags(_) >> { return [] }
 
     afterStages.isEmpty()
@@ -77,7 +77,7 @@ class ApplySourceServerGroupCapacityStageSpec extends Specification {
     then:
     notThrown(RuntimeException)
 
-    1 * featuresService.isStageAvailable("upsertEntityTags") >> { throw new RuntimeException("An Exception!") }
+    1 * featuresService.areEntityTagsAvailable() >> { throw new RuntimeException("An Exception!") }
     0 * oortService.getEntityTags(_)
 
     afterStages.isEmpty()
@@ -88,7 +88,7 @@ class ApplySourceServerGroupCapacityStageSpec extends Specification {
     def afterStages = stageBuilder.afterStages(stage)
 
     then:
-    1 * featuresService.isStageAvailable("upsertEntityTags") >> { return true }
+    1 * featuresService.areEntityTagsAvailable() >> { return true }
     1 * oortService.getEntityTags([
       "tag:spinnaker:pinned_capacity": "*",
       "entityId"                     : "app-stack-details-v001",


### PR DESCRIPTION
If entity tags are not enabled, the expectation is that the rollback
will fall back to looking at previous server groups and picking the
newest.
