### PR TITLE
revert(queue): `FAILED_CONTINUE` tasks should halt stage execution

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
@@ -49,7 +49,7 @@ class CompleteTaskHandler(
       } else {
         repository.storeStage(mergedContextStage)
 
-        if (message.status !in setOf(SUCCEEDED, FAILED_CONTINUE)) {
+        if (message.status !in setOf(SUCCEEDED)) {
           queue.push(CompleteStage(message))
         } else if (task.isStageEnd) {
           queue.push(CompleteStage(message))

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
@@ -50,7 +50,7 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
 
   fun resetMocks() = reset(queue, repository, publisher)
 
-  setOf(SUCCEEDED, FAILED_CONTINUE).forEach { successfulStatus ->
+  setOf(SUCCEEDED).forEach { successfulStatus ->
     describe("when a task completes with $successfulStatus status") {
       given("the stage contains further tasks") {
         val pipeline = pipeline {


### PR DESCRIPTION
Reverting spinnaker/orca#2112 for now.

The `RunTaskHandler` is manipulating the task status and the
expectation of spinnaker/orca#2112 was that it was working on the raw
task status.