### PR TITLE
fix(titus): Include `application` in context of a job run

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobRunner.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobRunner.groovy
@@ -32,6 +32,11 @@ interface JobRunner {
   List<Map> getOperations(Stage stage)
 
   /**
+   * @return any additional values that should be included in task outputs
+   */
+  Map<String, Object> getAdditionalOutputs(Stage stage, List<Map> operations)
+
+  /**
    * @return true if the resulting value from the Kato call should be used.
    */
   boolean isKatoResultExpected()

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/RunJobTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/RunJobTask.groovy
@@ -65,12 +65,16 @@ class RunJobTask extends AbstractCloudProviderAwareTask implements RetryableTask
     def ops = creator.getOperations(stage)
     def taskId = kato.requestOperations(cloudProvider, ops).toBlocking().first()
 
-    Map outputs = [
+    Map<String, Object> outputs = [
         "notification.type"   : "runjob",
         "kato.result.expected": creator.katoResultExpected,
         "kato.last.task.id"   : taskId,
         "deploy.account.name" : credentials,
     ]
+
+    outputs.putAll(
+      creator.getAdditionalOutputs(stage, ops)
+    )
 
     return new TaskResult(ExecutionStatus.SUCCEEDED, outputs)
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -87,7 +87,7 @@ public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implemen
 
       def name = names[0]
       def parsedName = Names.parseName(name)
-      String appName = stage.context.moniker?.app ?: stage.context.applicaton ?: parsedName.app
+      String appName = stage.context.moniker?.app ?: stage.context.application ?: parsedName.app
 
       InputStream jobStream
       retrySupport.retry({

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/dcos/DcosJobRunner.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/dcos/DcosJobRunner.groovy
@@ -42,5 +42,10 @@ class DcosJobRunner implements JobRunner {
 
     return [[(OPERATION): operation]]
   }
+
+  @Override
+  Map<String, Object> getAdditionalOutputs(Stage stage, List<Map> operations) {
+    return [:]
+  }
 }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunner.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunner.groovy
@@ -43,5 +43,10 @@ class KubernetesJobRunner implements JobRunner {
 
     return [[(OPERATION): operation]]
   }
+
+  @Override
+  Map<String, Object> getAdditionalOutputs(Stage stage, List<Map> operations) {
+    return [:]
+  }
 }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/titus/TitusJobRunner.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/titus/TitusJobRunner.groovy
@@ -52,6 +52,17 @@ class TitusJobRunner implements JobRunner {
     return [[(OPERATION): operation]]
   }
 
+  @Override
+  Map<String, Object> getAdditionalOutputs(Stage stage, List<Map> operations) {
+    if (stage.context.cluster?.application) {
+      return [
+          application: stage.context.cluster.application
+      ]
+    }
+
+    return [:]
+  }
+
   private static void addAllNonEmpty(List<String> baseList, List<String> listToBeAdded) {
     if (listToBeAdded) {
       listToBeAdded.each { itemToBeAdded ->


### PR DESCRIPTION
This avoids doing a `Names.parse()` on the titus job name which happens
to be a UUID.

Also correct the spelling of `application`.
