### PR TITLE
fix(pipeline-templates): Fix trigger merging when hydrating templates.

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutator.java
@@ -127,7 +127,7 @@ public class TemplatedPipelineModelMutator implements PipelineModelMutator {
     if (configuration.getTriggers() != null && !configuration.getTriggers().isEmpty()) {
       pipeline.put(
         "triggers",
-        TemplateMerge.mergeNamedContent(
+        TemplateMerge.mergeDistinct(
           pipelineTemplateObjectMapper.convertValue(pipeline.get("triggers"), new TypeReference<List<NamedHashMap>>() {}),
           configuration.getTriggers()
         )


### PR DESCRIPTION
@rz FYI also. We had issues where more than one trigger of the same type wasn't resolved properly -- e.g. two crons wound up with incorrect `cronExpressions` after a `roer pipeline-template publish <...>`.