### PR TITLE
fix(metrics): use string instead of class name

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -144,7 +144,7 @@ class DependentPipelineStarter implements ApplicationContextAware {
 
         Id id = registry.createId("pipelines.triggered")
           .withTag("application", Optional.ofNullable(pipeline.getApplication()).orElse("null"))
-          .withTag("monitor", getClass().getSimpleName())
+          .withTag("monitor", "DependentPipelineStarter")
         registry.counter(id).increment()
 
       } as Callable<Void>, true, principal)


### PR DESCRIPTION
Right now `getClass().getSimpleName()` == `_trigger_closure3`. Using a string instead.
