### PR TITLE
fix(queue): Pass original task status along for `CANCELED`

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -94,7 +94,7 @@ class RunTaskHandler(
                 CANCELED                             -> {
                   task.onCancel(stage)
                   val status = stage.failureStatus(default = result.status)
-                  queue.push(CompleteTask(message, status))
+                  queue.push(CompleteTask(message, status, result.status))
                   trackResult(stage, taskModel, status)
                 }
                 TERMINAL                             -> {


### PR DESCRIPTION
Similar to `TERMINAL`, we should pass the original task completion
status in the `CompleteTask` message whenever it has been overridden.
