### PR TITLE
More tags

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -17,10 +17,7 @@
 package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spectator.api.BasicTag
-import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
-import com.netflix.spectator.api.Tag
-import com.netflix.spectator.api.histogram.BucketCounter
 import com.netflix.spinnaker.orca.*
 import com.netflix.spinnaker.orca.ExecutionStatus.*
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
@@ -36,6 +33,7 @@ import com.netflix.spinnaker.orca.q.CompleteTask
 import com.netflix.spinnaker.orca.q.InvalidTaskType
 import com.netflix.spinnaker.orca.q.PauseTask
 import com.netflix.spinnaker.orca.q.RunTask
+import com.netflix.spinnaker.orca.q.metrics.MetricsTagHelper
 import com.netflix.spinnaker.orca.time.toDuration
 import com.netflix.spinnaker.orca.time.toInstant
 import com.netflix.spinnaker.q.Message
@@ -65,6 +63,8 @@ class RunTaskHandler(
   override fun handle(message: RunTask) {
     message.withTask { stage, taskModel, task ->
       val execution = stage.execution
+      val thisInvocationStartTimeMs = clock.millis()
+
       try {
         if (execution.isCanceled) {
           task.onCancel(stage)
@@ -88,22 +88,22 @@ class RunTaskHandler(
               when (result.status) {
                 RUNNING                              -> {
                   queue.push(message, task.backoffPeriod(taskModel, stage))
-                  trackResult(stage, taskModel, result.status)
+                  trackResult(stage, thisInvocationStartTimeMs, taskModel, result.status)
                 }
                 SUCCEEDED, REDIRECT, FAILED_CONTINUE -> {
                   queue.push(CompleteTask(message, result.status))
-                  trackResult(stage, taskModel, result.status)
+                  trackResult(stage, thisInvocationStartTimeMs, taskModel, result.status)
                 }
                 CANCELED                             -> {
                   task.onCancel(stage)
                   val status = stage.failureStatus(default = result.status)
                   queue.push(CompleteTask(message, status, result.status))
-                  trackResult(stage, taskModel, status)
+                  trackResult(stage, thisInvocationStartTimeMs, taskModel, status)
                 }
                 TERMINAL                             -> {
                   val status = stage.failureStatus(default = result.status)
                   queue.push(CompleteTask(message, status, result.status))
-                  trackResult(stage, taskModel, status)
+                  trackResult(stage, thisInvocationStartTimeMs, taskModel, status)
                 }
                 else                                 ->
                   TODO("Unhandled task status ${result.status}")
@@ -116,7 +116,7 @@ class RunTaskHandler(
         if (exceptionDetails?.shouldRetry == true) {
           log.warn("Error running ${message.taskType.simpleName} for ${message.executionType}[${message.executionId}]")
           queue.push(message, task.backoffPeriod(taskModel, stage))
-          trackResult(stage, taskModel, RUNNING)
+          trackResult(stage, thisInvocationStartTimeMs, taskModel, RUNNING)
         } else if (e is TimeoutException && stage.context["markSuccessfulOnTimeout"] == true) {
           queue.push(CompleteTask(message, SUCCEEDED))
         } else {
@@ -124,41 +124,25 @@ class RunTaskHandler(
           stage.context["exception"] = exceptionDetails
           repository.storeStage(stage)
           queue.push(CompleteTask(message, stage.failureStatus()))
-          trackResult(stage, taskModel, stage.failureStatus())
+          trackResult(stage, thisInvocationStartTimeMs, taskModel, stage.failureStatus())
         }
       }
     }
   }
 
-  private fun trackResult(stage: Stage, taskModel: com.netflix.spinnaker.orca.pipeline.model.Task, status: ExecutionStatus) {
-    val commonTags = arrayListOf(
-      BasicTag("status", status.toString()),
-      BasicTag("executionType", stage.execution.type.name.capitalize()),
-      BasicTag("isComplete", status.isComplete.toString()),
-      BasicTag("cloudProvider", stage.context["cloudProvider"].toString()?: "n_a"))
+  private fun trackResult(stage: Stage, thisInvocationStartTimeMs: Long, taskModel: com.netflix.spinnaker.orca.pipeline.model.Task, status: ExecutionStatus) {
+    val commonTags = MetricsTagHelper.commonTags(stage, taskModel, status)
+    val detailedTags = MetricsTagHelper.detailedTaskTags(stage, taskModel, status)
 
-    val taskInvocationsId = registry.createId("task.invocations")
-      .withTags(commonTags)
-      .withTag("application", stage.execution.application)
-
-    val taskInvocationsWithTypeId = registry.createId("task.invocations.withType")
-      .withTags(commonTags)
-      .withTag("taskType", taskModel.implementingClass)
-      .withTag("account", stage.context["account"].toString()?: "n_a")
-      .withTag("region", stage.context["region"].toString()?: "n_a")
-
-    registry.counter(taskInvocationsId).increment()
-    registry.counter(taskInvocationsWithTypeId).increment()
-
-    val elapsedMillis = clock.millis() - (taskModel.startTime ?: 0)
+    val elapsedMillis = clock.millis() - thisInvocationStartTimeMs
 
     hashMapOf(
-      "task.invocations.duration" to taskInvocationsId.tags(),
-      "task.invocations.duration.withType" to taskInvocationsWithTypeId.tags()
+      "task.invocations.duration" to commonTags + BasicTag("application", stage.execution.application),
+      "task.invocations.duration.withType" to commonTags + detailedTags
     ).forEach {
       name, tags ->
         val id = registry.createId(name).withTags(tags)
-        registry.timer(id).record(elapsedMillis, TimeUnit.MILLISECONDS)
+        registry.timer(name, tags).record(elapsedMillis, TimeUnit.MILLISECONDS)
     }
   }
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -135,7 +135,7 @@ class RunTaskHandler(
       BasicTag("status", status.toString()),
       BasicTag("executionType", stage.execution.type.name.capitalize()),
       BasicTag("isComplete", status.isComplete.toString()),
-      BasicTag("cloudProvider", stage.context["cloudProvider"].toString()?: "n/a"))
+      BasicTag("cloudProvider", stage.context["cloudProvider"].toString()?: "n_a"))
 
     val taskInvocationsId = registry.createId("task.invocations")
       .withTags(commonTags)
@@ -144,13 +144,13 @@ class RunTaskHandler(
     val taskInvocationsWithTypeId = registry.createId("task.invocations.withType")
       .withTags(commonTags)
       .withTag("taskType", taskModel.implementingClass)
-      .withTag("account", stage.context["account"].toString()?: "n/a")
-      .withTag("region", stage.context["region"].toString()?: "n/a")
+      .withTag("account", stage.context["account"].toString()?: "n_a")
+      .withTag("region", stage.context["region"].toString()?: "n_a")
 
     registry.counter(taskInvocationsId).increment()
     registry.counter(taskInvocationsWithTypeId).increment()
 
-    val elapsedMillis = System.currentTimeMillis() - (taskModel.startTime ?: 0)
+    val elapsedMillis = clock.millis() - (taskModel.startTime ?: 0)
 
     hashMapOf(
       "task.invocations.duration" to taskInvocationsId.tags(),

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/MetricsTagHelper.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/MetricsTagHelper.kt
@@ -1,0 +1,22 @@
+package com.netflix.spinnaker.orca.q.metrics
+
+import com.netflix.spectator.api.BasicTag
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+
+class MetricsTagHelper {
+  companion object {
+    fun commonTags(stage: Stage, taskModel: com.netflix.spinnaker.orca.pipeline.model.Task, status: ExecutionStatus): Iterable<BasicTag> =
+      arrayListOf(
+        BasicTag("status", status.toString()),
+        BasicTag("executionType", stage.execution.type.name.capitalize()),
+        BasicTag("isComplete", status.isComplete.toString()),
+        BasicTag("cloudProvider", stage.context["cloudProvider"].toString()?: "n_a"))
+
+    fun detailedTaskTags(stage: Stage, taskModel: com.netflix.spinnaker.orca.pipeline.model.Task, status: ExecutionStatus): Iterable<BasicTag> =
+      arrayListOf(
+        BasicTag("taskType", taskModel.implementingClass),
+        BasicTag("account", stage.context["account"].toString()?: "n_a"),
+        BasicTag("region", stage.context["region"].toString()?: "n_a"))
+  }
+}

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.orca.q.handler
 
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.ExecutionStatus.*
 import com.netflix.spinnaker.orca.events.TaskComplete
 import com.netflix.spinnaker.orca.fixture.pipeline
@@ -45,7 +47,7 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
   val clock = fixedClock()
 
   subject(GROUP) {
-    CompleteTaskHandler(queue, repository, ContextParameterProcessor(), publisher, clock)
+    CompleteTaskHandler(queue, repository, ContextParameterProcessor(), publisher, clock, NoopRegistry())
   }
 
   fun resetMocks() = reset(queue, repository, publisher)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -1184,21 +1184,4 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       verify(queue).push(isA<InvalidTaskType>())
     }
   }
-
-  describe("should bucket task durations") {
-    mapOf(
-      0 to "lt5m",
-      1 to "lt5m",
-      7 to "gt5m",
-      16 to "gt15m",
-      31 to "gt30m",
-      61 to "gt60m",
-      120 to "gt60m"
-    ).forEach { minutes, expectedBucket ->
-      given("a task that is ${minutes} minutes old") {
-        val millis = TimeUnit.MINUTES.toMillis(minutes.toLong())
-        assertThat(subject.bucketDuration(millis)).isEqualTo(expectedBucket)
-      }
-    }
-  }
 })


### PR DESCRIPTION
Keep the current metrics with the application tag:
* task.invocations
* task.invocations.duration

and introduce new ones without the application tag but with the task type,
account and region if applicable:
* task.invocations.withType
* task.invocations.duration.withType

This way, we should be able to dig into performance issues without blowing
up the cardinality of our metrics (#applications * #taskTypes may get high)