### PR TITLE
fix(executions): revert ExecutionComplete event publishing change

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
@@ -54,9 +54,6 @@ class CompleteExecutionHandler(
     message.withExecution { execution ->
       if (execution.status.isComplete) {
         log.info("Execution ${execution.id} already completed with ${execution.status} status")
-        publisher.publishEvent(
-          ExecutionComplete(this, message.executionType, message.executionId, execution.status)
-        )
       } else {
         message.determineFinalStatus(execution) { status ->
           repository.updateStatus(execution.type, message.executionId, status)


### PR DESCRIPTION
The change in ccbaf76bf48089c71e5a3ed83d4676b4cb6fb2d4 resulted in a
cancelled execution with many leaf nodes each publishing an ExecutionComplete
and causing dependant pipelines to run.
