### PR TITLE
fix(dryrun): Rollback cluster stages can run for real

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/RollbackClusterStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/RollbackClusterStage.java
@@ -37,17 +37,6 @@ import java.util.stream.Collectors;
 public class RollbackClusterStage implements StageDefinitionBuilder {
   public static final String PIPELINE_CONFIG_TYPE = "rollbackCluster";
 
-  private final RollbackServerGroupStage rollbackServerGroupStage;
-
-  private final WaitStage waitStage;
-
-  @Autowired
-  public RollbackClusterStage(RollbackServerGroupStage rollbackServerGroupStage,
-                              WaitStage waitStage) {
-    this.rollbackServerGroupStage = rollbackServerGroupStage;
-    this.waitStage = waitStage;
-  }
-
   @Override
   public void taskGraph(
     @Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
@@ -83,7 +72,7 @@ public class RollbackClusterStage implements StageDefinitionBuilder {
       }
 
       context.put("rollbackContext", rollbackContext);
-      context.put("type", rollbackServerGroupStage.getType());
+      context.put("type", RollbackServerGroupStage.PIPELINE_CONFIG_TYPE);
       context.put("region", region);
       context.put("credentials", stageData.credentials);
       context.put("cloudProvider", stageData.cloudProvider);
@@ -92,7 +81,7 @@ public class RollbackClusterStage implements StageDefinitionBuilder {
       context.putAll(propagateParentStageContext(parent.getParent()));
 
       graph.append((it) -> {
-        it.setType(rollbackServerGroupStage.getType());
+        it.setType(RollbackServerGroupStage.PIPELINE_CONFIG_TYPE);
         it.setName("Rollback " + region);
         it.setContext(context);
       });
@@ -100,7 +89,7 @@ public class RollbackClusterStage implements StageDefinitionBuilder {
       if (stageData.waitTimeBetweenRegions != null && regionsToRollback.indexOf(region) < regionsToRollback.size() - 1) {
         // only add the waitStage if we're not the very last region!
         graph.append((it) -> {
-          it.setType(waitStage.getType());
+          it.setType(WaitStage.STAGE_TYPE);
           it.setName("Wait after " + region);
           it.setContext(Collections.singletonMap("waitTime", stageData.waitTimeBetweenRegions));
         });

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/RollbackClusterStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/RollbackClusterStageSpec.groovy
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.cluster
 
-import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.RollbackServerGroupStage
-import com.netflix.spinnaker.orca.pipeline.WaitStage
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import spock.lang.Specification
@@ -26,11 +24,9 @@ import spock.lang.Unroll
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
 class RollbackClusterStageSpec extends Specification {
-  def rollbackServerGroupStageBuilder = new RollbackServerGroupStage()
-  def waitStageBuilder = new WaitStage()
 
   @Subject
-  def stageBuilder = new RollbackClusterStage(rollbackServerGroupStageBuilder, waitStageBuilder)
+  def stageBuilder = new RollbackClusterStage()
 
   def "should not build any aroundStages()"() {
     expect:

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.orca.pipeline.model.Task
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.RollbackClusterStage
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder
-import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DestroyServerGroupStage
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -31,7 +30,7 @@ import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 class CreateServerGroupStageSpec extends Specification {
   @Subject
   def createServerGroupStage = new CreateServerGroupStage(
-    rollbackClusterStage: new RollbackClusterStage(null, null),
+    rollbackClusterStage: new RollbackClusterStage(),
     destroyServerGroupStage: new DestroyServerGroupStage()
   )
 

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunStageDefinitionBuilderFactory.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunStageDefinitionBuilderFactory.kt
@@ -37,7 +37,7 @@ class DryRunStageDefinitionBuilderFactory(
     }
 
   private val Stage.shouldExecuteNormallyInDryRun: Boolean
-    get() = isManualJudgment || isPipeline || isExpressionPrecondition || isFindImage || isDetermineTargetServerGroup
+    get() = isManualJudgment || isPipeline || isExpressionPrecondition || isFindImage || isDetermineTargetServerGroup || isRollbackCluster
 
   private val Stage.isManualJudgment: Boolean
     get() = type == "manualJudgment"
@@ -65,4 +65,7 @@ class DryRunStageDefinitionBuilderFactory(
     get() = (context["preconditions"] as Iterable<Map<String, Any>>?)?.run {
       all { it["type"] == "expression" }
     } == true
+
+  private val Stage.isRollbackCluster: Boolean
+    get() = type == "rollbackCluster"
 }


### PR DESCRIPTION
The stage runs a task that identifies the cluster to roll back. That info is useful and it's just a read operation. Also, if that has not happened construction of the after stages that actually perform the rollback operations fails.