### PR TITLE
bug(orca-core): handle missing trigger json

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
@@ -89,7 +89,7 @@ internal class TriggerDeserializer
           get("slug").textValue()
         )
         else -> DefaultTrigger(
-          get("type").textValue(),
+          get("type")?.textValue() ?: "none",
           get("correlationId")?.textValue(),
           get("user")?.textValue() ?: "[anonymous]",
           get("parameters")?.mapValue(parser) ?: mutableMapOf(),

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/TriggerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/TriggerSpec.groovy
@@ -74,6 +74,24 @@ class TriggerSpec extends Specification {
     }'''
   }
 
+  def "can parse a trigger with no type"() {
+    given:
+    def trigger = mapper.readValue(triggerJson, Trigger)
+
+    expect:
+    with(trigger) {
+      type == "none"
+      user == "[anonymous]"
+      notifications == []
+    }
+
+    where:
+    triggerJson = '''
+    {
+    }'''
+  }
+
+
   def "can parse nested parameters"() {
     given:
     def trigger = mapper.readValue(triggerJson, Trigger)


### PR DESCRIPTION
Handle the case where an execution JSON may not have a trigger at all.
This makes older pipelines made by an older Orca in Kayenta still retrievable.