### PR TITLE
refactor(core): Polling agents to be persistence agnostic

### DIFF
--- a/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/PollingAgentExecutionRepositoryTck.groovy
+++ b/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/PollingAgentExecutionRepositoryTck.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipeline.persistence
+
+import com.netflix.spinnaker.orca.notifications.scheduling.PollingAgentExecutionRepository
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.orchestration
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+
+@Subject(PollingAgentExecutionRepository)
+@Unroll
+abstract class PollingAgentExecutionRepositoryTck<T extends PollingAgentExecutionRepository> extends Specification {
+
+  @Subject
+  PollingAgentExecutionRepository repository
+
+  @Subject
+  PollingAgentExecutionRepository previousRepository
+
+  void setup() {
+    repository = createExecutionRepository()
+    previousRepository = createExecutionRepositoryPrevious()
+  }
+
+  abstract T createExecutionRepository()
+
+  abstract T createExecutionRepositoryPrevious()
+
+  def "can retrieve all application names in database"() {
+    given:
+    def execution1 = pipeline {
+      application = "spindemo"
+    }
+    def execution2 = pipeline {
+      application = "orca"
+    }
+    def execution3 = orchestration {
+      application = "spindemo"
+    }
+
+    when:
+    repository.store(execution1)
+    repository.store(execution2)
+    repository.store(execution3)
+    def apps = repository.retrieveAllApplicationNames(executionType, minExecutions)
+
+    then:
+    apps.sort() == expectedApps.sort()
+
+    where:
+    executionType | minExecutions || expectedApps
+    ORCHESTRATION | 0             || ["spindemo"]
+    PIPELINE      | 0             || ["spindemo", "orca"]
+    null          | 0             || ["spindemo", "orca"]
+    null          | 2             || ["spindemo"]
+    PIPELINE      | 2             || []
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -65,7 +65,8 @@ import static org.springframework.context.annotation.AnnotationConfigUtils.EVENT
   "com.netflix.spinnaker.orca.pipeline",
   "com.netflix.spinnaker.orca.deprecation",
   "com.netflix.spinnaker.orca.pipeline.util",
-  "com.netflix.spinnaker.orca.telemetry"
+  "com.netflix.spinnaker.orca.telemetry",
+  "com.netflix.spinnaker.orca.notifications.scheduling"
 })
 @EnableConfigurationProperties
 public class OrcaConfiguration {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/PollingAgentExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/PollingAgentExecutionRepository.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.notifications.scheduling
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+
+interface PollingAgentExecutionRepository : ExecutionRepository {
+
+  fun retrieveAllApplicationNames(type: ExecutionType?): List<String>
+  fun retrieveAllApplicationNames(type: ExecutionType?, minExecutions: Int): List<String>
+  fun hasEntityTags(type: ExecutionType, id: String): Boolean
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgent.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgent.java
@@ -16,52 +16,41 @@
 
 package com.netflix.spinnaker.orca.notifications.scheduling;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.netflix.discovery.StatusChangeEvent;
-import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent;
+import com.netflix.spinnaker.orca.notifications.AbstractPollingNotificationAgent;
+import com.netflix.spinnaker.orca.notifications.NotificationClusterLock;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionCriteria;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.ScanParams;
-import redis.clients.jedis.ScanResult;
-import redis.clients.util.Pool;
 import rx.Observable;
 import rx.Scheduler;
-import rx.Subscription;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 
-import javax.annotation.PreDestroy;
 import java.time.Instant;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
-import static com.netflix.appinfo.InstanceInfo.InstanceStatus.UP;
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.toList;
 
-// TODO rz - Remove redis know-how and move back into orca-core
 @Component
 @ConditionalOnExpression(value = "${pollers.topApplicationExecutionCleanup.enabled:false}")
-public class TopApplicationExecutionCleanupPollingNotificationAgent implements ApplicationListener<RemoteStatusChangedEvent> {
+public class TopApplicationExecutionCleanupPollingNotificationAgent extends AbstractPollingNotificationAgent {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   private Scheduler scheduler = Schedulers.io();
-  private Subscription subscription;
 
   private Func1<Execution, Boolean> filter = (Execution execution) ->
     execution.getStatus().isComplete() || Instant.ofEpochMilli(execution.getBuildTime()).isBefore(Instant.now().minus(31, DAYS));
@@ -74,39 +63,32 @@ public class TopApplicationExecutionCleanupPollingNotificationAgent implements A
     return builder;
   };
 
-  @Autowired
-  ObjectMapper objectMapper;
+  private final PollingAgentExecutionRepository executionRepository;
+  private final long pollingIntervalMs;
+  private final int threshold;
 
   @Autowired
-  ExecutionRepository executionRepository;
-
-  @Autowired
-  Pool<Jedis> jedisPool;
-
-  @Value("${pollers.topApplicationExecutionCleanup.intervalMs:3600000}")
-  long pollingIntervalMs;
-
-  @Value("${pollers.topApplicationExecutionCleanup.threshold:2500}")
-  int threshold;
-
-  @PreDestroy
-  void stopPolling() {
-    if (subscription != null) subscription.unsubscribe();
+  public TopApplicationExecutionCleanupPollingNotificationAgent(NotificationClusterLock clusterLock,
+                                                                PollingAgentExecutionRepository executionRepository,
+                                                                @Value("${pollers.topApplicationExecutionCleanup.intervalMs:3600000}") long pollingIntervalMs,
+                                                                @Value("${pollers.topApplicationExecutionCleanup.threshold:2500}") int threshold) {
+    super(clusterLock);
+    this.executionRepository = executionRepository;
+    this.pollingIntervalMs = pollingIntervalMs;
+    this.threshold = threshold;
   }
 
   @Override
-  public void onApplicationEvent(RemoteStatusChangedEvent event) {
-    StatusChangeEvent it = event.getSource();
-    if (it.getStatus() == UP) {
-      log.info("Instance is {}... starting top application execution cleanup", it.getStatus());
-      startPolling();
-    } else if (it.getPreviousStatus() == UP) {
-      log.warn("Instance is {}... stopping top application execution cleanup", it.getStatus());
-      stopPolling();
-    }
+  protected long getPollingInterval() {
+    return pollingIntervalMs;
   }
 
-  private void startPolling() {
+  @Override
+  protected String getNotificationType() {
+    return TopApplicationExecutionCleanupPollingNotificationAgent.class.getSimpleName();
+  }
+
+  protected void startPolling() {
     subscription = Observable
       .timer(pollingIntervalMs, TimeUnit.MILLISECONDS, scheduler)
       .repeat()
@@ -115,46 +97,16 @@ public class TopApplicationExecutionCleanupPollingNotificationAgent implements A
 
   @VisibleForTesting
   void tick() {
-    ScanParams scanParams = new ScanParams().match("orchestration:app:*").count(2000);
-    String cursor = "0";
     try {
-      List<String> appOrchestrations = new ArrayList<>();
-      while (true) {
-        String finalCursor = cursor;
-        ScanResult<String> result = jedis(it -> it.scan(finalCursor, scanParams));
-        appOrchestrations.addAll(result.getResult());
-        cursor = result.getStringCursor();
-        if (cursor.equals("0")) {
-          break;
-        }
-      }
+      executionRepository.retrieveAllApplicationNames(ORCHESTRATION, threshold).forEach(app -> {
+        log.info("Cleaning up orchestration executions (application: {}, threshold: {})", app, threshold);
 
-      List<String> filtered = appOrchestrations.stream().filter(id ->
-        jedis(it -> it.scard(id)) > threshold
-      ).collect(toList());
-
-      filtered.forEach(id -> {
-        String[] parts = id.split(":");
-        String type = parts[0];
-        String application = parts[2];
-        if (type.equals("orchestration")) {
-          log.info("Cleaning up orchestration executions (application: {}, threshold: {})", application, threshold);
-
-          ExecutionCriteria executionCriteria = new ExecutionCriteria();
-          executionCriteria.setLimit(Integer.MAX_VALUE);
-          cleanup(executionRepository.retrieveOrchestrationsForApplication(application, executionCriteria), application, "orchestration");
-        } else {
-          log.error("Unable to cleanup executions, unsupported type: {}", type);
-        }
+        ExecutionCriteria executionCriteria = new ExecutionCriteria();
+        executionCriteria.setLimit(Integer.MAX_VALUE);
+        cleanup(executionRepository.retrieveOrchestrationsForApplication(app, executionCriteria), app, "orchestration");
       });
     } catch (Exception e) {
       log.error("Cleanup failed", e);
-    }
-  }
-
-  private <T> T jedis(Function<Jedis, T> work) {
-    try (Jedis jedis = jedisPool.getResource()) {
-      return work.apply(jedis);
     }
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -15,7 +15,6 @@
  */
 package com.netflix.spinnaker.orca.pipeline.persistence;
 
-import com.google.common.collect.Lists;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
@@ -53,22 +52,27 @@ public interface ExecutionRepository {
 
   void updateStatus(ExecutionType type, @Nonnull String id, @Nonnull ExecutionStatus status);
 
-  @Nonnull Execution retrieve(@Nonnull ExecutionType type, @Nonnull String id) throws ExecutionNotFoundException;
+  @Nonnull
+  Execution retrieve(@Nonnull ExecutionType type, @Nonnull String id) throws ExecutionNotFoundException;
 
   void delete(@Nonnull ExecutionType type, @Nonnull String id);
 
-  @Nonnull Observable<Execution> retrieve(ExecutionType type);
+  @Nonnull
+  Observable<Execution> retrieve(ExecutionType type);
 
-  @Nonnull Observable<Execution> retrievePipelinesForApplication(@Nonnull String application);
+  @Nonnull
+  Observable<Execution> retrievePipelinesForApplication(@Nonnull String application);
 
-  @Nonnull Observable<Execution> retrievePipelinesForPipelineConfigId(
-    @Nonnull String pipelineConfigId, @Nonnull ExecutionCriteria criteria);
+  @Nonnull
+  Observable<Execution> retrievePipelinesForPipelineConfigId(@Nonnull String pipelineConfigId,
+                                                             @Nonnull ExecutionCriteria criteria);
 
-  @Nonnull Observable<Execution> retrieveOrchestrationsForApplication(
-    @Nonnull String application, @Nonnull ExecutionCriteria criteria);
+  @Nonnull
+  Observable<Execution> retrieveOrchestrationsForApplication(@Nonnull String application,
+                                                             @Nonnull ExecutionCriteria criteria);
 
-  @Nonnull Execution retrieveOrchestrationForCorrelationId(
-    @Nonnull String correlationId) throws ExecutionNotFoundException;
+  @Nonnull
+  Execution retrieveOrchestrationForCorrelationId(@Nonnull String correlationId) throws ExecutionNotFoundException;
 
   @Nonnull
   List<Execution> retrieveBufferedExecutions();
@@ -78,16 +82,16 @@ public interface ExecutionRepository {
       return limit;
     }
 
-    public ExecutionCriteria setLimit(int limit) {
+    public @Nonnull ExecutionCriteria setLimit(int limit) {
       this.limit = limit;
       return this;
     }
 
-    public Collection<ExecutionStatus> getStatuses() {
+    public @Nonnull Collection<ExecutionStatus> getStatuses() {
       return statuses;
     }
 
-    public ExecutionCriteria setStatuses(Collection<String> statuses) {
+    public @Nonnull ExecutionCriteria setStatuses(Collection<String> statuses) {
       return setStatuses(
         statuses
           .stream()
@@ -97,7 +101,7 @@ public interface ExecutionRepository {
       );
     }
 
-    public ExecutionCriteria setStatuses(ExecutionStatus... statuses) {
+    public @Nonnull ExecutionCriteria setStatuses(ExecutionStatus... statuses) {
       this.statuses = Arrays.asList(statuses);
       return this;
     }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -15,16 +15,10 @@
  */
 package com.netflix.spinnaker.orca.notifications.scheduling
 
-import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
-import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.notifications.NotificationClusterLock
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Task
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
-import redis.clients.jedis.Jedis
-import redis.clients.jedis.ScanParams
-import redis.clients.jedis.ScanResult
-import redis.clients.util.Pool
 import spock.lang.Specification
 
 import java.time.Clock
@@ -42,7 +36,14 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
     def clock = Mock(Clock) {
       millis() >> { Duration.ofDays(3).toMillis() }
     }
-    def filter = new OldPipelineCleanupPollingNotificationAgent(clock: clock, thresholdDays: 1).filter
+    def filter = new OldPipelineCleanupPollingNotificationAgent(
+      Mock(NotificationClusterLock),
+      Mock(PollingAgentExecutionRepository),
+      clock,
+      5000,
+      1,
+      5
+    ).filter
 
     expect:
     filter.call(pipeline {
@@ -71,7 +72,14 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
     }
 
     and:
-    def mapper = new OldPipelineCleanupPollingNotificationAgent().mapper
+    def mapper = new OldPipelineCleanupPollingNotificationAgent(
+      Mock(NotificationClusterLock),
+      Mock(PollingAgentExecutionRepository),
+      Mock(Clock),
+      5000,
+      1,
+      5
+    ).mapper
 
     expect:
     with(mapper.call(pipeline)) {
@@ -93,24 +101,17 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
     def clock = Mock(Clock) {
       millis() >> { Duration.ofDays(10).toMillis() }
     }
-    def executionRepository = Mock(ExecutionRepository) {
+    def executionRepository = Mock(PollingAgentExecutionRepository) {
+      1 * retrieveAllApplicationNames(PIPELINE) >> ["orca"]
       1 * retrievePipelinesForApplication("orca") >> rx.Observable.from(pipelines)
     }
-    def jedisPool = Stub(Pool) {
-      getResource() >> {
-        return Stub(Jedis) {
-          scan("0", _ as ScanParams) >> { new ScanResult<String>("0", ["pipeline:app:orca"]) }
-        }
-      }
-    }
-    def redisClientDelegate = (RedisClientDelegate) new JedisClientDelegate(jedisPool)
-
     def agent = new OldPipelineCleanupPollingNotificationAgent(
-      executionRepository: executionRepository,
-      redisClientDelegate: redisClientDelegate,
-      clock: clock,
-      thresholdDays: 5,
-      minimumPipelineExecutions: 3
+      Mock(NotificationClusterLock),
+      executionRepository,
+      clock,
+      5000,
+      5,
+      3
     )
 
     when:

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
@@ -17,13 +17,9 @@
 package com.netflix.spinnaker.orca.notifications.scheduling
 
 import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.notifications.NotificationClusterLock
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Task
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
-import redis.clients.jedis.Jedis
-import redis.clients.jedis.ScanParams
-import redis.clients.jedis.ScanResult
-import redis.clients.util.Pool
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -37,7 +33,12 @@ class TopApplicationExecutionCleanupPollingNotificationAgentSpec extends Specifi
   @Unroll
   void "filter should only consider SUCCEEDED executions"() {
     given:
-    def filter = new TopApplicationExecutionCleanupPollingNotificationAgent().filter
+    def filter = new TopApplicationExecutionCleanupPollingNotificationAgent(
+      Mock(NotificationClusterLock),
+      Mock(PollingAgentExecutionRepository),
+      5000,
+      2500
+    ).filter
 
     expect:
     ExecutionStatus.values().each { s ->
@@ -61,7 +62,12 @@ class TopApplicationExecutionCleanupPollingNotificationAgentSpec extends Specifi
     }
 
     and:
-    def mapper = new TopApplicationExecutionCleanupPollingNotificationAgent().mapper
+    def mapper = new TopApplicationExecutionCleanupPollingNotificationAgent(
+      Mock(NotificationClusterLock),
+      Mock(PollingAgentExecutionRepository),
+      5000,
+      2500
+    ).mapper
 
     expect:
     with(mapper.call(pipeline)) {
@@ -78,28 +84,27 @@ class TopApplicationExecutionCleanupPollingNotificationAgentSpec extends Specifi
     def orchestrations = buildExecutions(startTime, 3)
     def pipelines = buildExecutions(startTime, 3, "P1") + buildExecutions(startTime, 5, "P2")
 
-    def agent = new TopApplicationExecutionCleanupPollingNotificationAgent(threshold: 2)
-    agent.jedisPool = Stub(Pool) {
-      getResource() >> {
-        return Stub(Jedis) {
-          scan("0", _ as ScanParams) >> { new ScanResult<String>("0", ["orchestration:app:app1"]) }
-          scard("orchestration:app:app1") >> { return orchestrations.size() }
-        }
-      }
+    def executionRepository = Mock(PollingAgentExecutionRepository) {
+      1 * retrieveAllApplicationNames(_, _) >> ["app1"]
+      1 * retrieveOrchestrationsForApplication("app1", _) >> rx.Observable.from(orchestrations)
     }
-    agent.executionRepository = Mock(ExecutionRepository) {
-      retrieveOrchestrationsForApplication("app1", _) >> rx.Observable.from(orchestrations)
-    }
+    def agent = new TopApplicationExecutionCleanupPollingNotificationAgent(
+      Mock(NotificationClusterLock),
+      executionRepository,
+      5000,
+      2
+    )
 
     when:
     agent.tick()
 
     then:
-    1 * agent.executionRepository.delete(ORCHESTRATION, orchestrations[0].id)
+    1 * executionRepository.delete(ORCHESTRATION, orchestrations[0].id)
   }
 
-  private
-  static Collection<Execution> buildExecutions(AtomicInteger stageStartTime, int count, String configId = null) {
+  private static Collection<Execution> buildExecutions(AtomicInteger stageStartTime,
+                                                       int count,
+                                                       String configId = null) {
     (1..count).collect {
       def time = stageStartTime.incrementAndGet()
       pipeline {

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/config/RedisConfiguration.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/config/RedisConfiguration.java
@@ -49,7 +49,6 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static redis.clients.jedis.Protocol.DEFAULT_DATABASE;
 
 @Configuration
-@ComponentScan("com.netflix.spinnaker.orca.notifications.scheduling")
 @Import({JedisClientConfiguration.class, JedisConfiguration.class})
 public class RedisConfiguration {
 

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisPollingAgentExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisPollingAgentExecutionRepositorySpec.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipeline.persistence.jedis
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.RedisClientSelector
+import com.netflix.spinnaker.orca.pipeline.persistence.PollingAgentExecutionRepositoryTck
+import redis.clients.jedis.Jedis
+import redis.clients.util.Pool
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+class RedisPollingAgentExecutionRepositorySpec extends PollingAgentExecutionRepositoryTck<RedisExecutionRepository> {
+
+  @Shared
+  @AutoCleanup("destroy")
+  EmbeddedRedis embeddedRedis
+
+  @Shared
+  @AutoCleanup("destroy")
+  EmbeddedRedis embeddedRedisPrevious
+
+  def setupSpec() {
+    embeddedRedis = EmbeddedRedis.embed()
+    embeddedRedisPrevious = EmbeddedRedis.embed()
+  }
+
+  def cleanup() {
+    embeddedRedis.jedis.withCloseable { it.flushDB() }
+    embeddedRedisPrevious.jedis.withCloseable { it.flushDB() }
+  }
+
+  Pool<Jedis> jedisPool = embeddedRedis.pool
+  Pool<Jedis> jedisPoolPrevious = embeddedRedisPrevious.pool
+
+  RedisClientDelegate redisClientDelegate = new JedisClientDelegate("primaryDefault", jedisPool)
+  RedisClientDelegate previousRedisClientDelegate = new JedisClientDelegate("previousDefault", jedisPoolPrevious)
+  RedisClientSelector redisClientSelector = new RedisClientSelector([redisClientDelegate, previousRedisClientDelegate])
+
+  Registry registry = new NoopRegistry()
+
+  @AutoCleanup
+  def jedis = jedisPool.resource
+
+  @Override
+  RedisExecutionRepository createExecutionRepository() {
+    return new RedisExecutionRepository(registry, redisClientSelector, 1, 50)
+  }
+
+  @Override
+  RedisExecutionRepository createExecutionRepositoryPrevious() {
+    return new RedisExecutionRepository(registry, new RedisClientSelector([new JedisClientDelegate("primaryDefault", jedisPoolPrevious)]), 1, 50)
+  }
+}


### PR DESCRIPTION
A few things changed here:

1. Switched `ExecutionCriteria` to be an interface. Ended up refactoring my current use for it out, but seemed handy enough to keep.
1. Added new `PollingAgentExecutionRepository` which has some additional poller-specific methods.
1. Moved the two polling agents back into `orca-core`