### PR TITLE
fix(after stages): Allow for just-in-time planning of after stages

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/stages.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/stages.kt
@@ -29,6 +29,7 @@ fun Stage.determineStatus(): ExecutionStatus {
   val taskStatuses = tasks.map(Task::getStatus)
   val allStatuses = syntheticStatuses + taskStatuses
   return when {
+    allStatuses.isEmpty() -> NOT_STARTED
     allStatuses.contains(TERMINAL) -> TERMINAL
     allStatuses.contains(STOPPED) -> STOPPED
     allStatuses.contains(CANCELED) -> CANCELED


### PR DESCRIPTION
This is a bridge to the 6.19.x branch of Orca where after stages are _always_ planned just in time. During deployment this can be an issue if a 6.19.x instance starts a stage (and does not plan after stages) and a 6.18.x instance tries to complete the stage (finding no before stages or tasks and no planned after stages).