### PR TITLE
fix(redis): fix multi-redis configuration

### DIFF
--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueShovelConfiguration.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueShovelConfiguration.kt
@@ -82,15 +82,15 @@ class RedisQueueShovelConfiguration {
 
   @Bean
   @ConditionalOnBean(name = arrayOf("previousQueueJedisPool")) fun redisQueueShovel(
-    queueImpl: RedisQueue,
+    queue: RedisQueue,
     @Qualifier("previousQueue") previousQueueImpl: RedisQueue,
     registry: Registry,
-    activator: Activator
+    discoveryActivator: Activator
   ) =
     QueueShovel(
-      queue = queueImpl,
+      queue = queue,
       previousQueue = previousQueueImpl,
       registry = registry,
-      activator = activator
+      activator = discoveryActivator
     )
 }

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/config/RedisConfiguration.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/config/RedisConfiguration.java
@@ -113,7 +113,7 @@ public class RedisConfiguration {
   @Deprecated // rz - Kept for backwards compat with old connection configs
   @Bean(name = "jedisPoolPrevious")
   @ConditionalOnProperty("redis.connectionPrevious")
-  @ConditionalOnExpression("${redis.connection} != ${redis.connectionPrevious}")
+  @ConditionalOnExpression("'${redis.connection}' != '${redis.connectionPrevious}'")
   JedisPool jedisPoolPrevious(
     @Value("${redis.connectionPrevious:#{null}}") String previousConnection,
     @Value("${redis.timeout:2000}") int timeout,


### PR DESCRIPTION
Fix 2 issues when Orca is configured with redis.connectionPrevious
  - Fix expression syntax
  - Change argument names to resolve the correct beans