### PR TITLE
fix(q): actually using dead letter handler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ junitVersion=1.0.2
 jupiterVersion=5.0.2
 junitLegacyVersion=4.12.0
 spekVersion=1.1.5
-keikoVersion=2.6.1
+keikoVersion=2.7.0

--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueShovelConfiguration.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueShovelConfiguration.kt
@@ -72,7 +72,7 @@ class RedisQueueShovelConfiguration {
       queueName = redisQueueProperties.queueName,
       pool = redisPool,
       clock = clock,
-      deadMessageHandler = deadMessageHandler,
+      deadMessageHandlers = listOf(deadMessageHandler),
       publisher = publisher,
       ackTimeout = Duration.ofSeconds(redisQueueProperties.ackTimeoutSeconds.toLong()),
       mapper = redisQueueObjectMapper,

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -923,7 +923,7 @@ class TestConfig {
   ) =
     InMemoryQueue(
       clock = clock,
-      deadMessageHandler = deadMessageHandler,
+      deadMessageHandlers = listOf(deadMessageHandler),
       publisher = publisher
     )
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandler.kt
@@ -25,15 +25,16 @@ import com.netflix.spinnaker.orca.q.ExecutionLevel
 import com.netflix.spinnaker.orca.q.StageLevel
 import com.netflix.spinnaker.orca.q.TaskLevel
 import com.netflix.spinnaker.q.Attribute
+import com.netflix.spinnaker.q.DeadMessageCallback
 import com.netflix.spinnaker.q.Message
 import com.netflix.spinnaker.q.Queue
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
-@Component class DeadMessageHandler {
+@Component class DeadMessageHandler : DeadMessageCallback {
   private val log = LoggerFactory.getLogger(javaClass)
 
-  fun handle(queue: Queue, message: Message) {
+  override fun invoke(queue: Queue, message: Message) {
     log.error("Dead message: $message")
     terminationMessageFor(message)
       ?.let {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandlerTest.kt
@@ -46,7 +46,7 @@ object DeadMessageHandlerTest : SubjectSpek<DeadMessageHandler>({
     afterGroup(::resetMocks)
 
     on("receiving a message") {
-      subject.handle(queue, message)
+      subject.invoke(queue, message)
     }
 
     it("terminates the execution") {
@@ -60,7 +60,7 @@ object DeadMessageHandlerTest : SubjectSpek<DeadMessageHandler>({
     afterGroup(::resetMocks)
 
     on("receiving a message") {
-      subject.handle(queue, message)
+      subject.invoke(queue, message)
     }
 
     it("aborts the stage") {
@@ -74,7 +74,7 @@ object DeadMessageHandlerTest : SubjectSpek<DeadMessageHandler>({
     afterGroup(::resetMocks)
 
     on("receiving a message") {
-      subject.handle(queue, message)
+      subject.invoke(queue, message)
     }
 
     it("terminates the task") {
@@ -90,7 +90,7 @@ object DeadMessageHandlerTest : SubjectSpek<DeadMessageHandler>({
     afterGroup(::resetMocks)
 
     on("receiving a message") {
-      subject.handle(queue, message)
+      subject.invoke(queue, message)
     }
 
     it("does nothing") {


### PR DESCRIPTION
Upgrading version of keiko.
Actually using our dead letter handler so that tasks/stages/executions are successfully canceled on error.