### PR TITLE
fix(clouddriver): Guard against an NPE when determining rollback target

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
@@ -267,6 +267,7 @@ public class DetermineRollbackCandidatesTask extends AbstractCloudProviderAwareT
     ServerGroup previousServerGroupWithImage = serverGroupsInRegion
       .stream()
       .filter(s -> !(s.name.equalsIgnoreCase(newestEnabledServerGroupInRegion.name)))
+      .filter(s -> s.image != null && s.image.imageId != null)
       .filter(s -> imageDetails.getImageId().equalsIgnoreCase(s.image.imageId))
       .findFirst()
       .orElse(null);

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
@@ -115,6 +115,7 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
     1 * oortService.getCluster("app", _, "app-stack-details", _) >> {
       return buildResponse([
         serverGroups: [
+          buildServerGroup("servergroup-v002", "us-west-2", 50, false, null, [:], 80),
           buildServerGroup("servergroup-v001", "us-west-2", 100, false, [:], [:], 80),
         ]
       ])


### PR DESCRIPTION
It's possible that a server group will not be fully indexed (missing
image information) when it's selected for rollback.

An edge case but this PR guards against the resulting NPE.
