### PR TITLE
fix(core): don't cancel waiting pipelines as well as starting them

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartWaitingExecutionsHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartWaitingExecutionsHandler.kt
@@ -49,13 +49,12 @@ class StartWaitingExecutionsHandler(
           pipelines
             .maxBy { it.buildTime ?: 0L }
             ?.let { newest ->
-              log.info("Starting queued {} {} {}", newest.application, newest.name, newest.id)
+              log.info("Starting queued pipeline {} {} {}", newest.application, newest.name, newest.id)
               queue.push(StartExecution(newest))
-              (pipelines - newest)
-                .also { queued ->
-                  log.info("Dropping queued {} {} {}", newest.application, newest.name, queued.map { it.id })
-                }
+              pipelines
+                .filter { it.id != newest.id }
                 .forEach {
+                  log.info("Dropping queued pipeline {} {} {}", it.application, it.name, it.id)
                   queue.push(CancelExecution(it))
                 }
             }
@@ -63,7 +62,7 @@ class StartWaitingExecutionsHandler(
           pipelines
             .minBy { it.buildTime ?: 0L }
             ?.let { oldest ->
-              log.info("Starting queued {} {} {}", oldest.application, oldest.name, oldest.id)
+              log.info("Starting queued pipeline {} {} {}", oldest.application, oldest.name, oldest.id)
               queue.push(StartExecution(oldest))
             }
         }


### PR DESCRIPTION
It turns out that we'd start the first waiting execution then cancel it as well. This is bad. Also the test is asserting that _doesn't_ happen, so is evidently not right. I've verified this fixes the behavior. Going to work on the test so it will catch any regression properly.