### PR TITLE
feat(rolling push): respect specified order of terminations

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTask.groovy
@@ -46,8 +46,8 @@ class DetermineTerminationCandidatesTask implements Task {
     def terminationInstancePool = knownInstanceIds
     if (stage.context.termination?.instances) {
       terminationInstancePool = knownInstanceIds.intersect(stage.context.termination?.instances)
-      if (stage.context.termination?.order == 'given') {
-        terminationInstancePool = terminationInstancePool.sort { stage.context.termination?.instances.indexOf(it) }
+      if (stage.context.termination.order == 'given') {
+        terminationInstancePool = terminationInstancePool.sort { stage.context.termination.instances.indexOf(it) }
       }
     }
     int totalRelaunches = getNumberOfRelaunches(stage.context.termination, terminationInstancePool.size())

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTask.groovy
@@ -46,6 +46,9 @@ class DetermineTerminationCandidatesTask implements Task {
     def terminationInstancePool = knownInstanceIds
     if (stage.context.termination?.instances) {
       terminationInstancePool = knownInstanceIds.intersect(stage.context.termination?.instances)
+      if (stage.context.termination?.order == 'given') {
+        terminationInstancePool = terminationInstancePool.sort { stage.context.termination?.instances.indexOf(it) }
+      }
     }
     int totalRelaunches = getNumberOfRelaunches(stage.context.termination, terminationInstancePool.size())
     def terminationInstanceIds = terminationInstancePool.take(totalRelaunches)

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTaskSpec.groovy
@@ -59,19 +59,21 @@ class DetermineTerminationCandidatesTaskSpec extends Specification {
     1 * oortService.getServerGroupFromCluster(application, account, cluster, serverGroup, region, cloudProvider) >> oortResponse
     response.context.terminationInstanceIds == expectedTerminations
     response.context.knownInstanceIds.toSet() == knownInstanceIds.toSet()
+    expectedTerminations == response.context.terminationInstanceIds
 
     where:
-    order    | relaunchAllInstances | totalRelaunches | instances             || expectedTerminations
-    null     | null                 | null            | null                  || ['i-1', 'i-2', 'i-3', 'i-4']
-    'oldest' | null                 | null            | null                  || ['i-1', 'i-2', 'i-3', 'i-4']
-    'newest' | null                 | null            | null                  || ['i-4', 'i-3', 'i-2', 'i-1']
-    'oldest' | null                 | 2               | null                  || ['i-1', 'i-2']
-    'oldest' | true                 | 2               | null                  || ['i-1', 'i-2', 'i-3', 'i-4']
-    'oldest' | false                | 2               | null                  || ['i-1', 'i-2']
-    'newest' | false                | 2               | null                  || ['i-4', 'i-3']
-    null     | true                 | 4               | null                  || ['i-1', 'i-2', 'i-3', 'i-4']
-    null     | true                 | 4               | ['i-4', 'i-9']        || ['i-4']
-    null     | true                 | 4               | ['i-4', 'i-2', 'i-3'] || ['i-4', 'i-2', 'i-3']
+    order    | relaunchAllInstances | totalRelaunches | instances                    || expectedTerminations
+    null     | null                 | null            | null                         || ['i-1', 'i-2', 'i-3', 'i-4']
+    'oldest' | null                 | null            | null                         || ['i-1', 'i-2', 'i-3', 'i-4']
+    'newest' | null                 | null            | null                         || ['i-4', 'i-3', 'i-2', 'i-1']
+    'oldest' | null                 | 2               | null                         || ['i-1', 'i-2']
+    'oldest' | true                 | 2               | null                         || ['i-1', 'i-2', 'i-3', 'i-4']
+    'oldest' | false                | 2               | null                         || ['i-1', 'i-2']
+    'newest' | false                | 2               | null                         || ['i-4', 'i-3']
+    null     | true                 | 4               | null                         || ['i-1', 'i-2', 'i-3', 'i-4']
+    null     | true                 | 4               | ['i-4', 'i-9']               || ['i-4']
+    null     | true                 | 4               | ['i-4', 'i-2', 'i-3']        || ['i-4', 'i-2', 'i-3']
+    'given'  | null                 | null            | ['i-3', 'i-2', 'i-4', 'i-1'] || ['i-3', 'i-2', 'i-4', 'i-1']
 
     account = 'test'
     application = 'foo'


### PR DESCRIPTION
If the order of instances is specified in rolling push (using `"order" == "given"`), then let's terminate instances in that order.

Let's also test to make sure that the order we terminate in is the order we expect.