### PR TITLE
fix(clouddriver): Handle missing server groups when checking instances

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/OortHelper.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/OortHelper.groovy
@@ -58,7 +58,9 @@ class OortHelper {
                                                    String serverGroupName,
                                                    String location,
                                                    String cloudProvider) {
-    return new TargetServerGroup(convert(oortService.getServerGroup(account, location, serverGroupName) , Map))
+    return convertedResponse(Map) {
+      oortService.getServerGroup(account, location, serverGroupName)
+    }.map({ Map serverGroup -> new TargetServerGroup(serverGroup) })
   }
 
   public <T> Optional<T> convertedResponse(Class<T> type, Closure<Response> request) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/OortHelperSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/OortHelperSpec.groovy
@@ -19,10 +19,14 @@ package com.netflix.spinnaker.orca.clouddriver.utils
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
+import retrofit.RetrofitError
 import retrofit.client.Response
 import retrofit.mime.TypedString
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND
 
 class OortHelperSpec extends Specification {
   @Subject oortHelper = Spy(OortHelper)
@@ -137,5 +141,41 @@ class OortHelperSpec extends Specification {
 
     then:
     result.size() == 4
+  }
+
+  @Unroll
+  def "should support fetching a target server group that does not exist"() {
+    when:
+    def optionalTargetServerGroup = Optional.empty()
+    def thrownException
+
+    try {
+      optionalTargetServerGroup = oortHelper.getTargetServerGroup("test", serverGroupName, "us-west-2", "aws")
+    } catch (Exception e) {
+      thrownException = e
+    }
+
+    then:
+    1 * oortService.getServerGroup("test", "us-west-2", serverGroupName) >> {
+      if (statusCode == 200) {
+        return new Response("http://clouddriver", statusCode, "OK", [], new TypedString("""{"name": "${serverGroupName}"}"""))
+      }
+
+      throw RetrofitError.httpError(
+        null,
+        new Response("http://clouddriver", statusCode, "", [], null),
+        null,
+        null
+      )
+    }
+
+    optionalTargetServerGroup.isPresent() == shouldExist
+    (thrownException != null) == shouldThrowException
+
+    where:
+    serverGroupName | statusCode || shouldExist || shouldThrowException
+    "app-v001"      | 200        || true        || false
+    "app-v002"      | 404        || false       || false
+    "app-v003"      | 500        || false       || true       // a non-404 should just rethrow the exception
   }
 }


### PR DESCRIPTION
This PR addresses a couple of situations where we were not handling a
non-existent server group.

We encountered some odd edge cases where `WaitForAllInstancesNotUpTask`
would end up getting stuck waiting on a server group that had previously
been destroyed. Easily reproduced by submitting slightly offset destroy
server group operations.

Should a server group with the same name happen to be created again, the
task would detect that and succeed (since a new server group has no UP
instances when first created!).

These tasks will now short-circuit if they're unable to find a server
group _AND_ they were expecting one to exist.
