### PR TITLE
Refactor oracle bmcs

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/oracle/OracleServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/oracle/OracleServerGroupCreator.groovy
@@ -6,7 +6,7 @@
  * If a copy of the Apache License Version 2.0 was not distributed with this file,
  * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
  */
-package com.netflix.spinnaker.orca.clouddriver.tasks.providers.oraclebmcs
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.oracle
 
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCreator
 import com.netflix.spinnaker.orca.kato.tasks.DeploymentDetailsAware
@@ -14,10 +14,10 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.stereotype.Component
 
 @Component
-class OracleBMCSServerGroupCreator implements ServerGroupCreator, DeploymentDetailsAware {
+class OracleServerGroupCreator implements ServerGroupCreator, DeploymentDetailsAware {
 
   final boolean katoResultExpected = false
-  final String cloudProvider = "oraclebmcs"
+  final String cloudProvider = "oracle"
 
   @Override
   List<Map> getOperations(Stage stage) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/oracle/OracleServerGroupCreatorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/oracle/OracleServerGroupCreatorSpec.groovy
@@ -6,12 +6,12 @@
  * If a copy of the Apache License Version 2.0 was not distributed with this file,
  * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
  */
-package com.netflix.spinnaker.orca.clouddriver.tasks.providers.oraclebmcs
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.oracle
 
 import com.netflix.spinnaker.orca.test.model.ExecutionBuilder
 import spock.lang.Specification
 
-class OracleBMCSServerGroupCreatorSpec extends Specification {
+class OracleServerGroupCreatorSpec extends Specification {
 
   def "should get operations"() {
     given:
@@ -26,7 +26,7 @@ class OracleBMCSServerGroupCreatorSpec extends Specification {
     }
 
     when:
-    def ops = new OracleBMCSServerGroupCreator().getOperations(stage)
+    def ops = new OracleServerGroupCreator().getOperations(stage)
 
     then:
     ops == [
@@ -48,7 +48,7 @@ class OracleBMCSServerGroupCreatorSpec extends Specification {
     stage = ExecutionBuilder.stage {
       context.putAll(ctx)
     }
-    ops = new OracleBMCSServerGroupCreator().getOperations(stage)
+    ops = new OracleServerGroupCreator().getOperations(stage)
 
     then:
     ops == [
@@ -69,7 +69,7 @@ class OracleBMCSServerGroupCreatorSpec extends Specification {
     stage = ExecutionBuilder.stage {
       context.putAll(ctx)
     }
-    new OracleBMCSServerGroupCreator().getOperations(stage)
+    new OracleServerGroupCreator().getOperations(stage)
 
     then:
     IllegalStateException ise = thrown()


### PR DESCRIPTION
Note: This is a duplicate PR of https://github.com/spinnaker/orca/pull/2280  TravisCI has not been able to successfully build #2280 due to gradle errors but I'm unable to reproduce those errors locally.  I want to see if a new PR gets a different result.

Original PR message:

The name oraclebmcs is no longer used in Oracle product offering. To avoid confusion, spinnaker provider "oracebmcs" is replaced with the name "oracle".
halyard has made this refactoring in spinnaker/halyard#959.