### PR TITLE
feat(artifacts): Parse Jenkins job properties for artifacts

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/JenkinsStage.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/JenkinsStage.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.orca.igor.tasks.StopJenkinsJobTask
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -42,6 +43,11 @@ public class JenkinsStage implements StageDefinitionBuilder, RestartableStage, C
 
     if (!stage.getContext().getOrDefault("waitForCompletion", "true").toString().equalsIgnoreCase("false")) {
       builder.withTask("monitor${getType().capitalize()}Job", MonitorJenkinsJobTask.class)
+    }
+
+    if (stage.context.containsKey("expectedArtifacts")) {
+      builder
+        .withTask(BindProducedArtifactsTask.TASK_NAME, BindProducedArtifactsTask.class)
     }
   }
 


### PR DESCRIPTION
Jenkins job stages support producing artifacts; artifacts will be parsed out from the existing properties file output that Jenkins jobs can declare. A key `artifacts` will be parsed for artifacts that match the declared artifacts.

This is the Orca work for https://github.com/spinnaker/spinnaker/issues/2643

Please don't merge yet-- this is my first Spinnaker PR and I need to validate this more; this current code is just a PoC and seems too easy.