### PR TITLE
fix(expressions): Include eval summary for unevaluated composite expressions

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
@@ -108,7 +108,7 @@ public class ExpressionTransform {
                                  EvaluationContext evaluationContext,
                                  ExpressionEvaluationSummary summary,
                                  Map<String, Object> additionalContext) {
-    if (source instanceof String && source.toString().contains(parserContext.getExpressionPrefix())) {
+    if (isExpression(source)) {
       String literalExpression = includeExecutionParameter(source.toString());
       Object result = null;
       String escapedExpressionString = null;
@@ -155,7 +155,7 @@ public class ExpressionTransform {
           );
 
           result = source;
-        } else if (result == null) {
+        } else if (result == null || isExpression(result)) {
           summary.add(
             escapedExpressionString,
             ExpressionEvaluationSummary.Result.Level.INFO,
@@ -163,7 +163,9 @@ public class ExpressionTransform {
             null
           );
 
-          result = source;
+          if (!isExpression(result)) {
+            result = source;
+          }
         }
 
         summary.appendAttempted(escapedExpressionString);
@@ -178,6 +180,10 @@ public class ExpressionTransform {
     }
 
     return source;
+  }
+
+  private boolean isExpression(Object obj) {
+    return (obj instanceof String && obj.toString().contains(parserContext.getExpressionPrefix()));
   }
 
   /**

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
@@ -76,6 +76,26 @@ class ContextParameterProcessorSpec extends Specification {
     'support partial resolution for composites' | 'a.${ENV1}.b.${replaceMe}'                                  | 'a.${ENV1}.b.newValue'
   }
 
+  def "should include evaluation summary errors on partially evaluated composite expression"() {
+    given:
+    def source = ['test': value]
+
+    when:
+    def result = contextParameterProcessor.process(source, ['replaceMe': 'newValue'], true)
+    def summary = result.getOrDefault('expressionEvaluationSummary', [:]) as Map<String, List>
+
+    then:
+    result.test == evaluatedValue
+    summary.values().size() == errorCount
+
+
+    where:
+    value                             | evaluatedValue          | errorCount
+    'a.${ENV1}.b.${ENV2}'             | 'a.${ENV1}.b.${ENV2}'   | 1
+    'a.${ENV1}.b.${replaceMe}'        | 'a.${ENV1}.b.newValue'  | 1
+    'a.${replaceMe}.b.${replaceMe}'   | 'a.newValue.b.newValue' | 0
+  }
+
   @Unroll
   def "should restrict fromUrl requests #desc"() {
     given:


### PR DESCRIPTION
- including error msg if composite spel is not evaluated or is partially evaluated