### PR TITLE
fix(cache/ondemand): re-request missed server group cache refreshes 

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
-import org.codehaus.groovy.runtime.StackTraceUtils
-
 import java.time.Clock
 import java.util.concurrent.TimeUnit
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -57,7 +55,7 @@ class ServerGroupCacheForceRefreshTask extends AbstractCloudProviderAwareTask im
 
   @Override
   TaskResult execute(Stage stage) {
-    StackTraceUtils.sanitize(new Exception()).printStackTrace()
+    
     if ((clock.millis() - stage.startTime) > autoSucceedAfterMs) {
       /*
        * If an issue arises performing a refresh, wait at least 10 minutes (the default ttl of a cache record) before


### PR DESCRIPTION
Partially addresses https://github.com/spinnaker/spinnaker/issues/3030 and treats symptoms when clouddriver doesn't return servergroups from ondemand cache refresh which orca expects. Previously, the logic was a bit broken and orca wouldn't issue a new request in a timely manner if clouddriver lost it.