### PR TITLE
fix(spel): Whitelist java.time.LocalDate to allow for date manipulation

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.pipeline.expressions.whitelisting;
 
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.time.LocalDate;
 
 public interface InstantiationTypeRestrictor {
   Set<Class<?>> allowedTypes = Collections.unmodifiableSet(
@@ -33,7 +34,8 @@ public interface InstantiationTypeRestrictor {
         Math.class,
         Random.class,
         UUID.class,
-        Boolean.class
+        Boolean.class,
+        LocalDate.class
       )
     )
   );


### PR DESCRIPTION
Java8 added java.time.LocalDate which allows for more advanced date manipulations. Very useful in pipeline parameters to calculate dates.

Works beautifully, for eg, to calculate the date 5 days from now: 
${ T(java.time.LocalDate).now().plusDays(5).toString() }