### PR TITLE
fix(front50): Additional flexibility for the `MonitorFront50Task`

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -52,6 +52,9 @@ interface Front50Service {
   @GET("/pipelines/{applicationName}")
   List<Map<String, Object>> getPipelines(@Path("applicationName") String applicationName, @Query("refresh") boolean refresh)
 
+  @GET("/pipelines/{pipelineId}/history")
+  List<Map<String, Object>> getPipelineHistory(@Path("pipelineId") String pipelineId, @Query("limit") int limit)
+
   @POST("/pipelines")
   Response savePipeline(@Body Map pipeline)
 


### PR DESCRIPTION
This PR introduces support for configuring the number of times to check
that a pipeline has been updated. It builds upon spinnaker/front50#2145
which only checked _once_.

This continues to offer a small bandaid around situations wherein a
Front50 backed by S3 does not always provide read-after-write
consistency.
