### PR TITLE
feat(qos): Adding initial naive Quality of Service module

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/ExecutionStatus.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/ExecutionStatus.java
@@ -80,7 +80,12 @@ public enum ExecutionStatus {
   /**
    * The task was skipped and the pipeline will proceed to the next task.
    */
-    SKIPPED(true, false);
+    SKIPPED(true, false),
+
+  /**
+   * The task is not started and must be transitioned to NOT_STARTED.
+   */
+    BUFFERED(false, false);
 
   /**
    * Indicates that the task/stage/pipeline has finished its work (successfully or not).

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/events/BeforeInitialExecutionPersist.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/events/BeforeInitialExecutionPersist.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.events;
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import org.springframework.context.ApplicationEvent;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An event emitted immediately before the initial persist of an execution.
+ */
+public final class BeforeInitialExecutionPersist extends ApplicationEvent {
+
+  private final Execution execution;
+
+  public BeforeInitialExecutionPersist(@Nonnull Object source, @Nonnull Execution execution) {
+    super(source);
+    this.execution = execution;
+  }
+
+  public final @Nonnull Execution getExecution() {
+    return execution;
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/events/ExecutionEvent.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/events/ExecutionEvent.java
@@ -16,9 +16,11 @@
 
 package com.netflix.spinnaker.orca.events;
 
-import java.time.Instant;
-import javax.annotation.Nonnull;
 import org.springframework.context.ApplicationEvent;
+
+import javax.annotation.Nonnull;
+import java.time.Instant;
+
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
 
 /**

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/ExecutionListener.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/ExecutionListener.java
@@ -16,12 +16,17 @@
 
 package com.netflix.spinnaker.orca.listeners;
 
-import javax.annotation.Nonnull;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import org.springframework.core.Ordered;
 
+import javax.annotation.Nonnull;
+
 public interface ExecutionListener extends Ordered, Comparable<ExecutionListener> {
+  default void beforeInitialPersist(@Nonnull Execution execution) {
+    // do nothing
+  }
+
   default void beforeExecution(@Nonnull Persister persister,
                                @Nonnull Execution execution) {
     // do nothing

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -23,10 +23,7 @@ import rx.Observable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Objects;
+import java.util.*;
 
 import static java.util.stream.Collectors.toList;
 
@@ -79,6 +76,9 @@ public interface ExecutionRepository {
 
   @Nonnull Execution retrieveOrchestrationForCorrelationId(
     @Nonnull String correlationId) throws ExecutionNotFoundException;
+
+  @Nonnull
+  List<Execution> retrieveBufferedExecutions();
 
   final class ExecutionCriteria {
     public int getLimit() {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherSpec.groovy
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.orca.pipeline
 
+import com.netflix.spinnaker.orca.events.BeforeInitialExecutionPersist
+import org.springframework.context.ApplicationEventPublisher
+
 import java.time.Clock
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
@@ -33,6 +36,7 @@ class ExecutionLauncherSpec extends Specification {
   def executionRunner = Mock(ExecutionRunner)
   def executionRepository = Mock(ExecutionRepository)
   def pipelineValidator = Stub(PipelineValidator)
+  def applicationEventPublisher = Mock(ApplicationEventPublisher)
 
   ExecutionLauncher create() {
     return new ExecutionLauncher(
@@ -40,6 +44,7 @@ class ExecutionLauncherSpec extends Specification {
       executionRepository,
       executionRunner,
       Clock.systemDefaultZone(),
+      applicationEventPublisher,
       Optional.of(pipelineValidator),
       Optional.<Registry> empty()
     )
@@ -103,6 +108,7 @@ class ExecutionLauncherSpec extends Specification {
     launcher.start(PIPELINE, json)
 
     then:
+    1 * applicationEventPublisher.publishEvent(_ as BeforeInitialExecutionPersist)
     1 * executionRunner.start(_)
 
     where:

--- a/orca-qos/orca-qos.gradle
+++ b/orca-qos/orca-qos.gradle
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply from: "$rootDir/gradle/kotlin.gradle"
+apply from: "$rootDir/gradle/spek.gradle"
+
+dependencies {
+  compile project(":orca-core")
+  compile project(":orca-front50")
+  compile project(":orca-queue")
+
+  testCompile project(":orca-test-kotlin")
+}

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/config/QosConfiguration.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/config/QosConfiguration.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConditionalOnProperty("qos.enabled")
+@ComponentScan("com.netflix.spinnaker.orca.qos")
+class QosConfiguration

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/BufferPolicy.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/BufferPolicy.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import org.springframework.core.Ordered
+
+/**
+ * A policy responsible for determining whether an [Execution] should be buffered.
+ */
+interface BufferPolicy : Ordered {
+
+  fun apply(execution: Execution): BufferResult
+
+  override fun getOrder() = 0
+}
+
+enum class BufferAction {
+  /**
+   * Marks the execution for buffering.
+   */
+  BUFFER,
+
+  /**
+   * Marks the execution for moving from buffered to queued.
+   */
+  ENQUEUE
+}
+
+/**
+ * @param action The action to take
+ * @param force If true, the chain of policies will be short-circuited and this result's action will be used.
+ * @param reason A human-friendly reason for the action.
+ */
+data class BufferResult(
+  val action: BufferAction,
+  val force: Boolean,
+  val reason: String
+)

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/BufferState.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/BufferState.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos
+
+/**
+ * The state of the QoS buffering system.
+ *
+ * When the QoS system is in an ACTIVE state, all new executions will become candidates for buffering. In an INACTIVE
+ * state, no executions will be buffered, however draining buffered executions will still continue according to
+ * the enabled Promotion Policies.
+ */
+enum class BufferState {
+  ACTIVE,
+  INACTIVE
+}

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/BufferStateSupplier.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/BufferStateSupplier.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos
+
+import java.util.function.Supplier
+
+/**
+ * The BufferStateSupplier is responsible for actuating the overall state of the QoS system.
+ */
+interface BufferStateSupplier : Supplier<BufferState>

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionBufferActuator.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionBufferActuator.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos
+
+import com.netflix.spinnaker.orca.ExecutionStatus.BUFFERED
+import com.netflix.spinnaker.orca.annotations.Sync
+import com.netflix.spinnaker.orca.events.BeforeInitialExecutionPersist
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.qos.BufferAction.BUFFER
+import com.netflix.spinnaker.orca.qos.BufferAction.ENQUEUE
+import com.netflix.spinnaker.orca.qos.BufferState.ACTIVE
+import net.logstash.logback.argument.StructuredArguments.value
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+/**
+ * Determines if an execution should be buffered.
+ */
+@Component
+class ExecutionBufferActuator(
+  private val bufferStateSupplier: BufferStateSupplier,
+  policies: List<BufferPolicy>
+) {
+
+  private val log = LoggerFactory.getLogger(ExecutionBufferActuator::class.java)
+
+  private val orderedPolicies = policies.sortedByDescending { it.order }.toList()
+
+  @Sync
+  @EventListener(BeforeInitialExecutionPersist::class)
+  fun beforeInitialPersist(event: BeforeInitialExecutionPersist) {
+    if (bufferStateSupplier.get() == ACTIVE) {
+      val execution = event.execution
+      withActionDecision(execution) {
+        when (it.action) {
+          BUFFER -> {
+            log.warn("Buffering execution: {}, reason: ${it.reason}", value("executionId", execution.id))
+            execution.status = BUFFERED
+          }
+          ENQUEUE -> {
+            log.debug("Enqueuing execution: {}, reason: ${it.reason}", value("executionId", execution.id))
+          }
+        }
+      }
+    }
+  }
+
+  fun withActionDecision(execution: Execution, fn: (BufferResult) -> Unit) {
+    orderedPolicies
+      .map { it.apply(execution) }
+      .let { bufferResults ->
+        if (bufferResults.isEmpty()) {
+          return@let null
+        }
+
+        val forcedDecision = bufferResults.firstOrNull { it.force }
+        if (forcedDecision != null) {
+          return@let forcedDecision
+        }
+
+        // Require all results to call for enqueuing the execution, otherwise buffer.
+        val enqueue = bufferResults.all { it.action == ENQUEUE }
+        val reasons = bufferResults.joinToString(",") { it.reason }
+
+        return@let BufferResult(
+          action = if (enqueue) ENQUEUE else BUFFER,
+          force = false,
+          reason = reasons
+        )
+      }
+      ?.run { fn.invoke(this) }
+  }
+}

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionPromoter.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionPromoter.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos
+
+import com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import net.logstash.logback.argument.StructuredArguments.value
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.BeanInitializationException
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Marker interface if someone wants to override the default promoter.
+ */
+interface ExecutionPromoter
+
+@Component
+@ConditionalOnMissingBean(ExecutionPromoter::class)
+class DefaultExecutionPromoter(
+  private val executionRepository: ExecutionRepository,
+  private val policies: List<PromotionPolicy>
+) : ExecutionPromoter {
+
+  private val log = LoggerFactory.getLogger(ExecutionPromoter::class.java)
+
+  init {
+    if (policies.isEmpty()) {
+      throw NoPromotionPolicies("At least one PromotionPolicy must be defined")
+    }
+  }
+
+  @Scheduled(fixedDelayString = "\${qos.executionPromoter.intervalMs:5000}")
+  fun promote() {
+    executionRepository.retrieveBufferedExecutions()
+      .sortedByDescending { it.buildTime }
+      .let {
+        // TODO rz - This is all temporary mess and isn't meant to live long-term. I'd like to calculate until
+        // result.finalized==true or the end of the list, then be able to pass all contributing source & reason pairs
+        // into a log, with a zipped summary that would be saved into an execution's system notifications.
+        var lastResult: PromotionResult? = null
+        var candidates = it
+        policies.forEach { policy ->
+          val result = policy.apply(candidates)
+          if (result.finalized) {
+            return@let result
+          }
+          candidates = result.candidates
+          lastResult = result
+        }
+        lastResult ?: PromotionResult(
+          source =  javaClass.simpleName,
+          candidates = candidates,
+          finalized = true,
+          reason = "No promotion policy resulted in an action"
+        )
+      }
+      .also { result ->
+        result.candidates.forEach {
+          log.info("Promoting execution {} for work: {}", value("executionId", it.id), result.reason)
+          executionRepository.updateStatus(it.id, NOT_STARTED)
+        }
+      }
+  }
+
+  private class NoPromotionPolicies(message: String) : BeanInitializationException(message)
+}

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/PromotionPolicy.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/PromotionPolicy.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import org.springframework.core.Ordered
+
+/**
+ * A policy responsible for determining what execution(s) should be promoted.
+ *
+ * PromotionPolicies can either reduce the list of candidates or re-order them, as well as short-circuit lower
+ * precedence PromotionPolicies.
+ */
+interface PromotionPolicy : Ordered {
+
+  fun apply(candidates: List<Execution>): PromotionResult
+
+  override fun getOrder() = 0
+}
+
+/**
+ * @param candidates A potentially reduced or re-ordered list of promotion candidates.
+ * @param finalized Flag controlling whether or not the [candidates] are the final list of executions to promote.
+ * Setting this this value to true will short-circuit lower-precedence [PromotionPolicy]s.
+ * @param reason A human-friendly reason for the promotion result.
+ */
+data class PromotionResult(
+  val source: String,
+  val candidates: List<Execution>,
+  val finalized: Boolean,
+  val reason: String
+)

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferstate/ActiveExecutionsBufferStateSupplier.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferstate/ActiveExecutionsBufferStateSupplier.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos.bufferstate
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.orca.qos.BufferState
+import com.netflix.spinnaker.orca.qos.BufferState.ACTIVE
+import com.netflix.spinnaker.orca.qos.BufferState.INACTIVE
+import com.netflix.spinnaker.orca.qos.BufferStateSupplier
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Supplies the buffering state based on a threshold of system-wide active executions.
+ *
+ * As an immediate implementation, this supplier depends on [RedisActiveExecutionMonitor] to update the registry with
+ * system-wide active executions. The polling interval of that monitor will determine the resolution of the buffering
+ * state. By default, this is 60 seconds.
+ */
+@Component
+class ActiveExecutionsBufferStateSupplier(
+  @Value("\${qos.bufferingState.activeExecutionsThreshold:100}") private val threshold: Int,
+  private val registry: Registry
+) : BufferStateSupplier {
+
+  private val log = LoggerFactory.getLogger(ActiveExecutionsBufferStateSupplier::class.java)
+
+  private var state: BufferState = INACTIVE
+
+  private val bufferingId = registry.createId("qos.buffering")
+
+  @Scheduled(fixedDelayString = "\${pollers.qosUpdateStateIntervalMs:5000}")
+  private fun updateCurrentState() {
+    val activeExecutions = registry.gauges()
+      .filter { it.id().name() == "executions.active" }
+      .map { it.value() }
+      .reduce { p: Double, o: Double -> o + p }
+      .get().toInt()
+
+    state = if (activeExecutions > threshold) {
+      if (state == INACTIVE) {
+        log.warn("Enabling buffering: System active executions over threshold ($activeExecutions/$threshold)")
+        registry.gauge(bufferingId).set(1.0)
+      }
+      ACTIVE
+    } else {
+      if (state == ACTIVE) {
+        log.warn("Disabling buffering: System active executions below threshold ($activeExecutions/$threshold)")
+        registry.gauge(bufferingId).set(0.0)
+      }
+      INACTIVE
+    }
+  }
+
+  override fun get() = state
+}

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/strategy/naive/NaiveBufferPolicy.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/strategy/naive/NaiveBufferPolicy.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos.strategy.naive
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.qos.BufferAction
+import com.netflix.spinnaker.orca.qos.BufferPolicy
+import com.netflix.spinnaker.orca.qos.BufferResult
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty("qos.strategy.naive.enabled")
+class NaiveBufferPolicy : BufferPolicy {
+
+  override fun apply(execution: Execution): BufferResult = BufferResult(
+    action = BufferAction.BUFFER,
+    force = false,
+    // If we're getting to the point of passing an execution through a BufferPolicy, the BufferStateSupplier has
+    // already made buffering active. There's nothing to decide here.
+    reason = "Naive policy will always buffer executions"
+  )
+}

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/strategy/naive/NaivePromotionPolicy.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/strategy/naive/NaivePromotionPolicy.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos.strategy.naive
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.qos.PromotionPolicy
+import com.netflix.spinnaker.orca.qos.PromotionResult
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty("qos.strategy.naive.enabled")
+class NaivePromotionPolicy : PromotionPolicy {
+
+  override fun apply(candidates: List<Execution>) =
+   PromotionResult(
+     source = javaClass.simpleName,
+     candidates = candidates.subList(0, 1),
+     finalized = false,
+     reason = "Naive policy promotes 1 execution every cycle"
+  )
+}

--- a/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/DefaultExecutionPromoterTest.kt
+++ b/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/DefaultExecutionPromoterTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos
+
+import com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED
+import com.netflix.spinnaker.orca.fixture.pipeline
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.nhaarman.mockito_kotlin.*
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.jetbrains.spek.api.lifecycle.CachingMode
+import org.jetbrains.spek.subject.SubjectSpek
+
+class DefaultExecutionPromoterTest : SubjectSpek<DefaultExecutionPromoter>({
+
+  val executionRepository: ExecutionRepository = mock()
+  val policy: PromotionPolicy = mock()
+
+  subject(CachingMode.GROUP) {
+    DefaultExecutionPromoter(executionRepository, listOf(policy))
+  }
+
+  fun resetMocks() = reset(executionRepository, policy)
+
+  describe("promoting executions") {
+    given("buffered executions") {
+      val execution1 = pipeline {
+        application = "orca"
+      }
+      val execution2 = pipeline {
+        application = "keel"
+      }
+      val execution3 = pipeline {
+        application = "clouddriver"
+      }
+
+      beforeGroup {
+        whenever(executionRepository.retrieveBufferedExecutions()) doReturn listOf(execution1, execution2)
+        whenever(policy.apply(any())) doReturn PromotionResult(
+          source = "mockPolicy",
+          candidates = listOf(execution1, execution2, execution3),
+          finalized = false,
+          reason = "Testing"
+        )
+      }
+
+      afterGroup(::resetMocks)
+
+      on("promote schedule") {
+        subject.promote()
+      }
+
+      it("promotes all policy-selected candidate executions via status update") {
+        verify(executionRepository).updateStatus(execution1.id, NOT_STARTED)
+        verify(executionRepository).updateStatus(execution2.id, NOT_STARTED)
+      }
+    }
+  }
+})

--- a/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/ExecutionBufferActuatorTest.kt
+++ b/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/ExecutionBufferActuatorTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos
+
+import com.netflix.spinnaker.orca.ExecutionStatus.BUFFERED
+import com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED
+import com.netflix.spinnaker.orca.events.BeforeInitialExecutionPersist
+import com.netflix.spinnaker.orca.fixture.pipeline
+import com.netflix.spinnaker.orca.qos.BufferAction.BUFFER
+import com.netflix.spinnaker.orca.qos.BufferAction.ENQUEUE
+import com.netflix.spinnaker.orca.qos.BufferState.ACTIVE
+import com.netflix.spinnaker.orca.qos.BufferState.INACTIVE
+import com.nhaarman.mockito_kotlin.*
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.jetbrains.spek.api.lifecycle.CachingMode
+import org.jetbrains.spek.subject.SubjectSpek
+
+class ExecutionBufferActuatorTest : SubjectSpek<ExecutionBufferActuator>({
+
+  val bufferStateSupplier: BufferStateSupplier = mock()
+  val policy1: BufferPolicy = mock()
+  val policy2: BufferPolicy = mock()
+
+  subject(CachingMode.GROUP) {
+    ExecutionBufferActuator(bufferStateSupplier, listOf(policy1, policy2))
+  }
+
+  fun resetMocks() = reset(bufferStateSupplier, policy1, policy2)
+
+  describe("buffering executions") {
+    afterGroup(::resetMocks)
+
+    given("buffer state is INACTIVE") {
+      val execution = pipeline {
+        application = "spintest"
+        status = NOT_STARTED
+      }
+
+      beforeGroup {
+        whenever(bufferStateSupplier.get()) doReturn INACTIVE
+      }
+
+      afterGroup(::resetMocks)
+
+      on("before initial persist event") {
+        subject.beforeInitialPersist(BeforeInitialExecutionPersist("orca-core", execution))
+      }
+
+      it("does nothing") {
+        verify(policy1, never()).apply(execution)
+        verify(policy2, never()).apply(execution)
+        assert(execution.status == NOT_STARTED)
+      }
+    }
+
+    given("buffer state is ACTIVE and policies decide ENQUEUE") {
+      val execution = pipeline {
+        application = "spintest"
+        status = NOT_STARTED
+      }
+
+      beforeGroup {
+        whenever(bufferStateSupplier.get()) doReturn ACTIVE
+        whenever(policy1.apply(any())) doReturn BufferResult(
+          action = ENQUEUE,
+          force = false,
+          reason = "Cannot determine action"
+        )
+        whenever(policy2.apply(any())) doReturn BufferResult(
+          action = ENQUEUE,
+          force = false,
+          reason = "Cannot determine action"
+        )
+      }
+
+      on("before initial persist event") {
+        subject.beforeInitialPersist(BeforeInitialExecutionPersist("orca-core", execution))
+      }
+
+      it("does nothing") {
+        verify(policy1, times(1)).apply(execution)
+        verify(policy2, times(1)).apply(execution)
+        assert(execution.status == NOT_STARTED)
+      }
+    }
+
+    given("buffer state is ACTIVE and policies decide BUFFER") {
+      val execution = pipeline {
+        application = "spintest"
+        status = NOT_STARTED
+      }
+
+      beforeGroup {
+        whenever(bufferStateSupplier.get()) doReturn ACTIVE
+        whenever(policy1.apply(any())) doReturn BufferResult(
+          action = BUFFER,
+          force = false,
+          reason = "Going to buffer"
+        )
+        whenever(policy2.apply(any())) doReturn BufferResult(
+          action = ENQUEUE,
+          force = false,
+          reason = "Cannot determine action"
+        )
+      }
+
+      on("before initial persist event") {
+        subject.beforeInitialPersist(BeforeInitialExecutionPersist("orca-core", execution))
+      }
+
+      it("does nothing") {
+        verify(policy1, times(1)).apply(execution)
+        verify(policy2, times(1)).apply(execution)
+        assert(execution.status == BUFFERED)
+      }
+    }
+
+    given("buffer state is ACTIVE and policy forces ENQUEUE") {
+      val execution = pipeline {
+        application = "spintest"
+        status = NOT_STARTED
+      }
+
+      beforeGroup {
+        whenever(bufferStateSupplier.get()) doReturn ACTIVE
+        whenever(policy1.apply(any())) doReturn BufferResult(
+          action = ENQUEUE,
+          force = true,
+          reason = "Going to buffer"
+        )
+        whenever(policy2.apply(any())) doReturn BufferResult(
+          action = BUFFER,
+          force = false,
+          reason = "Should buffer"
+        )
+      }
+
+      on("before initial persist event") {
+        subject.beforeInitialPersist(BeforeInitialExecutionPersist("orca-core", execution))
+      }
+
+      it("does nothing") {
+        verify(policy1, times(1)).apply(execution)
+        verify(policy2, times(1)).apply(execution)
+        assert(execution.status == NOT_STARTED)
+      }
+    }
+  }
+})

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -63,6 +63,7 @@ public class RedisExecutionRepository implements ExecutionRepository {
   private static final TypeReference<Map<String, Object>> MAP_STRING_TO_OBJECT =
     new TypeReference<Map<String, Object>>() {
     };
+
   private final RedisClientDelegate redisClientDelegate;
   private final Optional<RedisClientDelegate> previousRedisClientDelegate;
   private final ObjectMapper mapper = OrcaObjectMapper.newInstance();
@@ -499,6 +500,18 @@ public class RedisExecutionRepository implements ExecutionRepository {
         format("No Orchestration found for correlation ID %s", correlationId)
       );
     });
+  }
+
+  @Override
+  public @Nonnull List<Execution> retrieveBufferedExecutions() {
+    // TODO rz - This is definitely not a healthy way to do this.
+    return Observable.concat(
+        retrieve(PIPELINE),
+        retrieve(ORCHESTRATION)
+      )
+      .filter(execution -> execution.getStatus() == ExecutionStatus.BUFFERED)
+      .toList()
+      .toBlocking().single();
   }
 
   protected Execution buildExecution(@Nonnull Execution execution, @Nonnull Map<String, String> map, List<String> stageIds) {

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -50,6 +50,7 @@ dependencies {
   compile project(":orca-queue-redis")
   compile project(":orca-pipelinetemplate")
   compile project(":orca-keel")
+  compile project(":orca-qos")
 
   runtime spinnaker.dependency("kork")
   compile spinnaker.dependency('korkExceptions')

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/Main.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/Main.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca
 
 import com.netflix.spinnaker.config.ErrorConfiguration
+import com.netflix.spinnaker.config.QosConfiguration
 import com.netflix.spinnaker.config.StackdriverConfig
 import com.netflix.spinnaker.config.TomcatConfiguration
 import com.netflix.spinnaker.kork.PlatformComponents
@@ -69,7 +70,8 @@ import org.springframework.scheduling.annotation.EnableAsync
   PipelineTemplateConfiguration,
   KayentaConfiguration,
   WebhookConfiguration,
-  KeelConfiguration
+  KeelConfiguration,
+  QosConfiguration
 ])
 @ComponentScan([
   "com.netflix.spinnaker.config"

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,7 +42,8 @@ include "orca-extensionpoint",
   "orca-queue-redis",
   "orca-queue-tck",
   "orca-pipelinetemplate",
-  "orca-validation"
+  "orca-validation",
+  "orca-qos"
 
 rootProject.name = "orca"
 


### PR DESCRIPTION
We've been experiencing production pain in the form of higher bursty execution
load than what Orca's downstream services are able to take if offered in a
firehose fashion. This PR offers a framework (albeit simplistic first impl)
for enforcing QoS of executions.

The basic premise is that a new extension hook is added when executions are
initially saved into the system, they'll potentially be set with a BUFFERED
status, which will prevent StartExecutionHandler from seeing it, and thus
beginning any work.

A BufferStateSupplier is implemented (currently based off system-wide active
executions) that can flip the system from INACTIVE to ACTIVE. In the case of
this basic implementation, if a threshold of active execution is surpassed the
QoS system is set to ACTIVE.

Once ACTIVE, an ExecutionBufferActuator listening to the new
BeforeInitialExecutionPersist event will start passing the execution through
a pluggable & configurable set of ordered BufferPolicies. A BufferPolicy is
responsible for determining an action on the execution, either to ENQUEUE,
BUFFER or ABSTAIN from a decision. If ENQUEUE, the execution will be dropped
onto the queue immediately, BUFFER will set the execution's state to BUFFERED
and ABSTAIN will no-op.

On the other end, an ExecutionPromoter is always running on an interval,
regardless of BufferState, to promote BUFFERED executions into NOT_STARTED
(and thus enqueued). The ExecutionPromoter, similar to the
ExecutionBufferActuator, will pass all candidate executions through a list
of ordered PromotionPolicies. These Policies will apply heuristics for
filtering and ordering what executions will be promoted.

In both forms of Policy, a Policy can force an action if it decides that it
knows best. If multiple Policies perform a force, the highest precedence
Policy will win.

---

Currently, the implementation is very naive and basically on/off. Future work
will be done to implement application & execution criticality to inform
policies. I'd also like to profile individual clouddriver clients as another
form of BufferStateSupplier, so we can back off on work we're sending to
clouddriver if orca starts getting higher latencies or increased error rates.

There will be additional further work in attaching system notifications to
executions so that Orca can propagate QoS actions up to end users via the API
and UI so people aren't left wondering why their execution isn't immediately
starting.

This concept of execution buffering was chosen over something implemented
on the queue so that we can ensure in-flight executions are finished as
quickly as possible, rather than slowing all executions down. It's possible
this QoS system may grow more sophisticated in the future to tune QoS of
in-flight executions based on criticality, but that's a lot more work and a
little more dicey.

By default, everything is disabled.