### PR TITLE
refactor(core): Remove RxJava from ExecutionRepository interface

### DIFF
--- a/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -22,10 +22,10 @@ import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger
 import com.netflix.spinnaker.orca.pipeline.model.PipelineTrigger
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionCriteria
-import rx.schedulers.Schedulers
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
+
 import static com.netflix.spinnaker.orca.ExecutionStatus.*
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
@@ -106,7 +106,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     repository.store(succeededExecution)
     def orchestrations = repository.retrieveOrchestrationsForApplication(
       runningExecution.application, new ExecutionCriteria(limit: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"])
-    ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
+    ).toList()
 
     then:
     orchestrations*.id.sort() == [runningExecution.id, succeededExecution.id].sort()
@@ -114,7 +114,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     when:
     orchestrations = repository.retrieveOrchestrationsForApplication(
       runningExecution.application, new ExecutionCriteria(limit: 5, statuses: ["RUNNING"])
-    ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
+    ).toList()
 
     then:
     orchestrations*.id.sort() == [runningExecution.id].sort()
@@ -122,7 +122,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     when:
     orchestrations = repository.retrieveOrchestrationsForApplication(
       runningExecution.application, new ExecutionCriteria(limit: 5, statuses: ["TERMINAL"])
-    ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
+    ).toList()
 
     then:
     orchestrations.isEmpty()

--- a/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -66,7 +66,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     repository.store(succeededExecution)
     def pipelines = repository.retrievePipelinesForPipelineConfigId(
       "pipeline-1", new ExecutionCriteria(limit: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"])
-    ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
+    ).toList()
 
     then:
     pipelines*.id.sort() == [runningExecution.id, succeededExecution.id].sort()
@@ -74,7 +74,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     when:
     pipelines = repository.retrievePipelinesForPipelineConfigId(
       "pipeline-1", new ExecutionCriteria(limit: 5, statuses: ["RUNNING"])
-    ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
+    ).toList()
 
     then:
     pipelines*.id.sort() == [runningExecution.id].sort()
@@ -82,7 +82,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     when:
     pipelines = repository.retrievePipelinesForPipelineConfigId(
       "pipeline-1", new ExecutionCriteria(limit: 5, statuses: ["TERMINAL"])
-    ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
+    ).toList()
 
     then:
     pipelines.isEmpty()

--- a/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -154,7 +154,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     repository.store(pipeline)
 
     expect:
-    repository.retrieve(PIPELINE).toBlocking().first().id == pipeline.id
+    repository.retrieve(PIPELINE).first().id == pipeline.id
 
     with(repository.retrieve(pipeline.type, pipeline.id)) {
       id == pipeline.id
@@ -223,7 +223,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     thrown ExecutionNotFoundException
 
     and:
-    repository.retrieve(PIPELINE).toList().toBlocking().first() == []
+    repository.retrieve(PIPELINE).toList() == []
   }
 
   def "updateStatus sets startTime to current time if new status is RUNNING"() {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -58,7 +58,7 @@ public interface ExecutionRepository {
 
   @Nonnull Iterable<Execution> retrieve(ExecutionType type);
 
-  @Nonnull Observable<Execution> retrievePipelinesForApplication(@Nonnull String application);
+  @Nonnull Iterable<Execution> retrievePipelinesForApplication(@Nonnull String application);
 
   @Nonnull Observable<Execution> retrievePipelinesForPipelineConfigId(
     @Nonnull String pipelineConfigId, @Nonnull ExecutionCriteria criteria);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -24,6 +24,8 @@ import rx.Observable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 
@@ -60,7 +62,7 @@ public interface ExecutionRepository {
 
   @Nonnull Iterable<Execution> retrievePipelinesForApplication(@Nonnull String application);
 
-  @Nonnull Observable<Execution> retrievePipelinesForPipelineConfigId(
+  @Nonnull Iterable<Execution> retrievePipelinesForPipelineConfigId(
     @Nonnull String pipelineConfigId, @Nonnull ExecutionCriteria criteria);
 
   @Nonnull Observable<Execution> retrieveOrchestrationsForApplication(
@@ -114,6 +116,13 @@ public interface ExecutionRepository {
 
     @Override public int hashCode() {
       return Objects.hash(limit, statuses);
+    }
+  }
+
+  final class IterableUtil {
+
+    public static <T> Stream<T> toStream(Iterable<T> iterable) {
+      return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterable.iterator(), Spliterator.ORDERED), false);
     }
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -56,7 +56,7 @@ public interface ExecutionRepository {
 
   void delete(@Nonnull ExecutionType type, @Nonnull String id);
 
-  @Nonnull Observable<Execution> retrieve(ExecutionType type);
+  @Nonnull Iterable<Execution> retrieve(ExecutionType type);
 
   @Nonnull Observable<Execution> retrievePipelinesForApplication(@Nonnull String application);
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -19,7 +19,6 @@ import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
-import rx.Observable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -65,7 +64,7 @@ public interface ExecutionRepository {
   @Nonnull Iterable<Execution> retrievePipelinesForPipelineConfigId(
     @Nonnull String pipelineConfigId, @Nonnull ExecutionCriteria criteria);
 
-  @Nonnull Observable<Execution> retrieveOrchestrationsForApplication(
+  @Nonnull Iterable<Execution> retrieveOrchestrationsForApplication(
     @Nonnull String application, @Nonnull ExecutionCriteria criteria);
 
   @Nonnull Execution retrieveOrchestrationForCorrelationId(

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nullable;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -87,14 +88,12 @@ public class PipelineTemplateService {
     } else if (pipelineConfigId != null) {
       // No executionId set - use last execution
       ExecutionRepository.ExecutionCriteria criteria = new ExecutionRepository.ExecutionCriteria().setLimit(1);
-      try {
-        return executionRepository.retrievePipelinesForPipelineConfigId(pipelineConfigId, criteria)
-          .iterator()
-          .next();
-      } catch (NoSuchElementException e) {
-        throw new ExecutionNotFoundException("No pipeline execution could be found for config id " +
-          pipelineConfigId + ": " + e.getMessage());
+
+      Iterator<Execution> executions = executionRepository.retrievePipelinesForPipelineConfigId(pipelineConfigId, criteria).iterator();
+      if (!executions.hasNext()) {
+        throw new ExecutionNotFoundException("No pipeline execution could be found for config id " + pipelineConfigId);
       }
+      return executions.next();
     } else {
       throw new IllegalArgumentException("Either executionId or pipelineConfigId have to be set.");
     }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
@@ -15,10 +15,6 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate;
 
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import javax.annotation.Nullable;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
@@ -33,6 +29,12 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE;
 
 @Component
@@ -87,9 +89,8 @@ public class PipelineTemplateService {
       ExecutionRepository.ExecutionCriteria criteria = new ExecutionRepository.ExecutionCriteria().setLimit(1);
       try {
         return executionRepository.retrievePipelinesForPipelineConfigId(pipelineConfigId, criteria)
-          .toSingle()
-          .toBlocking()
-          .value();
+          .iterator()
+          .next();
       } catch (NoSuchElementException e) {
         throw new ExecutionNotFoundException("No pipeline execution could be found for config id " +
           pipelineConfigId + ": " + e.getMessage());

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/OrcaMessageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/OrcaMessageHandler.kt
@@ -96,9 +96,8 @@ internal interface OrcaMessageHandler<M : Message> : MessageHandler<M> {
       val criteria = ExecutionRepository.ExecutionCriteria().setLimit(1).setStatuses(ExecutionStatus.RUNNING)
       !repository
         .retrievePipelinesForPipelineConfigId(configId, criteria)
-        .isEmpty
-        .toBlocking()
-        .first()
+        .iterator()
+        .hasNext()
     } == true
   }
 }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
@@ -275,10 +275,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
           pipeline.isLimitConcurrent = true
           runningPipeline.isLimitConcurrent = true
 
-          whenever(
-            repository
-              .retrievePipelinesForPipelineConfigId(configId, ExecutionCriteria().setLimit(1).setStatuses(RUNNING))
-          ) doReturn listOf(runningPipeline)
+          whenever(pendingExecutionService.depth(configId)) doReturn 1
           whenever(
             repository.retrieve(message.executionType, message.executionId)
           ) doReturn pipeline
@@ -309,10 +306,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
           pipeline.isLimitConcurrent = false
           runningPipeline.isLimitConcurrent = false
 
-          whenever(
-            repository
-              .retrievePipelinesForPipelineConfigId(configId, ExecutionCriteria().setLimit(1).setStatuses(RUNNING))
-          ) doReturn listOf(runningPipeline)
+          whenever(pendingExecutionService.depth(configId)) doReturn 1
           whenever(
             repository.retrieve(message.executionType, message.executionId)
           ) doReturn pipeline

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
@@ -38,7 +38,6 @@ import org.jetbrains.spek.api.dsl.*
 import org.jetbrains.spek.api.lifecycle.CachingMode.GROUP
 import org.jetbrains.spek.subject.SubjectSpek
 import org.springframework.context.ApplicationEventPublisher
-import rx.Observable.just
 import java.util.*
 
 object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
@@ -279,7 +278,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
           whenever(
             repository
               .retrievePipelinesForPipelineConfigId(configId, ExecutionCriteria().setLimit(1).setStatuses(RUNNING))
-          ) doReturn just(runningPipeline)
+          ) doReturn listOf(runningPipeline)
           whenever(
             repository.retrieve(message.executionType, message.executionId)
           ) doReturn pipeline
@@ -313,7 +312,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
           whenever(
             repository
               .retrievePipelinesForPipelineConfigId(configId, ExecutionCriteria().setLimit(1).setStatuses(RUNNING))
-          ) doReturn just(runningPipeline)
+          ) doReturn listOf(runningPipeline)
           whenever(
             repository.retrieve(message.executionType, message.executionId)
           ) doReturn pipeline

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/migrations/MultiRedisOrchestrationMigrationNotificationAgent.groovy
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/migrations/MultiRedisOrchestrationMigrationNotificationAgent.groovy
@@ -122,10 +122,8 @@ class MultiRedisOrchestrationMigrationNotificationAgent extends AbstractPollingN
       def applicationName = application.name.toLowerCase()
       def unmigratedOrchestrations = executionRepositoryPrevious
         .retrieveOrchestrationsForApplication(applicationName, executionCriteria)
-        .filter({ orchestration -> !previouslyMigratedOrchestrationIds.contains(orchestration.id) })
         .toList()
-        .toBlocking()
-        .single()
+        .findAll { orchestration -> !previouslyMigratedOrchestrationIds.contains(orchestration.id) }
 
       def migratableOrchestrations = unmigratedOrchestrations.findAll { it.status.isComplete() }
       def pendingOrchestrations = unmigratedOrchestrations.findAll { !it.status.isComplete() }

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/migrations/MultiRedisPipelineMigrationNotificationAgent.groovy
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/migrations/MultiRedisPipelineMigrationNotificationAgent.groovy
@@ -120,10 +120,8 @@ class MultiRedisPipelineMigrationNotificationAgent extends AbstractPollingNotifi
     allPipelineConfigIds.eachWithIndex { String pipelineConfigId, int index ->
       def unmigratedPipelines = executionRepositoryPrevious
         .retrievePipelinesForPipelineConfigId(pipelineConfigId, executionCriteria)
-        .filter({ pipeline -> !previouslyMigratedPipelineIds.contains(pipeline.id) })
         .toList()
-        .toBlocking()
-        .single()
+        .findAll { pipeline -> !previouslyMigratedPipelineIds.contains(pipeline.id) }
 
       def migratablePipelines = unmigratedPipelines.findAll { it.status.isComplete() }
       def pendingPipelines = unmigratedPipelines.findAll { !it.status.isComplete() }

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgent.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgent.java
@@ -43,7 +43,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE;
 import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.IterableUtil.toStream;
@@ -185,10 +184,6 @@ public class OldPipelineCleanupPollingNotificationAgent implements ApplicationLi
     return redisClientDelegate.withCommandsClient(c -> {
       return c.sismember("existingServerGroups:pipeline", "pipeline:" + pipelineId);
     });
-  }
-
-  private <T> Stream<T> iteratorToStream(Iterable<T> executions) {
-    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(executions.iterator(), Spliterator.ORDERED), false);
   }
 
   private static class PipelineExecutionDetails {

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgent.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgent.java
@@ -43,6 +43,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE;
 import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.IterableUtil.toStream;
@@ -184,6 +185,10 @@ public class OldPipelineCleanupPollingNotificationAgent implements ApplicationLi
     return redisClientDelegate.withCommandsClient(c -> {
       return c.sismember("existingServerGroups:pipeline", "pipeline:" + pipelineId);
     });
+  }
+
+  private <T> Stream<T> iteratorToStream(Iterable<T> executions) {
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(executions.iterator(), Spliterator.ORDERED), false);
   }
 
   private static class PipelineExecutionDetails {

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgent.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgent.java
@@ -43,9 +43,9 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE;
+import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.IterableUtil.toStream;
 
 // TODO rz - Remove redis know-how and move back into orca-core
 @Component
@@ -141,7 +141,7 @@ public class OldPipelineCleanupPollingNotificationAgent implements ApplicationLi
 
       applications.forEach(app -> {
         log.debug("Cleaning up " + app);
-        cleanupApp(iteratorToStream(executionRepository.retrievePipelinesForApplication(app)));
+        cleanupApp(toStream(executionRepository.retrievePipelinesForApplication(app)));
       });
 
     } catch (Exception e) {
@@ -184,10 +184,6 @@ public class OldPipelineCleanupPollingNotificationAgent implements ApplicationLi
     return redisClientDelegate.withCommandsClient(c -> {
       return c.sismember("existingServerGroups:pipeline", "pipeline:" + pipelineId);
     });
-  }
-
-  private <T> Stream<T> iteratorToStream(Iterable<T> executions) {
-    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(executions.iterator(), Spliterator.ORDERED), false);
   }
 
   private static class PipelineExecutionDetails {

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -400,7 +400,10 @@ public class RedisExecutionRepository implements ExecutionRepository {
       );
 
       // merge primary + secondary observables
-      return Observable.merge(currentObservable, previousObservable).toList().toBlocking().single();
+      return Observable.merge(currentObservable, previousObservable)
+        .subscribeOn(queryByAppScheduler)
+        .toList()
+        .toBlocking().single();
     }
 
     return currentObservable.toList().toBlocking().single();
@@ -408,7 +411,7 @@ public class RedisExecutionRepository implements ExecutionRepository {
 
   @Override
   public @Nonnull
-  Observable<Execution> retrieveOrchestrationsForApplication(@Nonnull String application, @Nonnull ExecutionCriteria criteria) {
+  Iterable<Execution> retrieveOrchestrationsForApplication(@Nonnull String application, @Nonnull ExecutionCriteria criteria) {
     String allOrchestrationsKey = appKey(ORCHESTRATION, application);
 
     /*
@@ -482,10 +485,13 @@ public class RedisExecutionRepository implements ExecutionRepository {
       );
 
       // merge primary + secondary observables
-      return Observable.merge(currentObservable, previousObservable);
+      return Observable.merge(currentObservable, previousObservable)
+        .subscribeOn(queryByAppScheduler)
+        .toList()
+        .toBlocking().single();
     }
 
-    return currentObservable;
+    return currentObservable.subscribeOn(queryByAppScheduler).toList().toBlocking().single();
   }
 
   @Override

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -329,8 +329,8 @@ public class RedisExecutionRepository implements ExecutionRepository {
 
   @Override
   public @Nonnull
-  Observable<Execution> retrievePipelinesForPipelineConfigId(@Nonnull String pipelineConfigId,
-                                                             @Nonnull ExecutionCriteria criteria) {
+  Iterable<Execution> retrievePipelinesForPipelineConfigId(@Nonnull String pipelineConfigId,
+                                                           @Nonnull ExecutionCriteria criteria) {
     /*
      * Fetch pipeline ids from the primary redis (and secondary if configured)
      */
@@ -400,10 +400,10 @@ public class RedisExecutionRepository implements ExecutionRepository {
       );
 
       // merge primary + secondary observables
-      return Observable.merge(currentObservable, previousObservable);
+      return Observable.merge(currentObservable, previousObservable).toList().toBlocking().single();
     }
 
-    return currentObservable;
+    return currentObservable.toList().toBlocking().single();
   }
 
   @Override

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -320,11 +320,11 @@ public class RedisExecutionRepository implements ExecutionRepository {
 
   @Override
   public @Nonnull
-  Observable<Execution> retrievePipelinesForApplication(@Nonnull String application) {
+  Iterable<Execution> retrievePipelinesForApplication(@Nonnull String application) {
     List<Observable<Execution>> observables = allRedisDelegates().stream()
       .map(d -> allForApplication(PIPELINE, application, d))
       .collect(Collectors.toList());
-    return Observable.merge(observables);
+    return Observable.merge(observables).toList().toBlocking().single();
   }
 
   @Override

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -45,15 +45,15 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
     def filter = new OldPipelineCleanupPollingNotificationAgent(clock: clock, thresholdDays: 1).filter
 
     expect:
-    filter.call(pipeline {
+    filter.test(pipeline {
       status = ExecutionStatus.SUCCEEDED
       startTime = Duration.ofDays(1).toMillis()
     }) == true
-    filter.call(pipeline {
+    filter.test(pipeline {
       status = ExecutionStatus.RUNNING
       startTime = Duration.ofDays(1).toMillis()
     }) == false
-    filter.call(pipeline {
+    filter.test(pipeline {
       status = ExecutionStatus.SUCCEEDED
       startTime = Duration.ofDays(3).toMillis()
     }) == false
@@ -74,7 +74,7 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
     def mapper = new OldPipelineCleanupPollingNotificationAgent().mapper
 
     expect:
-    with(mapper.call(pipeline)) {
+    with(mapper.apply(pipeline)) {
       id == "ID1"
       application == "orca"
       pipelineConfigId == "P1"
@@ -94,7 +94,7 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
       millis() >> { Duration.ofDays(10).toMillis() }
     }
     def executionRepository = Mock(ExecutionRepository) {
-      1 * retrievePipelinesForApplication("orca") >> rx.Observable.from(pipelines)
+      1 * retrievePipelinesForApplication("orca") >> pipelines
     }
     def jedisPool = Stub(Pool) {
       getResource() >> {

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
@@ -48,7 +48,7 @@ class TopApplicationExecutionCleanupPollingNotificationAgentSpec extends Specifi
         status = s
       }
 
-      filter.call(pipeline) == (s == ExecutionStatus.SUCCEEDED)
+      filter.test(pipeline) == (s == ExecutionStatus.SUCCEEDED)
     }
   }
 
@@ -64,7 +64,7 @@ class TopApplicationExecutionCleanupPollingNotificationAgentSpec extends Specifi
     def mapper = new TopApplicationExecutionCleanupPollingNotificationAgent().mapper
 
     expect:
-    with(mapper.call(pipeline)) {
+    with(mapper.apply(pipeline)) {
       id == "ID1"
       startTime == 1000
       pipelineConfigId == "P1"
@@ -88,7 +88,7 @@ class TopApplicationExecutionCleanupPollingNotificationAgentSpec extends Specifi
       }
     }
     agent.executionRepository = Mock(ExecutionRepository) {
-      retrieveOrchestrationsForApplication("app1", _) >> rx.Observable.from(orchestrations)
+      retrieveOrchestrationsForApplication("app1", _) >> orchestrations
     }
 
     when:

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
@@ -357,7 +357,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     when:
     // TODO-AJ limits are current applied to each backing redis
     def retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionRepository.ExecutionCriteria(limit: 2))
-      .toList().toBlocking().first()
+      .toList()
 
     then:
     // pipelines are stored in a sorted sets and results should be reverse buildTime ordered
@@ -384,7 +384,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     when:
     repository.delete(pipeline1.type, pipeline1.id)
     def retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionRepository.ExecutionCriteria(limit: 2))
-      .toList().toBlocking().first()
+      .toList()
 
     then:
     retrieved*.id == [pipeline2.id]
@@ -392,7 +392,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     when:
     repository.delete(pipeline2.type, pipeline2.id)
     retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionRepository.ExecutionCriteria(limit: 2))
-      .toList().toBlocking().first()
+      .toList()
 
     then:
     retrieved.isEmpty()

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
@@ -145,7 +145,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionRepository.ExecutionCriteria(limit: limit))
-      .toList().toBlocking().first()
+      .toList()
 
     then:
     retrieved.size() == actual
@@ -256,7 +256,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     when:
     // TODO-AJ limits are current applied to each backing redis
     def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionRepository.ExecutionCriteria(limit: 2))
-      .toList().toBlocking().first()
+      .toList()
 
     then:
     // orchestrations are stored in an unsorted set and results are non-deterministic
@@ -281,7 +281,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     when:
     repository.delete(orchestration1.type, orchestration1.id)
     def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionRepository.ExecutionCriteria(limit: 2))
-      .toList().toBlocking().first()
+      .toList()
 
     then:
     retrieved*.id == [orchestration2.id]
@@ -289,7 +289,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     when:
     repository.delete(orchestration2.type, orchestration2.id)
     retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionRepository.ExecutionCriteria(limit: 2))
-      .toList().toBlocking().first()
+      .toList()
 
     then:
     retrieved.isEmpty()

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
@@ -92,7 +92,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     jedis.sadd("allJobs:pipeline", id)
 
     when:
-    def result = repository.retrieve(PIPELINE).toList().toBlocking().first()
+    def result = repository.retrieve(PIPELINE).toList()
 
     then:
     result.isEmpty()
@@ -129,7 +129,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     thrown ExecutionNotFoundException
 
     and:
-    repository.retrieve(PIPELINE).toList().toBlocking().first() == []
+    repository.retrieve(PIPELINE).toList() == []
     jedis.zrange(RedisExecutionRepository.executionsByPipelineKey(pipeline.pipelineConfigId), 0, 1).isEmpty()
   }
 

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/ProjectController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/ProjectController.groovy
@@ -22,9 +22,12 @@ import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 import retrofit.RetrofitError
-import rx.schedulers.Schedulers
 
 @RestController
 class ProjectController {
@@ -63,9 +66,9 @@ class ProjectController {
       statuses: (statuses.split(",") as Collection)
     )
 
-    def allPipelines = rx.Observable.merge(pipelineConfigIds.collect {
+    def allPipelines = pipelineConfigIds.collect {
       executionRepository.retrievePipelinesForPipelineConfigId(it, executionCriteria)
-    }).subscribeOn(Schedulers.io()).toList().toBlocking().single().sort(startTimeOrId)
+    }.toList().sort(startTimeOrId)
 
     return allPipelines
   }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -104,7 +104,7 @@ class TaskController {
   @PostFilter("hasPermission(filterObject.application, 'APPLICATION', 'READ')")
   @RequestMapping(value = "/tasks", method = RequestMethod.GET)
   List<OrchestrationViewModel> list() {
-    executionRepository.retrieve(ORCHESTRATION).toBlocking().iterator.collect {
+    executionRepository.retrieve(ORCHESTRATION).collect {
       convert it
     }
   }

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca.controllers
 
-import javax.servlet.http.HttpServletResponse
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
 import com.netflix.spinnaker.kork.web.exceptions.ValidationException
 import com.netflix.spinnaker.orca.igor.BuildArtifactFilter
@@ -40,10 +39,12 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.mock.env.MockEnvironment
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import rx.Observable
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
+
+import javax.servlet.http.HttpServletResponse
+
 import static com.netflix.spinnaker.orca.ExecutionStatus.CANCELED
 import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType
@@ -471,7 +472,7 @@ class OperationsControllerSpec extends Specification {
       startedPipeline.id = UUID.randomUUID().toString()
       startedPipeline
     }
-    executionRepository.retrievePipelinesForPipelineConfigId(*_) >> Observable.empty()
+    executionRepository.retrievePipelinesForPipelineConfigId(*_) >> []
     ArtifactResolver realArtifactResolver = new ArtifactResolver(mapper, executionRepository)
 
     // can't use @subject, since we need to test the behavior of otherwise mocked-out 'artifactResolver'

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -71,9 +71,7 @@ class TaskControllerSpec extends Specification {
     mockMvc.perform(get('/tasks')).andReturn().response
 
     then:
-    1 * executionRepository.retrieve(ORCHESTRATION) >> {
-      return rx.Observable.empty()
-    }
+    1 * executionRepository.retrieve(ORCHESTRATION) >> { [] }
   }
 
   void 'should cancel a list of tasks by id'() {
@@ -90,14 +88,14 @@ class TaskControllerSpec extends Specification {
 
   void 'step names are properly translated'() {
     given:
-    executionRepository.retrieve(ORCHESTRATION) >> rx.Observable.from([orchestration {
+    executionRepository.retrieve(ORCHESTRATION) >> [orchestration {
       id = "1"
       application = "covfefe"
       stage {
         type = "test"
         tasks = [new Task(name: 'jobOne'), new Task(name: 'jobTwo')]
       }
-    }])
+    }]
 
     when:
     def response = mockMvc.perform(get('/tasks')).andReturn().response
@@ -134,7 +132,7 @@ class TaskControllerSpec extends Specification {
     MockHttpServletResponse response = mockMvc.perform(get('/tasks')).andReturn().response
 
     then:
-    1 * executionRepository.retrieve(ORCHESTRATION) >> rx.Observable.from([])
+    1 * executionRepository.retrieve(ORCHESTRATION) >> []
     response.status == 200
     response.contentAsString == '[]'
   }


### PR DESCRIPTION
No functional changes. Not really prerequisite work for Squirrelly Quagmire Lounge, but will be a nice thing to have anyway. I didn't go about changing any internals of `RedisExecutionRepository` - I think using it inside is totally fine and probably makes a good deal of sense still.