### PR TITLE
fix(pipeline/expressions): reference trigger as map, not object

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.pipeline.util;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
@@ -89,7 +90,10 @@ public class ContextParameterProcessor {
       augmentedContext.putAll(stage.getContext());
     }
     if (stage.getExecution().getType() == PIPELINE) {
-      augmentedContext.put("trigger", stage.getExecution().getTrigger());
+      augmentedContext.put("trigger", mapper.convertValue(
+          stage.getExecution().getTrigger(),
+          new TypeReference<Map<String, Object>>() {})
+      );
       augmentedContext.put("execution", stage.getExecution());
     }
 


### PR DESCRIPTION
`buildExecutionContext` is only called by stages trying to evaluate SPeL inside a stage on some input text. The issue is, at this point in the execution, the trigger has already been cast to something other than the generic `Trigger.class`, which some expressions depend on. This explains why typical SPeL evaluation doesn't run into this problem, and only the "ContitionalOnExpression" and "DeployManifest" stages see this.