### PR TITLE
fix(front50): process expressions in dependent pipeline trigger

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -103,7 +103,10 @@ class DependentPipelineStarter implements ApplicationContextAware {
       artifactError = e
     }
 
-    pipelineConfig.trigger = objectMapper.readValue(objectMapper.writeValueAsString(pipelineConfig.trigger), Trigger.class)
+    // Process the raw trigger to resolve any expressions before converting it to a Trigger object, which will not be
+    // processed by the contextParameterProcessor (it only handles Maps, Lists, and Strings)
+    Map processedTrigger = contextParameterProcessor.process([trigger: pipelineConfig.trigger], [:], false).trigger
+    pipelineConfig.trigger = objectMapper.readValue(objectMapper.writeValueAsString(processedTrigger), Trigger.class)
     if (parentPipeline.trigger.dryRun) {
       pipelineConfig.trigger.dryRun = true
     }


### PR DESCRIPTION
This is a kind of clunky fix, but needed(?) because the context parameter processor only handles a few types of objects: Maps, Lists, and Strings. Anything else doesn't get processed, and the current code converts the trigger from a Map to a Trigger, so...no good.