### PR TITLE
feat(kayenta): support analysis lifetimes shorter than 1 hour

### DIFF
--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/model/KayentaCanaryContext.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/model/KayentaCanaryContext.kt
@@ -27,13 +27,19 @@ data class KayentaCanaryContext(
   val canaryConfigId: String,
   val scopes: List<CanaryConfigScope> = emptyList(),
   val scoreThresholds: Thresholds = Thresholds(pass = 75, marginal = 50),
+  @Deprecated("Kept to support pipelines that haven't been updated to use lifetimeDuration")
   private val lifetimeHours: Int? = null,
+  private val lifetimeDuration: Duration? = null,
   private val beginCanaryAnalysisAfterMins: Int = 0,
   private val lookbackMins: Int = 0,
   private val canaryAnalysisIntervalMins: Int? = null
 ) {
   @JsonIgnore
-  val lifetime = if (lifetimeHours == null) null else Duration.ofHours(lifetimeHours.toLong())
+  val lifetime = when {
+    lifetimeDuration != null -> lifetimeDuration
+    lifetimeHours != null -> Duration.ofHours(lifetimeHours.toLong())
+    else -> null
+  }
 
   @JsonIgnore
   val beginCanaryAnalysisAfter = Duration.ofMinutes(beginCanaryAnalysisAfterMins.toLong())

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/KayentaCanaryStage.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/KayentaCanaryStage.kt
@@ -73,7 +73,7 @@ class KayentaCanaryStage(private val clock: Clock) : StageDefinitionBuilder {
     } else if (canaryConfig.lifetime != null) {
       canaryConfig.lifetime
     } else {
-      throw IllegalArgumentException("Canary stage configuration must include either `endTime` or `lifetimeHours`.")
+      throw IllegalArgumentException("Canary stage configuration must include either `endTime` or `lifetimeDuration`.")
     }
 
     var canaryAnalysisInterval = canaryConfig.canaryAnalysisInterval ?: lifetime

--- a/orca-kayenta/src/test/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/KayentaCanaryStageTest.kt
+++ b/orca-kayenta/src/test/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/KayentaCanaryStageTest.kt
@@ -239,7 +239,7 @@ object KayentaCanaryStageTest : Spek({
             "beginCanaryAnalysisAfterMins" to warmupMins,
             "canaryAnalysisIntervalMins" to intervalMins,
             "lookbackMins" to lookbackMins,
-            "lifetimeHours" to canaryDuration.toHours().toString()
+            "lifetimeDuration" to canaryDuration
           )
         }
 

--- a/orca-kayenta/src/test/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/AggregateCanaryResultsTaskTest.kt
+++ b/orca-kayenta/src/test/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/AggregateCanaryResultsTaskTest.kt
@@ -28,6 +28,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import java.time.Duration
 import java.util.*
 
 object AggregateCanaryResultsTaskSpec : Spek({
@@ -86,7 +87,7 @@ object AggregateCanaryResultsTaskSpec : Spek({
               "experimentScope" to "myapp-v021"
             )),
             "scoreThresholds" to scoreThresholds,
-            "lifetimeHours" to "1"
+            "lifetimeDuration" to Duration.parse("PT1H")
           )
         }
       }


### PR DESCRIPTION
lifetimeHours continues to be supported for backwards compatibility.

lifetimeDuration can be passed as a string matching this format: https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-

https://github.com/spinnaker/kayenta/issues/283
Supporting UI: https://github.com/spinnaker/deck-kayenta/pull/311