### PR TITLE
feat(artifacts): Orca passes artifacts to bake to rosco

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import groovy.transform.CompileStatic
 import groovy.transform.Immutable
 
@@ -42,6 +43,7 @@ class BakeRequest {
 
   String user
   @JsonProperty("package") String packageName
+  List<Artifact> packageArtifacts
   String buildHost
   String job
   String buildNumber

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.bakery.api.BakeRequest
 import com.netflix.spinnaker.orca.bakery.api.BakeStatus
 import com.netflix.spinnaker.orca.bakery.api.BakeryService
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver
 import com.netflix.spinnaker.orca.pipeline.util.OperatingSystem
 import com.netflix.spinnaker.orca.pipeline.util.PackageInfo
 import com.netflix.spinnaker.orca.pipeline.util.PackageType
@@ -40,6 +41,9 @@ class CreateBakeTask implements RetryableTask {
 
   long backoffPeriod = 30000
   long timeout = 300000
+
+  @Autowired
+  ArtifactResolver artifactResolver
 
   @Autowired(required = false)
   BakeryService bakery
@@ -135,6 +139,10 @@ class CreateBakeTask implements RetryableTask {
       mapper)
 
     Map requestMap = packageInfo.findTargetPackage(allowMissingPackageInstallation)
+
+    requestMap.packageArtifacts = stage.context.packageArtifactIds.collect { String artifactId ->
+      artifactResolver.getBoundArtifactForId(stage, artifactId)
+    }
 
     def request = mapper.convertValue(requestMap, BakeRequest)
     if (!roscoApisEnabled) {


### PR DESCRIPTION
With this change, bake stages now support a field packageArtifactIds
that contains an array artifacts representing packages to bake into
the produced image.  This field will not be visible in the UI until
the corresponding change is made to deck.