### PR TITLE
fix(expressions): Better handling for composite spel

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionEvaluator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionEvaluator.java
@@ -19,5 +19,5 @@ package com.netflix.spinnaker.orca.pipeline.expressions;
 import java.util.Map;
 
 public interface ExpressionEvaluator {
-  Map<String, Object> evaluate(Map<String, Object> source, Object rootObject, ExpressionEvaluationSummary summary, boolean ignoreUnknownProperties);
+  Map<String, Object> evaluate(Map<String, Object> source, Object rootObject, ExpressionEvaluationSummary summary, boolean allowUnknownKeys);
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
@@ -37,9 +37,9 @@ public class PipelineExpressionEvaluator extends ExpressionsSupport implements E
   }
 
   @Override
-  public Map<String, Object> evaluate(Map<String, Object> source, Object rootObject, ExpressionEvaluationSummary summary, boolean ignoreUnknownProperties) {
-    StandardEvaluationContext evaluationContext = newEvaluationContext(rootObject, ignoreUnknownProperties);
-    return new ExpressionTransform(parserContext, parser).transform(source, evaluationContext, summary);
+  public Map<String, Object> evaluate(Map<String, Object> source, Object rootObject, ExpressionEvaluationSummary summary, boolean allowUnknownKeys) {
+    StandardEvaluationContext evaluationContext = newEvaluationContext(rootObject, allowUnknownKeys);
+    return new ExpressionTransform(parserContext, parser).transformMap(source, evaluationContext, summary);
   }
 }
 


### PR DESCRIPTION
- broke out the main transform method into type specific ones
- small cosmetic changes: corrected inconsitency var names including allowUnknownKeys
- added a way to stringify certain types before returning