### PR TITLE
fix(pipeline_template): Strings with boolean shall remain strings

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JsonRenderedValueConverter.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JsonRenderedValueConverter.java
@@ -43,8 +43,6 @@ public class JsonRenderedValueConverter implements RenderedValueConverter {
       } catch (NumberFormatException ignored) {
         return NumberUtils.createLong(rendered);
       }
-    } else if (rendered.equals("true") || rendered.equals("false")) {
-      return Boolean.parseBoolean(rendered);
     } else if (rendered.startsWith("{{") || (!rendered.startsWith("{") && !rendered.startsWith("["))) {
       return rendered;
     }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/YamlRenderedValueConverter.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/YamlRenderedValueConverter.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 public class YamlRenderedValueConverter implements RenderedValueConverter {
 
-  private static final List<String> YAML_KEYWORDS = Arrays.asList("yes", "no", "on", "off");
+  private static final List<String> YAML_KEYWORDS = Arrays.asList("yes", "no", "on", "off", "true", "false");
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
@@ -57,7 +57,7 @@ class JinjaRendererSpec extends Specification {
     template          || expectedType | expectedResult
     '1'               || Integer      | 1
     '1.1'             || Double       | 1.1
-    'true'            || Boolean      | true
+    'true'            || String       | 'true'
     '{{ stringVar }}' || String       | 'myStringValue'
     'yes'             || String       | 'yes'
     'on'              || String       | 'on'


### PR DESCRIPTION
Hello,

A template containing a deploy manifest stage with an annotation containing true gets converted to a boolean when generated for a pipeline which fails the deployment since annotations may only be strings.

Exemple:
For a template containing
```yaml
- apiVersion: extensions/v1beta1
  kind: Deployment
  metadata:
    annotations:
        prometheus.io/scrape: "true"
```

We get in the pipeline template on spinnaker
```json
"annotations": {
    "prometheus.io/scrape": "true"
}
```
And the in the generated pipeline we got
```
"annotations": {
    "prometheus.io/scrape": true
}
```
Which during the deployment got us this error
```
Annotations: ReadString: expects \" or n, but found t, error found in #10 byte of ...|/scrape\":true}
```
