### PR TITLE
fix(kayenta): be ok with iso-8601 non-instant format

### DIFF
--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/model/KayentaCanaryContext.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/model/KayentaCanaryContext.kt
@@ -65,8 +65,8 @@ data class CanaryConfigScope(
   // I don't love having these as separate properties but other things in Orca rely
   // on serializing Instant as epoch Millis which is not what Kayenta wants.
   @JsonIgnore
-  val startTime = if (startTimeIso == null) null else Instant.parse(startTimeIso)
+  val startTime = if (startTimeIso == null) null else Instant.parse(startTimeIso.replace("+00:00", "Z"))
 
   @JsonIgnore
-  val endTime = if (endTimeIso == null) null else Instant.parse(endTimeIso)
+  val endTime = if (endTimeIso == null) null else Instant.parse(endTimeIso.replace("+00:00", "Z"))
 }


### PR DESCRIPTION
We definitely specify iso-instant format, but some people (like me) definitely don't understand the difference between iso-8601 and iso-8601 instant. As a first step at making data parsing better, can we just do this simple string replace?

In the future, it would definitely be better to have a date picker/guidance/validation in the UI. 