### PR TITLE
fix(clouddriver): Refactor TargetReferenceLinearStageSupport to use before/afterStages

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceSupport.groovy
@@ -18,13 +18,12 @@ package com.netflix.spinnaker.orca.kato.pipeline.support
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.frigga.Names
-import com.netflix.spinnaker.orca.kato.pipeline.DetermineTargetReferenceStage
 import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.kato.pipeline.DetermineTargetReferenceStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.web.bind.annotation.ResponseStatus
 import retrofit.RetrofitError
 
 @Deprecated

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
@@ -49,9 +49,7 @@ class CompleteTaskHandler(
       } else {
         repository.storeStage(mergedContextStage)
 
-        if (message.status !in setOf(SUCCEEDED)) {
-          queue.push(CompleteStage(message))
-        } else if (task.isStageEnd) {
+        if (message.status !in setOf(SUCCEEDED) || task.isStageEnd) {
           queue.push(CompleteStage(message))
         } else {
           mergedContextStage.nextTask(task).let {


### PR DESCRIPTION
With the recent refactor of splitting `aroundStages` to `[before|after]Stages`, the `destroyAsg` stage started failing because `TargetReferenceLinearStageSupport` uses `aroundStages`, which would try to find the target server group once before the stage, and again after the stage. In the case of a destroy ASG operation, the stage would delete the ASG successfully, but fail to continue because it would try to re-resolve the target server group, but it wouldn't be there anymore.


This refactor updates the functionality to correctly use before/afterStages. Furthermore, since all of this code is still deprecated, I added a log statement so we can track down who is using this and start moving people off of it in hopes of a big PR full of red.