### PR TITLE
feat(core): Support for both sync/async application event listeners

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/annotations/Sync.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/annotations/Sync.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used for flagging application event listeners as synchronous. By default, orca's event listeners will be setup
+ * as asynchronous unless explicitly flagged with this annotation.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Sync {
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -15,9 +15,6 @@
  */
 package com.netflix.spinnaker.orca.config;
 
-import java.time.Clock;
-import java.time.Duration;
-import java.util.Collection;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.kork.core.RetrySupport;
@@ -27,15 +24,15 @@ import com.netflix.spinnaker.orca.exceptions.DefaultExceptionHandler;
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
 import com.netflix.spinnaker.orca.libdiffs.ComparableLooseVersion;
 import com.netflix.spinnaker.orca.libdiffs.DefaultComparableLooseVersion;
-import com.netflix.spinnaker.orca.listeners.ExecutionCleanupListener;
-import com.netflix.spinnaker.orca.listeners.ExecutionListener;
-import com.netflix.spinnaker.orca.listeners.MetricsExecutionListener;
+import com.netflix.spinnaker.orca.listeners.*;
 import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.orca.pipeline.util.ContextFunctionConfiguration;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -45,11 +42,23 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.event.EventListenerFactory;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import rx.Scheduler;
 import rx.schedulers.Schedulers;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Collection;
+
 import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.springframework.context.annotation.AnnotationConfigUtils.EVENT_LISTENER_FACTORY_BEAN_NAME;
 
 @Configuration
 @ComponentScan({
@@ -136,4 +145,35 @@ public class OrcaConfiguration {
     return new RetrySupport();
   }
 
+  @Bean
+  public ApplicationEventMulticaster applicationEventMulticaster(@Qualifier("applicationEventTaskExecutor") ThreadPoolTaskExecutor taskExecutor) {
+    // TODO rz - Add error handlers
+    SimpleApplicationEventMulticaster async = new SimpleApplicationEventMulticaster();
+    async.setTaskExecutor(taskExecutor);
+    SimpleApplicationEventMulticaster sync = new SimpleApplicationEventMulticaster();
+
+    return new DelegatingApplicationEventMulticaster(sync, async);
+  }
+
+  @Bean
+  public ThreadPoolTaskExecutor applicationEventTaskExecutor() {
+    ThreadPoolTaskExecutor threadPool = new ThreadPoolTaskExecutor();
+    threadPool.setThreadNamePrefix("events-");
+    threadPool.setCorePoolSize(20);
+    threadPool.setMaxPoolSize(20);
+    return threadPool;
+  }
+
+  @Bean
+  public TaskScheduler taskScheduler() {
+    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setThreadNamePrefix("scheduler-");
+    scheduler.setPoolSize(10);
+    return scheduler;
+  }
+
+  @Bean(name = EVENT_LISTENER_FACTORY_BEAN_NAME)
+  public EventListenerFactory eventListenerFactory() {
+    return new InspectableEventListenerFactory();
+  }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/DelegatingApplicationEventMulticaster.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/DelegatingApplicationEventMulticaster.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.listeners
+
+import com.netflix.spinnaker.orca.annotations.Sync
+import org.springframework.beans.factory.BeanClassLoaderAware
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.BeanFactoryAware
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.ApplicationEventMulticaster
+import org.springframework.core.ResolvableType
+
+/**
+ * Supports sync & async event listeners. Listeners are treated as asynchronous unless
+ * explicitly marked as synchronous via the {@code Sync} annotation.
+ */
+class DelegatingApplicationEventMulticaster(
+  private val syncApplicationEventMulticaster: ApplicationEventMulticaster,
+  private val asyncApplicationEventMulticaster: ApplicationEventMulticaster
+) : ApplicationEventMulticaster, BeanFactoryAware, BeanClassLoaderAware {
+
+  override fun multicastEvent(event: ApplicationEvent?) {
+    asyncApplicationEventMulticaster.multicastEvent(event)
+    syncApplicationEventMulticaster.multicastEvent(event)
+  }
+
+  override fun multicastEvent(event: ApplicationEvent?, eventType: ResolvableType?) {
+    asyncApplicationEventMulticaster.multicastEvent(event, eventType)
+    asyncApplicationEventMulticaster.multicastEvent(event, eventType)
+  }
+
+  override fun addApplicationListener(listener: ApplicationListener<*>) {
+    if (isSynchronous(listener)) {
+      syncApplicationEventMulticaster.addApplicationListener(listener)
+    } else {
+      asyncApplicationEventMulticaster.addApplicationListener(listener)
+    }
+  }
+
+  private fun isSynchronous(listener: ApplicationListener<*>): Boolean {
+    if (listener.javaClass.getAnnotation(Sync::class.java) != null) {
+      return true
+    }
+    if (listener is InspectableApplicationListenerMethodAdapter
+      && listener.getMethod().getAnnotation(Sync::class.java) != null) {
+      return true
+    }
+    return false
+  }
+
+  override fun addApplicationListenerBean(listenerBeanName: String) {
+    // Bean-name based listeners are async-only.
+    asyncApplicationEventMulticaster.addApplicationListenerBean(listenerBeanName)
+  }
+
+  override fun removeApplicationListener(listener: ApplicationListener<*>) {
+    asyncApplicationEventMulticaster.removeApplicationListener(listener)
+    syncApplicationEventMulticaster.removeApplicationListener(listener)
+  }
+
+  override fun removeAllListeners() {
+    asyncApplicationEventMulticaster.removeAllListeners()
+    syncApplicationEventMulticaster.removeAllListeners()
+  }
+
+  override fun removeApplicationListenerBean(listenerBeanName: String) {
+    // Bean-name based listeners are async-only.
+    asyncApplicationEventMulticaster.removeApplicationListenerBean(listenerBeanName)
+  }
+
+  override fun setBeanFactory(beanFactory: BeanFactory?) {
+    if (asyncApplicationEventMulticaster is BeanFactoryAware) {
+      asyncApplicationEventMulticaster.setBeanFactory(beanFactory)
+    }
+    if (syncApplicationEventMulticaster is BeanFactoryAware) {
+      syncApplicationEventMulticaster.setBeanFactory(beanFactory)
+    }
+  }
+
+  override fun setBeanClassLoader(classLoader: ClassLoader?) {
+    if (asyncApplicationEventMulticaster is BeanClassLoaderAware) {
+      asyncApplicationEventMulticaster.setBeanClassLoader(classLoader)
+    }
+    if (syncApplicationEventMulticaster is BeanClassLoaderAware) {
+      syncApplicationEventMulticaster.setBeanClassLoader(classLoader)
+    }
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/InspectableApplicationListenerMethodAdapter.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/InspectableApplicationListenerMethodAdapter.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.listeners
+
+import org.springframework.context.event.ApplicationListenerMethodAdapter
+import java.lang.reflect.Method
+
+class InspectableApplicationListenerMethodAdapter(
+  beanName: String,
+  targetClass: Class<*>,
+  private val method: Method
+) : ApplicationListenerMethodAdapter(beanName, targetClass, method) {
+
+  fun getMethod() = method
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/InspectableEventListenerFactory.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/InspectableEventListenerFactory.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.listeners
+
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.DefaultEventListenerFactory
+import java.lang.reflect.Method
+
+class InspectableEventListenerFactory : DefaultEventListenerFactory() {
+
+  override fun createApplicationListener(beanName: String, type: Class<*>, method: Method): ApplicationListener<*> {
+    return InspectableApplicationListenerMethodAdapter(beanName, type, method)
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/listeners/DelegatingApplicationEventMulticasterSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/listeners/DelegatingApplicationEventMulticasterSpec.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.listeners
+
+import com.netflix.spinnaker.orca.annotations.Sync
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.ApplicationEventMulticaster
+import org.springframework.context.event.EventListener
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class DelegatingApplicationEventMulticasterSpec extends Specification {
+
+  ApplicationEventMulticaster async = Mock()
+  ApplicationEventMulticaster sync = Mock()
+
+  @Subject
+  ApplicationEventMulticaster subject = new DelegatingApplicationEventMulticaster(sync, async)
+
+  def "should add listener as async by default"() {
+    when:
+    subject.addApplicationListener(new AsyncListener())
+
+    then:
+    1 * async.addApplicationListener(_)
+    0 * sync.addApplicationListener(_)
+  }
+
+  @Unroll
+  def "should add sync listeners when explicitly flagged"() {
+    when:
+    subject.addApplicationListener(listener)
+
+    then:
+    0 * async.addApplicationListener(_)
+    1 * sync.addApplicationListener(_)
+
+    where:
+    listener << [
+      new ClassSyncListener(),
+      new InspectableApplicationListenerMethodAdapter("methodSyncListener", MethodSyncListener, MethodSyncListener.class.getMethod("onEvent", TestEvent))
+    ]
+  }
+
+  private static class TestEvent extends ApplicationEvent {
+    TestEvent(Object source) {
+      super(source)
+    }
+  }
+
+  private static class AsyncListener implements ApplicationListener<TestEvent> {
+    @Override
+    void onApplicationEvent(TestEvent event) {}
+  }
+
+  @Sync
+  private static class ClassSyncListener implements ApplicationListener<TestEvent> {
+    @Override
+    void onApplicationEvent(TestEvent event) {}
+  }
+
+  private static class MethodSyncListener {
+    @Sync
+    @EventListener
+    void onEvent(TestEvent event) {}
+  }
+}

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -34,6 +34,7 @@ import com.netflix.spinnaker.orca.exceptions.DefaultExceptionHandler
 import com.netflix.spinnaker.orca.ext.withTask
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
+import com.netflix.spinnaker.orca.listeners.DelegatingApplicationEventMulticaster
 import com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWindow
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.newStage
@@ -60,6 +61,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration
@@ -68,6 +70,11 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
+import org.springframework.context.event.ApplicationEventMulticaster
+import org.springframework.context.event.SimpleApplicationEventMulticaster
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
 import org.springframework.test.context.junit4.SpringRunner
 import redis.clients.jedis.Jedis
 import redis.clients.util.Pool
@@ -923,5 +930,15 @@ class TestConfig {
   @Bean
   fun redisClientSelector(redisClientDelegates: List<RedisClientDelegate>) =
     RedisClientSelector(redisClientDelegates)
+
+  @Bean
+  fun applicationEventMulticaster(@Qualifier("applicationEventTaskExecutor") taskExecutor: ThreadPoolTaskExecutor): ApplicationEventMulticaster {
+    // TODO rz - Add error handlers
+    val async = SimpleApplicationEventMulticaster()
+    async.setTaskExecutor(taskExecutor)
+    val sync = SimpleApplicationEventMulticaster()
+
+    return DelegatingApplicationEventMulticaster(sync, async)
+  }
 }
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/OrcaQueueConfiguration.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/config/OrcaQueueConfiguration.kt
@@ -16,18 +16,11 @@
 
 package com.netflix.spinnaker.config
 
-import com.netflix.spectator.api.Registry
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.event.ApplicationEventMulticaster
-import org.springframework.context.event.SimpleApplicationEventMulticaster
-import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.annotation.EnableScheduling
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
 import java.time.Clock
 
 @Configuration
@@ -40,35 +33,4 @@ class OrcaQueueConfiguration {
   @Bean
   @ConditionalOnMissingBean(Clock::class)
   fun systemClock(): Clock = Clock.systemDefaultZone()
-
-  /**
-   * This overrides Spring's default application event multicaster as we need
-   * to _guarantee_ that exceptions thrown by listeners or just listeners taking
-   * a long time to do stuff do not affect the processing of the queue.
-   */
-  @Bean
-  fun applicationEventMulticaster(
-    @Qualifier("applicationEventTaskExecutor") taskExecutor: ThreadPoolTaskExecutor
-  ): ApplicationEventMulticaster =
-    SimpleApplicationEventMulticaster().apply {
-      setTaskExecutor(taskExecutor)
-      // TODO: should set an error handler as well
-    }
-
-  // TODO rz - move to a separate location since this is modifying the spring async tasks stuff
-  @Bean
-  fun applicationEventTaskExecutor(registry: Registry): ThreadPoolTaskExecutor =
-    ThreadPoolTaskExecutor().apply {
-      threadNamePrefix = "events-"
-      corePoolSize = 20
-      maxPoolSize = 20
-    }
-
-  // TODO rz - Move out of queueconfiguration
-  @Bean
-  fun taskScheduler(): TaskScheduler =
-    ThreadPoolTaskScheduler().apply {
-      threadNamePrefix = "scheduler-"
-      poolSize = 10
-    }
 }


### PR DESCRIPTION
Some plumbing work in preparation for implementing the QoS management system, which will be an `extensionpoint` to Orca's core functionality. Orca is currently written so that all Spring events are asynchronous, but we'll be adding event extensions that will need to be synchronous. Spring's normal behavior is to opt into async listeners, with sync being the default; in our case we need the inverse which requires switching up some Spring plumbing. 

Supports both class-based event listeners, as well as method-level event listeners. You can opt a listener of either kind into synchronous execution via the new `@Sync` annotation.

I've also addressed a series of TODOs that move the event task executor pool stuff into `orca-core` from `orca-queue`, since I was already touching this system.

At the point of this PR, there's no synchronous listeners.