### PR TITLE
feat(artifacts) Expose child pipeline outputs as outputs of a pipeline stage

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -151,7 +151,6 @@ public class Execution implements Serializable {
     this.keepWaitingPipelines = keepWaitingPipelines;
   }
 
-  @Deprecated
   @JsonIgnore
   public @Nonnull Map<String, Object> getContext() {
     return Stage.topologicalSort(stages)

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
@@ -44,7 +44,7 @@ class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
     Execution childPipeline = executionRepository.retrieve(PIPELINE, pipelineId)
 
     if (childPipeline.status == ExecutionStatus.SUCCEEDED) {
-      return new TaskResult(ExecutionStatus.SUCCEEDED, [status: childPipeline.status])
+      return new TaskResult(ExecutionStatus.SUCCEEDED, [status: childPipeline.status], childPipeline.getContext())
     }
 
     if (childPipeline.status.halt) {


### PR DESCRIPTION
Per Slack discussion with @ezimanyi https://spinnakerteam.slack.com/archives/C091CCWRJ/p1523425204000140; my intended use case is to access artifacts emitted by the child pipeline, but there may be other utility as well.

This appears to be the easiest way to do this, but it relies on the deprecated `getContext()` on `Execution`. In order to avoid that, I could recreate the outputs by walking the stages in the child pipeline, or just create a non-deprecated `getOutputs()` on `Execution`. If someone can comment on _why_ the method is deprecated, that might help. It was deprecated in a89c57b7d35ac8370f1955b465750ef0748c7f7b by @robfletcher.

I did _not_ add support for declaring Expected Artifacts and emitting only expected artifacts in the pipeline stage, but I can do that as well. Perhaps @lwander can comment on which behavior would be more in line with the underlying design of artifact resolution?