### PR TITLE
feat(pipeline_templates): Add stage looping support

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/GraphMutator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/GraphMutator.java
@@ -17,15 +17,7 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.PipelineTemplateVisitor;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConditionalStanzaTransform;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConfigModuleReplacementTransform;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConfigPartialReplacementTransform;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.ConfigStageInjectionTransform;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.DefaultVariableAssignmentTransform;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.PipelineConfigInheritanceTransform;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.RenderTransform;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.StageInheritanceControlTransform;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.TrimConditionalsTransform;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.transform.*;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/model/StageDefinition.java
@@ -17,16 +17,9 @@ package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.LinkedHashSet;
+import java.util.*;
 
 public class StageDefinition implements Identifiable, Conditional, Cloneable {
   private static final Splitter ON_DOTS = Splitter.on(".");
@@ -41,6 +34,13 @@ public class StageDefinition implements Identifiable, Conditional, Cloneable {
   private List<String> when = new ArrayList<>();
   private InheritanceControl inheritanceControl;
   private Set<String> requisiteStageRefIds = new LinkedHashSet<>();
+  private String loopWith;
+
+  @JsonIgnore
+  private List<StageDefinition> loopedStages = new ArrayList<>();
+
+  @JsonIgnore
+  private Map<String, Object> loopContext = new HashMap<>();
 
   @JsonIgnore
   private Boolean removed = false;
@@ -278,7 +278,6 @@ public class StageDefinition implements Identifiable, Conditional, Cloneable {
     return removed;
   }
 
-
   public void setWhen(List<String> when) {
     this.when = when;
   }
@@ -299,9 +298,30 @@ public class StageDefinition implements Identifiable, Conditional, Cloneable {
     this.requisiteStageRefIds = requisiteStageRefIds;
   }
 
+  public String getLoopWith() {
+    return loopWith;
+  }
+
+  public void setLoopWith(String loopWith) {
+    this.loopWith = loopWith;
+  }
+
+  public Map<String, Object> getLoopContext() {
+    return loopContext;
+  }
+
+  public List<StageDefinition> getLoopedStages() {
+    return loopedStages;
+  }
+
   @JsonIgnore
   public boolean isPartialType() {
     return type != null && type.startsWith("partial.");
+  }
+
+  @JsonIgnore
+  public boolean isLooping() {
+    return !Strings.isNullOrEmpty(loopWith);
   }
 
   @JsonIgnore
@@ -333,6 +353,7 @@ public class StageDefinition implements Identifiable, Conditional, Cloneable {
     }
     Collections.copy(stage.getNotifications(), getNotifications());
     Collections.copy(stage.getWhen(), getWhen());
+    stage.loopContext = new LinkedHashMap<>(getLoopContext());
     return stage;
   }
 

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/JinjaRendererSpec.groovy
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
-import org.yaml.snakeyaml.Yaml
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -86,6 +85,7 @@ class JinjaRendererSpec extends Specification {
 '''                   || String       | '"${ false }".equalsIgnoreCase("True")'
     '#stage("First Wait")["status"].toString() == "SUCCESS"' || String | '#stage("First Wait")["status"].toString() == "SUCCESS"'
     '${ #stage("First Wait")["status"].toString() == "SUCCESS" }' || String | '${ #stage("First Wait")["status"].toString() == "SUCCESS" }'
+    '${ #stage(\'Build Lambda\')[\'context\'][\'VERSION_PREFIX\'] }' || String | '${ #stage(\'Build Lambda\')[\'context\'][\'VERSION_PREFIX\'] }'
     '${ parameters.CONFIG_FOLDER ?: \'\' }' || String | '${ parameters.CONFIG_FOLDER ?: \'\' }'
     ''                || String       | null
     '* markdown list' || String       | '* markdown list'

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-config.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-config.yml
@@ -1,0 +1,9 @@
+---
+schema: "1"
+pipeline:
+  application: orca
+  variables:
+    waitTimes:
+    - 5
+    - 10
+stages: []

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-expected.json
@@ -1,0 +1,56 @@
+{
+  "id": "unknown",
+  "keepWaitingPipelines": false,
+  "limitConcurrent": true,
+  "application": "orca",
+  "name": "Unnamed Execution",
+  "stages": [
+    {
+      "requisiteStageRefIds": [],
+      "name": "Wait with loop variable",
+      "group": "waitGraph: loopedPartial",
+      "id": null,
+      "refId": "loopedPartial0.dynamicWait",
+      "type": "wait",
+      "waitTime": 5
+    },
+    {
+      "requisiteStageRefIds": [],
+      "name": "Wait with loop variable",
+      "group": "waitGraph: loopedPartial",
+      "id": null,
+      "refId": "loopedPartial1.dynamicWait",
+      "type": "wait",
+      "waitTime": 10
+    },
+    {
+      "requisiteStageRefIds": [
+        "loopedPartial0.dynamicWait",
+        "loopedPartial1.dynamicWait"
+      ],
+      "name": "joinWait",
+      "id": null,
+      "refId": "joinWait",
+      "type": "wait",
+      "waitTime": 3
+    },
+    {
+      "requisiteStageRefIds": ["joinWait"],
+      "name": "Wait 5 seconds",
+      "id": null,
+      "refId": "stageLoop0",
+      "type": "wait",
+      "waitTime": 5
+    },
+    {
+      "requisiteStageRefIds": ["joinWait"],
+      "name": "Wait 10 seconds",
+      "id": null,
+      "refId": "stageLoop1",
+      "type": "wait",
+      "waitTime": 10
+    }
+  ],
+  "notifications": [],
+  "parameterConfig": []
+}

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-template.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-template.yml
@@ -1,0 +1,42 @@
+---
+schema: "1"
+id: loops
+metadata:
+  name: Loops
+  description: Stage and partial looping with variables
+variables:
+- name: waitTimes
+  description: A list of wait times
+  type: list
+stages:
+- id: loopedPartial
+  type: partial.waitGraph
+  config:
+    waitTime: "{{ templateLoop.value }}"
+  loopWith: "{{ waitTimes }}"
+- id: joinWait
+  type: wait
+  config:
+    waitTime: 3
+  dependsOn:
+  - loopedPartial
+- id: stageLoop
+  type: wait
+  name: "Wait {{ templateLoop.value }} seconds"
+  config:
+    waitTime: "{{ templateLoop.value }}"
+  loopWith: "{{ waitTimes }}"
+  dependsOn:
+  - joinWait
+partials:
+- id: waitGraph
+  usage: Builds a graph of wait stages.
+  variables:
+  - name: waitTime
+    description: The amount of time to wait
+  stages:
+  - id: dynamicWait
+    type: wait
+    name: Wait with loop variable
+    config:
+      waitTime: "{{ waitTime }}"


### PR DESCRIPTION
Adding basic looping ability for stages & partials (non-recursive).

Required by a couple infrastructure teams internally. It's unlikely we'll be able to move them off to `spin` until sometime next year.