### PR TITLE
fix(front50): Correctly extract the pipeline identifier

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorFront50Task.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorFront50Task.java
@@ -40,12 +40,18 @@ public class MonitorFront50Task implements RetryableTask {
   private final Front50Service front50Service;
 
   private final int successThreshold;
+  private final int gracePeriodMs;
 
   @Autowired
   public MonitorFront50Task(Optional<Front50Service> front50Service,
-                            @Value("${tasks.monitorFront50Task.successThreshold:0}") int successThreshold) {
+                            @Value("${tasks.monitorFront50Task.successThreshold:0}") int successThreshold,
+                            @Value("${tasks.monitorFront50Task.gracePeriodMs:5000}") int gracePeriodMs) {
     this.front50Service = front50Service.orElse(null);
     this.successThreshold = successThreshold;
+
+    // some storage providers round the last modified time to the nearest second, this allows for a configurable
+    // grace period when comparing against a stage start time (always at millisecond granularity).
+    this.gracePeriodMs = gracePeriodMs;
   }
 
   @Override
@@ -88,9 +94,14 @@ public class MonitorFront50Task implements RetryableTask {
           }
 
           Long lastModifiedTime = Long.valueOf(pipeline.get().get("updateTs").toString());
-          if (lastModifiedTime < stage.getStartTime()) {
+          if (lastModifiedTime < (stage.getStartTime() - gracePeriodMs)) {
             return TaskResult.RUNNING;
           }
+
+          try {
+            // small delay between verification attempts
+            Thread.sleep(1000);
+          } catch (InterruptedException ignored) {}
         }
 
         return TaskResult.SUCCEEDED;
@@ -103,6 +114,12 @@ public class MonitorFront50Task implements RetryableTask {
         );
         return TaskResult.RUNNING;
       }
+    } else {
+      log.warn(
+        "No pipeline id found, unable to verify that pipeline has been updated (executionId: {}, pipeline: {})",
+        stage.getExecution().getId(),
+        stageData.pipelineName
+      );
     }
 
     return new TaskResult(ExecutionStatus.SUCCEEDED);

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
@@ -92,9 +92,17 @@ public class SavePipelineTask implements RetryableTask {
     outputs.put("application", pipeline.get("application"));
     outputs.put("pipeline.name", pipeline.get("name"));
 
-    if (pipeline.containsKey("id")) {
-      // a newly created pipeline will not yet have an `id`
-      outputs.put("pipeline.id", pipeline.get("id"));
+    try {
+      Map<String, Object> savedPipeline = (Map<String, Object>) objectMapper.readValue(
+        response.getBody().in(), Map.class
+      );
+      outputs.put("pipeline.id", savedPipeline.get("id"));
+    } catch (Exception e) {
+      log.error("Unable to deserialize saved pipeline, reason: ", e.getMessage());
+
+      if (pipeline.containsKey("id")) {
+        outputs.put("pipeline.id", pipeline.get("id"));
+      }
     }
 
     return new TaskResult(


### PR DESCRIPTION
The `SavePipelineTask` will now correctly capture the identifier for a
newly created pipeline.

The `MonitorFront50Task` requires a pipeline identifier in order to
verify that a pipeline has been updated, previously was no-op'ing for
new pipelines.

relates to spinnaker/front50#333
