### PR TITLE
feat(webhooks): support webhook artifacts

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStage.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStage.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.webhook.tasks.CreateWebhookTask
 import com.netflix.spinnaker.orca.webhook.tasks.MonitorWebhookTask
+import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask
 import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
@@ -39,6 +40,10 @@ class WebhookStage implements StageDefinitionBuilder, RestartableStage, Cancella
     if (waitForCompletion?.toBoolean()) {
       builder
         .withTask("monitorWebhook", MonitorWebhookTask)
+    }
+    if (stage.context.containsKey("expectedArtifacts")) {
+      builder
+        .withTask(BindProducedArtifactsTask.TASK_NAME, BindProducedArtifactsTask.class);
     }
   }
 

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
@@ -106,6 +106,15 @@ class CreateWebhookTask implements RetryableTask {
         outputs.webhook << [statusEndpoint: statusUrl]
         return new TaskResult(ExecutionStatus.SUCCEEDED, outputsDeprecated + outputs)
       }
+      if (stage.context.containsKey("expectedArtifacts")) {
+        try {
+          def artifacts = new JsonContext().parse(response.body).read("artifacts")
+          outputs << [artifacts: artifacts]
+        } catch(Exception e) {
+          outputs.webhook << [error: "Expected artifacts in webhook response none were found"]
+          return new TaskResult(ExecutionStatus.TERMINAL, outputs)
+        }
+      }
       return new TaskResult(ExecutionStatus.SUCCEEDED, outputsDeprecated + outputs)
     } else {
       outputs.webhook << [error: "The request did not return a 2xx/3xx status"]


### PR DESCRIPTION
as mentioned in spinnaker/spinnaker#2330, webhook stages now support
producing artifacts. this expects that there is a top-level `artifacts`
key in the response. these artifacts are then bound and available to
downstream stages.
