### PR TITLE
feat(spel): add support for Instant.java in spel

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java
@@ -17,8 +17,10 @@
 package com.netflix.spinnaker.orca.pipeline.expressions.whitelisting;
 
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
 
 public interface InstantiationTypeRestrictor {
   Set<Class<?>> allowedTypes = Collections.unmodifiableSet(
@@ -35,7 +37,9 @@ public interface InstantiationTypeRestrictor {
         Random.class,
         UUID.class,
         Boolean.class,
-        LocalDate.class
+        LocalDate.class,
+        Instant.class,
+        ChronoUnit.class
       )
     )
   );


### PR DESCRIPTION
From jasonfillo on slack

> jasonfillo [3:25 PM]
> LocalDate is just for Date operations. Instant will do Date and Time and is tied directly to UTC which all your backend, database, business logic, whatever should probably be using