### PR TITLE
chore(*): Bump keiko to 2.9.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ junitVersion=1.2.0
 jupiterVersion=5.0.2
 junitLegacyVersion=4.12.0
 spekVersion=1.1.5
-keikoVersion=2.9.3
+keikoVersion=2.9.5


### PR DESCRIPTION
Fixes an efficiency regression for low- to medium-volumed orca deployments.