### PR TITLE
feat(artifacts): Artifact matching should use entire string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
   group = "com.netflix.spinnaker.orca"
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.162.1'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '1.0.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]


### PR DESCRIPTION
BREAKING CHANGE: This change affects the way in which artifacts injected
into a pipeline are matched to expected artifacts. Prior to this change,
a match was successful if the regular expression in the expected artifact
matched any substring of the corresponding field in the incoming artifact;
after this change, the regular expression in the expected artifact must
match the entire corresponding field incoming artifact.

As an example, consider an incoming artifact with name 'artifact123'. Before
this change, it would match expected artifacts with names 'artifact' and
'artifact.*'.  After this change, the incoming artifact will no longer
match an expected artifact with name 'artifact' but will continue to match
'artifact*'; users will need to explicitly add a wildcard (or some more
complex regular expression) if substring matching is desired.