### PR TITLE
feat(provider/kubernetes): v2 Include manifest when finding resource

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactsFromResourceTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactsFromResourceTask.java
@@ -55,6 +55,7 @@ public class FindArtifactsFromResourceTask extends AbstractCloudProviderAwareTas
       ), 5, 1000, true);
 
     if (manifest != null) {
+      outputs.put("manifest", manifest.getManifest());
       outputs.put("artifacts", manifest.getArtifacts());
     } else {
       throw new IllegalArgumentException("Manifest " + stageData.manifestName + " not found in "


### PR DESCRIPTION
Include the manifest found in addition to the artifacts. Rename the stage to `FindManifest`, similar to find image stages.

This makes it possible to, for example, retrieve the current number of replicas for a deployment and use this when updating that deployment, or to use that number when creating a new deployment (for example, when doing blue-green deployments).