### PR TITLE
refactor(core): ExecutionRepository to require ExecutionType in methods

### DIFF
--- a/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -236,7 +236,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     }
 
     when:
-    repository.updateStatus(execution.id, RUNNING)
+    repository.updateStatus(execution.type, execution.id, RUNNING)
 
     then:
     with(repository.retrieve(execution.type, execution.id)) {
@@ -264,7 +264,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     }
 
     when:
-    repository.updateStatus(execution.id, status)
+    repository.updateStatus(execution.type, execution.id, status)
 
     then:
     with(repository.retrieve(execution.type, execution.id)) {
@@ -290,7 +290,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     }
 
     when:
-    repository.updateStatus(execution.id, status)
+    repository.updateStatus(execution.type, execution.id, status)
 
     then:
     with(repository.retrieve(execution.type, execution.id)) {
@@ -314,7 +314,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     }
 
     when:
-    repository.cancel(execution.id)
+    repository.cancel(execution.type, execution.id)
 
 
     then:
@@ -328,7 +328,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     given:
     def execution = pipeline()
     repository.store(execution)
-    repository.updateStatus(execution.id, RUNNING)
+    repository.updateStatus(execution.type, execution.id, RUNNING)
 
     expect:
     with(repository.retrieve(execution.type, execution.id)) {
@@ -336,7 +336,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     }
 
     when:
-    repository.cancel(execution.id)
+    repository.cancel(execution.type, execution.id)
 
 
     then:
@@ -352,7 +352,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     def execution = pipeline()
     def user = "user@netflix.com"
     repository.store(execution)
-    repository.updateStatus(execution.id, RUNNING)
+    repository.updateStatus(execution.type, execution.id, RUNNING)
 
     expect:
     with(repository.retrieve(execution.type, execution.id)) {
@@ -360,7 +360,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     }
 
     when:
-    repository.cancel(execution.id, user, reason)
+    repository.cancel(execution.type, execution.id, user, reason)
 
 
     then:
@@ -382,10 +382,10 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     given:
     def execution = pipeline()
     repository.store(execution)
-    repository.updateStatus(execution.id, RUNNING)
+    repository.updateStatus(execution.type, execution.id, RUNNING)
 
     when:
-    repository.pause(execution.id, "user@netflix.com")
+    repository.pause(execution.type, execution.id, "user@netflix.com")
 
     then:
     with(repository.retrieve(execution.type, execution.id)) {
@@ -398,7 +398,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     }
 
     when:
-    repository.resume(execution.id, "another@netflix.com")
+    repository.resume(execution.type, execution.id, "another@netflix.com")
 
     then:
     with(repository.retrieve(execution.type, execution.id)) {
@@ -417,10 +417,10 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     given:
     def execution = pipeline()
     repository.store(execution)
-    repository.updateStatus(execution.id, status)
+    repository.updateStatus(execution.type, execution.id, status)
 
     when:
-    repository."${method}"(execution.id, "user@netflix.com")
+    repository."${method}"(execution.type, execution.id, "user@netflix.com")
 
     then:
     def e = thrown(IllegalStateException)
@@ -439,18 +439,18 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     given:
     def execution = pipeline()
     repository.store(execution)
-    repository.updateStatus(execution.id, RUNNING)
+    repository.updateStatus(execution.type, execution.id, RUNNING)
 
     when:
-    repository.pause(execution.id, "user@netflix.com")
+    repository.pause(execution.type, execution.id, "user@netflix.com")
     execution = repository.retrieve(execution.type, execution.id)
 
     then:
     execution.paused.isPaused()
 
     when:
-    repository.updateStatus(execution.id, status)
-    repository.resume(execution.id, "user@netflix.com", true)
+    repository.updateStatus(execution.type, execution.id, status)
+    repository.resume(execution.type, execution.id, "user@netflix.com", true)
     execution = repository.retrieve(execution.type, execution.id)
 
     then:
@@ -467,7 +467,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
       trigger = new DefaultTrigger("manual", "covfefe")
     }
     repository.store(execution)
-    repository.updateStatus(execution.id, RUNNING)
+    repository.updateStatus(execution.type, execution.id, RUNNING)
 
     when:
     def result = repository.retrieveOrchestrationForCorrelationId('covfefe')
