### PR TITLE
fix(canary): When resolving final run score, filter on parent id and …

### DIFF
--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/KayentaCanaryStage.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/KayentaCanaryStage.kt
@@ -37,10 +37,8 @@ import java.time.Duration
 import java.time.Duration.ZERO
 import java.time.Instant
 import java.time.Instant.now
-import java.time.temporal.ChronoUnit
 import java.time.temporal.ChronoUnit.*
 import java.util.*
-import java.util.concurrent.TimeUnit
 
 @Component
 class KayentaCanaryStage(private val clock: Clock) : StageDefinitionBuilder {
@@ -112,7 +110,7 @@ class KayentaCanaryStage(private val clock: Clock) : StageDefinitionBuilder {
 
       graph.append {
         it.type = RunCanaryPipelineStage.STAGE_TYPE
-        it.name = "Run Canary #$i"
+        it.name = "${RunCanaryPipelineStage.STAGE_NAME_PREFIX}$i"
         it.context.putAll(mapper.convertValue<Map<String, Any>>(runCanaryContext))
         it.context["continuePipeline"] = parent.context["continuePipeline"]
       }

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/RunCanaryPipelineStage.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/RunCanaryPipelineStage.kt
@@ -68,5 +68,8 @@ class RunCanaryPipelineStage(
   companion object {
     @JvmStatic
     val STAGE_TYPE = "runCanary"
+
+    @JvmStatic
+    val STAGE_NAME_PREFIX = "Run Canary #"
   }
 }

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/AggregateCanaryResultsTask.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/AggregateCanaryResultsTask.kt
@@ -37,7 +37,8 @@ class AggregateCanaryResultsTask : Task {
     val runCanaryStages = stage
       .execution
       .stages
-      .filter { it -> it.type == RunCanaryPipelineStage.STAGE_TYPE }
+      .filter { it -> it.type == RunCanaryPipelineStage.STAGE_TYPE && it.parentStageId == stage.id }
+      .sortedBy { it.name.substringAfterLast("#").toInt() }
     val runCanaryScores = runCanaryStages
       .map { it -> it.mapTo<Number>("/canaryScore") }
       .map(Number::toDouble)

--- a/orca-kayenta/src/test/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/AggregateCanaryResultsTaskTest.kt
+++ b/orca-kayenta/src/test/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/AggregateCanaryResultsTaskTest.kt
@@ -70,9 +70,10 @@ object AggregateCanaryResultsTaskSpec : Spek({
       val pipeline = pipeline {
         canaryScores.forEachIndexed { i, score ->
           stage {
+            requisiteStageRefIds = if (i > 0) listOf("1<${i - 1}") else emptyList()
             refId = "1<$i"
             type = RunCanaryPipelineStage.STAGE_TYPE
-            name = "runCanary"
+            name = "${RunCanaryPipelineStage.STAGE_NAME_PREFIX}${i + 1}"
             context["canaryScore"] = score
           }
         }
@@ -91,7 +92,16 @@ object AggregateCanaryResultsTaskSpec : Spek({
           )
         }
       }
-      val canaryStage = pipeline.stageByRef("1")
+      // Reversing list of stages here which would cause test to fail if stages weren't first sorted by name before aggregating canary scores.
+      val parentStage = pipeline.stageByRef("1")
+      val reversedPipeline = pipeline {
+        stages.addAll(pipeline.stages.reversed())
+        stages.forEach { stage -> stage.execution = this }
+        stages
+          .filter { stage -> stage !== parentStage }
+          .forEach { stage -> stage.parentStageId = parentStage.id }
+      }
+      val canaryStage = reversedPipeline.stageByRef("1")
 
       val taskResult = task.execute(canaryStage)
 
@@ -101,6 +111,99 @@ object AggregateCanaryResultsTaskSpec : Spek({
 
       it("returns a status of $overallExecutionStatus") {
         assertThat(taskResult.status).isEqualTo(overallExecutionStatus)
+      }
+    }
+  }
+
+  describe("aggregation of canary scores from multiple canary stages is done independently") {
+    where(
+      "1st stage canary scores of %s and 2nd stage canary scores of %s and thresholds of %s",
+      values(listOf(10.5, 40.0, 60.5), listOf(25.0, 35.0, 45.0), SUCCEEDED, TERMINAL),
+      values(listOf(65.0), listOf(73.0), SUCCEEDED, SUCCEEDED),
+      values(listOf(55.0), listOf(75.0), TERMINAL, SUCCEEDED),
+      values(listOf(10.5, 40.0, 59.4), listOf(30.5, 40.5, 50.5), TERMINAL, TERMINAL)
+    ) { canaryScores1, canaryScores2, overallExecutionStatus1, overallExecutionStatus2 ->
+
+      val scoreThresholds = mapOf("pass" to 60.5)
+      val pipeline = pipeline {
+        stage {
+          refId = "1"
+          type = KayentaCanaryStage.STAGE_TYPE
+          name = "kayentaCanary"
+          context["canaryConfig"] = mapOf(
+            "canaryConfigId" to UUID.randomUUID().toString(),
+            "scopes" to listOf(mapOf(
+              "controlScope" to "myapp-v010",
+              "experimentScope" to "myapp-v021"
+            )),
+            "scoreThresholds" to scoreThresholds,
+            "lifetimeDuration" to Duration.parse("PT1H")
+          )
+        }
+        canaryScores1.forEachIndexed { i, score ->
+          stage {
+            requisiteStageRefIds = if (i > 0) listOf("1<${i - 1}") else emptyList()
+            refId = "1<$i"
+            parentStageId = stageByRef("1").id
+            type = RunCanaryPipelineStage.STAGE_TYPE
+            // Starting with 'Run Canary #9' to prove that the sorting is done treating everything after the '#' as a number.
+            name = "${RunCanaryPipelineStage.STAGE_NAME_PREFIX}${i + 9}"
+            context["canaryScore"] = score
+          }
+        }
+
+        stage {
+          requisiteStageRefIds = listOf("1")
+          refId = "2"
+          type = KayentaCanaryStage.STAGE_TYPE
+          name = "kayentaCanary"
+          context["canaryConfig"] = mapOf(
+            "canaryConfigId" to UUID.randomUUID().toString(),
+            "scopes" to listOf(mapOf(
+              "controlScope" to "myapp-v010",
+              "experimentScope" to "myapp-v021"
+            )),
+            "scoreThresholds" to scoreThresholds,
+            "lifetimeDuration" to Duration.parse("PT1H")
+          )
+        }
+        canaryScores2.forEachIndexed { i, score ->
+          stage {
+            requisiteStageRefIds = if (i > 0) listOf("1<${i - 1}") else emptyList()
+            refId = "2<$i"
+            parentStageId = stageByRef("2").id
+            type = RunCanaryPipelineStage.STAGE_TYPE
+            name = "${RunCanaryPipelineStage.STAGE_NAME_PREFIX}${i + 9}"
+            context["canaryScore"] = score
+          }
+        }
+      }
+      // Reversing list of stages here which would cause test to fail if stages weren't first sorted by refIds / requisiteStageRefIds before aggregating canary scores.
+      val reversedPipeline = pipeline {
+        stages.addAll(pipeline.stages.reversed())
+        stages.forEach { stage -> stage.execution = this }
+      }
+
+      val canaryStage1 = reversedPipeline.stageByRef("1")
+      val taskResult1 = task.execute(canaryStage1)
+
+      it("stores the aggregated scores independently") {
+        assertThat(taskResult1.context["canaryScores"]).isEqualTo(canaryScores1)
+      }
+
+      it("returns a status of $overallExecutionStatus1 for the correct set of scores") {
+        assertThat(taskResult1.status).isEqualTo(overallExecutionStatus1)
+      }
+
+      val canaryStage2 = reversedPipeline.stageByRef("2")
+      val taskResult2 = task.execute(canaryStage2)
+
+      it("stores the aggregated scores independently") {
+        assertThat(taskResult2.context["canaryScores"]).isEqualTo(canaryScores2)
+      }
+
+      it("returns a status of $overallExecutionStatus2 for the correct set of scores") {
+        assertThat(taskResult2.status).isEqualTo(overallExecutionStatus2)
       }
     }
   }


### PR DESCRIPTION
…sort all child run canary stages.

Cherry-pick into 1.9.