### PR TITLE
fix(clouddriver): Handle situations where the wrong `pinned_capacity` tags were deleted

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityStage.groovy
@@ -85,7 +85,7 @@ class ApplySourceServerGroupCapacityStage implements StageDefinitionBuilder {
         ]
       }
     } catch (Exception e) {
-      log.error(
+      log.warn(
         "Unable to determine whether server group is pinned (serverGroup: {}, account: {}, region: {})",
         stage.context.serverGroupName,
         stage.context.credentials,
@@ -98,6 +98,21 @@ class ApplySourceServerGroupCapacityStage implements StageDefinitionBuilder {
   }
 
   private static List<Map> fetchEntityTags(OortService oortService, RetrySupport retrySupport, Stage stage) {
+    def serverGroupName = stage.context.serverGroupName
+    def credentials = stage.context.credentials
+    def region = getRegion(stage)
+
+    if (!serverGroupName || !credentials || !region) {
+      log.warn(
+        "Unable to determine whether server group is pinned (serverGroup: {}, account: {}, region: {}, stageContext: {})",
+        serverGroupName,
+        credentials,
+        region,
+        stage.context
+      )
+      return []
+    }
+
     retrySupport.retry({
       return oortService.getEntityTags([
         ("tag:${PINNED_CAPACITY_TAG}".toString()): "*",


### PR DESCRIPTION
Only check for entity tags if the current stage context contains
sufficient coordinates to identify the target server group.

```
@GET('/tags')
List<Map> getEntityTags(@QueryMap Map parameters)
```

If `parameters` contains a null value (say for an account or server group
name), it will be stripped out and not sent across the wire.

This effectively changes a query for a very specific server group and
account into a wildcard.

The best way to ensure that server groups are correctly being unpinned
is to enable the `RestorePinnedServerGroupsPoller` is enabled.

`pollers.restorePinnedServerGroups.enabled: true`
