### PR TITLE
feat(clouddriver): Allow for external server group force cache refreshes

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ServerGroupForceCacheRefreshStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ServerGroupForceCacheRefreshStage.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup;
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ServerGroupForceCacheRefreshStage implements StageDefinitionBuilder {
+  @Override
+  public void taskGraph(Stage stage, TaskNode.Builder builder) {
+    builder
+      .withTask("refreshServerGroup", ServerGroupCacheForceRefreshTask.class);
+  }
+}


### PR DESCRIPTION
A new `ServerGroupForceCacheRefreshStage` that simply wraps the
`ServerGroupCacheForceRefreshTask.`

At some point will support renaming of tasks so I'm not too worried
about the slight inconsistency.
