### PR TITLE
feat(locking): Adds basic locking support.

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskExecutionInterceptor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskExecutionInterceptor.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.orca;
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+
+/**
+ * TaskExecutionInterceptor is a hook point to customize the specific execution of a task.
+ *
+ * Before execute is called on a Task, all TaskExecutionInterceptors will be called. The resulting
+ * Stage object from beforeTaskExecution is passed to subsequent invocations of TaskExecutionInterceptor
+ * and then used for the invocation of execute on Task.
+ *
+ * After a Task completes with a TaskResult, all TaskExecutionInterceptors are called. The resulting
+ * TaskResult is passed to subsequent invocations ot TaskExecutionInterceptor and the final TaskResult
+ * is used as the output of the task.
+ *
+ * A TaskExecutionInterceptor can specify the maximum backoff that should be allowed. As an example, the
+ * LockExtendingTaskExecutionInterceptor needs to ensure that a task doesn't delay longer than the
+ * lock extension. The minimum maxTaskBackoff among all registered TaskExecutionInterceptors will be used
+ * to constrain the task backoff supplied by a RetryableTask.
+ */
+public interface TaskExecutionInterceptor {
+
+  default long maxTaskBackoff() { return Long.MAX_VALUE; }
+
+  default Stage beforeTaskExecution(Task task, Stage stage) {
+    return stage;
+  }
+
+  default TaskResult afterTaskExecution(Task task, Stage stage, TaskResult taskResult) {
+    return taskResult;
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -62,6 +62,7 @@ import static org.springframework.context.annotation.AnnotationConfigUtils.EVENT
 
 @Configuration
 @ComponentScan({
+  "com.netflix.spinnaker.orca.locks",
   "com.netflix.spinnaker.orca.pipeline",
   "com.netflix.spinnaker.orca.deprecation",
   "com.netflix.spinnaker.orca.pipeline.util",

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/exceptions/ExceptionHandler.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/exceptions/ExceptionHandler.java
@@ -36,7 +36,7 @@ public interface ExceptionHandler {
     public Response(String exceptionType, String operation, Map<String, Object> responseDetails, boolean shouldRetry) {
       this.exceptionType = exceptionType;
       this.operation = operation;
-      this.details = responseDetails == null ? Collections.emptyMap() : Collections.unmodifiableMap(responseDetails);
+      this.details = responseDetails == null ? new HashMap<>() : new HashMap<>(responseDetails);
       this.shouldRetry = shouldRetry;
     }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/ExecutionCompleteLockReleasingListener.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/ExecutionCompleteLockReleasingListener.java
@@ -1,0 +1,48 @@
+package com.netflix.spinnaker.orca.locks;
+
+import com.netflix.spinnaker.orca.events.ExecutionComplete;
+import com.netflix.spinnaker.orca.pipeline.AcquireLockStage;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExecutionCompleteLockReleasingListener implements ApplicationListener<ExecutionComplete> {
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final ExecutionRepository executionRepository;
+  private final LockManager lockManager;
+  private final LockingConfigurationProperties lockingConfigurationProperties;
+
+  @Autowired
+  public ExecutionCompleteLockReleasingListener(ExecutionRepository executionRepository,
+                                                LockManager lockManager,
+                                                LockingConfigurationProperties lockingConfigurationProperties) {
+    this.executionRepository = executionRepository;
+    this.lockManager = lockManager;
+    this.lockingConfigurationProperties = lockingConfigurationProperties;
+  }
+
+  @Override
+  public void onApplicationEvent(ExecutionComplete event) {
+    if (!lockingConfigurationProperties.isEnabled()) {
+      return;
+    }
+    if (event.getStatus().isHalt()) {
+      Execution execution = executionRepository.retrieve(event.getExecutionType(), event.getExecutionId());
+      execution.getStages().forEach(s -> {
+        if (AcquireLockStage.PIPELINE_TYPE.equals(s.getType())) {
+          try {
+            LockContext lc = s.mapTo("/lock", LockContext.LockContextBuilder.class).withStage(s).build();
+            lockManager.releaseLock(lc.getLockName(), lc.getLockValue(), lc.getLockHolder());
+          } catch (LockFailureException lfe) {
+            logger.info("Failure releasing lock in ExecutionCompleteLockReleasingListener - ignoring", lfe);
+          }
+        }
+      });
+    }
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockContext.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockContext.java
@@ -1,0 +1,137 @@
+package com.netflix.spinnaker.orca.locks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class LockContext {
+  public static class LockContextBuilder {
+
+    public static class LockValueBuilder {
+      private String application;
+      private String type;
+      private String id;
+      private Stage stage;
+
+      LockValueBuilder() {
+        this(null, null, null, null);
+      }
+
+      @JsonCreator
+      public LockValueBuilder(@JsonProperty("application") String application,
+                              @JsonProperty("type") String type,
+                              @JsonProperty("id") String id) {
+        this(application, type, id, null);
+      }
+
+      LockValueBuilder(String application, String type, String id, Stage stage) {
+        this.application = application;
+        this.type = type;
+        this.id = id;
+        this.stage = stage;
+      }
+
+      public LockValueBuilder withStage(Stage stage) {
+        this.stage = stage;
+        return this;
+      }
+
+      public LockManager.LockValue build() {
+        final Optional<Execution> execution = Optional.ofNullable(stage).map(Stage::getExecution);
+
+        final String application = Optional.ofNullable(this.application).orElseGet(() ->
+          execution
+            .map(Execution::getApplication)
+            .orElse(null));
+
+        final String type = Optional.ofNullable(this.type).orElseGet(() ->
+          execution
+            .map(Execution::getType)
+            .map(Execution.ExecutionType::toString)
+            .orElse(null));
+
+        //TODO(cfieber): lockValue.id:
+        // if we are a child pipeline / strategy we probably need to use the parent execution id
+        final String id = Optional.ofNullable(this.id).orElseGet(() ->
+          execution
+            .map(Execution::getId)
+            .orElse(null));
+
+        return new LockManager.LockValue(application, type, id);
+      }
+    }
+
+
+    private String lockName;
+    private LockValueBuilder lockValue;
+    private String lockHolder;
+    private Stage stage;
+
+    public LockContextBuilder() {
+      this(null, null, null, null);
+    }
+
+    @JsonCreator
+    public LockContextBuilder(
+      @JsonProperty("lockName") String lockName,
+      @JsonProperty("lockValue") LockValueBuilder lockValue,
+      @JsonProperty("lockHolder") String lockHolder) {
+      this(lockName, lockValue, lockHolder, null);
+    }
+
+    LockContextBuilder(String lockName, LockValueBuilder lockValue, String lockHolder, Stage stage) {
+      this.lockName = lockName;
+      this.lockValue = lockValue;
+      this.lockHolder = lockHolder;
+      this.stage = stage;
+    }
+
+    public LockContextBuilder withStage(Stage stage) {
+      this.stage = stage;
+      Optional.ofNullable(lockValue).ifPresent(lv -> lv.withStage(stage));
+      return this;
+    }
+
+    public LockContext build() {
+      final LockManager.LockValue lockValue =
+        Optional.ofNullable(this.lockValue)
+          .orElseGet(() -> new LockValueBuilder().withStage(stage))
+          .build();
+
+      final String lockHolder = Optional.ofNullable(this.lockHolder).orElseGet(() ->
+        Optional.ofNullable(stage)
+          .map(Stage::getId)
+          .orElse(null));
+
+      return new LockContext(lockName, lockValue, lockHolder);
+    }
+  }
+
+  private final String lockName;
+  private final LockManager.LockValue lockValue;
+  private final String lockHolder;
+
+  LockContext(String lockName,
+              LockManager.LockValue lockValue,
+              String lockHolder) {
+    this.lockName = Objects.requireNonNull(lockName);
+    this.lockValue = Objects.requireNonNull(lockValue);
+    this.lockHolder = Objects.requireNonNull(lockHolder);
+  }
+
+  public String getLockName() {
+    return lockName;
+  }
+
+  public LockManager.LockValue getLockValue() {
+    return lockValue;
+  }
+
+  public String getLockHolder() {
+    return lockHolder;
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockExtendingTaskExecutionInterceptor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockExtendingTaskExecutionInterceptor.java
@@ -1,0 +1,112 @@
+package com.netflix.spinnaker.orca.locks;
+
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskExecutionInterceptor;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.pipeline.AcquireLockStage;
+import com.netflix.spinnaker.orca.pipeline.ReleaseLockStage;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.tasks.AcquireLockTask;
+import com.netflix.spinnaker.orca.pipeline.tasks.ReleaseLockTask;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Component
+public class LockExtendingTaskExecutionInterceptor implements TaskExecutionInterceptor {
+  private final LockManager lockManager;
+  private final LockingConfigurationProperties lockingConfigurationProperties;
+
+  @Autowired
+  public LockExtendingTaskExecutionInterceptor(LockManager lockManager,
+                                               LockingConfigurationProperties lockingConfigurationProperties) {
+    this.lockManager = lockManager;
+    this.lockingConfigurationProperties = lockingConfigurationProperties;
+  }
+
+  @Override
+  public long maxTaskBackoff() {
+    return Duration.ofSeconds(
+      lockingConfigurationProperties.getTtlSeconds() - lockingConfigurationProperties.getBackoffBufferSeconds()
+    ).toMillis();
+  }
+
+  @Override
+  public Stage beforeTaskExecution(Task task, Stage stage) {
+    extendLocks(task, stage);
+    return stage;
+  }
+
+  @Override
+  public TaskResult afterTaskExecution(Task task, Stage stage, TaskResult taskResult) {
+    extendLocks(task, stage);
+    return taskResult;
+  }
+
+  private void extendLocks(Task task, Stage stage) {
+    if (!lockingConfigurationProperties.isEnabled()) {
+      return;
+    }
+    if (task instanceof AcquireLockTask || task instanceof ReleaseLockTask) {
+      return;
+    }
+
+    Map<HeldLock, AtomicInteger> heldLocks = new HashMap<>();
+    Set<String> lockTypes = new HashSet<>(Arrays.asList(AcquireLockStage.PIPELINE_TYPE, ReleaseLockStage.PIPELINE_TYPE));
+    stage.getExecution().getStages()
+      .stream()
+      .filter(s -> lockTypes.contains(s.getType()) && s.getStatus() == ExecutionStatus.SUCCEEDED)
+      .forEach(s -> {
+      LockContext lc = s.mapTo("/lock", LockContext.LockContextBuilder.class).withStage(s).build();
+      AtomicInteger count = heldLocks.computeIfAbsent(
+        new HeldLock(lc.getLockName(), lc.getLockValue()),
+        hl -> new AtomicInteger(0));
+      if (AcquireLockStage.PIPELINE_TYPE.equals(s.getType())) {
+        count.incrementAndGet();
+      } else {
+        count.decrementAndGet();
+      }
+    });
+
+    List<HeldLock> toExtend = heldLocks
+      .entrySet()
+      .stream()
+      .filter(me -> me.getValue().get() > 0)
+      .map(Map.Entry::getKey)
+      .collect(Collectors.toList());
+    toExtend.forEach(hl ->
+      lockManager.extendLock(
+        hl.lockName,
+        hl.lockValue,
+        lockingConfigurationProperties.getTtlSeconds()));
+  }
+
+  private static class HeldLock {
+    final String lockName;
+    final LockManager.LockValue lockValue;
+
+    HeldLock(String lockName, LockManager.LockValue lockValue) {
+      this.lockName = lockName;
+      this.lockValue = lockValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      HeldLock heldLock = (HeldLock) o;
+      return Objects.equals(lockName, heldLock.lockName) &&
+        Objects.equals(lockValue, heldLock.lockValue);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(lockName, lockValue);
+    }
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockFailureException.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockFailureException.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.orca.locks;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+public class LockFailureException extends RuntimeException {
+  private final String lockName;
+  private final LockManager.LockValue currentLockValue;
+
+  private static String buildMessage(String lockName, @Nullable LockManager.LockValue currentLockValue) {
+    Optional<LockManager.LockValue> lv = Optional.ofNullable(currentLockValue);
+    return "Failed to acquire lock " + lockName
+      + " currently held by " + lv.map(LockManager.LockValue::getApplication).orElse("UNKNOWN")
+      + "/" + lv.map(LockManager.LockValue::getType).orElse("UNKNOWN")
+      + "/" + lv.map(LockManager.LockValue::getId).orElse("UNKNOWN");
+  }
+
+  public LockFailureException(String lockName, @Nullable LockManager.LockValue currentLockValue) {
+    super(buildMessage(lockName, currentLockValue));
+    this.lockName = lockName;
+    this.currentLockValue = currentLockValue;
+  }
+
+  public String getLockName() {
+    return lockName;
+  }
+
+  @Nullable
+  public LockManager.LockValue getCurrentLockValue() {
+    return currentLockValue;
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockManager.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockManager.java
@@ -1,0 +1,121 @@
+package com.netflix.spinnaker.orca.locks;
+
+import java.util.Objects;
+
+/**
+ * Manages acquisition / release of locks.
+ *
+ * The lock is held with a value which is the combination of application, type, and id. This
+ * would typically be the execution application, type (pipeline or orchestration) and execution id.
+ *
+ * A named lock can be acquired if either it is not currently locked, or if the current value of the
+ * lock matches the supplied lockValue fields.
+ *
+ * A lock has a TTL to ensure that in the event of an unexpected failure or JVM exit that eventually locks
+ * are released - the general expectation is that a call to acquireLock should be accompanied by a call to
+ * releaseLock.
+ *
+ * Multiple holders can acquire the same lock by supplying the same lockValue fields, and a lock continues to be
+ * held until all holders have issued a releaseLock.
+ *
+ * A stage that operates on a particular cluster should acquire the lock for that cluster. Any synthetic stages
+ * can also acquire the same lock. For example:
+ *
+ * As an example, a deploy with Red/Black would go through the following:
+ *
+ *
+ * lockValue = new LockValue(application, execution.type, execution.id)
+ * createServerGroup
+ *   acquireLock(clusterName, lockValue, createServerGroup.stage.id)
+ *   deploy
+ *   waitForUpInstances
+ *
+ *   disableCluster
+ *     acquireLock(clusterName, lockValue, disableCluster.stage.id)
+ *     disableCluster
+ *     waitForDisableCluster
+ *     releaseLock(clusterName, lockValue, disableCluster.stage.id)
+ *
+ *   scaleDownCluster
+ *     acquireLock(clusterName, lockValue, scaleDownCluster.stage.id)
+ *     scaleDownCluster
+ *     waitForScaleDown
+ *     releaseLock(clusterName, lockValue, scaleDownCluster.stage.id)
+ *
+ *   releaseLock(clusterName, lockValue, createServerGroup.stage.id)
+ *
+ *
+ * The lifespan of the lock would be the entire duration of the createServerGroup stage including all
+ * the child stages (disableCluster, scaleDownCluster).
+ */
+public interface LockManager {
+
+  class LockValue {
+    final String application;
+    final String type;
+    final String id;
+
+    public LockValue(String application, String type, String id) {
+      this.application = Objects.requireNonNull(application);
+      this.type = Objects.requireNonNull(type);
+      this.id = Objects.requireNonNull(id);
+    }
+
+    public String getApplication() {
+      return application;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      LockValue lockValue = (LockValue) o;
+      return Objects.equals(application, lockValue.application) &&
+        Objects.equals(type, lockValue.type) &&
+        Objects.equals(id, lockValue.id);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(application, type, id);
+    }
+  }
+
+  /**
+   * Acquires a named lock.
+   * @param lockName The name of the lock.
+   * @param lockValue The value of the lock - if the lock is already held with this value, acquisition is successful otherwise lock acquisition fails.
+   * @param lockHolder The holder of the lock.
+   * @param ttlSeconds How long to acquire for or extend an existing lock for.
+   * @throws LockFailureException if the lock is currently held with a different lockValueApplication/lockValueType/lockValue
+   */
+  void acquireLock(String lockName, LockValue lockValue, String lockHolder, int ttlSeconds) throws LockFailureException;
+
+  /**
+   * Extends a named lock ttl.
+   * @param lockName The name of the lock.
+   * @param lockValue The value of the lock - if the lock is already held with this value, the ttl extension is successful otherwise lock extension fails.
+   * @param ttlSeconds How long to extend the lock for.
+   * @throws LockFailureException if the lock is currently held with a different lockValueApplication/lockValueType/lockValue
+   */
+  void extendLock(String lockName, LockValue lockValue, int ttlSeconds) throws LockFailureException;
+
+  /**
+   * Releases a named lock for a specific lockHolder.
+   *
+   * After release, if there are no additional lock holders the lock itself is freed.
+   *
+   * @param lockName The name of the lock.
+   * @param lockValue The value of the lock - An existing lock must be held with this value for release to succeed.
+   * @param lockHolder The holder of the lock.
+   */
+  void releaseLock(String lockName, LockValue lockValue, String lockHolder);
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockingConfigurationProperties.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockingConfigurationProperties.java
@@ -1,0 +1,53 @@
+package com.netflix.spinnaker.orca.locks;
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("locking")
+public class LockingConfigurationProperties {
+  private boolean learningMode = true;
+  private boolean enabled = false;
+  private int ttlSeconds = 120;
+  private int backoffBufferSeconds = 10;
+  private final DynamicConfigService dynamicConfigService;
+
+  @Autowired
+  public LockingConfigurationProperties(DynamicConfigService dynamicConfigService) {
+    this.dynamicConfigService = dynamicConfigService;
+  }
+
+  public boolean isLearningMode() {
+    return dynamicConfigService.getConfig(Boolean.class, "locking.learningMode", learningMode);
+  }
+
+  public void setLearningMode(boolean learningMode) {
+    this.learningMode = learningMode;
+  }
+
+  public boolean isEnabled() {
+    return dynamicConfigService.isEnabled("locking", enabled);
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public int getTtlSeconds() {
+    return dynamicConfigService.getConfig(Integer.class, "locking.ttlSeconds", ttlSeconds);
+  }
+
+  public void setTtlSeconds(int ttlSeconds) {
+    this.ttlSeconds = ttlSeconds;
+  }
+
+  public int getBackoffBufferSeconds() {
+    return dynamicConfigService.getConfig(Integer.class, "locking.backoffBufferSeconds", backoffBufferSeconds);
+  }
+
+  public void setBackoffBufferSeconds(int backoffBufferSeconds) {
+    this.backoffBufferSeconds = backoffBufferSeconds;
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/AcquireLockStage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/AcquireLockStage.java
@@ -1,0 +1,24 @@
+package com.netflix.spinnaker.orca.pipeline;
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.tasks.AcquireLockTask;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+
+@Component
+public class AcquireLockStage implements StageDefinitionBuilder {
+
+  public static final String PIPELINE_TYPE = "acquireLock";
+
+  @Nonnull
+  @Override
+  public String getType() {
+    return PIPELINE_TYPE;
+  }
+
+  @Override
+  public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
+    builder.withTask("acquireLock", AcquireLockTask.class);
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ReleaseLockStage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ReleaseLockStage.java
@@ -1,0 +1,26 @@
+package com.netflix.spinnaker.orca.pipeline;
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.tasks.DetermineLockTask;
+import com.netflix.spinnaker.orca.pipeline.tasks.ReleaseLockTask;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+
+@Component
+public class ReleaseLockStage implements StageDefinitionBuilder {
+  public static final String PIPELINE_TYPE = "releaseLock";
+
+  @Nonnull
+  @Override
+  public String getType() {
+    return PIPELINE_TYPE;
+  }
+
+  @Override
+  public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
+    builder
+      .withTask("determineLock", DetermineLockTask.class)
+      .withTask("releaseLock", ReleaseLockTask.class);
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/AcquireLockTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/AcquireLockTask.java
@@ -1,0 +1,50 @@
+package com.netflix.spinnaker.orca.pipeline.tasks;
+
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.exceptions.DefaultExceptionHandler;
+import com.netflix.spinnaker.orca.exceptions.ExceptionHandler;
+import com.netflix.spinnaker.orca.locks.LockFailureException;
+import com.netflix.spinnaker.orca.locks.LockManager;
+import com.netflix.spinnaker.orca.locks.LockContext;
+import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class AcquireLockTask implements Task {
+
+  private final LockManager lockManager;
+  private final LockingConfigurationProperties lockingConfigurationProperties;
+
+  @Autowired
+  public AcquireLockTask(LockManager lockManager,
+                         LockingConfigurationProperties lockingConfigurationProperties) {
+    this.lockManager = lockManager;
+    this.lockingConfigurationProperties = lockingConfigurationProperties;
+  }
+
+  @Nonnull
+  @Override
+  public TaskResult execute(@Nonnull Stage stage) {
+    LockContext lock = stage.mapTo("/lock", LockContext.LockContextBuilder.class).withStage(stage).build();
+    try {
+      lockManager.acquireLock(lock.getLockName(), lock.getLockValue(), lock.getLockHolder(), lockingConfigurationProperties.getTtlSeconds());
+      return new TaskResult(ExecutionStatus.SUCCEEDED, Collections.singletonMap("lock", lock));
+    } catch (LockFailureException lfe) {
+      Map<String, Object> resultContext = new HashMap<>();
+      ExceptionHandler.Response exResult = new DefaultExceptionHandler().handle("acquireLock", lfe);
+      exResult.getDetails().put("lockName", lfe.getLockName());
+      exResult.getDetails().put("currentLockValue", lfe.getCurrentLockValue());
+      resultContext.put("exception", exResult);
+      return new TaskResult(ExecutionStatus.TERMINAL, resultContext);
+    }
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/DetermineLockTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/DetermineLockTask.java
@@ -1,0 +1,46 @@
+package com.netflix.spinnaker.orca.pipeline.tasks;
+
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.locks.LockContext;
+import com.netflix.spinnaker.orca.pipeline.AcquireLockStage;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class DetermineLockTask implements Task {
+
+  private final StageNavigator stageNavigator;
+
+  @Autowired
+  public DetermineLockTask(StageNavigator stageNavigator) {
+    this.stageNavigator = stageNavigator;
+  }
+
+  @Nonnull
+  @Override
+  public TaskResult execute(@Nonnull Stage stage) {
+    Map<String, Object> lock = (Map<String, Object>) stage.getContext().get("lock");
+    if (lock != null && lock.containsKey("lockValue")) {
+      return TaskResult.SUCCEEDED;
+    }
+
+    Optional<StageNavigator.Result> lockStageResult = stageNavigator.ancestors(stage).stream().filter(r -> r.getStageBuilder() instanceof AcquireLockStage).findFirst();
+
+    if (lockStageResult.isPresent()) {
+      final Stage lockStage = lockStageResult.get().getStage();
+      LockContext lockContext = lockStage.mapTo("/lock", LockContext.LockContextBuilder.class).withStage(lockStage).build();
+      return new TaskResult(ExecutionStatus.SUCCEEDED, Collections.singletonMap("lock", lockContext));
+    }
+
+    throw new IllegalStateException("Unable to determine parent lock stage");
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ReleaseLockTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ReleaseLockTask.java
@@ -1,0 +1,30 @@
+package com.netflix.spinnaker.orca.pipeline.tasks;
+
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.locks.LockManager;
+import com.netflix.spinnaker.orca.locks.LockContext;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+
+@Component
+public class ReleaseLockTask implements Task {
+
+  private final LockManager lockManager;
+
+  @Autowired
+  public ReleaseLockTask(LockManager lockManager) {
+    this.lockManager = lockManager;
+  }
+
+  @Nonnull
+  @Override
+  public TaskResult execute(@Nonnull Stage stage) {
+    final LockContext lock = stage.mapTo("/lock", LockContext.LockContextBuilder.class).withStage(stage).build();
+    lockManager.releaseLock(lock.getLockName(), lock.getLockValue(), lock.getLockHolder());
+    return TaskResult.SUCCEEDED;
+  }
+}

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
@@ -16,23 +16,18 @@
 
 package com.netflix.spinnaker.orca.q.handler
 
-import com.netflix.spinnaker.orca.ExecutionStatus.CANCELED
 import com.netflix.spinnaker.orca.ExecutionStatus.PAUSED
-import com.netflix.spinnaker.orca.events.ExecutionComplete
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.CancelExecution
 import com.netflix.spinnaker.orca.q.RescheduleExecution
 import com.netflix.spinnaker.orca.q.ResumeStage
 import com.netflix.spinnaker.q.Queue
-import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 
 @Component
 class CancelExecutionHandler(
   override val queue: Queue,
-  override val repository: ExecutionRepository,
-  @Qualifier("queueEventPublisher")private val publisher: ApplicationEventPublisher
+  override val repository: ExecutionRepository
 ) : OrcaMessageHandler<CancelExecution> {
   override val messageType = CancelExecution::class.java
 
@@ -51,8 +46,6 @@ class CancelExecutionHandler(
 
       // then, make sure those runTask messages get run right away
       queue.push(RescheduleExecution(execution))
-
-      publisher.publishEvent(ExecutionComplete(this, message.executionType, message.executionId, CANCELED))
     }
   }
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
@@ -54,6 +54,9 @@ class CompleteExecutionHandler(
     message.withExecution { execution ->
       if (execution.status.isComplete) {
         log.info("Execution ${execution.id} already completed with ${execution.status} status")
+        publisher.publishEvent(
+          ExecutionComplete(this, message.executionType, message.executionId, execution.status)
+        )
       } else {
         message.determineFinalStatus(execution) { status ->
           repository.updateStatus(execution.type, message.executionId, status)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandlerTest.kt
@@ -40,13 +40,12 @@ object CancelExecutionHandlerTest : SubjectSpek<CancelExecutionHandler>({
 
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
-  val publisher: ApplicationEventPublisher = mock()
 
   subject(CachingMode.GROUP) {
-    CancelExecutionHandler(queue, repository, publisher)
+    CancelExecutionHandler(queue, repository)
   }
 
-  fun resetMocks() = reset(queue, repository, publisher)
+  fun resetMocks() = reset(queue, repository)
 
   describe("cancelling an execution") {
     given("there are no paused stages") {
@@ -76,14 +75,6 @@ object CancelExecutionHandlerTest : SubjectSpek<CancelExecutionHandler>({
 
       it("it triggers a reevaluate") {
         verify(queue).push(RescheduleExecution(pipeline))
-      }
-
-      it("publishes an execution complete event") {
-        verify(publisher).publishEvent(check<ExecutionComplete> {
-          assertThat(it.executionType).isEqualTo(pipeline.type)
-          assertThat(it.executionId).isEqualTo(pipeline.id)
-          assertThat(it.status).isEqualTo(CANCELED)
-        })
       }
 
       it("does not send any further messages") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -68,6 +68,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       listOf(task, timeoutOverrideTask),
       clock,
       listOf(exceptionHandler),
+      emptyList(),
       NoopRegistry()
     )
   }

--- a/orca-redis/orca-redis.gradle
+++ b/orca-redis/orca-redis.gradle
@@ -2,6 +2,7 @@ apply from: "$rootDir/gradle/kotlin.gradle"
 apply from: "$rootDir/gradle/spock.gradle"
 
 dependencies {
+  compile project(":orca-core")
   compile project(":orca-front50")
 
   compile spinnaker.dependency('rxJava')

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/locks/RedisLockManager.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/locks/RedisLockManager.java
@@ -1,0 +1,243 @@
+package com.netflix.spinnaker.orca.locks;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import redis.clients.jedis.ScriptingCommands;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static java.util.Arrays.asList;
+
+@Component
+public class RedisLockManager implements LockManager {
+  private static final int LOCK_VALUE_APPLICATION_IDX = 0;
+  private static final int LOCK_VALUE_TYPE_IDX = 1;
+  private static final int LOCK_VALUE_IDX = 2;
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+  private RedisClientDelegate redisClientDelegate;
+  private final LockingConfigurationProperties lockingConfigurationProperties;
+
+  @Autowired
+  public RedisLockManager(RedisClientDelegate redisClientDelegate,
+                          LockingConfigurationProperties lockingConfigurationProperties) {
+    this.redisClientDelegate = redisClientDelegate;
+    this.lockingConfigurationProperties = lockingConfigurationProperties;
+    if (!redisClientDelegate.supportsScripting()) {
+      throw new IllegalArgumentException(
+        "Requires RedisClientDelegate that supports scripting but got " + redisClientDelegate);
+    }
+  }
+
+  @Override
+  public void acquireLock(String lockName,
+                          LockValue lockValue,
+                          String lockHolder,
+                          int ttlSeconds) throws LockFailureException {
+    withLockingConfiguration(LockOperation.acquire(lockName, lockValue, lockHolder, ttlSeconds), (op) -> {
+      final List<String> result = redisClientDelegate.withScriptingClient(scriptingCommands ->
+        (List<String>) scriptingCommands.eval(ACQUIRE_LOCK, op.key(), op.acquireArgs()));
+      checkResult(op, result);
+    });
+  }
+
+  @Override
+  public void extendLock(String lockName,
+                         LockValue lockValue,
+                         int ttlSeconds) throws LockFailureException {
+    withLockingConfiguration(LockOperation.extend(lockName, lockValue, ttlSeconds), (op) -> {
+      final List<String> result = redisClientDelegate.withScriptingClient(scriptingCommands ->
+        (List<String>) scriptingCommands.eval(EXTEND_LOCK, op.key(), op.extendArgs()));
+      checkResult(op, result);
+    });
+  }
+
+  @Override
+  public void releaseLock(String lockName,
+                          LockValue lockValue,
+                          String lockHolder) {
+    withLockingConfiguration(LockOperation.release(lockName, lockValue, lockHolder), (op) ->
+      redisClientDelegate.withScriptingClient((Consumer<ScriptingCommands>) scriptingCommands ->
+        scriptingCommands.eval(RELEASE_LOCK, op.key(), op.releaseArgs())));
+  }
+
+  private static class LockOperation {
+    static LockOperation acquire(String lockName, LockValue lockValue, String lockHolder, int ttlSeconds) {
+      return new LockOperation("acquireLock", lockName, lockValue, lockHolder, ttlSeconds);
+    }
+
+    static LockOperation extend(String lockName, LockValue lockValue, int ttlSeconds) {
+      return new LockOperation("extendLock", lockName, lockValue, null, ttlSeconds);
+    }
+
+    static LockOperation release(String lockName, LockValue lockValue, String lockHolder) {
+      return new LockOperation("releaseLock", lockName, lockValue, lockHolder, -1);
+    }
+
+    final String operationName;
+    final String lockName;
+    final LockValue lockValue;
+    final String lockHolder;
+    final int ttlSeconds;
+
+    private LockOperation(String operationName,
+                          String lockName,
+                          LockValue lockValue,
+                          String lockHolder,
+                          int ttlSeconds) {
+      this.operationName = Objects.requireNonNull(operationName);
+      this.lockName = Objects.requireNonNull(lockName);
+      this.lockValue = Objects.requireNonNull(lockValue);
+      this.lockHolder = lockHolder;
+      this.ttlSeconds = ttlSeconds;
+    }
+
+    List<String> key() {
+      return asList(getLockKey(lockName));
+    }
+
+    List<String> acquireArgs() {
+      return asList(
+        lockValue.getApplication(),
+        lockValue.getType(),
+        lockValue.getId(),
+        lockHolder,
+        Integer.toString(ttlSeconds));
+    }
+
+    List<String> extendArgs() {
+      return asList(
+        lockValue.getApplication(),
+        lockValue.getType(),
+        lockValue.getId(),
+        Integer.toString(ttlSeconds));
+    }
+
+    List<String> releaseArgs() {
+      return asList(
+        lockValue.getApplication(),
+        lockValue.getType(),
+        lockValue.getId(),
+        lockHolder);
+    }
+  }
+
+  private void checkResult(LockOperation op, List<String> result) {
+    final LockValue currentLockValue = buildResultLockValue(result);
+    if (!(op.lockValue.equals(currentLockValue))) {
+      throw new LockFailureException(op.lockName, currentLockValue);
+    }
+  }
+
+  private LockValue buildResultLockValue(List<String> result) {
+    if (result == null || result.size() < 3) {
+      throw new IllegalStateException("Unexpected result from redis: " + result);
+    }
+    if (result.stream().allMatch(Objects::isNull)) {
+      return null;
+    }
+    return new LockValue(
+      result.get(LOCK_VALUE_APPLICATION_IDX),
+      result.get(LOCK_VALUE_TYPE_IDX),
+      result.get(LOCK_VALUE_IDX));
+  }
+
+  private void withLockingConfiguration(LockOperation lockOperation,
+                                        Consumer<LockOperation> lockManagementOperation) throws LockFailureException {
+    if (!lockingConfigurationProperties.isEnabled()) {
+      return;
+    }
+    try {
+      lockManagementOperation.accept(lockOperation);
+    } catch (Throwable t) {
+      if (t instanceof LockFailureException) {
+        LockFailureException lfe = (LockFailureException) t;
+        Optional<LockValue> currentLockValue = Optional.ofNullable(lfe.getCurrentLockValue());
+        log.debug("LockFailureException during {} for lock {} currently held by {} {} {} requested by {} {} {} {}",
+          kv("operationName", lockOperation.operationName),
+          kv("lockName", lockOperation.lockName),
+          kv("currentLockValue.application", currentLockValue.map(LockValue::getApplication).orElse(null)),
+          kv("currentLockValue.type", currentLockValue.map(LockValue::getType).orElse(null)),
+          kv("currentLockValue.id", currentLockValue.map(LockValue::getId).orElse(null)),
+          kv("requestLockValue.application", lockOperation.lockValue.getApplication()),
+          kv("requestLockValue.type", lockOperation.lockValue.getType()),
+          kv("requestLockValue.id", lockOperation.lockValue.getId()),
+          kv("requestLockHolder", Optional.ofNullable(lockOperation.lockHolder).orElse("UNSPECIFIED")),
+          lfe);
+        if (lockingConfigurationProperties.isLearningMode()) {
+          return;
+        }
+        throw lfe;
+      } else {
+        log.debug("Exception during {} for lock {} requested by {} {} {} {}",
+          kv("operationName", lockOperation.operationName),
+          kv("operationName", lockOperation.lockName),
+          kv("requestLockValue.application", lockOperation.lockValue.getApplication()),
+          kv("requestLockValue.type", lockOperation.lockValue.getType()),
+          kv("requestLockValue.id", lockOperation.lockValue.getId()),
+          kv("requestLockHolder", Optional.ofNullable(lockOperation.lockHolder).orElse("UNSPECIFIED")),
+          t);
+        if (lockingConfigurationProperties.isLearningMode()) {
+          return;
+        }
+
+        if (t instanceof RuntimeException) {
+          throw (RuntimeException) t;
+        }
+        throw new RuntimeException("Exception in RedisLockManager", t);
+      }
+    }
+
+  }
+
+  static String getLockKey(String lockName) {
+    return "namedlock:" + lockName;
+  }
+
+  private static final String ACQUIRE_LOCK = "" +
+    "local lockKey, lockValueApplication, lockValueType, lockValue, holderHashKey, ttlSeconds = " +
+    "  KEYS[1], ARGV[1], ARGV[2], ARGV[3], 'lockHolder.' .. ARGV[4], tonumber(ARGV[5]);" +
+    "if redis.call('exists', lockKey) == 1 then" +
+    "  if not (redis.call('hget', lockKey, 'lockValueApplication') == lockValueApplication and " +
+    "          redis.call('hget', lockKey, 'lockValueType') == lockValueType and" +
+    "          redis.call('hget', lockKey, 'lockValue') == lockValue) then" +
+    "    return redis.call('hmget', lockKey, 'lockValueApplication', 'lockValueType', 'lockValue');" +
+    "  end;" +
+    "end;" +
+    "redis.call('hmset', lockKey, 'lockValueApplication', lockValueApplication, " +
+    "  'lockValueType', lockValueType, 'lockValue', lockValue, holderHashKey, 'true');" +
+    "redis.call('expire', lockKey, ttlSeconds);" +
+    "return {lockValueApplication, lockValueType, lockValue};";
+
+  private static final String EXTEND_LOCK = "" +
+    "local lockKey, lockValueApplication, lockValueType, lockValue, ttlSeconds = " +
+    "  KEYS[1], ARGV[1], ARGV[2], ARGV[3], tonumber(ARGV[4]);" +
+    "if not (redis.call('hget', lockKey, 'lockValueApplication') == lockValueApplication and " +
+    "        redis.call('hget', lockKey, 'lockValueType') == lockValueType and" +
+    "        redis.call('hget', lockKey, 'lockValue') == lockValue) then" +
+    "  return redis.call('hmget', lockKey, 'lockValueApplication', 'lockValueType', 'lockValue');" +
+    "end;" +
+    "redis.call('expire', lockKey, ttlSeconds);" +
+    "return {lockValueApplication, lockValueType, lockValue};";
+
+  private static final String RELEASE_LOCK = "" +
+    "local lockKey, lockValueApplication, lockValueType, lockValue, holderHashKey = " +
+    "  KEYS[1], ARGV[1], ARGV[2], ARGV[3], 'lockHolder.' .. ARGV[4];" +
+    "if (redis.call('hget', lockKey, 'lockValueApplication') == lockValueApplication and " +
+    "    redis.call('hget', lockKey, 'lockValueType') == lockValueType and" +
+    "    redis.call('hget', lockKey, 'lockValue') == lockValue) then" +
+    "  redis.call('hdel', lockKey, holderHashKey);" +
+    "  if (redis.call('hlen', lockKey) == 3) then" +
+    "    redis.call('del', lockKey);" +
+    "  end;" +
+    "end;" +
+    "return 1;";
+}

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/locks/RedisLockManagerSpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/locks/RedisLockManagerSpec.groovy
@@ -1,0 +1,202 @@
+package com.netflix.spinnaker.orca.locks
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
+import redis.clients.jedis.Jedis
+import redis.clients.util.Pool
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+class RedisLockManagerSpec extends Specification {
+
+  @Shared
+  EmbeddedRedis redisServer
+
+  @Shared
+  Pool<Jedis> pool
+
+  @Subject
+  RedisLockManager redisLockManager
+
+  @Shared
+  DynamicConfigService dynamicConfigService = Stub(DynamicConfigService) {
+    isEnabled(_, _) >> { flag, defaultvalue -> defaultvalue }
+    getConfig(_, _, _) >> { flagtype, flag, defaultvalue -> defaultvalue }
+  }
+
+  void setupSpec() {
+    redisServer = EmbeddedRedis.embed()
+    pool = redisServer.pool
+  }
+
+  void cleanupSpec() {
+    pool.close()
+    redisServer.destroy()
+  }
+
+  void setup() {
+    pool.resource.withCloseable { Jedis jedis -> jedis.flushAll() }
+    def cfg = new LockingConfigurationProperties(dynamicConfigService)
+    cfg.setLearningMode(false)
+    cfg.setEnabled(true)
+    redisLockManager = new RedisLockManager(new JedisClientDelegate(pool), cfg)
+  }
+
+  private LockManager.LockValue lv(String id) {
+    return new LockManager.LockValue('fooapp', 'pipeline', id)
+  }
+
+  def "should acquire a lock if none exists"() {
+    when:
+    redisLockManager.acquireLock('foo', lv('bar'), 'baz', 1)
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "should acquire a lock if already exists but same lockValue supplied"() {
+    given:
+    redisLockManager.acquireLock('foo', lv('bar'), 'baz', 300)
+
+    when:
+    redisLockManager.acquireLock('foo', lv('bar'), 'buzz', 300)
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "acquiring a lock should set TTL"() {
+    when:
+    redisLockManager.acquireLock('foo', lv('bar'), 'baz', 300)
+
+    then:
+    pool.resource.withCloseable { Jedis jedis ->
+      jedis.ttl(RedisLockManager.getLockKey('foo')) > 290
+    }
+  }
+
+  def "reacquiring a lock should reset TTL"() {
+    given:
+    redisLockManager.acquireLock('foo', lv('bar'), 'baz', 100)
+
+    when:
+    redisLockManager.acquireLock('foo', lv('bar'), 'baz', 300)
+
+    then:
+    pool.resource.withCloseable { Jedis jedis ->
+      jedis.ttl(RedisLockManager.getLockKey('foo')) > 290
+    }
+  }
+
+  def "extending a lock should reset TTL"() {
+    given:
+    redisLockManager.acquireLock('foo', lv('bar'), 'baz', 100)
+
+    when:
+    redisLockManager.extendLock('foo', lv('bar'), 300)
+
+    then:
+    pool.resource.withCloseable { Jedis jedis ->
+      jedis.ttl(RedisLockManager.getLockKey('foo')) > 290
+    }
+  }
+
+  def "should fail to extend a lock if held by a different lockValue"() {
+    given:
+    redisLockManager.acquireLock('foo', lv('bar'), 'baz', 100)
+
+    when:
+    redisLockManager.extendLock('foo', lv('bazinga'), 300)
+
+    then:
+    def ex = thrown(LockFailureException)
+    ex.currentLockValue.id == 'bar'
+  }
+
+  def "should fail to extend a lock if held by a different application"() {
+    given:
+    redisLockManager.acquireLock('foo', lv('bar'), 'baz', 100)
+
+    when:
+    redisLockManager.extendLock('foo', new LockManager.LockValue('fooapp2', 'pipeline', 'bar'), 300)
+
+    then:
+    def ex = thrown(LockFailureException)
+    ex.currentLockValue.application == 'fooapp'
+    ex.currentLockValue.id == 'bar'
+  }
+
+  def "should fail to extend a lock if held by a different lockValueType"() {
+    given:
+    redisLockManager.acquireLock('foo', lv('bar'), 'baz', 100)
+
+    when:
+    redisLockManager.extendLock('foo', new LockManager.LockValue('fooapp', 'orchestration', 'bar'), 300)
+
+    then:
+    def ex = thrown(LockFailureException)
+    ex.currentLockValue.type == 'pipeline'
+    ex.currentLockValue.id == 'bar'
+  }
+
+  def "should fail to extend an unknown lock"() {
+    when:
+    redisLockManager.extendLock('foo', lv('bazinga'), 300)
+
+    then:
+    def ex = thrown(LockFailureException)
+    ex.currentLockValue == null
+
+  }
+
+  def "should fail to acquire a lock if already held with a different lockValue"() {
+    given:
+    redisLockManager.acquireLock('foo', lv('bar'), 'baz', 300)
+
+    when:
+    redisLockManager.acquireLock('foo', lv('bazinga'), 'baz', 300)
+
+    then:
+    def ex = thrown(LockFailureException)
+    ex.currentLockValue.id == 'bar'
+  }
+
+  def "should be able to release non-existant lock"() {
+    when:
+    redisLockManager.releaseLock('foo', lv('bar'), 'baz')
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "releasing only lock holder should free the lock"() {
+    given:
+    redisLockManager.acquireLock('foo', lv('bar'), 'baz', 300)
+
+    when:
+    redisLockManager.releaseLock('foo', lv('bar'), 'baz')
+
+    then:
+    pool.resource.withCloseable { Jedis jedis ->
+      !jedis.exists(RedisLockManager.getLockKey('foo'))
+    }
+  }
+
+  def "releasing one of many lockHolders doesn't free the lock"() {
+    given:
+    def lockvalue = lv('bar')
+    redisLockManager.acquireLock('foo', lockvalue, 'baz', 300)
+    redisLockManager.acquireLock('foo', lockvalue, 'buzz', 300)
+    redisLockManager.releaseLock('foo', lockvalue, 'buzz')
+
+    when:
+    redisLockManager.acquireLock('foo', lv('bazinga'), 'bizz', 300)
+
+    then:
+    def ex = thrown(LockFailureException)
+    ex.currentLockValue.id == 'bar'
+  }
+
+}


### PR DESCRIPTION
Introduces a lock manager and Acquire/Release lock stages.

Locking is disabled completely by default, but can be enabled
with the configuration property:
```yaml
locking:
  enabled: true
```

Locking can run in learning mode where locking
failures are non fatal and are just logged:
```yaml
locking:
  enabled: true
  learningMode: true
```

Note that this initial implementation does not wire the acquire and
release lock stages into any operations, so the only way to exercise
them is to explicitly add them into a pipeline.

An example minimal pipeline that exercises locking looks like:
```json
{
  "application": "lockingtest",
  "stages": [
    {
      "name": "Acquire Lock",
      "refId": "1",
      "requisiteStageRefIds": [],
      "type": "acquireLock",
      "lock": {
        "lockName": "testlock"
      }
    },
    {
      "name": "Wait",
      "refId": "2",
      "requisiteStageRefIds": ["1"],
      "type": "wait",
      "waitTime": 5
    },
    {
      "name": "Release Lock",
      "refId": "3",
      "requisiteStageRefIds": ["2"],
      "type": "releaseLock"
    }
  ]
}
```


This is a subset of what was initially proposed in #1799 - the core locking constructs without wiring into any existing stages. Synthetic stage construction and monikers for cluster identification changed significantly enough while #1799 was stagnating, so most of the wiring into operations needs a revisit.


closes #1799 
