### PR TITLE
fix(serviceAccounts): Ensure service account names are always lowercase

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTask.java
@@ -138,7 +138,9 @@ public class SaveServiceAccountTask implements RetryableTask {
 
     String pipelineName = (String) pipeline.get("name");
     // Pipeline name can have spaces. Replace them with "-"
-    return pipelineName.replaceAll("\\s", "-") + SERVICE_ACCOUNT_SUFFIX;
+    pipelineName= pipelineName.replaceAll("\\s", "-") + SERVICE_ACCOUNT_SUFFIX;
+    // Fiat service account names are always lower case.
+    return pipelineName.toLowerCase();
   }
 
   private boolean isUserAuthorized(String user, List<String> pipelineRoles) {

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTaskSpec.groovy
@@ -69,7 +69,7 @@ class SaveServiceAccountTaskSpec extends Specification {
     given:
     def pipeline = [
       application: 'orca',
-      name: 'my pipeline',
+      name: 'My pipeline',
       stages: [],
       roles: ['foo']
     ]


### PR DESCRIPTION
Fiat service account names are always lower cased in Fiat/Front50. 