### PR TITLE
fix(caching): Fix bug resetting stageData after successful cache refresh

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
@@ -112,7 +112,7 @@ class ServerGroupCacheForceRefreshTaskSpec extends Specification {
 
     where:
     deployedServerGroups | refreshedServerGroups || executionStatus || forceCacheUpdatedServerGroups || expectedRefreshedServerGroups
-    ["s-v001"]           | []                    || SUCCEEDED       || ["s-v001"]                    || ["s-v001"]
+    ["s-v001"]           | []                    || SUCCEEDED       || ["s-v001"]                    || []
     ["s-v001"]           | []                    || RUNNING         || ["s-v001"]                    || ["s-v001"]
     ["s-v001", "s-v002"] | []                    || RUNNING         || ["s-v001", "s-v002"]          || ["s-v001", "s-v002"]
     ["s-v001", "s-v002"] | ["s-v001"]            || RUNNING         || ["s-v002"]                    || ["s-v001", "s-v002"]


### PR DESCRIPTION
If an on-demand cache update returns a 200 response, we exit immediately
from the ServerGroupCacheForceRefreshTask without needing to poll. In
that code path, we currently don't reset the stage data on server groups
to refresh, so a later ServerGroupCacheForceRefreshTask in the same
stage uses the prior (now stale) data.