### PR TITLE
chore(core): equals/hashCode don't need to reference super

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleRelativeResizeStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleRelativeResizeStrategySpec.groovy
@@ -21,13 +21,15 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Locat
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.test.model.ExecutionBuilder
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class ScaleRelativeResizeStrategySpec extends Specification {
   OortHelper oortHelper = Mock(OortHelper)
-  Stage stage = Mock(Stage)
+  Stage stage = ExecutionBuilder.stage {}
   ScaleRelativeResizeStrategy strategy = new ScaleRelativeResizeStrategy(oortHelper: oortHelper)
+
   @Unroll
   def "should scale target capacity up or down by percentage or number"() {
 
@@ -73,7 +75,8 @@ class ScaleRelativeResizeStrategySpec extends Specification {
   static final String region = 'us-east-1'
   static final String account = 'test'
   static final String clusterName = application + '-main'
-  static final Location location = new Location(type: Location.Type.REGION, value: region)
+  static
+  final Location location = new Location(type: Location.Type.REGION, value: region)
 
   ResizeStrategy.OptionalConfiguration cfg(String direction, Integer scalePct = null, Integer scaleNum = null) {
     def cfg = new ResizeStrategy.OptionalConfiguration()
@@ -87,12 +90,8 @@ class ScaleRelativeResizeStrategySpec extends Specification {
     return cfg
   }
 
-
-
   static String asgName() {
     clusterName + '-v' + asgSeq.incrementAndGet()
   }
-
-
 
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -316,20 +316,15 @@ public class Execution implements Serializable {
       .orElseThrow(() -> new IllegalArgumentException(String.format("No stage with refId %s exists", refId)));
   }
 
-  @Override public final boolean equals(Object o) {
+  @Override public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-
     Execution execution = (Execution) o;
-
-    return id.equals(execution.id);
+    return Objects.equals(id, execution.id);
   }
 
-  @Override public final int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + id.hashCode();
-    return result;
+  @Override public int hashCode() {
+    return Objects.hash(id);
   }
 
   @Deprecated

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -336,20 +336,15 @@ public class Stage implements Serializable {
     this.lastModified = lastModified;
   }
 
-  @Override public final boolean equals(Object o) {
+  @Override public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-
     Stage stage = (Stage) o;
-
-    return id.equals(stage.id);
+    return Objects.equals(id, stage.id);
   }
 
-  @Override public final int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + id.hashCode();
-    return result;
+  @Override public int hashCode() {
+    return Objects.hash(id);
   }
 
   public Task taskById(String taskId) {


### PR DESCRIPTION
Came across this while fixing something earlier today. I just re-generated the methods with IntelliJ.