### PR TITLE
fix(migrator): Set a limit on ExecutionCriteria so we get results back

### DIFF
--- a/orca-migration/src/main/kotlin/com/netflix/spinnaker/orca/pipeline/persistence/migration/OrchestrationMigrationAgent.kt
+++ b/orca-migration/src/main/kotlin/com/netflix/spinnaker/orca/pipeline/persistence/migration/OrchestrationMigrationAgent.kt
@@ -41,6 +41,7 @@ class OrchestrationMigrationAgent(
     val previouslyMigratedOrchestrationIds = dualExecutionRepository.primary.retrieveAllExecutionIds(ORCHESTRATION)
 
     val executionCriteria = ExecutionRepository.ExecutionCriteria().apply {
+      limit = 3500
       setStatuses(ExecutionStatus.COMPLETED.map { it.name })
     }
 


### PR DESCRIPTION
Setting a limit on orchestrations. If no limit is defined, then the default is set to 0. Not obvious... will be investigating that separately.