### PR TITLE
fix(queue): fail stage if `beforeStages` planning fails

### DIFF
--- a/orca-kotlin/src/main/kotlin/com/netflix/spinnaker/orca/ext/Stage.kt
+++ b/orca-kotlin/src/main/kotlin/com/netflix/spinnaker/orca/ext/Stage.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.ext
 
+import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.ExecutionStatus.*
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_AFTER
@@ -109,3 +110,10 @@ fun Stage.shouldFailPipeline(): Boolean =
 
 fun Stage.shouldContinueOnFailure(): Boolean =
   context["continuePipeline"] == true
+
+fun Stage.failureStatus(default: ExecutionStatus = TERMINAL) =
+  when {
+    shouldContinueOnFailure() -> FAILED_CONTINUE
+    shouldFailPipeline()      -> default
+    else                      -> STOPPED
+  }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.ExecutionStatus.*
 import com.netflix.spinnaker.orca.events.StageComplete
 import com.netflix.spinnaker.orca.ext.afterStages
+import com.netflix.spinnaker.orca.ext.failureStatus
 import com.netflix.spinnaker.orca.ext.firstAfterStages
 import com.netflix.spinnaker.orca.ext.syntheticStages
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
@@ -210,10 +211,14 @@ class CompleteStageHandler(
   }
 }
 
+private fun Stage.hasPlanningFailure() =
+  context["beforeStagePlanningFailed"] == true
+
 private fun Stage.determineStatus(): ExecutionStatus {
   val syntheticStatuses = syntheticStages().map(Stage::getStatus)
   val taskStatuses = tasks.map(Task::getStatus)
-  val allStatuses = syntheticStatuses + taskStatuses
+  val planningStatus = if (hasPlanningFailure()) listOf(failureStatus()) else emptyList()
+  val allStatuses = syntheticStatuses + taskStatuses + planningStatus
   val afterStageStatuses = afterStages().map(Stage::getStatus)
   return when {
     allStatuses.isEmpty()                    -> NOT_STARTED

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.*
 import com.netflix.spinnaker.orca.ExecutionStatus.*
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.exceptions.TimeoutException
+import com.netflix.spinnaker.orca.ext.failureStatus
 import com.netflix.spinnaker.orca.ext.shouldContinueOnFailure
 import com.netflix.spinnaker.orca.ext.shouldFailPipeline
 import com.netflix.spinnaker.orca.pipeline.model.Execution
@@ -249,10 +250,3 @@ class RunTaskHandler(
     }
   }
 }
-
-private fun Stage.failureStatus(default: ExecutionStatus = TERMINAL) =
-  when {
-    shouldContinueOnFailure() -> FAILED_CONTINUE
-    shouldFailPipeline()      -> default
-    else                      -> STOPPED
-  }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
@@ -99,7 +99,10 @@ class StartStageHandler(
               queue.push(message, retryDelay)
             } else {
               log.error("Error running ${stage.type} stage for ${message.executionType}[${message.executionId}]", e)
-              stage.context["exception"] = exceptionDetails
+              stage.apply {
+                context["exception"] = exceptionDetails
+                context["beforeStagePlanningFailed"] = true
+              }
               repository.storeStage(stage)
               queue.push(CompleteStage(message))
             }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
@@ -679,6 +679,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
             pipeline.stageByRef("1").apply {
               context["failPipeline"] = false
               context["continuePipeline"] = false
+              context["beforeStagePlanningFailed"] = null
             }
 
             whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
@@ -701,6 +702,12 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
               assertThat(it.context["exception"]).isEqualTo(exceptionDetails)
             })
           }
+
+          it("attaches flag to the stage context to indicate that before stage planning failed") {
+            verify(repository).storeStage(check {
+              assertThat(it.context["beforeStagePlanningFailed"]).isEqualTo(true)
+            })
+          }
         }
 
         and("the branch should be allowed to continue") {
@@ -708,6 +715,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
             pipeline.stageByRef("1").apply {
               context["failPipeline"] = false
               context["continuePipeline"] = true
+              context["beforeStagePlanningFailed"] = null
             }
 
             whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
@@ -728,6 +736,12 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
           it("attaches the exception to the stage context") {
             verify(repository).storeStage(check {
               assertThat(it.context["exception"]).isEqualTo(exceptionDetails)
+            })
+          }
+
+          it("attaches flag to the stage context to indicate that before stage planning failed") {
+            verify(repository).storeStage(check {
+              assertThat(it.context["beforeStagePlanningFailed"]).isEqualTo(true)
             })
           }
         }


### PR DESCRIPTION
Prior to this change, a stage that threw an exception while planning `beforeStages` would still plan + execute its `afterStages` (and not its `onFailureStages`).
