### PR TITLE
fix(queue): `FAILED_CONTINUE` tasks should not halt stage execution

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -99,7 +99,7 @@ class RunTaskHandler(
                 }
                 TERMINAL                             -> {
                   val status = stage.failureStatus(default = result.status)
-                  queue.push(CompleteTask(message, status))
+                  queue.push(CompleteTask(message, status, result.status))
                   trackResult(stage, taskModel, status)
                 }
                 else                                 ->

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/messages.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/messages.kt
@@ -73,10 +73,22 @@ data class CompleteTask(
   override val application: String,
   override val stageId: String,
   override val taskId: String,
-  val status: ExecutionStatus
+  val status: ExecutionStatus,
+  val originalStatus: ExecutionStatus?
 ) : Message(), TaskLevel {
   constructor(source: TaskLevel, status: ExecutionStatus) :
-    this(source.executionType, source.executionId, source.application, source.stageId, source.taskId, status)
+    this(source, status, status)
+
+  constructor(source: TaskLevel, status: ExecutionStatus, originalStatus: ExecutionStatus) :
+    this(
+      source.executionType,
+      source.executionId,
+      source.application,
+      source.stageId,
+      source.taskId,
+      status,
+      originalStatus
+    )
 }
 
 @JsonTypeName("pauseTask")

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
@@ -65,6 +65,7 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
           pipeline.application,
           pipeline.stages.first().id,
           "1",
+          successfulStatus,
           successfulStatus
         )
 
@@ -122,6 +123,7 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
           pipeline.application,
           pipeline.stages.first().id,
           "1",
+          SUCCEEDED,
           SUCCEEDED
         )
 
@@ -171,6 +173,7 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
             pipeline.application,
             pipeline.stageByRef("1").id,
             "4",
+            REDIRECT,
             REDIRECT
           )
 
@@ -224,6 +227,7 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
         pipeline.application,
         pipeline.stages.first().id,
         "1",
+        status,
         status
       )
 
@@ -268,6 +272,25 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
           assertThat(it.status).isEqualTo(status)
         })
       }
+    }
+  }
+
+  describe("when a task should complete parent stage") {
+    val task = fun(isStageEnd: Boolean) : Task {
+      val task = Task()
+      task.isStageEnd = isStageEnd
+      return task
+    }
+
+    it("is last task in stage") {
+      subject.shouldCompleteStage(task(true), SUCCEEDED, SUCCEEDED) == true
+      subject.shouldCompleteStage(task(false), SUCCEEDED, SUCCEEDED) == false
+    }
+
+    it("did not originally complete with FAILED_CONTINUE") {
+      subject.shouldCompleteStage(task(false), TERMINAL, TERMINAL) == true
+      subject.shouldCompleteStage(task(false), FAILED_CONTINUE, TERMINAL) == true
+      subject.shouldCompleteStage(task(false), FAILED_CONTINUE, FAILED_CONTINUE) == false
     }
   }
 })

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -469,6 +469,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           "foo",
           message.stageId,
           message.taskId,
+          CANCELED,
           CANCELED
         ))
       }
@@ -509,6 +510,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           "foo",
           message.stageId,
           message.taskId,
+          CANCELED,
           CANCELED
         ))
       }


### PR DESCRIPTION
This PR improves upon spinnaker/orca#2112 by only executing subsequent
tasks when a task _explicitly_ completes with the `FAILED_CONTINUE`
status.

An execution being flagged `"continuePipeline": true` is not enough to
cause subsequent tasks to execute if an unsuccessful status is
merely overridden to `FAILED_CONTINUE`.
