### PR TITLE
feat(authz):  Generate spinnaker managed service accounts based on pipeline roles.

### DIFF
--- a/orca-front50/orca-front50.gradle
+++ b/orca-front50/orca-front50.gradle
@@ -18,6 +18,7 @@ apply from: "$rootDir/gradle/groovy.gradle"
 
 dependencies {
   compile project(":orca-retrofit")
+  compileOnly spinnaker.dependency("lombok")
   spinnaker.group("fiat")
 
   testCompile project(":orca-test-groovy")

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.orca.front50
 
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount
 import com.netflix.spinnaker.orca.front50.model.Application
 import com.netflix.spinnaker.orca.front50.model.ApplicationNotifications
 import com.netflix.spinnaker.orca.front50.model.Front50Credential
@@ -102,6 +103,9 @@ interface Front50Service {
 
   @GET("/notifications/application/{applicationName}")
   ApplicationNotifications getApplicationNotifications(@Path("applicationName") String applicationName)
+
+  @POST("/serviceAccounts")
+  Response saveServiceAccount(@Body ServiceAccount serviceAccount)
 
   static class Project {
     String id

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/SavePipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/SavePipelineStage.java
@@ -17,16 +17,24 @@ package com.netflix.spinnaker.orca.front50.pipeline;
 
 import com.netflix.spinnaker.orca.front50.tasks.MonitorFront50Task;
 import com.netflix.spinnaker.orca.front50.tasks.SavePipelineTask;
+import com.netflix.spinnaker.orca.front50.tasks.SaveServiceAccountTask;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode.Builder;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SavePipelineStage implements StageDefinitionBuilder {
+  @Value("${tasks.useManagedServiceAccounts:false}")
+  boolean useManagedServiceAccounts;
 
   @Override
   public void taskGraph(Stage stage, Builder builder) {
+    if (useManagedServiceAccounts) {
+      builder.withTask("updatePipelinePermissions", SaveServiceAccountTask.class);
+    }
+
     builder
       .withTask("savePipeline", SavePipelineTask.class)
       .withTask("waitForPipelineSave", MonitorFront50Task.class);

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/UpdatePipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/UpdatePipelineStage.java
@@ -16,16 +16,24 @@
 package com.netflix.spinnaker.orca.front50.pipeline;
 
 import com.netflix.spinnaker.orca.front50.tasks.SavePipelineTask;
+import com.netflix.spinnaker.orca.front50.tasks.SaveServiceAccountTask;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode.Builder;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UpdatePipelineStage implements StageDefinitionBuilder {
+  @Value("${tasks.useManagedServiceAccounts:false}")
+  boolean useManagedServiceAccounts;
 
   @Override
   public void taskGraph(Stage stage, Builder builder) {
+    if (useManagedServiceAccounts) {
+      builder.withTask("updatePipelinePermissions", SaveServiceAccountTask.class);
+    }
+
     builder
       .withTask("updatePipeline", SavePipelineTask.class);
   }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTask.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.front50.tasks;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
+import com.netflix.spinnaker.fiat.shared.FiatStatus;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Save a pipeline-scoped Fiat Service Account. The roles from
+ * this service account are used for authorization decisions when
+ * the pipeline is executed from an automated trigger.
+ */
+
+@Component
+@Slf4j
+public class SaveServiceAccountTask implements RetryableTask {
+
+  private static final String SERVICE_ACCOUNT_SUFFIX = "@managed-service-account";
+
+  @Autowired(required = false)
+  private FiatStatus fiatStatus;
+
+  @Autowired(required = false)
+  private Front50Service front50Service;
+
+  @Autowired(required = false)
+  private FiatPermissionEvaluator fiatPermissionEvaluator;
+
+  @Override
+  public long getBackoffPeriod() {
+    return TimeUnit.SECONDS.toMillis(1);
+  }
+
+  @Override
+  public long getTimeout() {
+    return TimeUnit.SECONDS.toMillis(30);
+  }
+
+  @Nonnull
+  @SuppressWarnings("unchecked")
+  @Override
+  public TaskResult execute(@Nonnull Stage stage) {
+    if (!fiatStatus.isEnabled()) {
+      throw new UnsupportedOperationException("Fiat is not enabled, cannot save roles.");
+    }
+
+    if (front50Service == null) {
+      throw new UnsupportedOperationException(
+        "Front50 is not enabled, no way to save pipeline. Fix this by setting front50.enabled: true");
+    }
+
+    if (!stage.getContext().containsKey("pipeline")) {
+      throw new IllegalArgumentException("pipeline context must be provided");
+    }
+
+    if (!(stage.getContext().get("pipeline") instanceof String)) {
+      throw new IllegalArgumentException(
+        "'pipeline' context key must be a base64-encoded string: Ensure you're on the most recent version of gate");
+    }
+
+    Map<String, Object> pipeline;
+    try {
+      pipeline = (Map<String, Object>) stage.decodeBase64("/pipeline", Map.class);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("pipeline must be encoded as base64", e);
+    }
+
+    if (!pipeline.containsKey("roles")) {
+      log.debug("Skipping managed service accounts since roles field is not present.");
+      return new TaskResult(ExecutionStatus.SUCCEEDED);
+    }
+
+    List<String> roles = (List<String>) pipeline.get("roles");
+    String user = stage.getExecution().getTrigger().getUser();
+
+    if (!isUserAuthorized(user, roles)) {
+      // TODO: Push this to the output result so Deck can show it.
+      log.warn("User {} is not authorized with all roles for pipeline", user);
+      return new TaskResult(ExecutionStatus.TERMINAL);
+    }
+
+    ServiceAccount svcAcct = new ServiceAccount();
+    svcAcct.setName(generateSvcAcctName(pipeline));
+    svcAcct.setMemberOf(roles);
+
+    // Creating a service account with an existing name will overwrite it
+    // i.e. perform an update for our use case
+    // TODO(dibyom): If roles are unmodified, skip the create/update below.
+    Response response = front50Service.saveServiceAccount(svcAcct);
+
+    if (response.getStatus() != HttpStatus.OK.value()) {
+      return new TaskResult(ExecutionStatus.TERMINAL);
+    }
+
+    return new TaskResult(
+      ExecutionStatus.SUCCEEDED, ImmutableMap.of("pipeline.serviceAccount", svcAcct.getName()));
+  }
+
+  private String generateSvcAcctName(Map<String, Object> pipeline) {
+    if (pipeline.containsKey("serviceAccount")) {
+      return (String) pipeline.get("serviceAccount");
+    }
+
+    String pipelineName = (String) pipeline.get("name");
+    // Pipeline name can have spaces. Replace them with "-"
+    return pipelineName.replaceAll("\\s", "-") + SERVICE_ACCOUNT_SUFFIX;
+  }
+
+  private boolean isUserAuthorized(String user, List<String> pipelineRoles) {
+    if (user == null) {
+      return false;
+    }
+
+    if (pipelineRoles == null || pipelineRoles.isEmpty()) { // No permissions == everyone can access
+      return true;
+    }
+
+    UserPermission.View permission = fiatPermissionEvaluator.getPermission(user);
+    if (permission == null) { // Should never happen?
+      return false;
+    }
+
+    // User has to have all the pipeline roles.
+    Set<String> userRoles = permission.getRoles()
+      .stream()
+      .map(Role.View::getName)
+      .collect(Collectors.toSet());
+
+    return userRoles.containsAll(pipelineRoles);
+  }
+}

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTaskSpec.groovy
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.front50.tasks
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.collect.ImmutableMap
+import com.netflix.spinnaker.fiat.model.UserPermission
+import com.netflix.spinnaker.fiat.model.resources.Role
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
+import com.netflix.spinnaker.fiat.shared.FiatStatus
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.pipeline.model.DefaultTrigger
+import retrofit.client.Response
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class SaveServiceAccountTaskSpec extends Specification {
+  Front50Service front50Service = Mock(Front50Service)
+  FiatPermissionEvaluator fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
+  FiatStatus fiatStatus = Mock() {
+    _ * isEnabled() >> true
+  }
+  ObjectMapper objectMapper = new ObjectMapper()
+
+  @Subject
+  SaveServiceAccountTask task = new SaveServiceAccountTask(fiatStatus: fiatStatus,
+    front50Service: front50Service, fiatPermissionEvaluator: fiatPermissionEvaluator)
+
+  def "should do nothing if no pipeline roles present"() {
+    given:
+    def pipeline = [
+      application: 'orca',
+      name: 'my pipeline',
+      stages: []
+    ]
+    def stage = stage {
+      context = [
+        pipeline: Base64.encoder.encodeToString(objectMapper.writeValueAsString(pipeline).bytes)
+      ]
+    }
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    0 * front50Service.saveServiceAccount(_)
+    result.status == ExecutionStatus.SUCCEEDED
+  }
+
+  def "should create a serviceAccount with correct roles"() {
+    given:
+    def pipeline = [
+      application: 'orca',
+      name: 'my pipeline',
+      stages: [],
+      roles: ['foo']
+    ]
+    def stage = stage {
+      context = [
+        pipeline: Base64.encoder.encodeToString(objectMapper.writeValueAsString(pipeline).bytes)
+      ]
+    }
+
+    def expectedServiceAccount = new ServiceAccount(name: 'my-pipeline@managed-service-account', memberOf: ['foo'])
+
+    when:
+    stage.getExecution().setTrigger(new DefaultTrigger('manual', null, 'abc@somedomain.io'))
+    def result = task.execute(stage)
+
+    then:
+    1 * fiatPermissionEvaluator.getPermission('abc@somedomain.io') >> {
+      new UserPermission().addResources([new Role('foo')]).view
+    }
+
+    1 * front50Service.saveServiceAccount(expectedServiceAccount) >> {
+      new Response('http://front50', 200, 'OK', [], null)
+    }
+
+    result.status == ExecutionStatus.SUCCEEDED
+    result.context == ImmutableMap.of('pipeline.serviceAccount', expectedServiceAccount.name)
+  }
+
+  def "should not allow adding roles that a user does not have"() {
+    given:
+    def pipeline = [
+      application: 'orca',
+      name: 'my pipeline',
+      stages: [],
+      roles: ['foo', 'bar']
+    ]
+    def stage = stage {
+      context = [
+        pipeline: Base64.encoder.encodeToString(objectMapper.writeValueAsString(pipeline).bytes)
+      ]
+    }
+
+    when:
+    stage.getExecution().setTrigger(new DefaultTrigger('manual', null, 'abc@somedomain.io'))
+    def result = task.execute(stage)
+
+    then:
+    1 * fiatPermissionEvaluator.getPermission('abc@somedomain.io') >> {
+      new UserPermission().addResources([new Role('foo')]).view
+    }
+
+    0 * front50Service.saveServiceAccount(_)
+
+    result.status == ExecutionStatus.TERMINAL
+    result.context == ImmutableMap.of()
+  }
+
+}


### PR DESCRIPTION
Part of https://github.com/spinnaker/spinnaker/issues/3037

This adds an Orca task to generate/update service accounts if the pipeline spec contains a `roles` field.
