### PR TITLE
feat(clouddriver): Allow username to be overridden in `RestorePinnedServerGroupsPoller`

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPollerSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPollerSpec.groovy
@@ -89,6 +89,7 @@ class RestorePinnedServerGroupsPollerSpec extends Specification {
       registry,
       executionLauncher,
       executionRepository,
+      "spinnaker",
       pollerSupport
     ]
   )


### PR DESCRIPTION
This allows for a service account to be used that would grant access to
privileged accounts and applications.
