### PR TITLE
fix(spel): Fix escaping of SpEL expressions

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
@@ -108,6 +108,7 @@ public class ExpressionTransform {
                                  EvaluationContext evaluationContext,
                                  ExpressionEvaluationSummary summary,
                                  Map<String, Object> additionalContext) {
+    boolean isPartiallyEvaluated = false;
     if (isExpression(source)) {
       String literalExpression = includeExecutionParameter(source.toString());
       Object result = null;
@@ -123,6 +124,7 @@ public class ExpressionTransform {
             String value = e.getValue(evaluationContext, String.class);
             if (value == null) {
               value = String.format("${%s}", e.getExpressionString());
+              isPartiallyEvaluated = true;
             }
             sb.append(value);
           }
@@ -155,7 +157,7 @@ public class ExpressionTransform {
           );
 
           result = source;
-        } else if (result == null || isExpression(result)) {
+        } else if (result == null || isPartiallyEvaluated) {
           summary.add(
             escapedExpressionString,
             ExpressionEvaluationSummary.Result.Level.INFO,
@@ -163,7 +165,7 @@ public class ExpressionTransform {
             null
           );
 
-          if (!isExpression(result)) {
+          if (result == null) {
             result = source;
           }
         }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
@@ -108,7 +108,7 @@ public class ExpressionTransform {
                                  EvaluationContext evaluationContext,
                                  ExpressionEvaluationSummary summary,
                                  Map<String, Object> additionalContext) {
-    boolean isPartiallyEvaluated = false;
+    boolean hasUnresolvedExpressions = false;
     if (isExpression(source)) {
       String literalExpression = includeExecutionParameter(source.toString());
       Object result = null;
@@ -124,7 +124,7 @@ public class ExpressionTransform {
             String value = e.getValue(evaluationContext, String.class);
             if (value == null) {
               value = String.format("${%s}", e.getExpressionString());
-              isPartiallyEvaluated = true;
+              hasUnresolvedExpressions = true;
             }
             sb.append(value);
           }
@@ -157,7 +157,7 @@ public class ExpressionTransform {
           );
 
           result = source;
-        } else if (result == null || isPartiallyEvaluated) {
+        } else if (result == null || hasUnresolvedExpressions) {
           summary.add(
             escapedExpressionString,
             ExpressionEvaluationSummary.Result.Level.INFO,

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
@@ -91,10 +91,11 @@ class ContextParameterProcessorSpec extends Specification {
 
 
     where:
-    value                             | evaluatedValue          | errorCount
-    'a.${ENV1}.b.${ENV2}'             | 'a.${ENV1}.b.${ENV2}'   | 1
-    'a.${ENV1}.b.${replaceMe}'        | 'a.${ENV1}.b.newValue'  | 1
-    'a.${replaceMe}.b.${replaceMe}'   | 'a.newValue.b.newValue' | 0
+    value                                        | evaluatedValue                    | errorCount
+    'a.${ENV1}.b.${ENV2}'                        | 'a.${ENV1}.b.${ENV2}'             | 1
+    'a.${ENV1}.b.${replaceMe}'                   | 'a.${ENV1}.b.newValue'            | 1
+    'a.${replaceMe}.b.${replaceMe}'              | 'a.newValue.b.newValue'           | 0
+    'a.${\'${ESCAPED_LITERAL}\'}.b.${replaceMe}' | 'a.${ESCAPED_LITERAL}.b.newValue' | 0
   }
 
   @Unroll


### PR DESCRIPTION
Currently the SpEL evaluator returns an error if the result contains any SpEL; this means that it's impossible to escape expressions of the form "${VARIABLE:default}" (which are common in Helm templates) so that they are left verbatim by the SpEL evaluator. Change the way that the evaluator detects partial evaluation so that the result is allowed to contain strings that look like SpEL.