### PR TITLE
fix(canary-v2): Fix issue with serialization of duration string.

### DIFF
--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/MonitorKayentaCanaryTask.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/MonitorKayentaCanaryTask.kt
@@ -56,7 +56,7 @@ class MonitorKayentaCanaryTask(
           "canaryPipelineStatus" to SUCCEEDED,
           "lastUpdated" to canaryResults.endTimeIso?.toEpochMilli(),
           "lastUpdatedIso" to canaryResults.endTimeIso,
-          "durationString" to canaryResults.result.canaryDuration,
+          "durationString" to canaryResults.result.canaryDuration.toString(),
           "canaryScore" to canaryScore,
           "canaryScoreMessage" to "Canary score is not above the marginal score threshold."
         ))
@@ -65,7 +65,7 @@ class MonitorKayentaCanaryTask(
           "canaryPipelineStatus" to SUCCEEDED,
           "lastUpdated" to canaryResults.endTimeIso?.toEpochMilli(),
           "lastUpdatedIso" to canaryResults.endTimeIso,
-          "durationString" to canaryResults.result.canaryDuration,
+          "durationString" to canaryResults.result.canaryDuration.toString(),
           "canaryScore" to canaryScore
         ))
       }


### PR DESCRIPTION
Without this fix, `durationString` is serialized as a long in milliseconds. This causes the stage execution details to render like this:
![image](https://user-images.githubusercontent.com/8437718/37468141-851238cc-2838-11e8-8979-eb866c9377e9.png)

With the fix, it's back to:
![image](https://user-images.githubusercontent.com/8437718/37468154-8d2de0ce-2838-11e8-9565-de8a932c0802.png)


