### PR TITLE
fix(core): Make polling interval time unit configurable

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/EphemeralServerGroupsPoller.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/EphemeralServerGroupsPoller.java
@@ -87,6 +87,11 @@ public class EphemeralServerGroupsPoller extends AbstractPollingNotificationAgen
   }
 
   @Override
+  protected TimeUnit getPollingIntervalUnit() {
+    return TimeUnit.SECONDS;
+  }
+
+  @Override
   protected String getNotificationType() {
     return "ephemeralServerGroups";
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPoller.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPoller.java
@@ -111,6 +111,11 @@ class RestorePinnedServerGroupsPoller extends AbstractPollingNotificationAgent {
   }
 
   @Override
+  protected TimeUnit getPollingIntervalUnit() {
+    return TimeUnit.SECONDS;
+  }
+
+  @Override
   protected String getNotificationType() {
     return "restorePinnedServerGroups";
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/AbstractPollingNotificationAgent.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/AbstractPollingNotificationAgent.java
@@ -45,13 +45,17 @@ abstract public class AbstractPollingNotificationAgent implements ApplicationLis
 
   protected abstract long getPollingInterval();
 
+  protected TimeUnit getPollingIntervalUnit() {
+    return TimeUnit.MILLISECONDS;
+  }
+
   protected abstract String getNotificationType();
 
   protected abstract void tick();
 
   protected void startPolling() {
     subscription = Observable
-      .timer(getPollingInterval(), TimeUnit.SECONDS, scheduler)
+      .timer(getPollingInterval(), getPollingIntervalUnit(), scheduler)
       .repeat()
       .filter(interval -> tryAcquireLock())
       .subscribe(interval -> {


### PR DESCRIPTION
I missed the fact that some of our pollers are configured using seconds, and others milliseconds in https://github.com/spinnaker/orca/pull/2366, which fundamentally broke some stuff. This restores correct scheduling.