### PR TITLE
feat(qos): Adding support for `quiet time` qos

### DIFF
--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferpolicy/ApplicationConfigurationAwareSupport.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferpolicy/ApplicationConfigurationAwareSupport.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos.bufferpolicy
+
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.CacheLoader
+import com.google.common.cache.LoadingCache
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.model.Application
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.Clock
+import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
+
+open class ApplicationConfigurationAwareSupport(
+  private val clock: Clock,
+  private val front50Service: Front50Service
+) {
+  private val log: Logger = LoggerFactory.getLogger(javaClass)
+  private val applicationCache = applicationsCache(10)
+  internal fun Application.quietTimeEnabled(): Boolean = this.quietTimeConfiguration().isEnabled()
+
+  internal fun getApplication(name: String): Application {
+    return applicationCache.get(name)
+  }
+
+  internal fun Application.hasExitedQuietTimeWindow(): Boolean = !this.hasEnteredQuietTimeWindow()
+
+  internal fun Application.hasEnteredQuietTimeWindow(): Boolean {
+    val quietTimeConfiguration = quietTimeConfiguration()
+    return quietTimeConfiguration.isEnabled() && quietTimeConfiguration.inWindow(LocalDateTime.now(clock))
+  }
+
+  private fun Application.quietTimeConfiguration(): QuietTimeConfig {
+    (details()["quietTime"] as? Map<String, Any>)?.let {
+      return QuietTimeConfig(it)
+    }
+
+    return QuietTimeConfig(emptyMap())
+  }
+
+  private fun applicationsCache(durationMins: Long): LoadingCache<String, Application> {
+    return CacheBuilder.newBuilder()
+      .expireAfterWrite(durationMins, TimeUnit.MINUTES)
+      .build(
+        object : CacheLoader<String, Application>() {
+          override fun load(name: String): Application {
+            return front50Service.get(name)
+          }
+        }
+      )
+  }
+}
+
+class QuietTimeConfig(
+  private val map: Map<String, Any>
+) {
+  fun isEnabled(): Boolean {
+    return map.containsKey("enabled") && map["enabled"] as Boolean
+  }
+
+  // ISO_LOCAL_DATE_TIME example 2018-06-20T10:15:30"
+  fun inWindow(dateTime: LocalDateTime): Boolean {
+    (map["dates"] as? List<Map<*, *>>)?.forEach { startEndDate ->
+      val startDateTime: LocalDateTime = (startEndDate["startDateTime"] as String).toLocalDateTime()
+      val endDateTime: LocalDateTime = (startEndDate["endDateTime"] as String).toLocalDateTime()
+      return (dateTime.isAfter(startDateTime) && dateTime.isBefore(endDateTime))
+    }
+
+    return false
+  }
+}
+
+private fun String.toLocalDateTime(): LocalDateTime = LocalDateTime.parse(this)

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferpolicy/QuietTimeBufferPolicy.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferpolicy/QuietTimeBufferPolicy.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos.bufferpolicy
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.qos.BufferAction.BUFFER
+import com.netflix.spinnaker.orca.qos.BufferAction.ENQUEUE
+import com.netflix.spinnaker.orca.qos.BufferPolicy
+import com.netflix.spinnaker.orca.qos.BufferResult
+import org.springframework.stereotype.Component
+import java.time.Clock
+
+/**
+ * There are two types of Quiet times, Global & Application level.
+ * Global Quiet Time is when `qos.bufferPolicy.quietTime=true` and the current application is opted in.
+ * Application level quiet time can also provide a list of dates ranges on which this policy is enforced.
+ * The resulting quiet time is global || application.
+ */
+@Component
+class QuietTimeBufferPolicy(
+  clock: Clock,
+  private val configService: DynamicConfigService,
+  front50Service: Front50Service
+) : BufferPolicy, ApplicationConfigurationAwareSupport(clock, front50Service) {
+  override fun apply(execution: Execution): BufferResult {
+    val globalLevelQuietTime = configService.isEnabled("qos.bufferPolicy.quietTime", false)
+    val application = getApplication(execution.application)
+    if (globalLevelQuietTime && application.quietTimeEnabled()) {
+      // we are in Quiet Time window.
+      return BufferResult(
+        action = BUFFER,
+        force = true,
+        reason = "Buffering Execution during Quiet Time window."
+      )
+    }
+
+    if (application.hasEnteredQuietTimeWindow()) {
+      return BufferResult(
+        action = BUFFER,
+        force = true,
+        reason = "${application.name}:${execution.name} is set to be buffered during Quiet Time."
+      )
+    }
+
+    return BufferResult(
+      action = ENQUEUE,
+      force = false,
+      reason = "Execution is not affected by Quiet Time."
+    )
+  }
+}
+

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/promotionpolicy/QuietTimePromotionPolicy.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/promotionpolicy/QuietTimePromotionPolicy.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.qos.promotionpolicy
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.qos.PromotionPolicy
+import com.netflix.spinnaker.orca.qos.PromotionResult
+import com.netflix.spinnaker.orca.qos.bufferpolicy.ApplicationConfigurationAwareSupport
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.util.*
+
+/**
+ * This policy enforces Quiet Time period promotions of executions.
+ * Promotes all candidates if Quiet Time is over
+ * Promotes application level Quiet Time
+ * The resulting quiet time is global || application.
+ */
+@Component
+class QuietTimePromotionPolicy(
+  clock: Clock,
+  front50Service: Front50Service,
+  private val configService: DynamicConfigService
+) : PromotionPolicy, ApplicationConfigurationAwareSupport(clock, front50Service) {
+  override fun apply(candidates: List<Execution>): PromotionResult {
+    if (configService.isEnabled("qos.bufferPolicy.quietTime", false)) {
+      candidates.filter {
+        getApplication(it.application).hasExitedQuietTimeWindow()
+      }.let {
+        return if (!it.isEmpty()) PromotionResult(
+          candidates = it,
+          finalized = false,
+          reason = "Quiet Time window is enabled. Only promoting executions not affected by Quiet Time."
+        ) else PromotionResult(
+          candidates = Collections.emptyList(),
+          finalized = false,
+          reason = "Quiet Time window is enabled."
+        )
+      }
+    }
+
+    return PromotionResult(
+      candidates = candidates,
+      finalized = false,
+      reason = "Quiet Time window is over."
+    )
+  }
+}

