### PR TITLE
fix(retrofit): Do not retry requests that cannot succeed

### DIFF
--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.front50.model.Application
-import com.netflix.spinnaker.orca.front50.model.Front50Credential
 import com.netflix.spinnaker.orca.igor.BuildService
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.PipelineTrigger
@@ -35,6 +34,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
+
 import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 
 class GetCommitsTaskSpec extends Specification {
@@ -63,30 +63,6 @@ class GetCommitsTaskSpec extends Specification {
     then:
     0 * _
     result.status == SUCCEEDED
-  }
-
-  def "global credential is preferred to the stage account for application lookup"() {
-    given:
-    def stage = new Stage(pipeline, "stash", [application: app, account: account])//, "kato.tasks" : katoMap])
-    task.buildService = buildService
-    task.front50Service = front50Service
-
-    when:
-    task.execute(stage)
-
-    then:
-
-    1 * front50Service.getCredentials() >> credentials
-    1 * front50Service.get(app) >> new Application(repoSlug: null, repoProjectKey: null)
-    0 * _
-
-    where:
-    credentials                                           | account | expectedAccount
-    []                                                    | 'test'  | 'test'
-    [new Front50Credential(global: true, name: 'global')] | 'test'  | 'global'
-    [new Front50Credential(global: false, name: 'prod')]  | 'test'  | 'test'
-
-    app = "myapp"
   }
 
   @Unroll
@@ -312,7 +288,6 @@ class GetCommitsTaskSpec extends Specification {
     and:
     task.buildService = buildService
     task.front50Service = front50Service
-    1 * front50Service.getCredentials() >> []
     1 * front50Service.get(app) >> new Application()
 
     when:

--- a/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandlerSpec.groovy
+++ b/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandlerSpec.groovy
@@ -160,6 +160,7 @@ class RetrofitExceptionHandlerSpec extends Specification {
     }
   }
 
+  @Unroll
   def "should not retry a network error on a #httpMethod request"() {
     given:
     def client = Stub(Client) {


### PR DESCRIPTION
While fumbling around in our logs, I noticed a bunch of logs like this:

`retrofit.RetrofitError: Path parameter "imageId" value must not be null.`

Added a condition in the Retrofit ExceptionHandler to never retry these sort of requests since they'll never succeed anyway.

While digging, I also noticed the `GetCommitsTask` makes a call to front50 that is never used, so I tore that out.