### PR TITLE
refactor(core): Move stage sort logic to utility function

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryUtil.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryUtil.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipeline.persistence;
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+
+import javax.annotation.Nonnull;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_AFTER;
+
+public class ExecutionRepositoryUtil {
+
+  /**
+   * Ensure proper stage ordering even when stageIndex is an unsorted
+   * set or absent.
+   *
+   * Necessary for ensuring API responses and the UI render stages in
+   * the order of their execution.
+   */
+  public static void sortStagesByReference(@Nonnull Execution execution,
+                                           @Nonnull List<Stage> stages) {
+    if (!execution.getStages().isEmpty()) {
+      throw new StagesAlreadySorted();
+    }
+
+    if (stages.stream().map(Stage::getRefId).allMatch(Objects::nonNull)) {
+      execution.getStages().addAll(
+        stages.stream()
+          .filter(s -> s.getParentStageId() == null)
+          .sorted(Comparator.comparing(Stage::getRefId))
+          .collect(Collectors.toList())
+      );
+
+      stages.stream()
+        .filter(s -> s.getParentStageId() != null)
+        .sorted(Comparator.comparing(Stage::getRefId))
+        .forEach(
+          s -> {
+            Integer index = execution.getStages().indexOf(s.getParent());
+            if (s.getSyntheticStageOwner() == STAGE_AFTER) {
+              index++;
+            }
+            execution.getStages().add(index, s);
+          }
+        );
+    } else {
+      execution.getStages().addAll(stages);
+    }
+  }
+
+  private static class StagesAlreadySorted extends IllegalStateException {
+    StagesAlreadySorted() {
+      super("Execution already has stages defined");
+    }
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryUtilSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryUtilSpec.groovy
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipeline.persistence
+
+import spock.lang.Specification
+
+import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_AFTER
+import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_BEFORE
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.orchestration
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class ExecutionRepositoryUtilSpec extends Specification {
+
+  def "should order stages by ref id"() {
+    given:
+    def one = stage {
+      type = "three"
+      refId = "3"
+    }
+    def two = stage {
+      type = "one"
+      refId = "1"
+    }
+    def three = stage {
+      type = "two"
+      refId = "2"
+    }
+    def execution = orchestration {}
+
+    when:
+    ExecutionRepositoryUtil.sortStagesByReference(execution, [three, one, two])
+
+    then:
+    execution.stages*.refId == ["1", "2", "3"]
+  }
+
+  def "should order stages by synthetic owner"() {
+    given:
+    def execution = orchestration {
+      stage {
+        id = "01CGD1S7EBTG7A0T26RTXTF06J"
+        type = "findImage"
+        refId = "1"
+      }
+      stage {
+        id = "01CGD1S7EBSVYR6SAPQVP75MD9"
+        type = "deploy"
+        refId = "2"
+        requisiteStageRefIds = ["1"]
+      }
+      stage {
+        id = "01CGD1S80ZRGAPTRNYS91W7470"
+        type = "createServerGroup"
+        refId = "2<1"
+        syntheticStageOwner = STAGE_BEFORE
+        parentStageId = "01CGD1S7EBSVYR6SAPQVP75MD9"
+      }
+      stage {
+        id = "01CGD1VVW36VNSGTK06Y4JDVK5"
+        type = "applySourceServerGroupCapacity"
+        refId = "2<1>2"
+        syntheticStageOwner = STAGE_AFTER
+        requisiteStageRefIds = ["2<1>1"]
+        parentStageId = "01CGD1S80ZRGAPTRNYS91W7470"
+      }
+      stage {
+        id = "01CGD201G3KYDVDA2296JZWA2A"
+        type = "deleteEntityTags"
+        refId = "2<1>2>1"
+        syntheticStageOwner = STAGE_AFTER
+        parentStageId = "01CGD1VVW36VNSGTK06Y4JDVK5"
+      }
+      stage {
+        id = "01CGD1VVYD146H2YW29ZF3WQRJ"
+        type = "disableCluster"
+        refId = "2<1>1<1"
+        syntheticStageOwner = STAGE_BEFORE
+        parentStageId = "01CGD1VVW22YPFS1QATAR53SB2"
+      }
+      stage {
+        id = "01CGD1VVW22YPFS1QATAR53SB2"
+        type = "shrinkCluster"
+        refId = "2<1>1"
+        syntheticStageOwner = STAGE_AFTER
+        parentStageId = "01CGD1S80ZRGAPTRNYS91W7470"
+      }
+    }
+
+    def stages = new ArrayList(execution.stages)
+    execution.stages.clear()
+
+    when:
+    ExecutionRepositoryUtil.sortStagesByReference(execution, stages)
+
+    then:
+    execution.stages*.refId == ["1", "2<1", "2<1>2", "2<1>2>1", "2<1>1<1", "2<1>1", "2"]
+  }
+}

--- a/orca-test-groovy/src/main/groovy/com/netflix/spinnaker/orca/test/model/ExecutionBuilder.groovy
+++ b/orca-test-groovy/src/main/groovy/com/netflix/spinnaker/orca/test/model/ExecutionBuilder.groovy
@@ -86,7 +86,9 @@ class ExecutionBuilder {
     def parentStage = findParentStage(builder)
     if (parentStage) {
       stage.parentStageId = parentStage.id
-      stage.syntheticStageOwner = STAGE_BEFORE
+      if (stage.syntheticStageOwner == null) {
+        stage.syntheticStageOwner = STAGE_BEFORE
+      }
     }
 
     builder.delegate = stage


### PR DESCRIPTION
Necessary for fixing up the SQL version. Better this way than copying around some non-trivial sorting logic.