@@ -476,7 +476,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     result.id == execution.id
 
     when:
-    repository.updateStatus(execution.id, SUCCEEDED)
+    repository.updateStatus(execution.type, execution.id, SUCCEEDED)
     repository.retrieveOrchestrationForCorrelationId('covfefe')
 
     then:

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/DefaultPersister.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/DefaultPersister.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.listeners;
 
 import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 
@@ -33,12 +34,12 @@ public class DefaultPersister implements Persister {
   }
 
   @Override
-  public boolean isCanceled(String executionId) {
-    return executionRepository.isCanceled(executionId);
+  public boolean isCanceled(ExecutionType type, String executionId) {
+    return executionRepository.isCanceled(type, executionId);
   }
 
   @Override
-  public void updateStatus(String executionId, ExecutionStatus executionStatus) {
-    executionRepository.updateStatus(executionId, executionStatus);
+  public void updateStatus(ExecutionType type, String executionId, ExecutionStatus executionStatus) {
+    executionRepository.updateStatus(type, executionId, executionStatus);
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/Persister.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/Persister.java
@@ -17,12 +17,13 @@
 package com.netflix.spinnaker.orca.listeners;
 
 import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 
 public interface Persister {
   void save(Stage stage);
 
-  boolean isCanceled(String executionId);
+  boolean isCanceled(ExecutionType type, String executionId);
 
-  void updateStatus(String executionId, ExecutionStatus executionStatus);
+  void updateStatus(ExecutionType type, String executionId, ExecutionStatus executionStatus);
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -158,8 +158,8 @@ public class ExecutionLauncher {
     final ExecutionStatus status = ExecutionStatus.TERMINAL;
 
     log.error("Failed to start {} {}", execution.getType(), execution.getId(), failure);
-    executionRepository.updateStatus(execution.getId(), status);
-    executionRepository.cancel(execution.getId(), canceledBy, reason);
+    executionRepository.updateStatus(execution.getType(), execution.getId(), status);
+    executionRepository.cancel(execution.getType(), execution.getId(), canceledBy, reason);
     return executionRepository.retrieve(execution.getType(), execution.getId());
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -38,35 +38,27 @@ public interface ExecutionRepository {
 
   void addStage(@Nonnull Stage stage);
 
-  void cancel(@Nonnull String id);
+  void cancel(@Nonnull ExecutionType type, @Nonnull String id);
 
-  void cancel(
-    @Nonnull String id, @Nullable String user, @Nullable String reason);
+  void cancel(@Nonnull ExecutionType type, @Nonnull String id, @Nullable String user, @Nullable String reason);
 
-  void pause(@Nonnull String id, @Nullable String user);
+  void pause(@Nonnull ExecutionType type, @Nonnull String id, @Nullable String user);
 
-  void resume(@Nonnull String id, @Nullable String user);
+  void resume(@Nonnull ExecutionType type, @Nonnull String id, @Nullable String user);
 
-  void resume(
-    @Nonnull String id, @Nullable String user, boolean ignoreCurrentStatus);
+  void resume(@Nonnull ExecutionType type, @Nonnull String id, @Nullable String user, boolean ignoreCurrentStatus);
 
-  boolean isCanceled(@Nonnull String id);
+  boolean isCanceled(ExecutionType type, @Nonnull String id);
 
-  void updateStatus(@Nonnull String id, @Nonnull ExecutionStatus status);
+  void updateStatus(ExecutionType type, @Nonnull String id, @Nonnull ExecutionStatus status);
 
-  @Nonnull Execution retrieve(
-    @Nonnull ExecutionType type,
-    @Nonnull String id) throws ExecutionNotFoundException;
+  @Nonnull Execution retrieve(@Nonnull ExecutionType type, @Nonnull String id) throws ExecutionNotFoundException;
 
-  void delete(
-    @Nonnull ExecutionType type,
-    @Nonnull String id
-  );
+  void delete(@Nonnull ExecutionType type, @Nonnull String id);
 
   @Nonnull Observable<Execution> retrieve(ExecutionType type);
 
-  @Nonnull Observable<Execution> retrievePipelinesForApplication(
-    @Nonnull String application);
+  @Nonnull Observable<Execution> retrievePipelinesForApplication(@Nonnull String application);
 
   @Nonnull Observable<Execution> retrievePipelinesForPipelineConfigId(
     @Nonnull String pipelineConfigId, @Nonnull ExecutionCriteria criteria);

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
@@ -80,7 +80,7 @@ public class PipelineStage implements StageDefinitionBuilder, RestartableStage, 
           Execution childPipeline = executionRepository.retrieve(PIPELINE, executionId);
           if (!childPipeline.isCanceled()) {
             // flag the child pipeline as canceled (actual cancellation will happen asynchronously)
-            executionRepository.cancel(executionId, "parent pipeline", null);
+            executionRepository.cancel(stage.getExecution().getType(), executionId, "parent pipeline", null);
           }
         }
       }

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStageSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStageSpec.groovy
@@ -45,7 +45,7 @@ class PipelineStageSpec extends Specification {
     pipelineStage.cancel(stage)
 
     then:
-    (shouldCancel ? 1 : 0) * executionRepository.cancel(stageContext.executionId, "parent pipeline", null)
+    (shouldCancel ? 1 : 0) * executionRepository.cancel(PIPELINE, stageContext.executionId, "parent pipeline", null)
 
     where:
     stageContext                     || childPipelineIsCanceled || shouldCancel

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionPromoter.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionPromoter.kt
@@ -97,7 +97,7 @@ class DefaultExecutionPromoter(
         .also { result ->
           result.candidates.forEach {
             log.info("Promoting execution {} for work: {}", value("executionId", it.id), result.reason)
-            executionRepository.updateStatus(it.id, NOT_STARTED)
+            executionRepository.updateStatus(it.type, it.id, NOT_STARTED)
           }
           registry.counter(promotedId).increment(result.candidates.size.toLong())
         }

--- a/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/DefaultExecutionPromoterTest.kt
+++ b/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/DefaultExecutionPromoterTest.kt
@@ -73,8 +73,8 @@ class DefaultExecutionPromoterTest : SubjectSpek<DefaultExecutionPromoter>({
       }
 
       it("promotes all policy-selected candidate executions via status update") {
-        verify(executionRepository).updateStatus(execution1.id, NOT_STARTED)
-        verify(executionRepository).updateStatus(execution2.id, NOT_STARTED)
+        verify(executionRepository).updateStatus(execution1.type, execution1.id, NOT_STARTED)
+        verify(executionRepository).updateStatus(execution2.type, execution2.id, NOT_STARTED)
       }
     }
   }

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -883,7 +883,7 @@ class TestConfig {
       override fun getType() = "pipeline"
 
       override fun cancel(stage: Stage?): CancellableStage.Result {
-        repository.cancel(stage!!.context["executionId"] as String)
+        repository.cancel(PIPELINE, stage!!.context["executionId"] as String)
         return CancellableStage.Result(stage, mapOf("foo" to "bar"))
       }
     }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
@@ -38,7 +38,7 @@ class CancelExecutionHandler(
 
   override fun handle(message: CancelExecution) {
     message.withExecution { execution ->
-      repository.cancel(execution.id, message.user, message.reason)
+      repository.cancel(execution.type, execution.id, message.user, message.reason)
 
       // Resume any paused stages so that their RunTaskHandler gets executed
       // and handles the `canceled` flag.

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
@@ -53,7 +53,7 @@ class CompleteExecutionHandler(
         log.info("Execution ${execution.id} already completed with ${execution.status} status")
       } else {
         message.determineFinalStatus(execution) { status ->
-          repository.updateStatus(message.executionId, status)
+          repository.updateStatus(execution.type, message.executionId, status)
           publisher.publishEvent(
             ExecutionComplete(this, message.executionType, message.executionId, status)
           )

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandler.kt
@@ -40,7 +40,7 @@ class ConfigurationErrorHandler(
         log.error("No such ${message.executionType} ${message.executionId} for ${message.application}")
       else -> {
         log.error("${message.javaClass.simpleName} for ${message.executionType} ${message.executionId} for ${message.application}")
-        repository.updateStatus(message.executionId, TERMINAL)
+        repository.updateStatus(message.executionType, message.executionId, TERMINAL)
       }
     }
   }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
@@ -45,7 +45,7 @@ class RestartStageHandler(
       if (topStage.status.isComplete) {
         topStage.addRestartDetails(message.user)
         topStage.reset()
-        repository.updateStatus(topStage.execution.id, RUNNING)
+        repository.updateStatus(topStage.execution.type, topStage.execution.id, RUNNING)
         queue.push(StartStage(startMessage))
       }
     }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandler.kt
@@ -79,10 +79,10 @@ class StartExecutionHandler(
       val initialStages = execution.initialStages()
       if (initialStages.isEmpty()) {
         log.warn("No initial stages found (executionId: ${execution.id})")
-        repository.updateStatus(execution.id, TERMINAL)
+        repository.updateStatus(execution.type, execution.id, TERMINAL)
         publisher.publishEvent(ExecutionComplete(this, execution.type, execution.id, TERMINAL))
       } else {
-        repository.updateStatus(execution.id, RUNNING)
+        repository.updateStatus(execution.type, execution.id, RUNNING)
         initialStages.forEach { queue.push(StartStage(it)) }
         publisher.publishEvent(ExecutionStarted(this, execution.type, execution.id))
       }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandlerTest.kt
@@ -71,7 +71,7 @@ object CancelExecutionHandlerTest : SubjectSpek<CancelExecutionHandler>({
       }
 
       it("sets the canceled flag on the pipeline") {
-        verify(repository).cancel(pipeline.id, "fzlem@netflix.com", "because")
+        verify(repository).cancel(PIPELINE, pipeline.id, "fzlem@netflix.com", "because")
       }
 
       it("it triggers a reevaluate") {
@@ -113,7 +113,7 @@ object CancelExecutionHandlerTest : SubjectSpek<CancelExecutionHandler>({
       }
 
       it("sets the canceled flag on the pipeline") {
-        verify(repository).cancel(pipeline.id, "fzlem@netflix.com", "because")
+        verify(repository).cancel(PIPELINE, pipeline.id, "fzlem@netflix.com", "because")
       }
 
       it("unpauses the paused stage") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandlerTest.kt
@@ -72,7 +72,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
       }
 
       it("updates the execution") {
-        verify(repository).updateStatus(message.executionId, stageStatus)
+        verify(repository).updateStatus(message.executionType, message.executionId, stageStatus)
       }
 
       it("publishes an event") {
@@ -144,7 +144,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
       }
 
       it("waits for the other branch(es)") {
-        verify(repository, never()).updateStatus(eq(pipeline.id), any())
+        verify(repository, never()).updateStatus(eq(PIPELINE), eq(pipeline.id), any())
       }
 
       it("does not publish any events") {
@@ -187,7 +187,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
       }
 
       it("updates the pipeline status") {
-        verify(repository).updateStatus(pipeline.id, stageStatus)
+        verify(repository).updateStatus(PIPELINE, pipeline.id, stageStatus)
       }
 
       it("publishes an event") {
@@ -236,7 +236,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
     }
 
     it("updates the execution") {
-      verify(repository).updateStatus(message.executionId, TERMINAL)
+      verify(repository).updateStatus(PIPELINE, message.executionId, TERMINAL)
     }
 
     it("publishes an event") {
@@ -282,7 +282,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
     }
 
     it("updates the execution") {
-      verify(repository).updateStatus(message.executionId, SUCCEEDED)
+      verify(repository).updateStatus(PIPELINE, message.executionId, SUCCEEDED)
     }
 
     it("publishes an event") {
@@ -334,7 +334,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
     }
 
     it("does not complete the execution") {
-      verify(repository, never()).updateStatus(any(), any())
+      verify(repository, never()).updateStatus(eq(PIPELINE), any(), any())
     }
 
     it("publishes no events") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandlerTest.kt
@@ -74,7 +74,7 @@ object ConfigurationErrorHandlerTest : SubjectSpek<ConfigurationErrorHandler>({
       }
 
       it("marks the execution as terminal") {
-        verify(repository).updateStatus(message.executionId, TERMINAL)
+        verify(repository).updateStatus(PIPELINE, message.executionId, TERMINAL)
       }
 
       it("does not push any messages to the queue") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
@@ -199,7 +199,7 @@ object RestartStageHandlerTest : SubjectSpek<RestartStageHandler>({
       }
 
       it("marks the execution as running") {
-        verify(repository).updateStatus(pipeline.id, RUNNING)
+        verify(repository).updateStatus(PIPELINE, pipeline.id, RUNNING)
       }
 
       it("runs the stage") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.events.ExecutionComplete
 import com.netflix.spinnaker.orca.events.ExecutionStarted
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionCriteria
 import com.netflix.spinnaker.orca.q.CancelExecution
@@ -75,7 +76,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
       }
 
       it("marks the execution as running") {
-        verify(repository).updateStatus(message.executionId, RUNNING)
+        verify(repository).updateStatus(PIPELINE, message.executionId, RUNNING)
       }
 
       it("starts the first stage") {
@@ -211,7 +212,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
       }
 
       it("marks the execution as TERMINAL") {
-        verify(repository, times(1)).updateStatus(pipeline.id, TERMINAL)
+        verify(repository, times(1)).updateStatus(PIPELINE, pipeline.id, TERMINAL)
       }
 
       it("publishes an event with TERMINAL status") {
@@ -292,7 +293,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         }
 
         it("does not start the new pipeline") {
-          verify(repository, never()).updateStatus(message.executionId, RUNNING)
+          verify(repository, never()).updateStatus(PIPELINE, message.executionId, RUNNING)
           verify(queue, never()).push(isA<StartStage>())
         }
 
@@ -326,7 +327,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         }
 
         it("starts the new pipeline") {
-          verify(repository).updateStatus(message.executionId, RUNNING)
+          verify(repository).updateStatus(PIPELINE, message.executionId, RUNNING)
           verify(queue).push(isA<StartStage>())
         }
       }

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -173,12 +173,12 @@ public class RedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
-  public void cancel(@Nonnull String id) {
-    cancel(id, null, null);
+  public void cancel(ExecutionType type, @Nonnull String id) {
+    cancel(type, id, null, null);
   }
 
   @Override
-  public void cancel(@Nonnull String id, String user, String reason) {
+  public void cancel(ExecutionType type, @Nonnull String id, String user, String reason) {
     ImmutablePair<String, RedisClientDelegate> pair = fetchKey(id);
     RedisClientDelegate delegate = pair.getRight();
     delegate.withCommandsClient(c -> {
@@ -199,7 +199,7 @@ public class RedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
-  public void pause(@Nonnull String id, String user) {
+  public void pause(ExecutionType type, @Nonnull String id, String user) {
     ImmutablePair<String, RedisClientDelegate> pair = fetchKey(id);
     RedisClientDelegate delegate = pair.getRight();
 
@@ -229,12 +229,12 @@ public class RedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
-  public void resume(@Nonnull String id, String user) {
-    resume(id, user, false);
+  public void resume(ExecutionType type, @Nonnull String id, String user) {
+    resume(type, id, user, false);
   }
 
   @Override
-  public void resume(@Nonnull String id, String user, boolean ignoreCurrentStatus) {
+  public void resume(ExecutionType type, @Nonnull String id, String user, boolean ignoreCurrentStatus) {
     ImmutablePair<String, RedisClientDelegate> pair = fetchKey(id);
     RedisClientDelegate delegate = pair.getRight();
 
@@ -264,7 +264,7 @@ public class RedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
-  public boolean isCanceled(@Nonnull String id) {
+  public boolean isCanceled(ExecutionType type, @Nonnull String id) {
     ImmutablePair<String, RedisClientDelegate> pair = fetchKey(id);
     RedisClientDelegate delegate = pair.getRight();
 
@@ -274,7 +274,7 @@ public class RedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
-  public void updateStatus(@Nonnull String id, @Nonnull ExecutionStatus status) {
+  public void updateStatus(ExecutionType type, @Nonnull String id, @Nonnull ExecutionStatus status) {
     ImmutablePair<String, RedisClientDelegate> pair = fetchKey(id);
     RedisClientDelegate delegate = pair.getRight();
     String key = pair.getLeft();

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
@@ -220,7 +220,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
       trigger = new DefaultTrigger("manual", "covfefe")
     }
     previousRepository.store(execution)
-    previousRepository.updateStatus(execution.id, RUNNING)
+    previousRepository.updateStatus(execution.type, execution.id, RUNNING)
 
     when:
     def result = repository.retrieveOrchestrationForCorrelationId('covfefe')
@@ -229,7 +229,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     result.id == execution.id
 
     when:
-    repository.updateStatus(execution.id, SUCCEEDED)
+    repository.updateStatus(execution.type, execution.id, SUCCEEDED)
     repository.retrieveOrchestrationForCorrelationId('covfefe')
 
     then:

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -141,8 +141,8 @@ class TaskController {
   @RequestMapping(value = "/tasks/{id}/cancel", method = RequestMethod.PUT)
   @ResponseStatus(HttpStatus.ACCEPTED)
   void cancelTask(@PathVariable String id) {
-    executionRepository.cancel(id, AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"), null)
-    executionRepository.updateStatus(id, ExecutionStatus.CANCELED)
+    executionRepository.cancel(ORCHESTRATION, id, AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"), null)
+    executionRepository.updateStatus(ORCHESTRATION, id, ExecutionStatus.CANCELED)
   }
 
   @PreFilter("hasPermission(this.getOrchestration(filterObject)?.application, 'APPLICATION', 'WRITE')")
@@ -150,8 +150,8 @@ class TaskController {
   @ResponseStatus(HttpStatus.ACCEPTED)
   void cancelTasks(@RequestBody List<String> taskIds) {
     taskIds.each {
-      executionRepository.cancel(it, AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"), null)
-      executionRepository.updateStatus(it, ExecutionStatus.CANCELED)
+      executionRepository.cancel(ORCHESTRATION, it, AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"), null)
+      executionRepository.updateStatus(ORCHESTRATION, it, ExecutionStatus.CANCELED)
     }
   }
 
@@ -208,14 +208,14 @@ class TaskController {
         reason
       )
     }
-    executionRepository.updateStatus(id, ExecutionStatus.CANCELED)
+    executionRepository.updateStatus(PIPELINE, id, ExecutionStatus.CANCELED)
   }
 
   @PreAuthorize("hasPermission(this.getPipeline(#id)?.application, 'APPLICATION', 'WRITE')")
   @RequestMapping(value = "/pipelines/{id}/pause", method = RequestMethod.PUT)
   @ResponseStatus(HttpStatus.ACCEPTED)
   void pause(@PathVariable String id) {
-    executionRepository.pause(id, AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"))
+    executionRepository.pause(PIPELINE, id, AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"))
     def pipeline = executionRepository.retrieve(PIPELINE, id)
     executionRunner.reschedule(pipeline)
   }
@@ -224,7 +224,7 @@ class TaskController {
   @RequestMapping(value = "/pipelines/{id}/resume", method = RequestMethod.PUT)
   @ResponseStatus(HttpStatus.ACCEPTED)
   void resume(@PathVariable String id) {
-    executionRepository.resume(id, AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"))
+    executionRepository.resume(PIPELINE, id, AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"))
     def pipeline = executionRepository.retrieve(PIPELINE, id)
     executionRunner.unpause(pipeline)
   }

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -84,8 +84,8 @@ class TaskControllerSpec extends Specification {
 
     then:
     response.andExpect(status().isAccepted())
-    1 * executionRepository.cancel('id2', _, null)
-    1 * executionRepository.cancel('id1', _, null)
+    1 * executionRepository.cancel(ORCHESTRATION, 'id2', _, null)
+    1 * executionRepository.cancel(ORCHESTRATION, 'id1', _, null)
   }
 
   void 'step names are properly translated'() {


### PR DESCRIPTION
No functional change. I did not update `RedisExecutionRepository` to take advantage of the perf benefits that this interface change would pave the path for. Primarily unblocking myself from weird hacks in operation Super Quirky Lemmings. 