### PR TITLE
fix(clouddriver): stop logging the force cache contents

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
@@ -159,11 +159,6 @@ class ServerGroupCacheForceRefreshTask extends AbstractCloudProviderAwareTask im
                                                   Long startTime) {
 
     def pendingForceCacheUpdates = cacheStatusService.pendingForceCacheUpdates(cloudProvider, REFRESH_TYPE)
-    log.debug(
-      "Force cache refresh clouddriver response was: {} (executionId: {})",
-      pendingForceCacheUpdates,
-      executionId
-    )
     boolean isRecent = (startTime != null) ? pendingForceCacheUpdates.find { it.cacheTime >= startTime } : false
 
     boolean finishedProcessing = true


### PR DESCRIPTION
It's far too verbose and just clutters the logs in our environment.

If in the future there is interest in improving this, I would suggest
filtering the response down to the cluster being operated on and logging
that.
