### PR TITLE
feat(expressions): Adding support for failing stage on failed evaluations

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -54,6 +54,12 @@ class CompleteStageHandler(
     message.withStage { stage ->
       if (stage.status in setOf(RUNNING, NOT_STARTED)) {
         var status = stage.determineStatus()
+        if (stage.shouldFailOnFailedExpressionEvaluation()) {
+          log.warn("Stage ${stage.id} (${stage.type}) of ${stage.execution.id} " +
+            "is set to fail because of failed expressions.")
+          status = TERMINAL
+        }
+
         try {
           if (status in setOf(RUNNING, NOT_STARTED) || (status.isComplete && !status.isHalt)) {
             // check to see if this stage has any unplanned synthetic after stages

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
@@ -76,6 +76,13 @@ interface ExpressionAware {
     }
   }
 
+  fun Stage.hasFailedExpressions(): Boolean = PipelineExpressionEvaluator.SUMMARY in this.context
+
+  fun Stage.shouldFailOnFailedExpressionEvaluation(): Boolean {
+    return this.hasFailedExpressions() && this.context.containsKey("failOnFailedExpressions")
+      && this.context["failOnFailedExpressions"] as Boolean
+  }
+
   private fun mergedExceptionErrors(exception: Map<*, *>?, errors: List<String>): Map<*, *> =
     if (exception == null) {
       mapOf("details" to ExceptionHandler.responseDetails(PipelineExpressionEvaluator.ERROR, errors))


### PR DESCRIPTION
- fail stage on `failOnFailedExpressions==true` and failed expressions
- `failOnFailedExpressions` must be in the context and has to be `true`
- sample stage:
```
 {
      "name": "Wait",
      "refId": "1",
      "requisiteStageRefIds": [],
      "type": "wait",
      "waitTime": 120,
     "failOnFailedExpressions": true,
     "comments": "${failing spel missing closing parens"
}
```