### PR TITLE
feat(sql): Adding SQL execution persistence backend

### DIFF
--- a/gradle/spek.gradle
+++ b/gradle/spek.gradle
@@ -30,6 +30,7 @@ dependencies {
   testRuntime "org.junit.jupiter:junit-jupiter-engine:$jupiterVersion"
   testRuntime "org.junit.vintage:junit-vintage-engine:$junitLegacyVersion"
   testRuntime "org.jetbrains.spek:spek-junit-platform-engine:$spekVersion"
+  testCompile "io.strikt:strikt-core:0.11.5"
 }
 
 test {

--- a/orca-sql-mysql/orca-sql-mysql.gradle
+++ b/orca-sql-mysql/orca-sql-mysql.gradle
@@ -1,0 +1,4 @@
+dependencies {
+  compile project(":orca-sql")
+  compile "mysql:mysql-connector-java:8.0.12"
+}

--- a/orca-sql/orca-sql.gradle
+++ b/orca-sql/orca-sql.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply from: "$rootDir/gradle/kotlin.gradle"
+apply from: "$rootDir/gradle/spek.gradle"
+
+dependencies {
+  compile project(":orca-core")
+
+  // TODO rz - Prefer definitely not having this
+  compile project(":orca-queue-redis")
+
+  compile "org.springframework:spring-jdbc:${spinnaker.version("spring")}"
+  compile "org.springframework:spring-tx:${spinnaker.version("spring")}"
+  compile "org.jooq:jooq:3.9.6"
+  compile "org.liquibase:liquibase-core:3.6.1"
+  compile 'com.zaxxer:HikariCP:2.5.1'
+
+  testCompile project(":orca-core-tck")
+  testCompile "com.h2database:h2:1.4.197"
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.orca.sql.JooqSqlCommentAppender
+import com.netflix.spinnaker.orca.sql.JooqToSpringExceptionTransformer
+import com.netflix.spinnaker.orca.sql.SqlHealthIndicator
+import com.netflix.spinnaker.orca.sql.SqlHealthcheckActivator
+import com.netflix.spinnaker.orca.sql.config.DataSourceConfiguration
+import com.netflix.spinnaker.orca.sql.pipeline.persistence.SqlExecutionRepository
+import com.netflix.spinnaker.orca.sql.telemetry.SlowQueryLogger
+import com.netflix.spinnaker.orca.sql.telemetry.SqlInstrumentedExecutionRepository
+import liquibase.integration.spring.SpringLiquibase
+import org.jooq.DSLContext
+import org.jooq.impl.DataSourceConnectionProvider
+import org.jooq.impl.DefaultConfiguration
+import org.jooq.impl.DefaultDSLContext
+import org.jooq.impl.DefaultExecuteListenerProvider
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy
+import sun.net.InetAddressCachePolicy
+import java.lang.reflect.Field
+import java.security.Security
+import java.sql.Connection
+import javax.sql.DataSource
+
+@Configuration
+@ConditionalOnProperty("sql.enabled")
+@EnableConfigurationProperties(SqlProperties::class)
+@Import(DataSourceConfiguration::class, DataSourceAutoConfiguration::class)
+@ComponentScan("com.netflix.spinnaker.orca.sql")
+class SqlConfiguration {
+
+  init {
+    // Ugh, jOOQ, why. WHY.
+    System.setProperty("org.jooq.no-logo", "true")
+
+    forceInetAddressCachePolicy()
+    Security.setProperty("networkaddress.cache.ttl", "0");
+  }
+
+  @Bean fun liquibase(properties: SqlProperties): SpringLiquibase =
+    properties.migration
+      .run {
+        val ds = SingleConnectionDataSource(jdbcUrl, user, password, false)
+        if (driver != null) {
+          ds.setDriverClassName(driver)
+        }
+        ds
+      }
+      .let { ds ->
+        SpringLiquibase().apply {
+          changeLog = "classpath:db/changelog-master.yml"
+          dataSource = ds
+        }
+      }
+
+  @Bean fun transactionManager(dataSource: DataSource): DataSourceTransactionManager =
+    DataSourceTransactionManager(dataSource)
+
+  @Bean fun dataSourceConnectionProvider(dataSource: DataSource): DataSourceConnectionProvider =
+    object: DataSourceConnectionProvider(TransactionAwareDataSourceProxy(dataSource)) {
+      // Use READ COMMITTED if possible
+      override fun acquire(): Connection = super.acquire().apply {
+          if (metaData.supportsTransactionIsolationLevel(Connection.TRANSACTION_READ_COMMITTED)) {
+            transactionIsolation = Connection.TRANSACTION_READ_COMMITTED
+          }
+        }
+    }
+
+  @Bean fun jooqConfiguration(connectionProvider: DataSourceConnectionProvider,
+                              properties: SqlProperties): DefaultConfiguration =
+    DefaultConfiguration().apply {
+      set(*DefaultExecuteListenerProvider.providers(
+        JooqToSpringExceptionTransformer(),
+        JooqSqlCommentAppender(),
+        SlowQueryLogger()
+      ))
+      set(connectionProvider)
+      setSQLDialect(properties.connectionPool.dialect)
+    }
+
+  @Bean(destroyMethod = "close") fun dsl(jooqConfiguration: DefaultConfiguration): DSLContext =
+    DefaultDSLContext(jooqConfiguration)
+
+  @ConditionalOnProperty("executionRepository.sql.enabled")
+  @Bean fun sqlExecutionRepository(dsl: DSLContext,
+                                   mapper: ObjectMapper,
+                                   registry: Registry,
+                                   properties: SqlProperties) =
+    SqlInstrumentedExecutionRepository(
+      SqlExecutionRepository(properties.partitionName, dsl, mapper, properties.transactionRetry),
+      registry
+    )
+
+  @Bean fun sqlHealthcheckActivator(dsl: DSLContext, registry: Registry) =
+    SqlHealthcheckActivator(dsl, registry)
+
+  @Bean("dbHealthIndicator") fun dbHealthIndicator(sqlHealthcheckActivator: SqlHealthcheckActivator,
+                                                   sqlProperties: SqlProperties) =
+    SqlHealthIndicator(sqlHealthcheckActivator, sqlProperties.connectionPool.dialect)
+}
+
+/**
+ * When deployed with replicas, we want failover to be as fast as possible, so there's no DNS caching.
+ */
+private fun forceInetAddressCachePolicy() {
+  if (InetAddressCachePolicy.get() != InetAddressCachePolicy.NEVER) {
+    val field: Field
+    try {
+      field = InetAddressCachePolicy::class.java.getDeclaredField("cachePolicy")
+      field.isAccessible = true
+    } catch (e: NoSuchFieldException) {
+      throw InetAddressOverrideFailure(e)
+    } catch (e: SecurityException) {
+      throw InetAddressOverrideFailure(e)
+    }
+    field.set(InetAddressCachePolicy::class.java.getDeclaredField("cachePolicy"), InetAddressCachePolicy.NEVER)
+  }
+}
+
+class InetAddressOverrideFailure(cause: Throwable) : IllegalStateException(cause)

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlProperties.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlProperties.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import org.jooq.SQLDialect
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.util.concurrent.TimeUnit.MINUTES
+import java.util.concurrent.TimeUnit.SECONDS
+
+@ConfigurationProperties("sql")
+data class SqlProperties(
+  var migration: MigrationProperties = MigrationProperties(),
+  var connectionPool: ConnectionPoolProperties = ConnectionPoolProperties(),
+  var transactionRetry: TransactionRetryProperties = TransactionRetryProperties(),
+  var partitionName: String? = null
+)
+
+data class MigrationProperties(
+  var jdbcUrl: String = "jdbc:mysql://localhost/orca",
+  var user: String? = null,
+  var password: String? = null,
+  var driver: String? = null
+)
+
+data class ConnectionPoolProperties(
+  var dialect: SQLDialect = SQLDialect.MYSQL,
+  var jdbcUrl: String = "jdbc:mysql://localhost/orca",
+  var driver: String? = null,
+  var user: String? = null,
+  var password: String? = null,
+  var connectionTimeoutMs: Long = SECONDS.toMillis(5),
+  var validationTimeoutMs: Long = SECONDS.toMillis(5),
+  var idleTimeoutMs: Long = MINUTES.toMillis(1),
+  var maxLifetimeMs: Long = SECONDS.toMillis(30),
+  var minIdle: Int = 5,
+  var maxPoolSize: Int = 20
+)
+
+data class TransactionRetryProperties(
+  var maxRetries: Int = 5,
+  var backoffMs: Long = 100
+)

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/JooqSqlCommentAppender.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/JooqSqlCommentAppender.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.sql
+
+import com.netflix.spinnaker.security.AuthenticatedRequest
+import org.jooq.ExecuteContext
+import org.jooq.impl.DefaultExecuteListener
+import org.slf4j.MDC
+
+/**
+ * Appends contextual information about the source of a SQL query for
+ * debugging purposes.
+ */
+class JooqSqlCommentAppender : DefaultExecuteListener() {
+
+  override fun renderEnd(ctx: ExecuteContext) {
+    val comments: ArrayList<String> = ArrayList()
+
+    if (AuthenticatedRequest.getSpinnakerExecutionId().isPresent) {
+      comments.add("executionId: " + AuthenticatedRequest.getSpinnakerExecutionId().get())
+    }
+
+    if (AuthenticatedRequest.getSpinnakerUser().isPresent) {
+      comments.add("user: " + AuthenticatedRequest.getSpinnakerUser().get())
+    }
+
+    if (AuthenticatedRequest.getSpinnakerUserOrigin().isPresent) {
+      comments.add("origin: " + AuthenticatedRequest.getSpinnakerUserOrigin().get())
+    }
+
+    val poller: String? = MDC.get("agentClass")
+    if (poller != null) {
+      comments.add("agentClass: $poller")
+    }
+
+    if (comments.isNotEmpty()) {
+      ctx.sql(ctx.sql() + comments.joinToString(prefix = " -- ", separator = " "))
+    }
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/JooqToSpringExceptionTransformer.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/JooqToSpringExceptionTransformer.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql
+
+import org.jooq.ExecuteContext
+import org.jooq.impl.DefaultExecuteListener
+import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator
+import org.springframework.jdbc.support.SQLStateSQLExceptionTranslator
+
+class JooqToSpringExceptionTransformer : DefaultExecuteListener() {
+
+  override fun exception(ctx: ExecuteContext) {
+    val dialect = ctx.configuration().dialect()
+    val translator = if (dialect != null)
+      SQLErrorCodeSQLExceptionTranslator(dialect.name)
+    else
+      SQLStateSQLExceptionTranslator()
+    ctx.exception(translator.translate("jOOQ", ctx.sql(), ctx.sqlException()))
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/SqlHealthIndicator.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/SqlHealthIndicator.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql
+
+import org.jooq.SQLDialect
+import org.springframework.boot.actuate.health.AbstractHealthIndicator
+import org.springframework.boot.actuate.health.Health
+
+/**
+ * Overrides the default Spring DataSourceHealthIndicator, which perfroms
+ * queries at request-time (bad). Uses the background agent of
+ * [SqlHealthcheckActivator] to determine if SQL connections are healthy.
+ */
+class SqlHealthIndicator(
+  private val sqlHealthcheckActivator: SqlHealthcheckActivator,
+  private val sqlDialect: SQLDialect
+) : AbstractHealthIndicator() {
+
+  override fun doHealthCheck(builder: Health.Builder) {
+    if (sqlHealthcheckActivator.enabled) {
+      builder.up().withDetail("database", sqlDialect.name)
+    } else {
+      builder.down().withDetail("database", sqlDialect.name).let {
+        sqlHealthcheckActivator.healthException?.let { exception ->
+          it.withException(exception)
+        }
+      }
+    }
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/SqlHealthcheckActivator.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/SqlHealthcheckActivator.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.q.Activator
+import org.jooq.DSLContext
+import org.jooq.impl.DSL.table
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Continually performs writes to the SQL backend in order to detect master
+ * failures and to deactivate queue processing as a result.
+ *
+ * Behaves quite like load balancer healthchecks. By default, this activator
+ * will fail fast and be slow to come healthy again.
+ */
+class SqlHealthcheckActivator(
+  private val jooq: DSLContext,
+  private val registry: Registry,
+  private val unhealthyThreshold: Int = 2,
+  private val healthyThreshold: Int = 10
+) : Activator {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  internal val _enabled = AtomicBoolean(false)
+  private val _healthException: AtomicReference<Exception> = AtomicReference()
+
+  private val healthyCounter = AtomicInteger(0)
+  private val unhealthyCounter = AtomicInteger(0)
+
+  private val invocationId = registry.createId("sql.queueActivator.invocations")
+
+  override val enabled: Boolean
+    get() = _enabled.get()
+
+  val healthException: Exception?
+    get() = _healthException.get()
+
+  @Scheduled(fixedDelay = 1_000)
+  fun performWrite() {
+    try {
+      // THIS IS VERY ADVANCED
+      jooq.delete(table("healthcheck")).execute()
+
+      if (!_enabled.get()) {
+        if (healthyCounter.incrementAndGet() >= healthyThreshold) {
+          _enabled.set(true)
+          _healthException.set(null)
+          log.info("Enabling activator after $healthyThreshold healthy cycles")
+        }
+      }
+      unhealthyCounter.set(0)
+    } catch (e: Exception) {
+      _healthException.set(e)
+      healthyCounter.set(0)
+      unhealthyCounter.incrementAndGet().also { unhealthyCount ->
+        log.error("Encountered exception, $unhealthyCount/$unhealthyThreshold failures", e)
+        if (unhealthyCount >= unhealthyThreshold && _enabled.get()) {
+          log.warn("Encountered exception, disabling Activator after $unhealthyCount failures")
+          _enabled.set(false)
+        }
+      }
+    } finally {
+      registry.counter(invocationId.withTag("status", if (enabled) "enabled" else "disabled")).increment()
+    }
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgent.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgent.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.sql.cleanup
+
+import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.LongTaskTimer
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.notifications.AbstractPollingNotificationAgent
+import com.netflix.spinnaker.orca.notifications.NotificationClusterLock
+import com.netflix.spinnaker.orca.sql.pipeline.persistence.transactional
+import org.jooq.DSLContext
+import org.jooq.impl.DSL.count
+import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.table
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@Component
+@ConditionalOnExpression("\${pollers.oldPipelineCleanup.enabled:false} && !\${executionRepository.redis.enabled:false}")
+class OldPipelineCleanupPollingNotificationAgent(
+  clusterLock: NotificationClusterLock,
+  private val jooq: DSLContext,
+  private val clock: Clock,
+  private val registry: Registry,
+  @Value("\${pollers.oldPipelineCleanup.intervalMs:3600000}") private val pollingIntervalMs: Long,
+  @Value("\${pollers.oldPipelineCleanup.thresholdDays:30}") private val thresholdDays: Long,
+  @Value("\${pollers.oldPipelineCleanup.minimumPipelineExecutions:5}") private val minimumPipelineExecutions: Int,
+  @Value("\${pollers.oldPipelineCleanup.chunkSize:1}") private val chunkSize: Int
+) : AbstractPollingNotificationAgent(clusterLock) {
+
+  companion object {
+    internal val retrySupport = RetrySupport()
+  }
+
+  private val log = LoggerFactory.getLogger(OldPipelineCleanupPollingNotificationAgent::class.java)
+
+  private val deletedId: Id
+  private val errorsCounter: Counter
+  private val invocationTimer: LongTaskTimer
+
+  private val completedStatuses = ExecutionStatus.COMPLETED.map { it.toString() }
+
+  init {
+    deletedId = registry.createId("pollers.oldPipelineCleanup.deleted")
+    errorsCounter = registry.counter("pollers.oldPipelineCleanup.errors")
+
+    invocationTimer = com.netflix.spectator.api.patterns.LongTaskTimer.get(
+      registry, registry.createId("pollers.oldPipelineCleanup.timing")
+    )
+  }
+
+  override fun getPollingInterval(): Long {
+    return pollingIntervalMs
+  }
+
+  override fun getNotificationType(): String {
+    return OldPipelineCleanupPollingNotificationAgent::class.java.simpleName
+  }
+
+  override fun tick() {
+    val timerId = invocationTimer.start()
+    val startTime = System.currentTimeMillis()
+
+    try {
+      log.info("Agent {} started", notificationType)
+      performCleanup()
+    } catch (e: Exception) {
+      log.error("Agent {} failed to perform cleanup", e)
+    } finally {
+      log.info("Agent {} completed in {}ms", notificationType, System.currentTimeMillis() - startTime)
+      invocationTimer.stop(timerId)
+    }
+  }
+
+  private fun performCleanup() {
+    val thresholdMillis = Instant.ofEpochMilli(clock.millis()).minus(thresholdDays, ChronoUnit.DAYS).toEpochMilli()
+
+    val pipelineConfigsWithOldExecutions = jooq
+      .select(field("application"), field("config_id"), count(field("id")).`as`("count"))
+      .from(table("pipelines"))
+      .where(
+        field("build_time").le(thresholdMillis).and(
+          "status IN (${completedStatuses.joinToString(",") { "'$it'" }})"
+        )
+      )
+      .groupBy(field("application"), field("config_id"))
+      .having(count(field("id")).gt(minimumPipelineExecutions))
+      .fetch()
+
+    pipelineConfigsWithOldExecutions.forEach {
+      val application = it.getValue(field("application")) as String? ?: return@forEach
+      val pipelineConfigId = it.getValue(field("config_id")) as String? ?: return@forEach
+
+      try {
+        val startTime = System.currentTimeMillis()
+
+        log.debug("Cleaning up old pipelines for $application (pipelineConfigId: $pipelineConfigId)")
+        val deletedPipelineCount = performCleanup(application, pipelineConfigId, thresholdMillis)
+        log.debug(
+          "Cleaned up {} old pipelines for {} in {}ms (pipelineConfigId: {})",
+          deletedPipelineCount,
+          application,
+          System.currentTimeMillis() - startTime,
+          pipelineConfigId
+        )
+      } catch (e: Exception) {
+        log.error("Failed to cleanup old pipelines for $application (pipelineConfigId: $pipelineConfigId)", e)
+        errorsCounter.increment();
+      }
+    }
+  }
+
+  /**
+   * Cleanup any execution of [pipelineConfigId] in [application] that is older than [thresholdMillis].
+   *
+   * _Only_ executions in a completed status are candidates for cleanup.
+   *
+   * In order to avoid removing _all_ executions of a particular pipeline configuration, [minimumPipelineExecutions] can
+   * be used to indicate that a specific number of the most recent executions should be preserved even though they are
+   * older than [thresholdMillis].
+   */
+  private fun performCleanup(application: String,
+                             pipelineConfigId: String,
+                             thresholdMillis: Long) : Int {
+    val deletedExecutionCount = AtomicInteger()
+
+    val executionsToRemove = jooq
+      .select(field("id"))
+      .from(table("pipelines"))
+      .where(
+        field("build_time").le(thresholdMillis).and(
+          "status IN (${completedStatuses.joinToString(",") { "'$it'" }})"
+        ).and(
+          field("application").eq(application)
+        ).and(
+          field("config_id").eq(pipelineConfigId)
+        )
+      )
+      .orderBy(field("build_time").desc())
+      .limit(minimumPipelineExecutions, Int.MAX_VALUE)
+      .fetch()
+      .map { it.getValue(field("id")) }
+
+    executionsToRemove.chunked(chunkSize).forEach { ids ->
+      deletedExecutionCount.addAndGet(ids.size)
+      jooq.transactional(retrySupport) {
+        it.delete(table("correlation_ids")).where(
+          "pipeline_id IN (${ids.joinToString(",") { "'$it'" }})"
+        ).execute()
+        it.delete(table("pipeline_stages")).where(
+          "execution_id IN (${ids.joinToString(",") { "'$it'" }})"
+        ).execute()
+        it.delete(table("pipelines")).where(
+          "id IN (${ids.joinToString(",") { "'$it'" }})"
+        ).execute()
+      }
+
+      registry.counter(deletedId.withTag("application", application)).add(ids.size.toDouble())
+    }
+
+    return deletedExecutionCount.toInt()
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgent.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgent.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.sql.cleanup
+
+import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.LongTaskTimer
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.notifications.AbstractPollingNotificationAgent
+import com.netflix.spinnaker.orca.notifications.NotificationClusterLock
+import com.netflix.spinnaker.orca.sql.pipeline.persistence.transactional
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.util.concurrent.atomic.AtomicInteger
+
+
+@Component
+@ConditionalOnExpression("\${pollers.topApplicationExecutionCleanup.enabled:false} && !\${executionRepository.redis.enabled:false}")
+class TopApplicationExecutionCleanupPollingNotificationAgent(
+  clusterLock: NotificationClusterLock,
+  private val jooq: DSLContext,
+  private val registry: Registry,
+  private val retrySupport: RetrySupport,
+  @Value("\${pollers.topApplicationExecutionCleanup.intervalMs:3600000}") private val pollingIntervalMs: Long,
+  @Value("\${pollers.topApplicationExecutionCleanup.threshold:2000}") private val threshold: Int,
+  @Value("\${pollers.topApplicationExecutionCleanup.chunkSize:1}") private val chunkSize: Int
+) : AbstractPollingNotificationAgent(clusterLock) {
+
+  private val log = LoggerFactory.getLogger(TopApplicationExecutionCleanupPollingNotificationAgent::class.java)
+
+  private val deletedId: Id
+  private val errorsCounter: Counter
+  private val invocationTimer: LongTaskTimer
+
+  private val completedStatuses = ExecutionStatus.COMPLETED.map { it.toString() }
+
+  init {
+    deletedId = registry.createId("pollers.topApplicationExecutionCleanup.deleted")
+    errorsCounter = registry.counter("pollers.topApplicationExecutionCleanup.errors")
+
+    invocationTimer = com.netflix.spectator.api.patterns.LongTaskTimer.get(
+      registry, registry.createId("pollers.topApplicationExecutionCleanup.timing")
+    )
+  }
+
+  override fun getPollingInterval(): Long {
+    return pollingIntervalMs
+  }
+
+  override fun getNotificationType(): String {
+    return TopApplicationExecutionCleanupPollingNotificationAgent::class.java.simpleName
+  }
+
+  override fun tick() {
+    val timerId = invocationTimer.start()
+    val startTime = System.currentTimeMillis()
+
+    try {
+      log.info("Agent {} started", notificationType)
+      performCleanup()
+    } catch (e: Exception) {
+      log.error("Agent {} failed to perform cleanup", e)
+    } finally {
+      log.info("Agent {} completed in {}ms", notificationType, System.currentTimeMillis() - startTime)
+      invocationTimer.stop(timerId)
+    }
+  }
+
+  private fun performCleanup() {
+    val applicationsWithOldOrchestrations = jooq
+      .select(DSL.field("application"), DSL.count(DSL.field("id")).`as`("count"))
+      .from(DSL.table("orchestrations"))
+      .groupBy(DSL.field("application"))
+      .having(DSL.count(DSL.field("id")).gt(threshold))
+      .fetch()
+
+    applicationsWithOldOrchestrations.forEach {
+      val application = it.getValue(DSL.field("application")) as String? ?: return@forEach
+
+      try {
+        val startTime = System.currentTimeMillis()
+
+        log.debug("Cleaning up old orchestrations for $application")
+        val deletedOrchestrationCount = performCleanup(application)
+        log.debug(
+          "Cleaned up {} old orchestrations for {} in {}ms",
+          deletedOrchestrationCount,
+          application,
+          System.currentTimeMillis() - startTime
+        )
+      } catch (e: Exception) {
+        log.error("Failed to cleanup old orchestrations for $application", e)
+        errorsCounter.increment();
+      }
+    }
+  }
+
+  /**
+   * An application can have at most [threshold] completed orchestrations.
+   */
+  private fun performCleanup(application: String) : Int {
+    val deletedExecutionCount = AtomicInteger()
+
+    val executionsToRemove = jooq
+      .select(DSL.field("id"))
+      .from(DSL.table("orchestrations"))
+      .where(
+        DSL.field("application").eq(application).and(
+          "status IN (${completedStatuses.joinToString(",") { "'$it'" }})"
+        )
+      )
+      .orderBy(DSL.field("build_time").desc())
+      .limit(threshold, Int.MAX_VALUE)
+      .fetch()
+      .map { it.getValue(DSL.field("id")) }
+
+    log.debug("Found {} old orchestrations for {}", executionsToRemove.size, application)
+
+    executionsToRemove.chunked(chunkSize).forEach { ids ->
+      deletedExecutionCount.addAndGet(ids.size)
+      jooq.transactional(retrySupport) {
+        it.delete(DSL.table("correlation_ids")).where(
+          "orchestration_id IN (${ids.joinToString(",") { "'$it'" }})"
+        ).execute()
+        it.delete(DSL.table("orchestration_stages")).where(
+          "execution_id IN (${ids.joinToString(",") { "'$it'" }})"
+        ).execute()
+        it.delete(DSL.table("orchestrations")).where(
+          "id IN (${ids.joinToString(",") { "'$it'" }})"
+        ).execute()
+      }
+
+      registry.counter(deletedId.withTag("application", application)).add(ids.size.toDouble())
+    }
+
+    return deletedExecutionCount.toInt()
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/config/DataSourceConfiguration.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/config/DataSourceConfiguration.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.config
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.config.SqlProperties
+import com.netflix.spinnaker.orca.sql.telemetry.SpectatorHikariMetricsTrackerFactory
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.DependsOn
+import javax.sql.DataSource
+
+@Configuration
+@ConditionalOnMissingBean(DataSource::class)
+class DataSourceConfiguration {
+
+  @Bean
+  fun spectatorMetricsTrackerFactory(registry: Registry): MetricsTrackerFactory =
+    SpectatorHikariMetricsTrackerFactory(registry)
+
+  @DependsOn("liquibase")
+  @Bean fun hikariConfig(metricsTrackerFactory: MetricsTrackerFactory, properties: SqlProperties): HikariConfig =
+    HikariConfig().apply {
+      properties.apply {
+        jdbcUrl = connectionPool.jdbcUrl
+        username = connectionPool.user
+        password = connectionPool.password
+        connectionTimeout = connectionPool.connectionTimeoutMs
+        validationTimeout = connectionPool.validationTimeoutMs
+        idleTimeout = connectionPool.idleTimeoutMs
+        maxLifetime = connectionPool.maxLifetimeMs
+        minimumIdle = connectionPool.minIdle
+        maximumPoolSize = connectionPool.maxPoolSize
+        if (connectionPool.driver != null) {
+          driverClassName = connectionPool.driver
+        }
+      }
+      setMetricsTrackerFactory(metricsTrackerFactory)
+    }
+
+  @Bean(destroyMethod = "close") fun dataSource(hikariConfig: HikariConfig): DataSource =
+    HikariDataSource(hikariConfig)
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/ExecutionMapper.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/ExecutionMapper.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.pipeline.persistence
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.jooq.DSLContext
+import java.sql.ResultSet
+
+/**
+ * Converts a SQL [ResultSet] into an Execution.
+ *
+ * When retrieving an Execution from SQL, we lazily load its stages on-demand
+ * in this mapper as well.
+ */
+class ExecutionMapper(
+  private val mapper: ObjectMapper
+) {
+
+  fun map(rs: ResultSet, context: DSLContext): Collection<Execution> {
+    val results = mutableListOf<Execution>()
+
+    while (rs.next()) {
+      mapper.readValue<Execution>(rs.getString("body"))
+        .also { execution ->
+          context.selectExecutionStages(execution.type, rs.getString("id")).let { stageResultSet ->
+            while (stageResultSet.next()) {
+              mapStage(stageResultSet, execution)
+            }
+          }
+          execution.stages.sortBy { it.refId }
+        }
+        .also { results.add(it) }
+    }
+
+    return results
+  }
+
+  private fun mapStage(rs: ResultSet, execution: Execution) {
+    execution.stages.add(mapper.readValue<Stage>(rs.getString("body")).apply {
+      setExecution(execution)
+    })
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/ExecutionStatisticsRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/ExecutionStatisticsRepository.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.pipeline.persistence
+
+interface ExecutionStatisticsRepository {
+
+  fun countActiveExecutions(): ActiveExecutionsReport
+}
+
+data class ActiveExecutionsReport(
+  val orchestrations: Int,
+  val pipelines: Int
+) {
+  fun total() = orchestrations + pipelines
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/PagedIterator.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/PagedIterator.kt
@@ -1,0 +1,41 @@
+package com.netflix.spinnaker.orca.sql.pipeline.persistence
+
+/**
+ * An iterator that can fetch paginated data transparently to clients.
+ */
+internal class PagedIterator<T, C>(
+  private val pageSize: Int,
+  private val toCursor: (T) -> C,
+  private val nextPage: (Int, C?) -> Iterable<T>
+) : Iterator<T> {
+  override fun hasNext(): Boolean =
+    if (isLastPage && index > currentPage.lastIndex) {
+      false
+    } else {
+      loadNextChunkIfNecessary()
+      index <= currentPage.lastIndex
+    }
+
+  override fun next(): T =
+    if (isLastPage && index > currentPage.lastIndex) {
+      throw NoSuchElementException()
+    } else {
+      loadNextChunkIfNecessary()
+      currentPage[index++]
+    }
+
+  private fun loadNextChunkIfNecessary() {
+    if (index !in currentPage.indices) {
+      currentPage.clear()
+      nextPage(pageSize, cursor).let(currentPage::addAll)
+      index = 0
+      cursor = currentPage.lastOrNull()?.let(toCursor)
+      isLastPage = currentPage.size < pageSize
+    }
+  }
+
+  private var cursor: C? = null
+  private val currentPage: MutableList<T> = mutableListOf()
+  private var index: Int = -1
+  private var isLastPage: Boolean = false
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -1,0 +1,684 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.pipeline.persistence
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.config.TransactionRetryProperties
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.ExecutionStatus.BUFFERED
+import com.netflix.spinnaker.orca.ExecutionStatus.CANCELED
+import com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED
+import com.netflix.spinnaker.orca.ExecutionStatus.PAUSED
+import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
+import com.netflix.spinnaker.orca.pipeline.model.Execution.PausedDetails
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionCriteria
+import com.netflix.spinnaker.orca.pipeline.persistence.UnpausablePipelineException
+import com.netflix.spinnaker.orca.pipeline.persistence.UnresumablePipelineException
+import de.huxhorn.sulky.ulid.SpinULID
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.Record
+import org.jooq.SelectConditionStep
+import org.jooq.SelectConnectByStep
+import org.jooq.SelectForUpdateStep
+import org.jooq.SelectJoinStep
+import org.jooq.SelectWhereStep
+import org.jooq.Table
+import org.jooq.exception.SQLDialectNotSupportedException
+import org.jooq.impl.DSL
+import org.jooq.impl.DSL.count
+import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.name
+import org.jooq.impl.DSL.table
+import org.slf4j.LoggerFactory
+import rx.Observable
+import java.lang.System.currentTimeMillis
+import java.security.SecureRandom
+
+/**
+ * A generic SQL [ExecutionRepository].
+ *
+ * There is a small amount of MySQL/PostgreSQL specific commands inside, but
+ * all of which safely fallback to common SQL if the dialect does not match.
+ */
+class SqlExecutionRepository(
+  private val partitionName: String?,
+  private val jooq: DSLContext,
+  private val mapper: ObjectMapper,
+  private val transactionRetryProperties: TransactionRetryProperties
+) : ExecutionRepository, ExecutionStatisticsRepository {
+  companion object {
+    val ulid = SpinULID(SecureRandom())
+    internal val retrySupport = RetrySupport()
+  }
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  override fun store(execution: Execution) {
+    jooq.transactional { storeExecutionInternal(it, execution, true) }
+  }
+
+  override fun storeStage(stage: Stage) {
+    jooq.transactional { storeStageInternal(it, stage) }
+  }
+
+  override fun updateStageContext(stage: Stage) {
+    storeStage(stage)
+  }
+
+  override fun removeStage(execution: Execution, stageId: String) {
+    jooq.transactional {
+      it.delete(execution.type.stagesTableName)
+        .where(stageId.toWhereCondition()).execute()
+    }
+  }
+
+  override fun addStage(stage: Stage) {
+    if (stage.syntheticStageOwner == null || stage.parentStageId == null) {
+      throw SyntheticStageRequired()
+    }
+    storeStage(stage)
+  }
+
+  override fun cancel(type: ExecutionType, id: String) {
+    cancel(type, id, null, null)
+  }
+
+  override fun cancel(type: ExecutionType, id: String, user: String?, reason: String?) {
+    jooq.transactional {
+      selectExecution(it, type, id)
+        ?.let { execution ->
+          execution.isCanceled = true
+          if (user != null) {
+            execution.canceledBy = user
+          }
+          if (reason != null && reason.isNotEmpty()) {
+            execution.cancellationReason = reason
+          }
+          if (execution.status == NOT_STARTED) {
+            execution.status = CANCELED
+          }
+          storeExecutionInternal(it, execution)
+        }
+    }
+  }
+
+  override fun pause(type: ExecutionType, id: String, user: String?) {
+    jooq.transactional {
+      selectExecution(it, type, id)
+        ?.let { execution ->
+          if (execution.status != RUNNING) {
+            throw UnpausablePipelineException("Unable to pause pipeline that is not RUNNING " +
+              "(executionId: $id, currentStatus: ${execution.status})")
+          }
+          execution.status = PAUSED
+          execution.paused = PausedDetails().apply {
+            pausedBy = user
+            pauseTime = currentTimeMillis()
+          }
+          storeExecutionInternal(it, execution)
+        }
+    }
+  }
+
+  override fun resume(type: ExecutionType, id: String, user: String?) {
+    resume(type, id, user, false)
+  }
+
+  override fun resume(type: ExecutionType, id: String, user: String?, ignoreCurrentStatus: Boolean) {
+    jooq.transactional {
+      selectExecution(it, type, id)
+        ?.let { execution ->
+          if (!ignoreCurrentStatus && execution.status != PAUSED) {
+            throw UnresumablePipelineException("Unable to resume pipeline that is not PAUSED " +
+              "(executionId: $id, currentStatus: ${execution.status}")
+          }
+          execution.status = RUNNING
+          execution.paused?.resumedBy = user
+          execution.paused?.resumeTime = currentTimeMillis()
+          storeExecutionInternal(it, execution)
+        }
+    }
+  }
+
+  override fun isCanceled(type: ExecutionType, id: String): Boolean {
+    return jooq.fetchExists(
+      jooq.selectFrom(type.tableName)
+        .where(id.toWhereCondition())
+        .and(field("canceled").eq(true))
+    )
+  }
+
+  override fun updateStatus(type: ExecutionType, id: String, status: ExecutionStatus) {
+    jooq.transactional {
+      selectExecution(it, type, id)
+        ?.let { execution ->
+          execution.status = status
+          if (status == RUNNING) {
+            execution.isCanceled = false
+            execution.startTime = currentTimeMillis()
+          } else if (status.isComplete && execution.startTime != null) {
+            execution.endTime = currentTimeMillis()
+          }
+          storeExecutionInternal(it, execution)
+        }
+    }
+  }
+
+  override fun delete(type: ExecutionType, id: String) {
+    jooq.transactional {
+      val correlationField = if (type == PIPELINE) "pipeline_id" else "orchestration_id"
+      val (ulid, _) = mapLegacyId(it, type.tableName, id)
+      it.delete(table("correlation_ids")).where(field(correlationField).eq(ulid)).execute()
+      it.delete(type.stagesTableName).where(field("execution_id").eq(ulid)).execute()
+      it.delete(type.tableName).where(field("id").eq(ulid)).execute()
+    }
+  }
+
+  // TODO rz - Refactor to not use exceptions. So weird.
+  override fun retrieve(type: ExecutionType, id: String) =
+    selectExecution(jooq, type, id)
+      ?: throw ExecutionNotFoundException("No $type found for $id")
+
+  override fun retrieve(type: ExecutionType): Observable<Execution> =
+    Observable.from(fetchExecutions { pageSize, cursor ->
+      selectExecutions(type, pageSize, cursor)
+    })
+
+  override fun retrieve(type: ExecutionType, criteria: ExecutionCriteria): Observable<Execution> {
+    return retrieve(type, criteria, null)
+  }
+
+  private fun retrieve(type: ExecutionType, criteria: ExecutionCriteria, partition: String?): Observable<Execution> {
+    val select = jooq.selectExecutions(
+      type,
+      fields = selectFields() + field("status"),
+      conditions = {
+        if (partition.isNullOrEmpty()) {
+          it.statusIn(criteria.statuses)
+        } else {
+          it.where(field(name("partition")).eq(partition))
+            .statusIn(criteria.statuses)
+        }
+      },
+      seek = {
+        it.orderBy(field("id").desc())
+          .run {
+            if (criteria.limit > 0) {
+              limit(criteria.limit)
+            } else {
+              this
+            }
+          }
+      })
+
+    return Observable.from(select.fetchExecutions())
+  }
+
+  override fun retrievePipelinesForApplication(application: String): Observable<Execution> =
+    Observable.from(fetchExecutions { pageSize, cursor ->
+      selectExecutions(PIPELINE, pageSize, cursor) {
+        it.where(field("application").eq(application))
+      }
+    })
+
+  override fun retrievePipelinesForPipelineConfigId(
+    pipelineConfigId: String,
+    criteria: ExecutionCriteria
+  ): Observable<Execution> {
+    val select = jooq.selectExecutions(
+      PIPELINE,
+      conditions = {
+        it.where(field("config_id").eq(pipelineConfigId))
+          .statusIn(criteria.statuses)
+      },
+      seek = {
+        it.orderBy(field("id").desc()).limit(criteria.limit)
+      }
+    )
+
+    return Observable.from(select.fetchExecutions())
+  }
+
+  override fun retrieveOrchestrationsForApplication(
+    application: String,
+    criteria: ExecutionCriteria
+  ): Observable<Execution> {
+    val select = jooq.selectExecutions(
+      ORCHESTRATION,
+      conditions = {
+        it.where(field("application").eq(application))
+          .statusIn(criteria.statuses)
+      },
+      seek = {
+        it.orderBy(field("id").desc())
+          .offset((criteria.page - 1) * criteria.limit)
+          .limit(criteria.limit)
+      }
+    )
+
+    return Observable.from(select.fetchExecutions())
+  }
+
+  // TODO rz - Refactor to not use exceptions
+  // TODO rz - Refactor to allow different ExecutionTypes
+  override fun retrieveOrchestrationForCorrelationId(correlationId: String): Execution {
+    val execution = jooq.selectExecution(ORCHESTRATION)
+      .where(field("id").eq(
+        field(
+          jooq.select(field("c.orchestration_id"))
+            .from(table("correlation_ids").`as`("c"))
+            .where(field("c.id").eq(correlationId))
+            .limit(1)
+        ) as Any
+      ))
+      .fetchExecution()
+
+    if (execution != null) {
+      if (!execution.status.isComplete) {
+        return execution
+      }
+      jooq.transactional {
+        it.deleteFrom(table("correlation_ids")).where(field("id").eq(correlationId)).execute()
+      }
+    }
+
+    throw ExecutionNotFoundException("No Orchestration found for correlation ID $correlationId")
+  }
+
+  override fun retrieveBufferedExecutions(): MutableList<Execution> =
+    ExecutionCriteria().setStatuses(BUFFERED)
+      .let { criteria ->
+        rx.Observable.merge(
+          retrieve(ORCHESTRATION, criteria, partitionName),
+          retrieve(PIPELINE, criteria, partitionName)
+        ).toList().toBlocking().single()
+      }
+
+  override fun retrieveAllApplicationNames(type: ExecutionType?): List<String> {
+    return if (type == null) {
+      jooq.select(field("application"))
+        .from(PIPELINE.tableName)
+        .groupBy(field("application"))
+        .unionAll(
+          jooq.select(field("application"))
+            .from(ORCHESTRATION.tableName)
+            .groupBy(field("application"))
+        )
+        .fetch(0, String::class.java)
+        .distinct()
+    } else {
+      jooq.select(field("application"))
+        .from(type.tableName)
+        .groupBy(field("application"))
+        .fetch(0, String::class.java)
+        .distinct()
+    }
+  }
+
+  override fun retrieveAllApplicationNames(type: ExecutionType?, minExecutions: Int): List<String> {
+    return if (type == null) {
+      jooq.select(field("application"))
+        .from(PIPELINE.tableName)
+        .groupBy(field("application"))
+        .having(count().ge(minExecutions))
+        .unionAll(
+          jooq.select(field("application"))
+            .from(ORCHESTRATION.tableName)
+            .groupBy(field("application"))
+            .having(count().ge(minExecutions))
+        )
+        .fetch(0, String::class.java)
+        .distinct()
+    } else {
+      jooq.select(field("application"))
+        .from(type.tableName)
+        .groupBy(field("application"))
+        .having(count().ge(minExecutions))
+        .fetch(0, String::class.java)
+        .distinct()
+    }
+  }
+
+  override fun countActiveExecutions(): ActiveExecutionsReport {
+    val orchestrationsQuery = jooq.selectCount()
+      .from(ORCHESTRATION.tableName)
+      .where(field("status").eq(RUNNING.toString()))
+      .asField<Int>("orchestrations")
+    val pipelinesQuery = jooq.selectCount()
+      .from(PIPELINE.tableName)
+      .where(field("status").eq(RUNNING.toString()))
+      .asField<Int>("pipelines")
+
+    val record = jooq.select(orchestrationsQuery, pipelinesQuery).fetchOne()
+
+    return ActiveExecutionsReport(
+      record.get(0, Int::class.java),
+      record.get(1, Int::class.java)
+    )
+  }
+
+  override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(pipelineConfigIds: MutableList<String>,
+                                                                             buildTimeStartBoundary: Long,
+                                                                             buildTimeEndBoundary: Long): Observable<Execution> {
+    val select = jooq.selectExecutions(
+      ORCHESTRATION,
+      conditions = {
+        it.where(field("config_id").`in`(pipelineConfigIds.toTypedArray()))
+          .and(field("build_time").gt(buildTimeStartBoundary))
+          .and(field("build_time").lt(buildTimeEndBoundary))
+      },
+      seek = {
+        it.orderBy(field("id").desc())
+      }
+    )
+
+    return Observable.from(select.fetchExecutions())
+  }
+
+  override fun hasExecution(type: ExecutionType, id: String): Boolean {
+    return jooq.selectCount()
+      .from(type.tableName)
+      .where(id.toWhereCondition())
+      .fetchOne(count()) > 0
+  }
+
+  override fun retrieveAllExecutionIds(type: ExecutionType): MutableList<String> {
+    return jooq.select(field("id")).from(type.tableName).fetch("id", String::class.java)
+  }
+
+  /**
+   * Given an id, returns a tuple of [ULID, LegacyID]
+   *
+   * - When the provided id a ULID, returns: [id, null]
+   * - When id is not a ULID but exists in the table, fetches ulid and returns: [fetched_ulid, id]
+   * - When id is not a ULID and does not exist, creates new_ulid and returns: [new_ulid, id]
+   */
+  private fun mapLegacyId(ctx: DSLContext,
+                          table: Table<Record>,
+                          id: String,
+                          timestamp: Long? = null): Pair<String, String?> {
+    if (isULID(id)) return Pair(id, null)
+
+    val ts = (timestamp ?: System.currentTimeMillis())
+    val row = ctx.select(field("id"))
+      .from(table)
+      .where(field("legacy_id").eq(id))
+      .limit(1)
+      .fetchOne()
+    val ulid = row?.let { it.getValue(field("id")) as String } ?: ulid.nextULID(ts)
+
+    return Pair(ulid, id)
+  }
+
+  private fun storeExecutionInternal(ctx: DSLContext, execution: Execution, storeStages: Boolean = false) {
+    // TODO rz - Nasty little hack here to save the execution without any of its stages.
+    val stages = execution.stages.toMutableList().toList()
+    execution.stages.clear()
+
+    try {
+      val tableName = execution.type.tableName
+      val stageTableName = execution.type.stagesTableName
+      val status = execution.status.toString()
+      val body = mapper.writeValueAsString(execution)
+
+      val (executionId, legacyId) = mapLegacyId(ctx, tableName, execution.id, execution.startTime)
+
+      val insertPairs = mapOf(
+        field("id") to executionId,
+        field("legacy_id") to legacyId,
+        field(name("partition")) to partitionName,
+        field("status") to status,
+        field("application") to execution.application,
+        field("build_time") to (execution.buildTime ?: currentTimeMillis()),
+        field("canceled") to execution.isCanceled,
+        field("updated_at") to currentTimeMillis(),
+        field("body") to body
+      )
+
+      val updatePairs = mapOf(
+        field("status") to status,
+        field("body") to body,
+        field("canceled") to execution.isCanceled,
+        field("updated_at") to currentTimeMillis()
+      )
+
+      when (execution.type) {
+        PIPELINE      -> upsert(
+          ctx,
+          execution.type.tableName,
+          insertPairs.plus(field("config_id") to execution.pipelineConfigId),
+          updatePairs.plus(field("config_id") to execution.pipelineConfigId),
+          executionId
+        )
+        ORCHESTRATION -> upsert(
+          ctx,
+          execution.type.tableName,
+          insertPairs,
+          updatePairs,
+          executionId
+        )
+      }
+
+      storeCorrelationIdInternal(ctx, execution)
+
+      if (storeStages) {
+        val stageIds = stages.map { it.id }.toTypedArray()
+
+        // Remove stages that are no longer part of the execution. This
+        // would happen while restarting a completed or paused execution
+        // and synthetics need to be cleaned up.
+        ctx.deleteFrom(stageTableName)
+          .where(field("execution_id").eq(executionId))
+          .apply {
+            if (!stageIds.isEmpty()) {
+              and(field("id").notIn(*stageIds))
+                .and(field("legacy_id").notIn(*stageIds).or(field("legacy_id").isNull))
+            }
+          }.execute()
+
+        stages.forEach { storeStageInternal(ctx, it, executionId) }
+      }
+    } finally {
+      execution.stages.addAll(stages)
+    }
+  }
+
+  private fun storeStageInternal(ctx: DSLContext, stage: Stage, executionId: String? = null) {
+    val stageTable = stage.execution.type.stagesTableName
+    val table = stage.execution.type.tableName
+    val body = mapper.writeValueAsString(stage)
+    val buildTime = stage.execution.buildTime
+
+    val executionUlid = executionId ?: mapLegacyId(ctx, table, stage.execution.id, buildTime).first
+    val (stageId, legacyId) = mapLegacyId(ctx, stageTable, stage.id, buildTime)
+
+    val insertPairs = mapOf(
+      field("id") to stageId,
+      field("legacy_id") to legacyId,
+      field("execution_id") to executionUlid,
+      field("status") to stage.status.toString(),
+      field("updated_at") to currentTimeMillis(),
+      field("body") to body
+    )
+
+    val updatePairs = mapOf(
+      field("status") to stage.status.toString(),
+      field("updated_at") to currentTimeMillis(),
+      field("body") to body
+    )
+
+    upsert(ctx, stageTable, insertPairs, updatePairs, stage.id)
+  }
+
+  private fun storeCorrelationIdInternal(ctx: DSLContext, execution: Execution) {
+    if (execution.trigger.correlationId != null && !execution.status.isComplete) {
+      val executionIdField = when (execution.type) {
+        PIPELINE      -> field("pipeline_id")
+        ORCHESTRATION -> field("orchestration_id")
+      }
+
+      val exists = ctx.fetchExists(
+        ctx.select()
+          .from("correlation_ids")
+          .where(field("id").eq(execution.trigger.correlationId))
+          .and(executionIdField.eq(execution.id))
+      )
+      if (!exists) {
+        ctx.insertInto(table("correlation_ids"))
+          .columns(field("id"), executionIdField)
+          .values(execution.trigger.correlationId, execution.id)
+          .execute()
+      }
+    }
+  }
+
+  private fun upsert(ctx: DSLContext,
+                     table: Table<Record>,
+                     insertPairs: Map<Field<Any?>, Any?>,
+                     updatePairs: Map<Field<Any>, Any?>,
+                     updateId: String) {
+    // MySQL & PG support upsert concepts. A nice little efficiency here, we
+    // can avoid a network call if the dialect supports it, otherwise we need
+    // to do a select for update first.
+    // TODO rz - Unfortunately, this seems to come at the cost of try/catching
+    // to fallback to the simpler behavior.
+    try {
+      ctx.insertInto(table, *insertPairs.keys.toTypedArray())
+        .values(insertPairs.values)
+        .onDuplicateKeyUpdate()
+        .set(updatePairs)
+        .execute()
+    } catch (e: SQLDialectNotSupportedException) {
+      log.debug("Falling back to primitive upsert logic: ${e.message}")
+      val exists = ctx.fetchExists(ctx.select().from(table).where(field("id").eq(updateId)).forUpdate())
+      if (exists) {
+        ctx.update(table).set(updatePairs).where(field("id").eq(updateId)).execute()
+      } else {
+        ctx.insertInto(table).columns(insertPairs.keys).values(insertPairs.values).execute()
+      }
+    }
+  }
+
+  private fun SelectConnectByStep<out Record>.statusIn(
+    statuses: Collection<ExecutionStatus>
+  ): SelectConnectByStep<out Record> {
+    // jOOQ doesn't seem to play well with Kotlin here. Using the vararg interface for `in` doesn't construct the
+    // SQL clause correctly, and I can't seem to get Kotlin to use the Collection<T> interface. We can manually
+    // build this clause and it remain reasonably safe.
+    if (statuses.isEmpty() || statuses.size == ExecutionStatus.values().size) {
+      return this
+    }
+    val clause = "status IN (${statuses.joinToString(",") { "'$it'" }})"
+
+    return run {
+      when (this) {
+        is SelectWhereStep<*> -> where(clause)
+        is SelectConditionStep<*> -> and(clause)
+        else -> this
+      }
+    }
+  }
+
+  private fun selectExecution(ctx: DSLContext,
+                              type: ExecutionType,
+                              id: String,
+                              forUpdate: Boolean = false): Execution? {
+    val select = ctx.selectExecution(type).where(id.toWhereCondition())
+    if (forUpdate) {
+      select.forUpdate()
+    }
+    return select.fetchExecution()
+  }
+
+  private fun selectExecutions(
+    type: ExecutionType,
+    limit: Int,
+    cursor: String?,
+    where: ((SelectJoinStep<Record>) -> SelectConditionStep<Record>)? = null
+  ): Collection<Execution> {
+    val select = jooq.selectExecutions(
+      type,
+      conditions = {
+        if (cursor == null) {
+          it.where("1=1")
+        } else {
+          if (where == null) {
+            it.where(field("id").gt(cursor))
+          } else {
+            where(it).and(field("id").gt(cursor))
+          }
+        }
+      },
+      seek = {
+        it.orderBy(field("id").desc())
+          .limit(limit)
+      }
+    )
+
+    return select.fetchExecutions()
+  }
+
+  /**
+   * Run the provided [fn] in a transaction.
+   */
+  private fun DSLContext.transactional(fn: (DSLContext) -> Unit) {
+    retrySupport.retry({
+      transaction { ctx ->
+        fn(DSL.using(ctx))
+      }
+    }, transactionRetryProperties.maxRetries, transactionRetryProperties.backoffMs, false)
+  }
+
+  private fun DSLContext.selectExecutions(type: ExecutionType,
+                                          fields: List<Field<Any>> = selectFields(),
+                                          conditions: (SelectJoinStep<Record>) -> SelectConnectByStep<out Record>,
+                                          seek: (SelectConnectByStep<out Record>) -> SelectForUpdateStep<out Record>) =
+      select(fields)
+        .from(type.tableName)
+        .let { conditions(it) }
+        .let { seek(it) }
+
+  private fun DSLContext.selectExecution(type: ExecutionType, fields: List<Field<Any>> = selectFields()) =
+    select(fields)
+      .from(type.tableName)
+
+  private fun selectFields() =
+    listOf(field("id"), field("body"))
+
+  private fun SelectForUpdateStep<out Record>.fetchExecutions() =
+    ExecutionMapper(mapper).map(fetch().intoResultSet(), jooq)
+
+  private fun SelectForUpdateStep<out Record>.fetchExecution() =
+    fetchExecutions().firstOrNull()
+
+  // TODO rz - Need to make pageSize configurable; doubtful that 10 is the right size.
+  private fun fetchExecutions(nextPage: (Int, String?) -> Iterable<Execution>) =
+    object : Iterable<Execution> {
+      override fun iterator(): Iterator<Execution> =
+        PagedIterator(10, Execution::getId, nextPage)
+    }
+
+  class SyntheticStageRequired : IllegalArgumentException("Only synthetic stages can be inserted ad-hoc")
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/jooq.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/jooq.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.pipeline.persistence
+
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType
+import de.huxhorn.sulky.ulid.ULID
+import org.jooq.DSLContext
+import org.jooq.Record
+import org.jooq.Table
+import org.jooq.impl.DSL
+import org.jooq.impl.DSL.field
+
+/**
+ * Run the provided [fn] in a transaction.
+ */
+internal fun DSLContext.transactional(retrySupport: RetrySupport,
+                                      fn: (DSLContext) -> Unit) {
+  retrySupport.retry({
+    transaction { ctx ->
+      fn(DSL.using(ctx))
+    }
+  }, 5, 100, false)
+}
+
+/**
+ * Converts a String id to a jooq where condition, either using the legacy
+ * UUID scheme or modern ULID.
+ */
+internal fun String.toWhereCondition() =
+  if (isULID(this)) {
+    field("id").eq(this)
+  } else {
+    field("legacy_id").eq(this)
+  }
+
+/**
+ * Determines if the given [id] is ULID format or not.
+ */
+internal fun isULID(id: String): Boolean {
+  try {
+    if (id.length == 26) {
+      ULID.parseULID(id)
+      return true
+    }
+  } catch (ignored: Exception) {}
+
+  return false
+}
+
+/**
+ * Convert an execution type to its jooq table object.
+ */
+internal val ExecutionType.tableName: Table<Record>
+  get() = when (this) {
+    ExecutionType.PIPELINE -> DSL.table("pipelines")
+    ExecutionType.ORCHESTRATION -> DSL.table("orchestrations")
+  }
+
+/**
+ * Convert an execution type to its jooq stages table object.
+ */
+internal val ExecutionType.stagesTableName: Table<Record>
+  get() = when (this) {
+    ExecutionType.PIPELINE -> DSL.table("pipeline_stages")
+    ExecutionType.ORCHESTRATION -> DSL.table("orchestration_stages")
+  }
+
+/**
+ * Selects all stages for an [executionType] and [executionId].
+ */
+internal fun DSLContext.selectExecutionStages(executionType: ExecutionType, executionId: String) =
+  select(field("body"))
+    .from(executionType.stagesTableName)
+    .where(field("execution_id").eq(executionId))
+    .fetch()
+    .intoResultSet()

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SlowQueryLogger.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SlowQueryLogger.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.telemetry
+
+import org.jooq.ExecuteContext
+import org.jooq.impl.DefaultExecuteListener
+import org.jooq.tools.StopWatch
+import org.slf4j.LoggerFactory
+import java.util.concurrent.TimeUnit
+
+class SlowQueryLogger(
+  slowQuerySecondsThreshold: Long = 1
+) : DefaultExecuteListener() {
+
+  private lateinit var watch: StopWatch
+
+  private val log = LoggerFactory.getLogger(javaClass)
+  private val slowQueryThreshold = TimeUnit.SECONDS.toNanos(slowQuerySecondsThreshold)
+
+  override fun executeStart(ctx: ExecuteContext) {
+    super.executeStart(ctx)
+    watch = StopWatch()
+  }
+
+  override fun executeEnd(ctx: ExecuteContext) {
+    super.executeEnd(ctx)
+    if (watch.split() > slowQueryThreshold) {
+      log.warn("Slow SQL (${watch.splitToMillis()}ms):\n${ctx.query()}")
+    }
+  }
+
+  private fun StopWatch.splitToMillis() = TimeUnit.NANOSECONDS.toMillis(split())
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SpectatorHikariMetricsTracker.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SpectatorHikariMetricsTracker.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.telemetry
+
+import com.netflix.spectator.api.Registry
+import com.zaxxer.hikari.metrics.MetricsTracker
+import com.zaxxer.hikari.metrics.PoolStats
+import java.util.concurrent.TimeUnit
+
+class SpectatorHikariMetricsTracker(
+  poolName: String,
+  private val poolStats: PoolStats,
+  private val registry: Registry
+) : MetricsTracker() {
+
+  val connectionAcquiredId = registry.createId("sql.pool.$poolName.connectionAcquiredTiming")
+  val connectionUsageId = registry.createId("sql.pool.$poolName.connectionUsageTiming")
+  val connectionTimeoutId = registry.createId("sql.pool.$poolName.connectionTimeout")
+
+  val idleConnectionsId = registry.createId("sql.pool.$poolName.idle")
+  val activeConnectionsId = registry.createId("sql.pool.$poolName.active")
+  val totalConnectionsId = registry.createId("sql.pool.$poolName.total")
+  val blockedThreadsId = registry.createId("sql.pool.$poolName.blocked")
+
+  fun recordPoolStats() {
+    registry.gauge(idleConnectionsId).set(poolStats.idleConnections.toDouble())
+    registry.gauge(activeConnectionsId).set(poolStats.activeConnections.toDouble())
+    registry.gauge(totalConnectionsId).set(poolStats.totalConnections.toDouble())
+    registry.gauge(blockedThreadsId).set(poolStats.pendingThreads.toDouble())
+  }
+
+  override fun recordConnectionAcquiredNanos(elapsedAcquiredNanos: Long) {
+    registry.timer(connectionAcquiredId).record(elapsedAcquiredNanos, TimeUnit.NANOSECONDS)
+  }
+
+  override fun recordConnectionUsageMillis(elapsedBorrowedMillis: Long) {
+    registry.timer(connectionUsageId).record(elapsedBorrowedMillis, TimeUnit.MILLISECONDS)
+  }
+
+  override fun recordConnectionTimeout() {
+    registry.counter(connectionTimeoutId).increment()
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SpectatorHikariMetricsTrackerFactory.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SpectatorHikariMetricsTrackerFactory.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.telemetry
+
+import com.netflix.spectator.api.Registry
+import com.zaxxer.hikari.metrics.MetricsTracker
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory
+import com.zaxxer.hikari.metrics.PoolStats
+import org.springframework.scheduling.annotation.Scheduled
+
+class SpectatorHikariMetricsTrackerFactory(
+  private val registry: Registry
+) : MetricsTrackerFactory {
+
+  private val trackers: MutableMap<String, SpectatorHikariMetricsTracker> = mutableMapOf()
+
+  @Scheduled(fixedRate = 5000L)
+  fun recordConnectionPoolMetrics() {
+    trackers.values.forEach { it.recordPoolStats() }
+  }
+
+  override fun create(poolName: String, poolStats: PoolStats): MetricsTracker =
+    SpectatorHikariMetricsTracker(poolName, poolStats, registry).let {
+      trackers.putIfAbsent(poolName, it)
+      it
+    }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlActiveExecutionsMonitor.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlActiveExecutionsMonitor.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.telemetry
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
+import com.netflix.spinnaker.orca.sql.pipeline.persistence.ExecutionStatisticsRepository
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@Component
+@ConditionalOnProperty("monitor.activeExecutions.redis", havingValue = "false")
+class SqlActiveExecutionsMonitor(
+  private val executionRepository: ExecutionStatisticsRepository,
+  registry: Registry,
+  @Value("\${monitor.activeExecutions.refresh.frequency.ms:60000}") refreshFrequencyMs: Long
+) {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  private val executor = Executors.newScheduledThreadPool(1)
+
+  private val activePipelineCounter = registry.gauge(
+    registry.createId("executions.active").withTag("executionType", PIPELINE.toString()),
+    AtomicInteger(0)
+  )
+
+  private val activeOrchestrationCounter = registry.gauge(
+    registry.createId("executions.active").withTag("executionType", ORCHESTRATION.toString()),
+    AtomicInteger(0)
+  )
+
+  init {
+    executor.scheduleWithFixedDelay(
+      {
+        try {
+          refreshGauges()
+        } catch (e : Exception) {
+          log.error("Unable to refresh active execution gauges", e)
+        }
+      },
+      0,
+      refreshFrequencyMs,
+      TimeUnit.MILLISECONDS
+    )
+  }
+
+  fun refreshGauges() {
+    executionRepository.countActiveExecutions().run {
+      log.info("Refreshing active execution gauges (active: ${total()})")
+
+      activePipelineCounter.set(pipelines)
+      activeOrchestrationCounter.set(orchestrations)
+    }
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.telemetry
+
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.histogram.PercentileTimer
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.persistence.DelegatingExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionCriteria
+import com.netflix.spinnaker.orca.sql.pipeline.persistence.ActiveExecutionsReport
+import com.netflix.spinnaker.orca.sql.pipeline.persistence.ExecutionStatisticsRepository
+import com.netflix.spinnaker.orca.sql.pipeline.persistence.SqlExecutionRepository
+import rx.Observable
+import java.lang.System.currentTimeMillis
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+class SqlInstrumentedExecutionRepository(
+  private val executionRepository: SqlExecutionRepository,
+  private val registry: Registry
+) : DelegatingExecutionRepository<SqlExecutionRepository>, ExecutionStatisticsRepository {
+
+  private fun invocationId(method: String) =
+    registry.createId("sql.executionRepository.$method.invocations")
+
+  private fun timingId(method: String) =
+    registry.createId("sql.executionRepository.$method.timing")
+
+  private fun <T> withMetrics(method: String, fn: () -> T): T {
+    val start = currentTimeMillis()
+
+    try {
+      val result = fn()
+      registry.counter(invocationId(method).withTag("result", "success")).increment()
+      recordTiming(timingId(method).withTag("result", "success"), start)
+      return result
+    } catch (e: Exception) {
+      registry.counter(invocationId(method).withTag("result", "failure")).increment()
+      recordTiming(timingId(method).withTag("result", "failure"), start)
+      throw e
+    }
+  }
+
+  private fun recordTiming(id: Id, startTimeMs: Long) {
+    PercentileTimer.get(registry, id).record(currentTimeMillis() - startTimeMs, MILLISECONDS)
+  }
+
+  override fun getDelegate() = executionRepository
+
+  override fun store(execution: Execution) {
+    withMetrics("store") {
+      executionRepository.store(execution)
+    }
+  }
+
+  override fun storeStage(stage: Stage) {
+    withMetrics("storeStage") {
+      executionRepository.storeStage(stage)
+    }
+  }
+
+  override fun updateStageContext(stage: Stage) {
+    withMetrics("updateStageContext") {
+      executionRepository.updateStageContext(stage)
+    }
+  }
+
+  override fun removeStage(execution: Execution, stageId: String) {
+    withMetrics("removeStage") {
+      executionRepository.removeStage(execution, stageId)
+    }
+  }
+
+  override fun addStage(stage: Stage) {
+    withMetrics("addStage") {
+      executionRepository.addStage(stage)
+    }
+  }
+
+  override fun cancel(type: Execution.ExecutionType, id: String) {
+    withMetrics("cancel2") {
+      executionRepository.cancel(type, id)
+    }
+  }
+
+  override fun cancel(type: Execution.ExecutionType, id: String, user: String?, reason: String?) {
+    withMetrics("cancel4") {
+      executionRepository.cancel(type, id, user, reason)
+    }
+  }
+
+  override fun pause(type: Execution.ExecutionType, id: String, user: String?) {
+    withMetrics("pause") {
+      executionRepository.pause(type, id, user)
+    }
+  }
+
+  override fun resume(type: Execution.ExecutionType, id: String, user: String?) {
+    withMetrics("resume3") {
+      executionRepository.resume(type, id, user)
+    }
+  }
+
+  override fun resume(type: Execution.ExecutionType, id: String, user: String?, ignoreCurrentStatus: Boolean) {
+    withMetrics("resume4") {
+      executionRepository.resume(type, id, user, ignoreCurrentStatus)
+    }
+  }
+
+  override fun isCanceled(type: Execution.ExecutionType, id: String): Boolean {
+    return withMetrics("isCanceled") {
+      executionRepository.isCanceled(type, id)
+    }
+  }
+
+  override fun updateStatus(type: Execution.ExecutionType, id: String, status: ExecutionStatus) {
+    withMetrics("updateStatus") {
+      executionRepository.updateStatus(type, id, status)
+    }
+  }
+
+  override fun delete(type: Execution.ExecutionType, id: String) {
+    withMetrics("delete") {
+      executionRepository.delete(type, id)
+    }
+  }
+
+  override fun retrieve(type: Execution.ExecutionType, id: String): Execution {
+    return withMetrics("retrieve2") {
+      executionRepository.retrieve(type, id)
+    }
+  }
+
+  override fun retrieve(type: Execution.ExecutionType): Observable<Execution> {
+    return withMetrics("retrieve1") {
+      executionRepository.retrieve(type)
+    }
+  }
+
+  override fun retrieve(type: Execution.ExecutionType, criteria: ExecutionCriteria): Observable<Execution> {
+    return withMetrics("retrieve3") {
+      executionRepository.retrieve(type, criteria)
+    }
+  }
+
+  override fun retrieveBufferedExecutions(): MutableList<Execution> {
+    return withMetrics("retrieveBufferedExecutions") {
+      executionRepository.retrieveBufferedExecutions()
+    }
+  }
+
+  override fun retrieveOrchestrationsForApplication(application: String,
+                                                    criteria: ExecutionCriteria): Observable<Execution> {
+    return withMetrics("retrieveOrchestrationsForApplication") {
+      executionRepository.retrieveOrchestrationsForApplication(application, criteria)
+    }
+  }
+
+  override fun retrievePipelinesForApplication(application: String): Observable<Execution> {
+    return withMetrics("retrievePipelinesForApplication") {
+      executionRepository.retrievePipelinesForApplication(application)
+    }
+  }
+
+  override fun retrievePipelinesForPipelineConfigId(pipelineConfigId: String,
+                                                    criteria: ExecutionCriteria): Observable<Execution> {
+    return withMetrics("retrievePipelinesForPipelineConfigId") {
+      executionRepository.retrievePipelinesForPipelineConfigId(pipelineConfigId, criteria)
+    }
+  }
+
+  override fun retrieveOrchestrationForCorrelationId(correlationId: String): Execution {
+    return withMetrics("retrieveOrchestrationForCorrelationId") {
+      executionRepository.retrieveOrchestrationForCorrelationId(correlationId)
+    }
+  }
+
+  override fun retrieveAllApplicationNames(type: Execution.ExecutionType?): List<String> {
+    return withMetrics("retrieveAllApplicationNames1") {
+      executionRepository.retrieveAllApplicationNames(type)
+    }
+  }
+
+  override fun retrieveAllApplicationNames(type: Execution.ExecutionType?, minExecutions: Int): List<String> {
+    return withMetrics("retrieveAllApplicationNames2") {
+      executionRepository.retrieveAllApplicationNames(type, minExecutions)
+    }
+  }
+
+  override fun countActiveExecutions(): ActiveExecutionsReport {
+    return withMetrics("countActiveExecutions") {
+      executionRepository.countActiveExecutions()
+    }
+  }
+
+  override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(pipelineConfigIds: MutableList<String>,
+                                                                             buildTimeStartBoundary: Long,
+                                                                             buildTimeEndBoundary: Long): Observable<Execution> {
+    return withMetrics("retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary") {
+      executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+        pipelineConfigIds,
+        buildTimeStartBoundary,
+        buildTimeEndBoundary
+      )
+    }
+  }
+
+  override fun hasExecution(type: Execution.ExecutionType, id: String): Boolean {
+    return withMetrics("hasExecution") {
+      executionRepository.hasExecution(type, id)
+    }
+  }
+
+  override fun retrieveAllExecutionIds(type: Execution.ExecutionType): MutableList<String> {
+    return withMetrics("retrieveAllExecutionIds") {
+      executionRepository.retrieveAllExecutionIds(type)
+    }
+  }
+}

--- a/orca-sql/src/main/kotlin/de/huxhorn/sulky/ulid/SpinULID.kt
+++ b/orca-sql/src/main/kotlin/de/huxhorn/sulky/ulid/SpinULID.kt
@@ -1,0 +1,11 @@
+package de.huxhorn.sulky.ulid
+
+import java.util.*
+
+class SpinULID(random: Random): ULID(random) {
+  val _random: Random? = random
+
+  fun nextULID(timestamp: Long): String {
+    return internalUIDString(timestamp, _random);
+  }
+}

--- a/orca-sql/src/main/resources/db/changelog-master.yml
+++ b/orca-sql/src/main/resources/db/changelog-master.yml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+- include:
+    file: changelog/20180424-initial-schema.yml
+    relativeToChangelogFile: true
+- include:
+    file: changelog/20180515-execution-canceled-column.yml
+    relativeToChangelogFile: true
+- include:
+    file: changelog/20180510-add-legacy-id-fields.yml
+    relativeToChangelogFile: true
+- include:
+    file: changelog/20180521-status-enum.yml
+    relativeToChangelogFile: true
+- include:
+    file: changelog/20180530-add-legacy-id-constraints.yml
+    relativeToChangelogFile: true
+- include:
+    file: changelog/20180601-add-healthcheck-table.yml
+    relativeToChangelogFile: true
+- include:
+    file: changelog/20180724-partitions.yml
+    relativeToChangelogFile: true
+- include:
+    file: changelog/20180724-indices.yml
+    relativeToChangelogFile: true
+- include:
+    file: changelog/20180905-add-application-status-build_time-index.yml
+    relativeToChangelogFile: true

--- a/orca-sql/src/main/resources/db/changelog/20180424-initial-schema.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180424-initial-schema.yml
@@ -1,0 +1,289 @@
+databaseChangeLog:
+- changeSet:
+    id: create-pipelines-table
+    author: robzienert
+    changes:
+    - createTable:
+        tableName: pipelines
+        columns:
+        - column:
+            name: id
+            type: char(26)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: config_id
+            type: char(36)
+        - column:
+            name: application
+            type: varchar(255)
+            constraints:
+              nullable: false
+        - column:
+            name: status
+            type: varchar(45)
+            constraints:
+              nullable: false
+        - column:
+            name: build_time
+            type: bigint
+            constraints:
+              nullable: false
+        - column:
+            name: body
+            type: longtext
+            constraints:
+              nullable: false
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb"
+    rollback:
+    - dropTable:
+        tableName: pipelines
+
+- changeSet:
+    id: create-pipelines-indices
+    author: robzienert
+    changes:
+    - createIndex:
+        indexName: pipeline_application_status_buildtime_idx
+        tableName: pipelines
+        columns:
+        - column:
+            name: application
+        - column:
+            name: status
+        - column:
+            name: build_time
+    - createIndex:
+        indexName: pipeline_status_buildtime_idx
+        tableName: pipelines
+        columns:
+        - column:
+            name: status
+        - column:
+            name: build_time
+    - createIndex:
+        indexName: pipeline_config_status_idx
+        tableName: pipelines
+        columns:
+        - column:
+            name: config_id
+        - column:
+            name: status
+    rollback:
+    - dropIndex:
+        indexName: pipeline_application_status_buildtime_idx
+        tableName: pipelines
+    - dropIndex:
+        indexName: pipeline_status_buildtime_idx
+        tableName: pipelines
+    - dropIndex:
+        indexName: pipeline_config_status_idx
+        tableName: pipelines
+
+- changeSet:
+    id: create-pipeline-stages-table
+    author: robzienert
+    changes:
+    - createTable:
+        tableName: pipeline_stages
+        columns:
+        - column:
+            name: id
+            type: char(26)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: execution_id
+            type: char(26)
+            constraints:
+              nullable: false
+        - column:
+            name: status
+            type: varchar(45)
+            constraints:
+              nullable: false
+        - column:
+            name: body
+            type: longtext
+            constraints:
+              nullable: false
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb"
+    rollback:
+    - dropTable:
+        tableName: pipeline_stages
+
+- changeSet:
+    id: create-pipeline-stages-indices
+    author: robzienert
+    changes:
+    - createIndex:
+        indexName: pipelinestage_status_idx
+        tableName: pipeline_stages
+        columns:
+        - column:
+            name: execution_id
+        - column:
+            name: status
+    rollback:
+    - dropIndex:
+        indexName: pipelinestage_status_idx
+        tableName: pipeline_stages
+
+- changeSet:
+    id: create-orchestrations-table
+    author: robzienert
+    changes:
+    - createTable:
+        tableName: orchestrations
+        columns:
+        - column:
+            name: id
+            type: char(26)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: status
+            type: varchar(45)
+            constraints:
+              nullable: false
+        - column:
+            name: application
+            type: varchar(255)
+            constraints:
+              nullable: false
+        - column:
+            name: build_time
+            type: bigint
+            constraints:
+              nullable: false
+        - column:
+            name: body
+            type: longtext
+            constraints:
+              nullable: false
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb"
+    rollback:
+    - dropTable:
+        tableName: orchestrations
+
+- changeSet:
+    id: create-orchestrations-indices
+    author: robzienert
+    changes:
+    - createIndex:
+        indexName: orchestration_application_status_buildtime_idx
+        tableName: orchestrations
+        columns:
+        - column:
+            name: application
+        - column:
+            name: status
+        - column:
+            name: build_time
+    - createIndex:
+        indexName: orchestration_status_buildtime_idx
+        tableName: orchestrations
+        columns:
+        - column:
+            name: status
+        - column:
+            name: build_time
+    rollback:
+    - dropIndex:
+        indexName: orchestration_application_status_buildtime_idx
+        tableName: orchestrations
+    - dropIndex:
+        indexName: orchestration_status_buildtime_idx
+        tableName: orchestrations
+
+- changeSet:
+    id: create-orchestration-stages-table
+    author: robzienert
+    changes:
+    - createTable:
+        tableName: orchestration_stages
+        columns:
+        - column:
+            name: id
+            type: char(26)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: execution_id
+            type: char(26)
+            constraints:
+              nullable: false
+        - column:
+            name: status
+            type: varchar(45)
+            constraints:
+              nullable: false
+        - column:
+            name: body
+            type: longtext
+            constraints:
+              nullable: false
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb"
+    rollback:
+    - dropTable:
+        tableName: orchestration_stages
+
+- changeSet:
+    id: create-orchestration-stages-indices
+    author: robzienert
+    changes:
+    - createIndex:
+        indexName: orchestrationstage_status_idx
+        tableName: orchestration_stages
+        columns:
+        - column:
+            name: execution_id
+        - column:
+            name: status
+    rollback:
+    - dropIndex:
+        indexName: orchestrationstage_status_idx
+        tableName: orchestration_stages
+
+- changeSet:
+    id: create-correlationids-table
+    author: robzienert
+    changes:
+    - createTable:
+        tableName: correlation_ids
+        columns:
+        - column:
+            name: id
+            type: varchar(255)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: orchestration_id
+            type: char(26)
+        - column:
+            name: pipeline_id
+            type: char(26)
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb"
+    rollback:
+    - dropTable:
+        tableName: correlation_ids

--- a/orca-sql/src/main/resources/db/changelog/20180510-add-legacy-id-fields.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180510-add-legacy-id-fields.yml
@@ -1,0 +1,81 @@
+databaseChangeLog:
+- changeSet:
+    id: add-legacy-id-fields
+    author: cthielen
+
+    changes:
+    - addColumn:
+        tableName: orchestrations
+        columns:
+        - column:
+            name: legacy_id
+            type: varchar(500)
+            afterColumn: id
+    - addColumn:
+        tableName: orchestration_stages
+        afterColumn: id
+        columns:
+        - column:
+            name: legacy_id
+            type: varchar(500)
+            afterColumn: id
+    - addColumn:
+        tableName: pipelines
+        afterColumn: id
+        columns:
+        - column:
+            name: legacy_id
+            type: varchar(500)
+            afterColumn: id
+    - addColumn:
+        tableName: pipeline_stages
+        afterColumn: id
+        columns:
+        - column:
+            name: legacy_id
+            type: varchar(500)
+            afterColumn: id
+
+    rollback:
+    - dropColumn:
+        tableName: orchestrations
+        columnName: legacy_id
+    - dropColumn:
+        tableName: orchestration_stages
+        columnName: legacy_id
+    - dropColumn:
+        tableName: pipelines
+        columnName: legacy_id
+    - dropColumn:
+        tableName: pipeline_stages
+        columnName: legacy_id
+
+
+- changeSet:
+    id: create-legacy-id-indexes
+    author: cthielen
+    changes:
+    - createIndex:
+        indexName: pipelines_legacy_id_idx
+        tableName: pipelines
+        columns:
+        - column:
+            name: legacy_id
+    - createIndex:
+        indexName: pipeline_stages_legacy_id_idx
+        tableName: pipeline_stages
+        columns:
+        - column:
+            name: legacy_id
+    - createIndex:
+        indexName: orchestrations_legacy_id_idx
+        tableName: orchestrations
+        columns:
+        - column:
+            name: legacy_id
+    - createIndex:
+        indexName: orchestration_stages_legacy_id_idx
+        tableName: orchestration_stages
+        columns:
+        - column:
+            name: legacy_id

--- a/orca-sql/src/main/resources/db/changelog/20180515-execution-canceled-column.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180515-execution-canceled-column.yml
@@ -1,0 +1,50 @@
+databaseChangeLog:
+- changeSet:
+    id: add-canceled-column
+    author: robzienert
+    changes:
+    - addColumn:
+        tableName: pipelines
+        columns:
+        - column:
+            name: canceled
+            type: boolean
+            afterColumn: build_time
+            defaultValueBoolean: false
+            constraints:
+              nullable: false
+    - addColumn:
+        tableName: orchestrations
+        columns:
+        - column:
+            name: canceled
+            type: boolean
+            afterColumn: build_time
+            defaultValueBoolean: false
+            constraints:
+              nullable: false
+    - createIndex:
+        indexName: pipeline_canceled_idx
+        tableName: pipelines
+        columns:
+        - column:
+            name: canceled
+    - createIndex:
+        indexName: orchestration_canceled_idx
+        tableName: orchestrations
+        columns:
+        - column:
+            name: canceled
+    rollback:
+    - dropIndex:
+        indexName: orchestration_canceled_idx
+        tableName: orchestrations
+    - dropIndex:
+        indexName: pipeline_canceled_idx
+        tableName: pipelines
+    - dropColumn:
+        tableName: orchestrations
+        columnName: canceled
+    - dropColumn:
+        tableName: pipelines
+        columnName: canceled

--- a/orca-sql/src/main/resources/db/changelog/20180521-status-enum.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180521-status-enum.yml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+- changeSet:
+   id: modify-status-column-enum
+   author: afeldman
+   changes:
+    - sql:
+        dbms: mysql
+        sql: ALTER TABLE `pipelines` MODIFY COLUMN `status` ENUM("NOT_STARTED", "BUFFERED", "RUNNING", "PAUSED", "SUSPENDED", "SUCCEEDED", "FAILED_CONTINUE", "TERMINAL", "CANCELED", "REDIRECT", "STOPPED", "SKIPPED") NOT NULL DEFAULT "NOT_STARTED"
+    - sql:
+        dbms: mysql
+        sql: ALTER TABLE `pipeline_stages` MODIFY COLUMN `status` ENUM("NOT_STARTED", "BUFFERED", "RUNNING", "PAUSED", "SUSPENDED", "SUCCEEDED", "FAILED_CONTINUE", "TERMINAL", "CANCELED", "REDIRECT", "STOPPED", "SKIPPED") NOT NULL DEFAULT "NOT_STARTED"
+    - sql:
+        dbms: mysql
+        sql: ALTER TABLE `orchestrations` MODIFY COLUMN `status` ENUM("NOT_STARTED", "BUFFERED", "RUNNING", "PAUSED", "SUSPENDED", "SUCCEEDED", "FAILED_CONTINUE", "TERMINAL", "CANCELED", "REDIRECT", "STOPPED", "SKIPPED") NOT NULL DEFAULT "NOT_STARTED"
+    - sql:
+        dbms: mysql
+        sql: ALTER TABLE `orchestration_stages` MODIFY COLUMN `status` ENUM("NOT_STARTED", "BUFFERED", "RUNNING", "PAUSED", "SUSPENDED", "SUCCEEDED", "FAILED_CONTINUE", "TERMINAL", "CANCELED", "REDIRECT", "STOPPED", "SKIPPED") NOT NULL DEFAULT "NOT_STARTED"
+
+   rollback:
+    - sql:
+        dbms: mysql
+        sql: ALTER TABLE `pipelines` MODIFY COLUMN `status` varchar(45) NOT NULL
+    - sql:
+        dbms: mysql
+        sql: ALTER TABLE `pipeline_stages` MODIFY COLUMN `status` varchar(45) NOT NULL
+    - sql:
+        dbms: mysql
+        sql: ALTER TABLE `orchestrations` MODIFY COLUMN `status` varchar(45) NOT NULL
+    - sql:
+        dbms: mysql
+        sql: ALTER TABLE `orchestration_stages` MODIFY COLUMN `status` varchar(45) NOT NULL

--- a/orca-sql/src/main/resources/db/changelog/20180530-add-legacy-id-constraints.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180530-add-legacy-id-constraints.yml
@@ -1,0 +1,37 @@
+databaseChangeLog:
+- changeSet:
+    id: add-legacy-id-constraints
+    author: cthielen
+
+    changes:
+    - addUniqueConstraint:
+        tableName: orchestrations
+        constraintName: orchestrations_legacy_id_unique
+        columnNames: legacy_id
+    - addUniqueConstraint:
+        tableName: orchestration_stages
+        constraintName: orchestration_stages_legacy_id_unique
+        columnNames: legacy_id
+    - addUniqueConstraint:
+        tableName: pipelines
+        constraintName: pipelines_legacy_id_unique
+        columnNames: legacy_id
+    - addUniqueConstraint:
+        tableName: pipeline_stages
+        constraintName: pipeline_stages_legacy_id_unique
+        columnNames: legacy_id
+
+    rollback:
+    - dropUniqueConstraint:
+        tableName: orchestrations
+        constraintName: orchestrations_legacy_id_unique
+    - dropUniqueConstraint:
+        tableName: orchestration_stages
+        constraintName: orchestration_stages_legacy_id_unique
+    - dropUniqueConstraint:
+        tableName: pipelines
+        constraintName: pipelines_legacy_id_unique
+    - dropUniqueConstraint:
+        tableName: pipeline_stages
+        constraintName: pipeline_stages_legacy_id_unique
+

--- a/orca-sql/src/main/resources/db/changelog/20180601-add-healthcheck-table.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180601-add-healthcheck-table.yml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+- changeSet:
+    id: create-healthcheck-table
+    author: rzienert
+    changes:
+    - createTable:
+        tableName: healthcheck
+        columns:
+        - column:
+            name: id
+            type: boolean
+            constraints:
+              primaryKey: true
+              nullable: false
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb"
+    rollback:
+    - dropTable:
+        tableName: healthcheck

--- a/orca-sql/src/main/resources/db/changelog/20180724-indices.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180724-indices.yml
@@ -1,0 +1,113 @@
+databaseChangeLog:
+- changeSet:
+    id: 20180724-add-and-remove-indices
+    author: afeldman
+    changes:
+    - createIndex:
+        indexName: pipeline_config_idx
+        tableName: pipelines
+        columns:
+        - column:
+            name: config_id
+    - createIndex:
+        indexName: pipeline_application_idx
+        tableName: pipelines
+        columns:
+        - column:
+            name: application
+    - createIndex:
+        indexName: orchestration_application_idx
+        tableName: orchestrations
+        columns:
+        - column:
+            name: application
+    - dropIndex:
+        indexName: pipeline_canceled_idx
+        tableName: pipelines
+    - dropIndex:
+        indexName: pipeline_application_status_buildtime_idx
+        tableName: pipelines
+    - dropIndex:
+        indexName: pipelines_legacy_id_idx
+        tableName: pipelines
+    - dropIndex:
+        indexName: pipeline_stages_legacy_id_idx
+        tableName: pipeline_stages
+    - dropIndex:
+        indexName: orchestrations_legacy_id_idx
+        tableName: orchestrations
+    - dropIndex:
+        indexName: orchestration_application_status_buildtime_idx
+        tableName: orchestrations
+    - dropIndex:
+        indexName: orchestration_canceled_idx
+        tableName: orchestrations
+    - dropIndex:
+        indexName: orchestration_stages_legacy_id_idx
+        tableName: orchestration_stages
+    rollback:
+    - createIndex:
+        indexName: pipeline_canceled_idx
+        tableName: pipelines
+        columns:
+        - column:
+            name: canceled
+    - createIndex:
+        indexName: pipelines_legacy_id_idx
+        tableName: pipelines
+        columns:
+        - column:
+            name: legacy_id
+    - createIndex:
+        indexName: orchestration_canceled_idx
+        tableName: orchestrations
+        columns:
+        - column:
+            name: canceled
+    - createIndex:
+        indexName: orchestrations_legacy_id_idx
+        tableName: orchestrations
+        columns:
+        - column:
+            name: legacy_id
+    - createIndex:
+        indexName: pipeline_application_status_buildtime_idx
+        tableName: pipelines
+        columns:
+        - column:
+            name: application
+        - column:
+            name: status
+        - column:
+            name: build_time
+    - createIndex:
+        indexName: orchestration_application_status_buildtime_idx
+        tableName: orchestrations
+        columns:
+        - column:
+            name: application
+        - column:
+            name: status
+        - column:
+            name: build_time
+    - createIndex:
+        indexName: pipeline_stages_legacy_id_idx
+        tableName: pipeline_stages
+        columns:
+        - column:
+            name: legacy_id
+    - createIndex:
+        indexName: orchestration_stages_legacy_id_idx
+        tableName: orchestration_stages
+        columns:
+        - column:
+            name: legacy_id
+    - dropIndex:
+        indexName: pipeline_config_idx
+        tableName: pipelines
+    - dropIndex:
+        indexName: pipeline_application_idx
+        tableName: pipelines
+    - dropIndex:
+        indexName: orchestration_application_idx
+        tableName: orchestrations

--- a/orca-sql/src/main/resources/db/changelog/20180724-partitions.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180724-partitions.yml
@@ -1,0 +1,88 @@
+databaseChangeLog:
+- changeSet:
+    id: partition-updated-executions
+    author: rzienert
+    changes:
+    - addColumn:
+        tableName: orchestrations
+        columns:
+        - column:
+            name: partition
+            type: varchar(32)
+            afterColumn: legacy_id
+        - column:
+            name: updated_at
+            type: bigint
+            afterColumn: build_time
+    - addColumn:
+        tableName: pipelines
+        columns:
+        - column:
+            name: partition
+            type: varchar(32)
+            afterColumn: legacy_id
+        - column:
+            name: updated_at
+            type: bigint
+            afterColumn: build_time
+    - addColumn:
+        tableName: orchestration_stages
+        columns:
+        - column:
+            name: updated_at
+            type: bigint
+            afterColumn: status
+    - addColumn:
+        tableName: pipeline_stages
+        columns:
+        - column:
+            name: updated_at
+            type: bigint
+            afterColumn: status
+    rollback:
+    - dropColumn:
+        tableName: orchestrations
+        columnName: partition
+    - dropColumn:
+        tableName: orchestrations
+        columnName: updated_at
+    - dropColumn:
+        tableName: pipelines
+        columnName: partition
+    - dropColumn:
+        tableName: pipelines
+        columnName: updated_at
+    - dropColumn:
+        tableName: orchestration_stages
+        columnName: updated_at
+    - dropColumn:
+        tableName: pipeline_stages
+        columnName: updated_at
+
+- changeSet:
+    id: add-partition-indexes
+    author: rzienert
+    changes:
+    - createIndex:
+        indexName: pipelines_partition_updated_idx
+        tableName: pipelines
+        columns:
+        - column:
+            name: updated_at
+        - column:
+            name: partition
+    - createIndex:
+        indexName: orchestrations_partition_updated_idx
+        tableName: orchestrations
+        column:
+        - column:
+            name: updated_at
+        - column:
+            name: partition
+    rollback:
+    - dropIndex:
+        indexName: pipelines_partition_updated_idx
+        tableName: pipelines
+    - dropIndex:
+        indexName: orchestrations_partition_updated_idx
+        tableName: orchestrations

--- a/orca-sql/src/main/resources/db/changelog/20180905-add-application-status-build_time-index.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180905-add-application-status-build_time-index.yml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+- changeSet:
+    id: 20180905-add-application-status-build_time-index
+    author: ajordens
+    changes:
+    - createIndex:
+        indexName: orchestration_application_status_buildtime_idx
+        tableName: orchestrations
+        columns:
+        - column:
+            name: application
+        - column:
+            name: status
+        - column:
+            name: build_time
+    rollback:
+    - dropIndex:
+        indexName: orchestration_application_status_buildtime_idx
+        tableName: orchestrations

--- a/orca-sql/src/main/resources/db/database-mysql.sql
+++ b/orca-sql/src/main/resources/db/database-mysql.sql
@@ -1,0 +1,2 @@
+-- utf8mb4, because MySQL's utf8 is bad and should feel bad.
+CREATE SCHEMA `orca` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ;

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.sql.cleanup
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.TransactionRetryProperties
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
+import com.netflix.spinnaker.orca.notifications.NotificationClusterLock
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.sql.SqlTestUtil
+import com.netflix.spinnaker.orca.sql.pipeline.persistence.SqlExecutionRepository
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.time.Clock
+
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
+import static com.netflix.spinnaker.orca.sql.SqlTestUtil.initDatabase
+
+class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
+  @Shared
+  ObjectMapper mapper = OrcaObjectMapper.newInstance().with {
+    registerModule(new KotlinModule())
+    it
+  }
+
+  @Shared
+  @AutoCleanup("close")
+  SqlTestUtil.TestDatabase currentDatabase
+
+  @Shared
+  ExecutionRepository executionRepository
+
+  def cleanupAgent = new OldPipelineCleanupPollingNotificationAgent(
+    Mock(NotificationClusterLock),
+    currentDatabase.context,
+    Clock.systemDefaultZone(),
+    new NoopRegistry(),
+    0,
+    10, // threshold days
+    5,  // minimum pipeline executions
+    1
+  )
+
+  def setupSpec() {
+    currentDatabase = initDatabase()
+    executionRepository = new SqlExecutionRepository("test", currentDatabase.context, mapper, new TransactionRetryProperties())
+  }
+
+  def "should preserve the most recent 5 executions when cleaning up old pipeline executions"() {
+    given:
+    (1..10).each {
+      executionRepository.store(buildExecution(10 + it))
+    }
+    executionRepository.store(buildExecution(1))
+    executionRepository.store(buildExecution(2))
+
+    when:
+    def allExecutions = executionRepository.retrievePipelinesForApplication("app").toList().toBlocking().first().unique()
+
+    then:
+    allExecutions.size() == 10
+
+    when:
+    cleanupAgent.tick()
+    allExecutions = executionRepository.retrievePipelinesForApplication("app").toList().toBlocking().first().unique()
+
+    then:
+    // preserve any execution more recent than `thresholdDays` _AND_
+    // the most recent `minimumPipelineExecutions` older than `thresholdDays`
+    allExecutions*.name.sort() == ["#01", "#02", "#11", "#12", "#13", "#14", "#15"]
+  }
+
+  Execution buildExecution(int daysOffset) {
+    Execution e = new Execution(PIPELINE, "app")
+    e.status = ExecutionStatus.SUCCEEDED
+    e.pipelineConfigId = "pipeline-001"
+    e.buildTime = (new Date() - daysOffset).time
+
+    e.name = "#${daysOffset.toString().padLeft(2, "0")}"
+    e.stages.add(new Stage(e, "wait", "wait stage", [waitTime: 10]))
+
+    return e
+  }
+}

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositorySpec.groovy
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.pipeline.persistence
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.netflix.spinnaker.config.TransactionRetryProperties
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepositoryTck
+import rx.schedulers.Schedulers
+import de.huxhorn.sulky.ulid.ULID
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Unroll
+import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionCriteria
+
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
+import static com.netflix.spinnaker.orca.sql.SqlTestUtil.*
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.orchestration
+
+class SqlExecutionRepositorySpec extends ExecutionRepositoryTck<SqlExecutionRepository> {
+
+  @Shared
+  ObjectMapper mapper = OrcaObjectMapper.newInstance().with {
+    registerModule(new KotlinModule())
+    it
+  }
+
+  def ulid = new ULID()
+
+  @Shared
+  @AutoCleanup("close")
+  TestDatabase currentDatabase
+
+  @Shared
+  @AutoCleanup("close")
+  TestDatabase previousDatabase
+
+  def setupSpec() {
+    currentDatabase = initDatabase()
+    previousDatabase = initPreviousDatabase()
+  }
+
+  def cleanup() {
+    cleanupDb(currentDatabase)
+    cleanupDb(previousDatabase)
+  }
+
+  @Override
+  SqlExecutionRepository createExecutionRepository() {
+    new SqlExecutionRepository("test", currentDatabase.context, mapper, new TransactionRetryProperties())
+  }
+
+  @Override
+  SqlExecutionRepository createExecutionRepositoryPrevious() {
+    new SqlExecutionRepository("test", previousDatabase.context, mapper, new TransactionRetryProperties())
+  }
+
+  def "can store a new pipeline"() {
+    given:
+    ExecutionRepository repo = createExecutionRepository()
+    Execution e = new Execution(PIPELINE, "myapp")
+    e.stages.add(new Stage(e, "wait", "wait stage", [foo: 'FOO']))
+
+    when:
+    repo.store(e)
+
+    then:
+    def pipelines = repo.retrieve(PIPELINE).toList().toBlocking().single()
+    pipelines.size() == 1
+    pipelines[0].id == e.id
+    pipelines[0].stages.size() == 1
+    pipelines[0].stages[0].id == e.stages[0].id
+    pipelines[0].stages[0].context.foo == 'FOO'
+  }
+
+  def "can store a pipeline with a provided ULID"() {
+    given:
+    def id = ulid.nextULID()
+    ExecutionRepository repo = createExecutionRepository()
+    Execution e = new Execution(PIPELINE, id, "myapp")
+    e.stages.add(new Stage(e, "wait", "wait stage", [foo: 'FOO']))
+
+    when:
+    repo.store(e)
+
+    then:
+    def pipelines = repo.retrieve(PIPELINE).toList().toBlocking().single()
+    pipelines.size() == 1
+    pipelines[0].id == id
+    pipelines[0].stages.size() == 1
+    pipelines[0].stages[0].id == e.stages[0].id
+    pipelines[0].stages[0].context.foo == 'FOO'
+  }
+
+  def "can store a pipeline with a provided UUID"() {
+    given:
+    def id = UUID.randomUUID().toString()
+    ExecutionRepository repo = createExecutionRepository()
+    Execution e = new Execution(PIPELINE, id, "myapp")
+    e.stages.add(new Stage(e, "wait", "wait stage", [foo: 'FOO']))
+
+    when:
+    repo.store(e)
+
+    then:
+    def pipelines = repo.retrieve(PIPELINE).toList().toBlocking().single()
+    pipelines.size() == 1
+    pipelines[0].id == id
+    pipelines[0].stages.size() == 1
+    pipelines[0].stages[0].id == e.stages[0].id
+    pipelines[0].stages[0].context.foo == 'FOO'
+  }
+
+  def "can load a pipeline by ULID"() {
+    given:
+    def id = ulid.nextULID()
+    ExecutionRepository repo = createExecutionRepository()
+    Execution orig = new Execution(PIPELINE, id, "myapp")
+    orig.stages.add(new Stage(orig, "wait", "wait stage 0", [foo: 'FOO']))
+    repo.store(orig)
+
+    when:
+    Execution e = repo.retrieve(PIPELINE, id)
+
+    then:
+    e.id == id
+    e.stages.size() == 1
+    e.stages[0].context.foo == 'FOO'
+  }
+
+  def "can load a pipeline by UUID"() {
+    given:
+    def id = UUID.randomUUID().toString()
+    ExecutionRepository repo = createExecutionRepository()
+    Execution orig = new Execution(PIPELINE, id, "myapp")
+    orig.stages.add(new Stage(orig, "wait", "wait stage 0", [foo: 'FOO']))
+    repo.store(orig)
+
+    when:
+    Execution e = repo.retrieve(PIPELINE, id)
+
+    then:
+    e.id == id
+    e.stages.size() == 1
+    e.stages[0].id == orig.stages[0].id
+    e.stages[0].context.foo == 'FOO'
+  }
+
+  def "can delete a pipeline"() {
+    given:
+    ExecutionRepository repo = createExecutionRepository()
+    Execution orig = new Execution(PIPELINE, "myapp")
+    orig.stages.add(new Stage(orig, "wait", "wait stage 0", [foo: 'FOO']))
+    repo.store(orig)
+
+    when:
+    def pipelines = repo.retrieve(PIPELINE).toList().toBlocking().single()
+
+    then:
+    pipelines.size() == 1
+
+    when:
+    repo.delete(PIPELINE, orig.id)
+    pipelines = repo.retrieve(PIPELINE).toList().toBlocking().single()
+
+    then:
+    pipelines.size() == 0
+  }
+
+  def "can delete a pipeline by UUID"() {
+    given:
+    def id = UUID.randomUUID().toString()
+    ExecutionRepository repo = createExecutionRepository()
+    Execution orig = new Execution(PIPELINE, id, "myapp")
+    orig.stages.add(new Stage(orig, "wait", "wait stage 0", [foo: 'FOO']))
+    repo.store(orig)
+
+    when:
+    def pipelines = repo.retrieve(PIPELINE).toList().toBlocking().single()
+
+    then:
+    pipelines.size() == 1
+
+    when:
+    repo.delete(PIPELINE, id)
+    pipelines = repo.retrieve(PIPELINE).toList().toBlocking().single()
+
+    then:
+    pipelines.size() == 0
+  }
+
+  def "can update a pipeline"() {
+    given:
+    ExecutionRepository repo = createExecutionRepository()
+    Execution orig = new Execution(PIPELINE, "myapp")
+    orig.stages.add(new Stage(orig, "wait", "wait stage", [foo: 'FOO']))
+    repo.store(orig)
+
+    when:
+    Execution e = new Execution(PIPELINE, orig.id, "myapp")
+    e.stages.add(new Stage(e, "wait", "wait stage 1", [foo: 'FOO']))
+    e.stages.add(new Stage(e, "wait", "wait stage 2", [bar: 'BAR']))
+    repo.store(e)
+
+    def pipelines = repo.retrieve(PIPELINE).toList().toBlocking().single()
+    def storedStages = e.stages
+    def loadedStages = pipelines*.stages.flatten()
+
+    then:
+    pipelines.size() == 1
+    pipelines[0].id == orig.id
+    loadedStages.size() == 2
+    loadedStages*.id.sort() == storedStages*.id.sort()
+    loadedStages*.name.sort() == storedStages*.name.sort()
+  }
+
+  def "can update a pipeline by UUID"() {
+    given:
+    def id = UUID.randomUUID().toString()
+    ExecutionRepository repo = createExecutionRepository()
+    Execution orig = new Execution(PIPELINE, id, "myapp")
+    orig.stages.add(new Stage(orig, "wait", "wait stage", [foo: 'FOO']))
+    repo.store(orig)
+
+    when:
+    Execution e = new Execution(PIPELINE, id, "myapp")
+    e.stages.add(new Stage(e, "wait", "wait stage 1", [foo: 'FOO']))
+    e.stages.add(new Stage(e, "wait", "wait stage 2", [bar: 'BAR']))
+    repo.store(e)
+
+    def pipelines = repo.retrieve(PIPELINE).toList().toBlocking().single()
+    def storedStages = e.stages as Set
+    def loadedStages = pipelines*.stages.flatten() as Set
+
+    then:
+    pipelines.size() == 1
+    pipelines[0].id == id
+    pipelines[0].stages.size() == 2
+    loadedStages == storedStages
+  }
+
+  def "can update a stage"() {
+    given:
+    ExecutionRepository repo = createExecutionRepository()
+    Execution orig = new Execution(PIPELINE, "myapp")
+    orig.stages.add(new Stage(orig, "wait", "wait stage", [foo: 'FOO']))
+    repo.store(orig)
+
+    when:
+    def stage = orig.stages[0]
+    stage.name = "wait stage updated"
+
+    repo.storeStage(stage)
+    def pipelines = repo.retrieve(PIPELINE).toList().toBlocking().single()
+
+    then:
+    pipelines.size() == 1
+    pipelines[0].id == orig.id
+    pipelines[0].stages.size() == 1
+    pipelines[0].stages[0].name == "wait stage updated"
+  }
+
+  def "no specified page retrieves first page"() {
+    given:
+    def criteria = new ExecutionCriteria().setLimit(limit)
+
+    and:
+    (limit + 1).times { i ->
+      repository.store(orchestration {
+        application = "spinnaker"
+        name = "Orchestration #${i + 1}"
+      })
+    }
+
+    when:
+    def results = repository
+      .retrieveOrchestrationsForApplication("spinnaker", criteria)
+      .subscribeOn(Schedulers.immediate())
+      .toList()
+      .toBlocking()
+      .first()
+
+    then:
+    with(results) {
+      size() == criteria.limit
+      first().name == "Orchestration #${limit + 1}"
+      last().name == "Orchestration #2"
+    }
+
+    where:
+    limit = 20
+  }
+
+  def "out of range page retrieves empty result set"() {
+    given:
+    def criteria = new ExecutionCriteria().setLimit(limit).setPage(3)
+
+    and:
+    (limit + 1).times { i ->
+      repository.store(orchestration {
+        application = "spinnaker"
+        name = "Orchestration #${i + 1}"
+      })
+    }
+
+    when:
+    def results = repository
+      .retrieveOrchestrationsForApplication("spinnaker", criteria)
+      .subscribeOn(Schedulers.immediate())
+      .toList()
+      .toBlocking()
+      .first()
+
+    then:
+    results.isEmpty()
+
+    where:
+    limit = 20
+  }
+
+  def "page param > 1 retrieves the relevant page"() {
+    given:
+    def criteria = new ExecutionCriteria().setLimit(limit).setPage(2)
+
+    and:
+    (limit + 1).times { i ->
+      repository.store(orchestration {
+        application = "spinnaker"
+        name = "Orchestration #${i + 1}"
+      })
+    }
+
+    when:
+    def results = repository
+      .retrieveOrchestrationsForApplication("spinnaker", criteria)
+      .subscribeOn(Schedulers.immediate())
+      .toList()
+      .toBlocking()
+      .first()
+
+    then:
+    with(results) {
+      size() == 1
+      first().name == "Orchestration #1"
+    }
+
+    where:
+    limit = 20
+  }
+
+  @Unroll
+  def "page size param restricts the number of results"() {
+    given:
+    def criteria = new ExecutionCriteria().setLimit(limit).setPage(page)
+
+    and:
+    executions.times { i ->
+      repository.store(orchestration {
+        application = "spinnaker"
+        name = "Orchestration #${i + 1}"
+      })
+      // our ULID implementation isn't monotonic
+      sleep(1)
+    }
+
+    when:
+    def results = repository
+      .retrieveOrchestrationsForApplication("spinnaker", criteria)
+      .subscribeOn(Schedulers.immediate())
+      .toList()
+      .toBlocking()
+      .first()
+
+    then:
+    with(results) {
+      size() == expectedResults
+      first().name == firstResult
+      last().name == lastResult
+    }
+
+    where:
+    executions | page | limit || expectedResults | firstResult         | lastResult
+    21         | 2    | 5     || 5               | "Orchestration #16" | "Orchestration #12"
+    21         | 5    | 5     || 1               | "Orchestration #1"  | "Orchestration #1"
+    21         | 5    | 2     || 2               | "Orchestration #13" | "Orchestration #12"
+  }
+}

--- a/orca-sql/src/test/java/com/netflix/spinnaker/orca/sql/SqlTestUtil.java
+++ b/orca-sql/src/test/java/com/netflix/spinnaker/orca/sql/SqlTestUtil.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.LiquibaseException;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.jooq.DSLContext;
+import org.jooq.impl.DataSourceConnectionProvider;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultDSLContext;
+
+import javax.sql.DataSource;
+import java.io.Closeable;
+import java.sql.SQLException;
+import java.util.Arrays;
+
+import static org.jooq.SQLDialect.H2;
+import static org.jooq.conf.RenderNameStyle.AS_IS;
+
+public class SqlTestUtil {
+
+  public static TestDatabase initDatabase() {
+    return initDatabase("jdbc:h2:mem:orca_test");
+  }
+
+  public static TestDatabase initPreviousDatabase() {
+    return initDatabase("jdbc:h2:mem:orca_test_previous");
+  }
+
+  public static TestDatabase initDatabase(String jdbcUrl) {
+    HikariConfig cpConfig = new HikariConfig();
+    cpConfig.setJdbcUrl(jdbcUrl);
+    cpConfig.setMaximumPoolSize(5);
+    DataSource dataSource = new HikariDataSource(cpConfig);
+
+    DefaultConfiguration config = new DefaultConfiguration();
+    config.set(new DataSourceConnectionProvider(dataSource));
+    config.setSQLDialect(H2);
+    config.settings().withRenderNameStyle(AS_IS);
+
+    DSLContext context = new DefaultDSLContext(config);
+
+    Liquibase migrate;
+    try {
+      migrate = new Liquibase(
+        "db/changelog-master.yml",
+        new ClassLoaderResourceAccessor(),
+        DatabaseFactory.getInstance()
+          .findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection()))
+      );
+    } catch (DatabaseException |SQLException e) {
+      throw new DatabaseInitializationFailed(e);
+    }
+
+    try {
+      migrate.update("test");
+    } catch (LiquibaseException e) {
+      throw new DatabaseInitializationFailed(e);
+    }
+
+    return new TestDatabase(context, migrate);
+  }
+
+  public static void cleanupDb(TestDatabase databaseContext) {
+    // TODO rz - iterate over schema instead
+    Arrays.asList(
+      "correlation_ids",
+      "orchestration_stages",
+      "orchestrations",
+      "pipeline_stages",
+      "pipelines",
+      "healthcheck"
+    ).forEach(table -> databaseContext.context.truncate(table).execute());
+  }
+
+
+  public static class TestDatabase implements Closeable {
+    public final DSLContext context;
+    public final Liquibase liquibase;
+
+    TestDatabase(DSLContext context, Liquibase liquibase) {
+      this.context = context;
+      this.liquibase = liquibase;
+    }
+
+    @Override
+    public void close() {
+      context.close();
+    }
+  }
+
+  private static class DatabaseInitializationFailed extends RuntimeException {
+    DatabaseInitializationFailed(Throwable cause) {
+      super(cause);
+    }
+  }
+}

--- a/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/SqlHealthcheckQueueActivatorSpec.kt
+++ b/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/SqlHealthcheckQueueActivatorSpec.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql
+
+import com.netflix.spectator.api.NoopRegistry
+import com.nhaarman.mockito_kotlin.*
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.jooq.DSLContext
+import org.jooq.DeleteWhereStep
+import org.jooq.Table
+import strikt.api.expect
+import strikt.assertions.isEqualTo
+
+object SqlHealthcheckQueueActivatorSpec : Spek({
+
+  describe("healthchecking sql") {
+
+    val dslContext = mock<DSLContext>()
+    val query = mock<DeleteWhereStep<*>>()
+
+    given("a healthy current state") {
+      val subject = SqlHealthcheckActivator(dslContext, NoopRegistry(), unhealthyThreshold = 1).apply {
+        _enabled.set(true)
+      }
+
+      afterEachTest { reset(dslContext, query) }
+
+      on("successive write failures") {
+        whenever(dslContext.delete(isA<Table<*>>())) doThrow RuntimeException("oh no")
+
+        subject.performWrite()
+        subject.performWrite()
+
+        it("deactivates its enabled flag") {
+          expect(subject.enabled).isEqualTo(false)
+        }
+      }
+    }
+
+    given("an unhealthy sql connection") {
+      val subject = SqlHealthcheckActivator(dslContext, NoopRegistry(), healthyThreshold = 1).apply {
+        _enabled.set(false)
+      }
+
+      afterEachTest { reset(dslContext, query) }
+
+      on("successive write failures") {
+        whenever(dslContext.delete(isA<Table<*>>())) doReturn query
+
+        subject.performWrite()
+        subject.performWrite()
+
+        it("deactivates its enabled flag") {
+          expect(subject.enabled).isEqualTo(true)
+        }
+      }
+
+    }
+  }
+})

--- a/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/PagedIteratorSpec.kt
+++ b/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/PagedIteratorSpec.kt
@@ -1,0 +1,145 @@
+package com.netflix.spinnaker.orca.sql.pipeline.persistence
+
+import com.nhaarman.mockito_kotlin.*
+import org.assertj.core.api.AbstractAssert
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.*
+
+internal object PagedIteratorSpec : Spek({
+
+  describe("fetching paged data") {
+
+    val pageSize = 3
+    val nextPage = mock<(Int, String?) -> Iterable<String>>()
+
+    given("there is no data") {
+      val subject = PagedIterator(pageSize, String::toString, nextPage)
+
+      beforeGroup {
+        whenever(nextPage(eq(pageSize), anyOrNull())) doReturn emptyList<String>()
+      }
+
+      afterGroup { reset(nextPage) }
+
+      it("has no elements") {
+        assertThat(subject.hasNext()).isFalse()
+      }
+
+      it("won't return anything") {
+        assertThatThrownBy { subject.next() }
+          .isInstanceOf<NoSuchElementException>()
+      }
+    }
+
+    given("there is less than one full page of data") {
+      val subject = PagedIterator(pageSize, String::toString, nextPage)
+
+      beforeGroup {
+        whenever(nextPage(eq(pageSize), anyOrNull())) doAnswer {
+          val (_, cursor) = it.arguments
+          when (cursor) {
+            null -> listOf("ONE", "TWO")
+            else -> emptyList()
+          }
+        }
+      }
+
+      afterGroup { reset(nextPage) }
+
+      it("has some elements") {
+        assertThat(subject.hasNext()).isTrue()
+      }
+
+      on("draining the iterator") {
+        val results = mutableListOf<String>()
+        subject.forEachRemaining { results.add(it) }
+
+        it("iterates over the available elements") {
+          assertThat(results).containsExactly("ONE", "TWO")
+        }
+
+        it("does not try to fetch another page") {
+          verify(nextPage).invoke(pageSize, null)
+          verifyNoMoreInteractions(nextPage)
+        }
+      }
+    }
+
+    given("there is exactly one full page of data") {
+      val subject = PagedIterator(pageSize, String::toString, nextPage)
+
+      beforeGroup {
+        whenever(nextPage(eq(pageSize), anyOrNull())) doAnswer {
+          val (_, cursor) = it.arguments
+          when (cursor) {
+            null -> listOf("ONE", "TWO", "THREE")
+            else -> emptyList()
+          }
+        }
+      }
+
+      afterGroup { reset(nextPage) }
+
+      it("has some elements") {
+        assertThat(subject.hasNext()).isTrue()
+      }
+
+      on("draining the iterator") {
+        val results = mutableListOf<String>()
+        subject.forEachRemaining { results.add(it) }
+
+        it("iterates over the available elements") {
+          assertThat(results).containsExactly("ONE", "TWO", "THREE")
+        }
+
+        it("tries to fetch the next page before stopping") {
+          verify(nextPage).invoke(pageSize, null)
+          verify(nextPage).invoke(pageSize, "THREE")
+          verifyNoMoreInteractions(nextPage)
+        }
+      }
+    }
+
+    given("there are multiple pages of data") {
+      val subject = PagedIterator(pageSize, String::toString, nextPage)
+
+      beforeGroup {
+        whenever(nextPage(eq(pageSize), anyOrNull())) doAnswer {
+          val (_, cursor) = it.arguments
+          when (cursor) {
+            null    -> listOf("ONE", "TWO", "THREE")
+            "THREE" -> listOf("FOUR", "FIVE", "SIX")
+            "SIX"   -> listOf("SEVEN")
+            else    -> emptyList()
+          }
+        }
+      }
+
+      afterGroup { reset(nextPage) }
+
+      it("has some elements") {
+        assertThat(subject.hasNext()).isTrue()
+      }
+
+      on("draining the iterator") {
+        val results = mutableListOf<String>()
+        subject.forEachRemaining { results.add(it) }
+
+        it("iterates over the available elements") {
+          assertThat(results)
+            .containsExactly("ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN")
+        }
+
+        it("does not try to fetch additional pages") {
+          verify(nextPage, times(3)).invoke(eq(pageSize), anyOrNull())
+        }
+      }
+    }
+  }
+
+})
+
+private inline fun <reified T> AbstractAssert<*, *>.isInstanceOf() =
+  isInstanceOf(T::class.java)

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -52,6 +52,8 @@ dependencies {
   compile project(":orca-keel")
   compile project(":orca-qos")
   compile project(":orca-migration")
+  compile project(":orca-sql")
+  compile project(":orca-sql-mysql")
 
   runtime spinnaker.dependency("kork")
   compile spinnaker.dependency('korkExceptions')

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,7 +44,9 @@ include "orca-extensionpoint",
   "orca-pipelinetemplate",
   "orca-validation",
   "orca-qos",
-  "orca-migration"
+  "orca-migration",
+  "orca-sql",
+  "orca-sql-mysql"
 
 rootProject.name = "orca"
 


### PR DESCRIPTION
Sorry it's gigantic. I can break this up if people want.

For Netflix reviewers, here's the sole difference:

1. MariaDB is not coming along for the OSS ride, but I showed how we do it here: https://github.com/robzienert/orca-mariadb-extension
1. `orca-sql-mysql` is a new module. We'll need to exclude the mysql connector in our deployments.
