### PR TITLE
refactor(qos): Move buffering metric to actuator

### DIFF
--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionBufferActuator.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionBufferActuator.kt
@@ -45,6 +45,7 @@ class ExecutionBufferActuator(
 
   private val orderedPolicies = policies.sortedByDescending { it.order }.toList()
 
+  private val bufferingId = registry.createId("qos.buffering")
   private val bufferedId = registry.createId("qos.executionsBuffered")
   private val enqueuedId = registry.createId("qos.executionsEnqueued")
   private val elapsedTimeId = registry.createId("qos.actuator.elapsedTime")
@@ -60,6 +61,8 @@ class ExecutionBufferActuator(
 
     val supplierName = bufferStateSupplier.javaClass.simpleName
     if (bufferStateSupplier.get() == ACTIVE) {
+      registry.gauge(bufferingId).set(1.0)
+
       val execution = event.execution
       withActionDecision(execution) {
         when (it.action) {
@@ -79,6 +82,8 @@ class ExecutionBufferActuator(
           }
         }
       }
+    } else {
+      registry.gauge(bufferingId).set(0.0)
     }
   }
 

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferstate/ActiveExecutionsBufferStateSupplier.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferstate/ActiveExecutionsBufferStateSupplier.kt
@@ -42,8 +42,6 @@ class ActiveExecutionsBufferStateSupplier(
 
   private var state: BufferState = INACTIVE
 
-  private val bufferingId = registry.createId("qos.buffering")
-
   @Scheduled(fixedDelayString = "\${pollers.qos.updateStateIntervalMs:5000}")
   private fun updateCurrentState() {
     if (!enabled()) {
@@ -61,13 +59,11 @@ class ActiveExecutionsBufferStateSupplier(
     state = if (activeExecutions > threshold) {
       if (state == INACTIVE) {
         log.warn("Enabling buffering: System active executions over threshold ($activeExecutions/$threshold)")
-        registry.gauge(bufferingId).set(1.0)
       }
       ACTIVE
     } else {
       if (state == ACTIVE) {
         log.warn("Disabling buffering: System active executions below threshold ($activeExecutions/$threshold)")
-        registry.gauge(bufferingId).set(0.0)
       }
       INACTIVE
     }


### PR DESCRIPTION
Moving the metrics reporting of buffering state to the actuator, so we don't need to worry about implementing this metric in each `BufferStateSupplier` implementation.