### PR TITLE
fix(pipeline_template): Don't share snakeyaml instance across threads

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
@@ -64,7 +64,7 @@ public class PipelineTemplateConfiguration {
 
   @Bean
   RenderedValueConverter yamlRenderedValueConverter() {
-    return new YamlRenderedValueConverter(new Yaml());
+    return new YamlRenderedValueConverter();
   }
 
   @Bean

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/YamlRenderedValueConverter.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/YamlRenderedValueConverter.java
@@ -31,11 +31,7 @@ public class YamlRenderedValueConverter implements RenderedValueConverter {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  private Yaml yaml;
-
-  public YamlRenderedValueConverter(Yaml yaml) {
-    this.yaml = yaml;
-  }
+  private static final ThreadLocal<Yaml> yaml = ThreadLocal.withInitial(Yaml::new);
 
   @Override
   public Object convertRenderedValue(String renderedValue) {
@@ -47,7 +43,7 @@ public class YamlRenderedValueConverter implements RenderedValueConverter {
     }
 
     try {
-      Object converted = yaml.load(renderedValue);
+      Object converted = yaml.get().load(renderedValue);
       if (converted == null || converted instanceof String) {
         return "".equals(converted) || "".equals(renderedValue) ? null : renderedValue;
       }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -42,7 +42,7 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
   TemplateLoader templateLoader = new TemplateLoader([new FileTemplateSchemeLoader(objectMapper)])
 
   Renderer renderer = new JinjaRenderer(
-    new YamlRenderedValueConverter(new Yaml()), objectMapper, Mock(Front50Service), []
+    new YamlRenderedValueConverter(), objectMapper, Mock(Front50Service), []
   )
 
   Registry registry = Mock() {

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy
@@ -49,7 +49,7 @@ class V1SchemaIntegrationSpec extends Specification {
   TemplateLoader templateLoader = new TemplateLoader([new ResourceSchemeLoader("/integration/v1schema", objectMapper)])
 
   Renderer renderer = new JinjaRenderer(
-    new YamlRenderedValueConverter(new Yaml()), objectMapper, Mock(Front50Service), []
+    new YamlRenderedValueConverter(), objectMapper, Mock(Front50Service), []
   )
 
   Registry registry = Mock() {

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
@@ -28,7 +28,7 @@ class JinjaRendererSpec extends Specification {
 
   ObjectMapper objectMapper = new ObjectMapper()
 
-  RenderedValueConverter renderedValueConverter = new YamlRenderedValueConverter(new Yaml())
+  RenderedValueConverter renderedValueConverter = new YamlRenderedValueConverter()
 
   @Subject
   Renderer subject = new JinjaRenderer(renderedValueConverter, objectMapper, Mock(Front50Service), [])


### PR DESCRIPTION
The snakeyaml processor is not thread-safe, and we are currently sharing
it across threads, leading to intermittent NPEs when concurrent uses put
it in an inconsistent state.