### PR TITLE
fix(cancel): consistent CANCELED event

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/ExecutionStatus.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/ExecutionStatus.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.orca;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 
 public enum ExecutionStatus {
   /**
@@ -31,62 +30,62 @@ public enum ExecutionStatus {
    * The task is still running and the {@code Task} may be re-executed in order
    * to continue.
    */
-    RUNNING(false, false),
+  RUNNING(false, false),
 
   /**
    * The task is still running and the {@code Task} may be resumed in order
    * to continue.
    */
-    PAUSED(false, false),
+  PAUSED(false, false),
 
   /**
    * The task is complete but the pipeline should now be stopped pending a
    * trigger of some kind.
    */
-    SUSPENDED(false, false),
+  SUSPENDED(false, false),
 
   /**
    * The task executed successfully and the pipeline may now proceed to the next
    * task.
    */
-    SUCCEEDED(true, false),
+  SUCCEEDED(true, false),
 
   /**
    * The task execution failed,  but the pipeline may proceed to the next
    * task.
    */
-    FAILED_CONTINUE(true, false),
+  FAILED_CONTINUE(true, false),
 
   /**
    * The task failed and the failure was terminal. The pipeline will not
    * progress any further.
    */
-    TERMINAL(true, true),
+  TERMINAL(true, true),
 
   /**
    * The task was canceled. The pipeline will not progress any further.
    */
-    CANCELED(true, true),
+  CANCELED(true, true),
 
   /**
    * The step completed but is indicating that a decision path should be followed, not the default path.
    */
-    REDIRECT(false, false),
+  REDIRECT(false, false),
 
   /**
    * The task was stopped. The pipeline will not progress any further.
    */
-    STOPPED(true, true),
+  STOPPED(true, true),
 
   /**
    * The task was skipped and the pipeline will proceed to the next task.
    */
-    SKIPPED(true, false),
+  SKIPPED(true, false),
 
   /**
    * The task is not started and must be transitioned to NOT_STARTED.
    */
-    BUFFERED(false, false);
+  BUFFERED(false, false);
 
   /**
    * Indicates that the task/stage/pipeline has finished its work (successfully or not).

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
@@ -16,23 +16,18 @@
 
 package com.netflix.spinnaker.orca.q.handler
 
-import com.netflix.spinnaker.orca.ExecutionStatus.CANCELED
 import com.netflix.spinnaker.orca.ExecutionStatus.PAUSED
-import com.netflix.spinnaker.orca.events.ExecutionComplete
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.CancelExecution
 import com.netflix.spinnaker.orca.q.RescheduleExecution
 import com.netflix.spinnaker.orca.q.ResumeStage
 import com.netflix.spinnaker.q.Queue
-import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 
 @Component
 class CancelExecutionHandler(
   override val queue: Queue,
-  override val repository: ExecutionRepository,
-  @Qualifier("queueEventPublisher")private val publisher: ApplicationEventPublisher
+  override val repository: ExecutionRepository
 ) : OrcaMessageHandler<CancelExecution> {
   override val messageType = CancelExecution::class.java
 
@@ -51,8 +46,6 @@ class CancelExecutionHandler(
 
       // then, make sure those runTask messages get run right away
       queue.push(RescheduleExecution(execution))
-
-      publisher.publishEvent(ExecutionComplete(this, message.executionType, message.executionId, CANCELED))
     }
   }
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
@@ -56,19 +56,23 @@ class CompleteExecutionHandler(
         log.info("Execution ${execution.id} already completed with ${execution.status} status")
       } else {
         message.determineFinalStatus(execution) { status ->
-          repository.updateStatus(execution.type, message.executionId, status)
-          publisher.publishEvent(
-            ExecutionComplete(this, message.executionType, message.executionId, status)
-          )
-          registry.counter(completedId.withTags(
-            "status", status.name,
-            "executionType", execution.type.name,
-            "application", execution.application
-          )).increment()
+          var runningStages: Boolean = false
           if (status != SUCCEEDED) {
             execution.topLevelStages.filter { it.status == RUNNING }.forEach {
+              runningStages = true
               queue.push(CancelStage(it))
             }
+          }
+          if (!runningStages) {
+            repository.updateStatus(execution.type, message.executionId, status)
+            publisher.publishEvent(
+              ExecutionComplete(this, message.executionType, message.executionId, status)
+            )
+            registry.counter(completedId.withTags(
+              "status", status.name,
+              "executionType", execution.type.name,
+              "application", execution.application
+            )).increment()
           }
         }
       }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandlerTest.kt
@@ -205,22 +205,18 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
         subject.handle(message)
       }
 
-      it("updates the pipeline status") {
-        verify(repository).updateStatus(PIPELINE, pipeline.id, stageStatus)
-      }
-
-      it("publishes an event") {
-        verify(publisher).publishEvent(check<ExecutionComplete> {
-          assertThat(it.executionType).isEqualTo(pipeline.type)
-          assertThat(it.executionId).isEqualTo(pipeline.id)
-          assertThat(it.status).isEqualTo(stageStatus)
-        })
-      }
-
       it("cancels other stages") {
         verify(queue).push(CancelStage(pipeline.stageByRef("2")))
         verify(queue).push(CancelStage(pipeline.stageByRef("3")))
         verifyNoMoreInteractions(queue)
+      }
+
+      it("does not update execution status") {
+        verify(repository, never()).updateStatus(any(), any(), any())
+      }
+
+      it("does not publish an event") {
+        verifyZeroInteractions(publisher)
       }
     }
   }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -358,7 +358,6 @@ class TaskController {
         reason
       )
     }
-    executionRepository.updateStatus(PIPELINE, id, ExecutionStatus.CANCELED)
   }
 
   @PreAuthorize("hasPermission(this.getPipeline(#id)?.application, 'APPLICATION', 'WRITE')")


### PR DESCRIPTION
Routes cancelation into the CompleteExecutionHandler, allowing it to
determine the final pipeline status, and not updating the pipeline status
until other branches with running stages have been marked as canceled.
