### PR TITLE
fix(core) Populate trigger.artifacts when it's a manual execution with the context of a previous build trigger

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -195,6 +195,9 @@ class OperationsController {
           log.warn("Igor is not enabled, unable to lookup build artifacts. Fix this by setting igor.enabled: true")
         } else {
           buildInfo.artifacts = buildArtifactFilter.filterArtifacts(buildInfo.artifacts)
+          if (trigger.type == "manual") {
+            trigger.artifacts = buildInfo.artifacts
+          }
         }
 
       }


### PR DESCRIPTION
When a pipeline is initiated via manual execution and using the context of a previous build, the field `trigger.artifacts` is not populated. 
The artifacts information is in `trigger.buildinfo`, but when the execution happens via the build trigger, Echo puts the artifacts into `pipeline.receivedArtifacts` which will then end in `trigger.artifacts`. Such doesn't happen when it's a manual execution.

~~This PR will make the `ArtifactResolver` look into `trigger.buildinfo` to check if there are artifacts to be processed.~~