### PR TITLE
chore(trafficguard): Add metrics to traffic guards

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardException.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.clouddriver.utils;
+
+public class TrafficGuardException extends IllegalStateException {
+  public TrafficGuardException(String s) {
+    super(s);
+  }
+}


### PR DESCRIPTION
Also added some markers for things to do to Traffic Guards to improve reliability of the feature itself.

My current plan to improve Traffic Guards is to add a new purpose-specific endpoint clouddriver for the data that guards need:

1. `GET /trafficGuards/{application}/clusters/{account}/{name}` - Get a cluster.
2. `GET /trafficGuards/{application}/instanceServerGroups?instanceIds=[]` - Get a `Map<InstanceId, ServerGroup>` response.

These two endpoints will allow us to cut down the number of network calls `orca -> clouddriver` in a traffic guarded codepath by quite a lot and also allow us to get the freshest data. Within clouddriver we'll end up going direct to the cloud provider for data if we don't detect a traffic guard condition. Using this PR to collect opinions (although will probably merge once we're good on the metric).

Before going down this path at all, I've added a new metric so we know how many cases we're actually catching with traffic guards by application/account, and also updated the log message to not imply an actual failure.