### PR TITLE
chore(dependencies): bump `spinnaker-dependencies` to 0.161.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
   group = "com.netflix.spinnaker.orca"
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.161.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.161.1'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]


### PR DESCRIPTION
This PR also adds an `OkHttpMetricsInterceptor` to the `Ok3Client`
used for inter-service communication.

See the service-specific `okhttp.requests` metric.