--- a/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/bufferpolicy/QuietTimeBufferPolicyTest.kt
+++ b/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/bufferpolicy/QuietTimeBufferPolicyTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.qos.bufferpolicy
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.orca.fixture.pipeline
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.model.Application
+import com.netflix.spinnaker.orca.qos.BufferAction
+import com.netflix.spinnaker.orca.qos.BufferResult
+import com.netflix.spinnaker.time.fixedClock
+import com.nhaarman.mockito_kotlin.*
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.jetbrains.spek.api.lifecycle.CachingMode
+import org.jetbrains.spek.subject.SubjectSpek
+import java.time.LocalDateTime
+
+class QuietTimeBufferPolicyTest : SubjectSpek<QuietTimeBufferPolicy>({
+  val clock = fixedClock()
+  val front50Service: Front50Service = mock()
+  val configService: DynamicConfigService = mock()
+
+  subject(CachingMode.GROUP) {
+    QuietTimeBufferPolicy(clock, configService, front50Service)
+  }
+
+  fun resetMocks() = reset(front50Service, configService)
+
+  describe("a global Quiet Time Buffer Policy") {
+    given("an execution submitted during Quiet Time") {
+      val app = Application().apply {
+        name = "testApp"
+      }
+
+      val execution = pipeline {
+        application = app.name
+      }
+
+      beforeGroup {
+        whenever(front50Service.get(execution.application)) doReturn app
+        whenever(configService.isEnabled("qos.bufferPolicy.quietTime", false)) doReturn true
+      }
+
+      afterGroup(::resetMocks)
+
+      on("Quiet Time enforced on execution because app is opted in") {
+        app.set("quietTime", mapOf("enabled" to true))
+        val result: BufferResult = subject.apply(execution)
+        it("buffers execution") {
+          verify(configService).isEnabled(any(), any())
+          assertThat(result.action).isEqualTo(BufferAction.BUFFER)
+        }
+      }
+
+      on("Quiet Time not enforced on execution because app is opted out") {
+        app.set("quietTime", mapOf("enabled" to false))
+        val result: BufferResult = subject.apply(execution)
+        it("buffers execution") {
+          assertThat(result.action).isEqualTo(BufferAction.ENQUEUE)
+        }
+      }
+    }
+  }
+
+  describe("an application level Quiet Time Buffer Policy") {
+    given("an execution submitted during app level Quiet Time") {
+      val app = Application().apply {
+        name = "testApp"
+        set("quietTime", mapOf(
+          "enabled" to true,
+          "dates" to listOf(
+            mapOf(
+              "startDateTime" to LocalDateTime.now().minusSeconds(10).toString(),
+              "endDateTime" to LocalDateTime.now().plusSeconds(10).toString()))
+          )
+        )
+      }
+
+      val execution = pipeline {
+        application = app.name
+      }
+
+      beforeGroup {
+        whenever(front50Service.get(execution.application)) doReturn app
+      }
+
+      afterGroup(::resetMocks)
+
+      on("Quiet Time enforced on execution because app is opted in") {
+        val result: BufferResult = subject.apply(execution)
+        it("buffers execution") {
+          verify(configService).isEnabled(any(), any())
+          assertThat(result.action).isEqualTo(BufferAction.BUFFER)
+        }
+      }
+    }
+  }
+})

