### PR TITLE
feat(core): Change Execution & Stage IDs to use ULIDs

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -39,6 +39,7 @@ dependencies {
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${spinnaker.version('jackson')}"
   compile "com.fasterxml.jackson.module:jackson-module-kotlin:${spinnaker.version('jackson')}"
   compile "org.apache.commons:commons-lang3:3.7"
+  compile "de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.1.1"
 
   compileOnly spinnaker.dependency("lombok")
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import com.netflix.spinnaker.security.User;
+import de.huxhorn.sulky.ulid.ULID;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -40,9 +41,10 @@ import static java.util.stream.Collectors.toMap;
 public class Execution implements Serializable {
 
   public static final DefaultTrigger NO_TRIGGER = new DefaultTrigger("none");
+  private static final ULID ID_GENERATOR = new ULID();
 
   public Execution(ExecutionType type, String application) {
-    this(type, UUID.randomUUID().toString(), application);
+    this(type, ID_GENERATOR.nextULID(), application);
   }
 
   @JsonCreator

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
 import com.netflix.spinnaker.orca.pipeline.model.support.RequisiteStageRefIdDeserializer;
+import de.huxhorn.sulky.ulid.ULID;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -44,6 +45,8 @@ import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
 
 public class Stage implements Serializable {
+
+  private static final ULID ID_GENERATOR = new ULID();
 
   /**
    * Sorts stages into order according to their refIds / requisiteStageRefIds.
@@ -104,7 +107,7 @@ public class Stage implements Serializable {
   /**
    * A stage's unique identifier
    */
-  private String id = UUID.randomUUID().toString();
+  private String id = ID_GENERATOR.nextULID();
 
   public @Nonnull String getId() {
     return id;


### PR DESCRIPTION
Switching from `java.util.UUID` to [ulid](https://github.com/ulid/spec) (via impl [sulky-ulid](https://github.com/huxi/sulky/tree/master/sulky-ulid)) to get us a time-sortable ID in executions and stages. This is internals work for SQL.