### PR TITLE
feat(fiat): Delegate whether fiat is enabled to `FiatStatus`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
   group = "com.netflix.spinnaker.orca"
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.158.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.161.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.front50.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.orca.events.ExecutionEvent
 import com.netflix.spinnaker.orca.events.ExecutionListenerAdapter
 import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
@@ -84,9 +85,9 @@ class Front50Configuration {
   DependentPipelineExecutionListener dependentPipelineExecutionListener(
     Front50Service front50Service,
     DependentPipelineStarter dependentPipelineStarter,
-    @Value('${services.fiat.enabled:false}') boolean fiatEnabled
+    FiatStatus fiatStatus
   ) {
-    new DependentPipelineExecutionListener(front50Service, dependentPipelineStarter, fiatEnabled)
+    new DependentPipelineExecutionListener(front50Service, dependentPipelineStarter, fiatStatus)
   }
 
   @Bean

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.front50.spring
 
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
 import com.netflix.spinnaker.orca.front50.Front50Service
@@ -33,14 +34,14 @@ class DependentPipelineExecutionListener implements ExecutionListener {
 
   private final Front50Service front50Service
   private DependentPipelineStarter dependentPipelineStarter
-  private final boolean fiatEnabled;
+  private final FiatStatus fiatStatus
 
   DependentPipelineExecutionListener(Front50Service front50Service,
                                      DependentPipelineStarter dependentPipelineStarter,
-                                     boolean fiatEnabled) {
+                                     FiatStatus fiatStatus) {
     this.front50Service = front50Service
     this.dependentPipelineStarter = dependentPipelineStarter
-    this.fiatEnabled = fiatEnabled
+    this.fiatStatus = fiatStatus
   }
 
   @Override
@@ -61,7 +62,7 @@ class DependentPipelineExecutionListener implements ExecutionListener {
         ) {
           User authenticatedUser = null
 
-          if (fiatEnabled && trigger.runAsUser) {
+          if (fiatStatus.enabled && trigger.runAsUser) {
             authenticatedUser = new User()
             authenticatedUser.setEmail(trigger.runAsUser)
           }

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListenerSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListenerSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.front50.spring
 
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
 import com.netflix.spinnaker.orca.front50.Front50Service
@@ -42,9 +43,13 @@ class DependentPipelineExecutionListenerSpec extends Specification {
     }
   }
 
+  def fiatStatus = Mock(FiatStatus) {
+    _ * isEnabled() >> { return true }
+  }
+
   @Subject
   DependentPipelineExecutionListener listener = new DependentPipelineExecutionListener(
-    front50Service, dependentPipelineStarter, true
+    front50Service, dependentPipelineStarter, fiatStatus
   )
 
   def "should trigger downstream pipeline when status and pipelines match"() {

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.controllers
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.shared.FiatService
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
 import com.netflix.spinnaker.kork.web.exceptions.ValidationException
 import com.netflix.spinnaker.orca.extensionpoint.pipeline.PipelinePreprocessor
@@ -34,9 +35,7 @@ import com.netflix.spinnaker.orca.pipelinetemplate.PipelineTemplateService
 import com.netflix.spinnaker.orca.webhook.service.WebhookService
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.util.logging.Slf4j
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
@@ -81,8 +80,8 @@ class OperationsController {
   @Autowired(required = false)
   ArtifactResolver artifactResolver
 
-  @Value('${services.fiat.enabled:false}')
-  boolean fiatEnabled;
+  @Autowired
+  FiatStatus fiatStatus
 
   @Autowired(required = false)
   FiatService fiatService
@@ -248,7 +247,7 @@ class OperationsController {
     }
     def webhooks = webhookService.preconfiguredWebhooks
 
-    if (fiatEnabled) {
+    if (fiatStatus.isEnabled()) {
       String user = AuthenticatedRequest.getSpinnakerUser().orElse("anonymous")
       UserPermission.View userPermission = fiatService.getUserPermission(user)
 


### PR DESCRIPTION
This allows for fiat to be selectively enabled at runtime via the
`DynamicConfigService` (environment-specific).
