### PR TITLE
fix(clouddriver): overwrite entity tags when creating new server group

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTask.groovy
@@ -76,6 +76,7 @@ class AddServerGroupEntityTagsTask extends AbstractCloudProviderAwareTask implem
         operations <<
           [
             "upsertEntityTags": [
+              isPartial: false,
               tags     : tags,
               entityRef: [
                 entityType   : "servergroup",

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/PinnedServerGroupTagGenerator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/PinnedServerGroupTagGenerator.java
@@ -28,7 +28,10 @@ import java.util.Map;
 
 @Component
 public class PinnedServerGroupTagGenerator implements ServerGroupEntityTagGenerator {
+  private static final Logger log = LoggerFactory.getLogger(PinnedServerGroupTagGenerator.class);
+
   public static final String PINNED_CAPACITY_TAG = "spinnaker:pinned_capacity";
+
 
   @Override
   public Collection<Map<String, Object>> generateTags(Stage stage,
@@ -57,6 +60,17 @@ public class PinnedServerGroupTagGenerator implements ServerGroupEntityTagGenera
       .put("pinnedCapacity", stageData.capacity.toMap())
       .put("unpinnedCapacity", stageData.sourceServerGroupCapacitySnapshot.toMap())
       .build();
+
+    log.debug(
+      "{}:{}:{} has been tagged with '{}' (executionId: {}, stageId: {}, value: {})",
+      account,
+      location,
+      serverGroup,
+      PINNED_CAPACITY_TAG,
+      stage.getExecution().getId(),
+      stage.getId(),
+      value
+    );
 
     return Collections.singletonList(
       ImmutableMap.<String, Object>builder()


### PR DESCRIPTION
No sense preserving pre-existing entity tags when a new server group
is created.

This can happen if `clouddriver` fails to delete entity tags alongside
the previous server group.

spinnaker/clouddriver#2640 has improved the entity tag delete story in
`clodudriver.`
