### PR TITLE
Fix failure when re-entering aroundStages method of TargetServerGroupLinearStageSupport

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/appengine/StartAppEngineServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/appengine/StartAppEngineServerGroupStage.groovy
@@ -33,7 +33,7 @@ class StartAppEngineServerGroupStage extends TargetServerGroupLinearStageSupport
   public static final String PIPELINE_CONFIG_TYPE = "startServerGroup"
 
   @Override
-  void taskGraph(Stage stage, TaskNode.Builder builder) {
+  protected void taskGraphInternal(Stage stage, TaskNode.Builder builder) {
     builder
       .withTask("determineHealthProviders", DetermineHealthProvidersTask)
       .withTask("startServerGroup", StartAppEngineServerGroupTask)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/appengine/StopAppEngineServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/appengine/StopAppEngineServerGroupStage.groovy
@@ -33,7 +33,7 @@ class StopAppEngineServerGroupStage extends TargetServerGroupLinearStageSupport 
   public static final String PIPELINE_CONFIG_TYPE = "stopServerGroup"
 
   @Override
-  void taskGraph(Stage stage, TaskNode.Builder builder) {
+  protected void taskGraphInternal(Stage stage, TaskNode.Builder builder) {
     builder
       .withTask("determineHealthProviders", DetermineHealthProvidersTask)
       .withTask("stopServerGroup", StopAppEngineServerGroupTask)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Component
 class ModifyAwsScalingProcessStage extends TargetServerGroupLinearStageSupport {
 
   @Override
-  void taskGraph(Stage stage, TaskNode.Builder builder) {
+  protected void taskGraphInternal(Stage stage, TaskNode.Builder builder) {
     def data = stage.mapTo(StageData)
     switch (data.action) {
       case StageAction.suspend:

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
@@ -36,9 +36,6 @@ import org.springframework.stereotype.Component
 @Component
 @CompileStatic
 class ModifyAwsScalingProcessStage extends TargetServerGroupLinearStageSupport {
-  ModifyAwsScalingProcessStage() {
-    name = "Modify Scaling Process"
-  }
 
   @Override
   void taskGraph(Stage stage, TaskNode.Builder builder) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
@@ -37,6 +37,8 @@ import org.springframework.stereotype.Component
 @CompileStatic
 class ModifyAwsScalingProcessStage extends TargetServerGroupLinearStageSupport {
 
+  public static final String TYPE = getType(ModifyAwsScalingProcessStage)
+
   @Override
   protected void taskGraphInternal(Stage stage, TaskNode.Builder builder) {
     def data = stage.mapTo(StageData)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -22,15 +22,11 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.*
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
 class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport {
   static final String PIPELINE_CONFIG_TYPE = "destroyServerGroup"
-
-  @Autowired
-  DisableServerGroupStage disableServerGroupStage
 
   @Override
   protected void taskGraphInternal(Stage stage, TaskNode.Builder builder) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -33,7 +33,7 @@ class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport {
   DisableServerGroupStage disableServerGroupStage
 
   @Override
-  void taskGraph(Stage stage, TaskNode.Builder builder) {
+  protected void taskGraphInternal(Stage stage, TaskNode.Builder builder) {
     try {
       builder
         .withTask("disableServerGroup", DisableServerGroupTask)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DisableServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DisableServerGroupStage.groovy
@@ -33,7 +33,7 @@ class DisableServerGroupStage extends TargetServerGroupLinearStageSupport {
   static final String PIPELINE_CONFIG_TYPE = "disableServerGroup"
 
   @Override
-  void taskGraph(Stage stage, TaskNode.Builder builder) {
+  protected void taskGraphInternal(Stage stage, TaskNode.Builder builder) {
     builder
       .withTask("determineHealthProviders", DetermineHealthProvidersTask)
       .withTask("disableServerGroup", DisableServerGroupTask)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/EnableServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/EnableServerGroupStage.groovy
@@ -32,7 +32,7 @@ class EnableServerGroupStage extends TargetServerGroupLinearStageSupport {
   public static final String PIPELINE_CONFIG_TYPE = "enableServerGroup"
 
   @Override
-  void taskGraph(Stage stage, TaskNode.Builder builder) {
+  protected void taskGraphInternal(Stage stage, TaskNode.Builder builder) {
     builder
       .withTask("determineHealthProviders", DetermineHealthProvidersTask)
       .withTask("enableServerGroup", EnableServerGroupTask)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ResizeServerGrou
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForCapacityMatchTask
 import com.netflix.spinnaker.orca.pipeline.TaskNode
+import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
@@ -43,7 +44,7 @@ class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
   ModifyAwsScalingProcessStage modifyAwsScalingProcessStage
 
   @Override
-  void taskGraph(Stage stage, TaskNode.Builder builder) {
+  protected void taskGraphInternal(Stage stage, TaskNode.Builder builder) {
     builder
       .withTask("determineHealthProviders", DetermineHealthProvidersTask)
       .withTask("resizeServerGroup", ResizeServerGroupTask)
@@ -53,70 +54,64 @@ class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
   }
 
   @Override
-  protected List<Injectable> preStatic(Map descriptor) {
-    if (descriptor.cloudProvider != 'aws') {
-      return []
+  protected void preStatic(Map<String, Object> descriptor, StageGraphBuilder graph) {
+    if (descriptor.cloudProvider == "aws") {
+      graph.add {
+        it.name = "resumeScalingProcesses"
+        it.type = modifyAwsScalingProcessStage.type
+        it.context = [
+          serverGroupName: descriptor.asgName,
+          cloudProvider  : descriptor.cloudProvider,
+          credentials    : descriptor.credentials,
+          region         : descriptor.region,
+          action         : "resume",
+          processes      : ["Launch", "Terminate"]
+        ]
+      }
     }
-    [new Injectable(
-      name: "resumeScalingProcesses",
-      stage: modifyAwsScalingProcessStage,
-      context: [
-        serverGroupName: descriptor.asgName,
-        cloudProvider  : descriptor.cloudProvider,
-        credentials    : descriptor.credentials,
-        region         : descriptor.region,
-        action         : "resume",
-        processes      : ["Launch", "Terminate"]
-      ]
-    )]
   }
 
   @Override
-  protected List<Injectable> postStatic(Map descriptor) {
-    if (descriptor.cloudProvider != 'aws') {
-      return []
+  protected void postStatic(Map<String, Object> descriptor, StageGraphBuilder graph) {
+    if (descriptor.cloudProvider == "aws") {
+      graph.add {
+        it.name = "suspendScalingProcesses"
+        it.type = modifyAwsScalingProcessStage.type
+        it.context = [
+          serverGroupName: descriptor.asgName,
+          cloudProvider  : descriptor.cloudProvider,
+          credentials    : descriptor.credentials,
+          region         : descriptor.region,
+          action         : "suspend"
+        ]
+      }
     }
-    [new Injectable(
-      name: "suspendScalingProcesses",
-      stage: modifyAwsScalingProcessStage,
-      context: [
-        serverGroupName: descriptor.asgName,
-        cloudProvider  : descriptor.cloudProvider,
-        credentials    : descriptor.credentials,
-        region         : descriptor.region,
-        action         : "suspend"
-      ]
-    )]
   }
 
   @Override
-  protected List<Injectable> preDynamic(Map context) {
-    if (context.cloudProvider != 'aws') {
-      return []
+  protected void preDynamic(Map<String, Object> context, StageGraphBuilder graph) {
+    if (context.cloudProvider == "aws") {
+      context.remove("asgName")
+      graph.add {
+        it.name = "resumeScalingProcesses"
+        it.type = modifyAwsScalingProcessStage.type
+        it.context.putAll(context)
+        it.context["action"] = "resume"
+        it.context["processes"] = ["Launch", "Terminate"]
+      }
     }
-    context.remove("asgName")
-    [new Injectable(
-      name: "resumeScalingProcesses",
-      stage: modifyAwsScalingProcessStage,
-      context: context + [
-        action   : "resume",
-        processes: ["Launch", "Terminate"]
-      ]
-    )]
   }
 
   @Override
-  protected List<Injectable> postDynamic(Map context) {
-    if (context.cloudProvider != 'aws') {
-      return []
+  protected void postDynamic(Map<String, Object> context, StageGraphBuilder graph) {
+    if (context.cloudProvider == "aws") {
+      context.remove("asgName")
+      graph.add {
+        it.name = "suspendScalingProcesses"
+        it.type = modifyAwsScalingProcessStage.type
+        it.context.putAll(context)
+        it.context["action"] = "suspend"
+      }
     }
-    context.remove("asgName")
-    [new Injectable(
-      name: "suspendScalingProcesses",
-      stage: modifyAwsScalingProcessStage,
-      context: context + [
-        action: "suspend",
-      ],
-    )]
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
@@ -27,7 +27,6 @@ import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 /**
@@ -39,9 +38,6 @@ import org.springframework.stereotype.Component
 @Slf4j
 class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
   public static final String TYPE = getType(ResizeServerGroupStage)
-
-  @Autowired
-  ModifyAwsScalingProcessStage modifyAwsScalingProcessStage
 
   @Override
   protected void taskGraphInternal(Stage stage, TaskNode.Builder builder) {
@@ -58,7 +54,7 @@ class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
     if (descriptor.cloudProvider == "aws") {
       graph.add {
         it.name = "resumeScalingProcesses"
-        it.type = modifyAwsScalingProcessStage.type
+        it.type = ModifyAwsScalingProcessStage.TYPE
         it.context = [
           serverGroupName: descriptor.asgName,
           cloudProvider  : descriptor.cloudProvider,
@@ -76,7 +72,7 @@ class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
     if (descriptor.cloudProvider == "aws") {
       graph.add {
         it.name = "suspendScalingProcesses"
-        it.type = modifyAwsScalingProcessStage.type
+        it.type = ModifyAwsScalingProcessStage.TYPE
         it.context = [
           serverGroupName: descriptor.asgName,
           cloudProvider  : descriptor.cloudProvider,
@@ -94,7 +90,7 @@ class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
       context.remove("asgName")
       graph.add {
         it.name = "resumeScalingProcesses"
-        it.type = modifyAwsScalingProcessStage.type
+        it.type = ModifyAwsScalingProcessStage.TYPE
         it.context.putAll(context)
         it.context["action"] = "resume"
         it.context["processes"] = ["Launch", "Terminate"]
@@ -108,7 +104,7 @@ class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
       context.remove("asgName")
       graph.add {
         it.name = "suspendScalingProcesses"
-        it.type = modifyAwsScalingProcessStage.type
+        it.type = ModifyAwsScalingProcessStage.TYPE
         it.context.putAll(context)
         it.context["action"] = "suspend"
       }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import groovy.transform.InheritConstructors
-import groovy.transform.ToString
-import groovy.util.logging.Slf4j
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.transform.InheritConstructors
+import groovy.transform.ToString
+import groovy.util.logging.Slf4j
 
 /**
  * A TargetServerGroup is a ServerGroup that is dynamically resolved using a target like "current" or "oldest".

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupLinearStageSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupLinearStageSupport.groovy
@@ -31,9 +31,6 @@ abstract class TargetServerGroupLinearStageSupport implements StageDefinitionBui
 
   @Autowired TargetServerGroupResolver resolver
 
-  // TODO: get rid
-  @Autowired DetermineTargetServerGroupStage determineTargetServerGroupStage
-
   @Override
   String getName() {
     return type

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupLinearStageSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupLinearStageSupport.groovy
@@ -29,16 +29,16 @@ import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAG
 @Slf4j
 abstract class TargetServerGroupLinearStageSupport implements StageDefinitionBuilder, Nameable {
 
-  @Autowired
-  TargetServerGroupResolver resolver
-
-  @Autowired
-  DetermineTargetServerGroupStage determineTargetServerGroupStage
-
-  String name = this.type
+  @Autowired TargetServerGroupResolver resolver
+  @Autowired DetermineTargetServerGroupStage determineTargetServerGroupStage
 
   @Override
-  def List<Stage> aroundStages(Stage parentStage) {
+  String getName() {
+    return type
+  }
+
+  @Override
+  List<Stage> aroundStages(Stage parentStage) {
     return composeTargets(parentStage)
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
@@ -95,7 +95,7 @@ public interface StageDefinitionBuilder {
   /**
    * Implement this method to define any stages that should run after any tasks in
    * this stage as part of a composed workflow.
-   *
+   * <p>
    * This default implementation is for backward compatibility with the legacy
    * {@link #aroundStages} and {@link #parallelStages} methods.
    */


### PR DESCRIPTION
Spotted by @duftler.

This was caused by the new before / after stage mechanism defaulting to `aroundStages` twice. After the action has taken place it may not be able to resolve target server groups, though.