--- a/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/promotionpolicy/QuietTimePromotionPolicyTest.kt
+++ b/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/promotionpolicy/QuietTimePromotionPolicyTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.qos.promotionpolicy
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.orca.fixture.pipeline
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.model.Application
+import com.netflix.spinnaker.time.fixedClock
+import com.nhaarman.mockito_kotlin.*
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.jetbrains.spek.api.lifecycle.CachingMode
+import org.jetbrains.spek.subject.SubjectSpek
+import java.time.LocalDateTime
+
+class QuietTimePromotionPolicyTest : SubjectSpek<QuietTimePromotionPolicy>({
+  val clock = fixedClock()
+  val front50Service: Front50Service = mock()
+  val configService: DynamicConfigService = mock()
+
+  subject(CachingMode.GROUP) {
+    QuietTimePromotionPolicy(clock, front50Service, configService)
+  }
+
+  fun resetMocks() = reset(front50Service, configService)
+
+  describe("a Quiet Time Promotion Policy", {
+    given("Executions submitted during Quiet Time") {
+      val executions = listOf(
+        pipeline {
+          application = "testApp"
+        },
+        pipeline {
+          application = "testApp"
+        }
+      )
+
+      beforeGroup {
+        whenever(configService.isEnabled("qos.bufferPolicy.quietTime", false)) doReturn true
+      }
+
+      afterGroup(::resetMocks)
+
+      on("Quiet Time in effect") {
+        it("zero execution gets promoted") {
+          subject.apply(executions).let { result ->
+            assertThat(result.candidates.size).isEqualTo(0)
+          }
+        }
+      }
+    }
+
+    given("Executions submitted outside of Quiet Time window") {
+      val app = Application().apply {
+        name = "testApp"
+        set("quietTime", mapOf(
+          "enabled" to true,
+          "dates" to listOf(
+            mapOf(
+              "startDateTime" to LocalDateTime.now().minusMinutes(10).toString(),
+              "endDateTime" to LocalDateTime.now().plusMinutes(5).toString())))
+        )
+      }
+
+      val app2 = Application().apply { name = "testApp2" }
+
+      val executions = listOf(
+        pipeline {
+          application = app.name
+        },
+        pipeline {
+          application = app2.name
+        }
+      )
+
+      beforeGroup {
+        whenever(configService.isEnabled("qos.bufferPolicy.quietTime", false)) doReturn false
+        whenever(front50Service.get(app.name)) doReturn app
+        whenever(front50Service.get(app2.name)) doReturn app2
+      }
+
+      afterGroup(::resetMocks)
+
+      on("Quiet Time window is over") {
+        it("promotes executions of applications not currently in Quiet Time window") {
+          subject.apply(executions).let { result ->
+            assertThat(result.candidates.size).isEqualTo(1)
+          }
+        }
+      }
+    }
+  })
+})
+


### PR DESCRIPTION
- configurable buffer policy
- allows per application configuration of quiet time periods
- manually triggered pipelines are exempt