### PR TITLE
fix(entitytags): improved timeout handling for servergroup entity tagging.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
@@ -118,7 +118,7 @@ public class SpinnakerMetadataServerGroupTagGenerator implements ServerGroupEnti
         return getPreviousServerGroupFromClusterByTarget(
           application, account, cluster, cloudProvider, location, "NEWEST"
         );
-      }, 12, 5000, false); // retry for up to one minute
+      }, 10, 3000, false); // retry for up to 30 seconds
 
       if (newestServerGroup == null) {
         // cluster has no enabled server groups
@@ -136,7 +136,7 @@ public class SpinnakerMetadataServerGroupTagGenerator implements ServerGroupEnti
       return getPreviousServerGroupFromClusterByTarget(
         application, account, cluster, cloudProvider, location, "ANCESTOR"
       );
-    }, 12, 5000, false); // retry for up to one minute
+    }, 10, 3000, false); // retry for up to 30 seconds
   }
 
   Map<String, Object> getPreviousServerGroupFromClusterByTarget(String application,


### PR DESCRIPTION
SpinnakerMetadataServerGroupTagGenerator makes clouddriver calls with retry, which can eventually result in an exception/timeout.
AddServerGRoupEntityTagsTask now has an increased timeout to account for remote timeout from multiple server groups.
In addition, an exception from a single tagger is not fatal to the tagging operation - any successfully generated tags will get applied, and an error logged for a failed tagger
