### PR TITLE
refactor(core): Alter startTimeTtl -> expiry, fix serialization

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -16,12 +16,6 @@
 
 package com.netflix.spinnaker.orca.pipeline;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.time.Clock;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.orca.ExecutionStatus;
@@ -35,6 +29,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.AuthenticationDetails;
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION;
@@ -176,6 +178,7 @@ public class ExecutionLauncher {
       .withKeepWaitingPipelines(getBoolean(config, "keepWaitingPipelines"))
       .withNotifications((List<Map<String, Object>>) config.get("notifications"))
       .withOrigin(getString(config, "origin"))
+      .withStartTimeExpiry(getString(config, "startTimeExpiry"))
       .build();
   }
 
@@ -210,6 +213,7 @@ public class ExecutionLauncher {
     orchestration.setBuildTime(clock.millis());
     orchestration.setAuthentication(AuthenticationDetails.build().orElse(new AuthenticationDetails()));
     orchestration.setOrigin((String) config.getOrDefault("origin", "unknown"));
+    orchestration.setStartTimeExpiry((Long) config.get("startTimeExpiry"));
 
     return orchestration;
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.security.User;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
-import java.time.Instant;
 import java.util.*;
 
 import static com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED;
@@ -194,18 +193,17 @@ public class Execution implements Serializable {
   }
 
   /**
-   * Gets the start ttl timestamp for this execution. If the execution has not
+   * Gets the start expiry timestamp for this execution. If the execution has not
    * started before this timestamp, the execution will immediately terminate.
    */
-  private Instant startTimeTtl;
+  private Long startTimeExpiry;
 
-  public @Nullable
-  Instant getStartTimeTtl() {
-    return startTimeTtl;
+  public @Nullable Long getStartTimeExpiry() {
+    return startTimeExpiry;
   }
 
-  public void setStartTimeTtl(@Nullable Instant startTimeTtl) {
-    this.startTimeTtl = startTimeTtl;
+  public void setStartTimeExpiry(@Nullable Long startTimeExpiry) {
+    this.startTimeExpiry = startTimeExpiry;
   }
 
   private ExecutionStatus status = NOT_STARTED;

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
@@ -83,5 +83,12 @@ public class PipelineBuilder {
     return this;
   }
 
+  public PipelineBuilder withStartTimeExpiry(String startTimeExpiry) {
+    if (startTimeExpiry != null) {
+      pipeline.setStartTimeExpiry(Long.valueOf(startTimeExpiry));
+    }
+    return this;
+  }
+
   private final Execution pipeline;
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -32,7 +32,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
-import java.time.Instant;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -85,6 +84,9 @@ public class Stage implements Serializable {
     this.context.putAll(context);
 
     this.refId = (String) context.remove("refId");
+    this.startTimeExpiry = Optional
+      .ofNullable((Long) context.remove("startTimeExpiry"))
+      .orElse(null);
     this.requisiteStageRefIds = Optional
       .ofNullable((Collection<String>) context.remove("requisiteStageRefIds"))
       .orElse(emptySet());
@@ -190,18 +192,17 @@ public class Stage implements Serializable {
   }
 
   /**
-   * Gets the start ttl timestamp for this stage. If the stage has not started
-   * before this timestamp, the stage will fail.
+   * Gets the start expiry timestamp for this stage. If the stage has not started
+   * before this timestamp, the stage will be skipped.
    */
-  private Instant startTimeTtl;
+  private Long startTimeExpiry;
 
-  public @Nullable
-  Instant getStartTimeTtl() {
-    return startTimeTtl;
+  public @Nullable Long getStartTimeExpiry() {
+    return startTimeExpiry;
   }
 
-  public void setStartTimeTtl(@Nullable Instant startTimeTtl) {
-    this.startTimeTtl = startTimeTtl;
+  public void setStartTimeExpiry(@Nullable Long startTimeExpiry) {
+    this.startTimeExpiry = startTimeExpiry;
   }
 
   /**

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -33,7 +33,6 @@ import rx.schedulers.Schedulers;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -515,8 +514,8 @@ public class RedisExecutionRepository implements ExecutionRepository {
       execution.setLimitConcurrent(Boolean.parseBoolean(map.get("limitConcurrent")));
       execution.setBuildTime(NumberUtils.createLong(map.get("buildTime")));
       execution.setStartTime(NumberUtils.createLong(map.get("startTime")));
-      if (map.get("startTimeTtl") != null) {
-        execution.setStartTimeTtl(Instant.ofEpochMilli(Long.valueOf(map.get("startTimeTtl"))));
+      if (map.get("startTimeExpiry") != null) {
+        execution.setStartTimeExpiry(Long.valueOf(map.get("startTimeExpiry")));
       }
       execution.setEndTime(NumberUtils.createLong(map.get("endTime")));
       if (map.get("status") != null) {
@@ -546,8 +545,8 @@ public class RedisExecutionRepository implements ExecutionRepository {
         stage.setStartTime(NumberUtils.createLong(map.get(prefix + "startTime")));
         stage.setEndTime(NumberUtils.createLong(map.get(prefix + "endTime")));
         stage.setStatus(ExecutionStatus.valueOf(map.get(prefix + "status")));
-        if (map.get(prefix + "startTimeTtl") != null) {
-          stage.setStartTimeTtl(Instant.ofEpochMilli(Long.valueOf(map.get(prefix + "startTimeTtl"))));
+        if (map.get(prefix + "startTimeExpiry") != null) {
+          stage.setStartTimeExpiry(Long.valueOf(map.get(prefix + "startTimeExpiry")));
         }
         if (map.get(prefix + "syntheticStageOwner") != null) {
           stage.setSyntheticStageOwner(SyntheticStageOwner.valueOf(map.get(prefix + "syntheticStageOwner")));
@@ -642,7 +641,7 @@ public class RedisExecutionRepository implements ExecutionRepository {
       map.put("buildTime", String.valueOf(execution.getBuildTime() != null ? execution.getBuildTime() : 0L));
       map.put("startTime", execution.getStartTime() != null ? execution.getStartTime().toString() : null);
       map.put("endTime", execution.getEndTime() != null ? execution.getEndTime().toString() : null);
-      map.put("startTimeTtl", execution.getStartTimeTtl() != null ? String.valueOf(execution.getStartTimeTtl().toEpochMilli()) : null);
+      map.put("startTimeExpiry", execution.getStartTimeExpiry() != null ? String.valueOf(execution.getStartTimeExpiry()) : null);
       map.put("status", execution.getStatus().name());
       map.put("authentication", mapper.writeValueAsString(execution.getAuthentication()));
       map.put("paused", mapper.writeValueAsString(execution.getPaused()));
@@ -678,7 +677,7 @@ public class RedisExecutionRepository implements ExecutionRepository {
     map.put(prefix + "name", stage.getName());
     map.put(prefix + "startTime", stage.getStartTime() != null ? stage.getStartTime().toString() : null);
     map.put(prefix + "endTime", stage.getEndTime() != null ? stage.getEndTime().toString() : null);
-    map.put(prefix + "startTimeTtl", stage.getStartTimeTtl() != null ? String.valueOf(stage.getStartTimeTtl().toEpochMilli()) : null);
+    map.put(prefix + "startTimeExpiry", stage.getStartTimeExpiry() != null ? String.valueOf(stage.getStartTimeExpiry()) : null);
     map.put(prefix + "status", stage.getStatus().name());
     map.put(prefix + "syntheticStageOwner", stage.getSyntheticStageOwner() != null ? stage.getSyntheticStageOwner().name() : null);
     map.put(prefix + "parentStageId", stage.getParentStageId());

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
@@ -28,10 +28,9 @@ import com.netflix.spinnaker.orca.q.StartExecution
 import com.netflix.spinnaker.orca.q.StartStage
 import com.netflix.spinnaker.orca.q.singleTaskStage
 import com.netflix.spinnaker.q.Queue
-import com.nhaarman.mockito_kotlin.*
-import com.netflix.spinnaker.time.fixedClock
 import com.netflix.spinnaker.spek.and
-import org.assertj.core.api.Assertions.assertThat
+import com.netflix.spinnaker.time.fixedClock
+import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.given
@@ -229,7 +228,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         stage {
           type = singleTaskStage.type
         }
-        startTimeTtl = clock.instant().minusSeconds(30)
+        startTimeExpiry = clock.instant().minusSeconds(30).toEpochMilli()
       }
       val message = StartExecution(pipeline)
 
@@ -247,7 +246,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         verify(queue).push(CancelExecution(
           pipeline,
           "spinnaker",
-          "Could not begin execution before start time TTL"
+          "Could not begin execution before start time expiry"
         ))
       }
     }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
@@ -610,7 +610,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
         stage {
           refId = "bar"
           type = singleTaskStage.type
-          startTimeTtl = clock.instant().minusSeconds(30)
+          startTimeExpiry = clock.instant().minusSeconds(30).toEpochMilli()
         }
       }
       val message = StartStage(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id)
@@ -618,7 +618,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       beforeGroup {
         whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
       }
-  
+
       afterGroup(::resetMocks)
 
       on("receiving a message") {
@@ -626,7 +626,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       }
 
       it("cancels the stage") {
-        verify(queue).push(CancelStage(
+        verify(queue).push(SkipStage(
           pipeline.stageByRef("bar")
         ))
       }


### PR DESCRIPTION
Changing up how `startTimeTtl` works a little bit, as well as fixing up some bugs.

* Property is now `startTimeExpiry`, which is more self-descriptive.
* I had a hell of a time getting `Instant` to serialize to a `long`, despite configuring the object mapper to do so, so I switched away to a `Long` for the internal type.
* Changed the `StartStageHandler` behavior to use `SkipStage` instead of `CancelStage`, since this seems more in line with current queue behavior
* I wasn't correctly slotting the request properties into the models, derp.