### PR TITLE
fix(queue): `ContinueParentStageHandler` should complete if all after stages are complete

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
@@ -80,15 +80,17 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage {
 
   @Override
   void onFailureStages(@Nonnull Stage stage, StageGraphBuilder graph) {
-    super.onFailureStages(stage, graph)
-
     def stageData = stage.mapTo(StageData)
     if (!stageData.rollback?.onFailure) {
+      super.onFailureStages(stage, graph)
+
       // rollback on failure is not enabled
       return
     }
 
     if (!stageData.getServerGroup()) {
+      super.onFailureStages(stage, graph)
+
       // did not get far enough to create a new server group
       log.warn("No server group was created, skipping rollback! (executionId: ${stage.execution.id}, stageId: ${stage.id})")
       return
@@ -139,6 +141,9 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage {
         ]
       }
     }
+
+    // any on-failure stages from the parent should be executed _after_ the rollback completes
+    super.onFailureStages(stage, graph)
   }
 
   private static class StageData {

--- a/orca-kotlin/src/main/kotlin/com/netflix/spinnaker/orca/ext/Stage.kt
+++ b/orca-kotlin/src/main/kotlin/com/netflix/spinnaker/orca/ext/Stage.kt
@@ -89,10 +89,10 @@ fun Stage.beforeStages(): List<Stage> =
 fun Stage.afterStages(): List<Stage> =
   syntheticStages().filter { it.syntheticStageOwner == STAGE_AFTER }
 
-fun Stage.allBeforeStagesComplete(): Boolean =
+fun Stage.allBeforeStagesSuccessful(): Boolean =
   beforeStages().all { it.status in listOf(SUCCEEDED, FAILED_CONTINUE, SKIPPED) }
 
-fun Stage.allAfterStagesComplete(): Boolean =
+fun Stage.allAfterStagesSuccessful(): Boolean =
   afterStages().all { it.status in listOf(SUCCEEDED, FAILED_CONTINUE, SKIPPED) }
 
 fun Stage.anyBeforeStagesFailed(): Boolean =
@@ -100,6 +100,9 @@ fun Stage.anyBeforeStagesFailed(): Boolean =
 
 fun Stage.anyAfterStagesFailed(): Boolean =
   afterStages().any { it.status in listOf(TERMINAL, STOPPED, CANCELED) }
+
+fun Stage.allAfterStagesComplete(): Boolean =
+  afterStages().all { it.status.isComplete }
 
 fun Stage.hasTasks(): Boolean =
   tasks.isNotEmpty()

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/admin/HydrateQueueCommand.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/admin/HydrateQueueCommand.kt
@@ -20,8 +20,8 @@ import com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED
 import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.ext.afterStages
-import com.netflix.spinnaker.orca.ext.allAfterStagesComplete
-import com.netflix.spinnaker.orca.ext.allBeforeStagesComplete
+import com.netflix.spinnaker.orca.ext.allAfterStagesSuccessful
+import com.netflix.spinnaker.orca.ext.allBeforeStagesSuccessful
 import com.netflix.spinnaker.orca.ext.allUpstreamStagesComplete
 import com.netflix.spinnaker.orca.ext.beforeStages
 import com.netflix.spinnaker.orca.ext.isInitial
@@ -159,9 +159,9 @@ class HydrateQueueCommand(
         stage.afterStages().forEach { actions.addAll(processStage(it)) }
       }
 
-      if (stage.allBeforeStagesComplete() &&
+      if (stage.allBeforeStagesSuccessful() &&
         stage.tasks.all { it.status.isComplete } &&
-        stage.allAfterStagesComplete()) {
+        stage.allAfterStagesSuccessful()) {
         actions.add(Action(
           description = "All tasks and known synthetic stages are complete",
           message = CompleteStage(stage),

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandler.kt
@@ -44,7 +44,7 @@ class ContinueParentStageHandler(
   override fun handle(message: ContinueParentStage) {
     message.withStage { stage ->
       if (message.phase == STAGE_BEFORE) {
-        if (stage.allBeforeStagesComplete()) {
+        if (stage.allBeforeStagesSuccessful()) {
           when {
             stage.hasTasks() -> stage.runFirstTask()
             else             -> queue.push(CompleteStage(stage))
@@ -56,7 +56,7 @@ class ContinueParentStageHandler(
       } else {
         if (stage.allAfterStagesComplete()) {
           queue.push(CompleteStage(stage))
-        } else if (!stage.anyAfterStagesFailed()) {
+        } else {
           log.warn("Re-queuing $message as other ${message.phase} stages are still running")
           queue.push(message, retryDelay)
         }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandlerTest.kt
@@ -243,8 +243,8 @@ object ContinueParentStageHandlerTest : SubjectSpek<ContinueParentStageHandler>(
           subject.handle(message)
         }
 
-        it("does nothing") {
-          verifyZeroInteractions(queue)
+        it("tells the stage to complete") {
+          verify(queue).push(CompleteStage(pipeline.stageByRef("1")))
         }
       }
 


### PR DESCRIPTION
This addresses a scenario where an execution would never complete if
the set of after stage statuses contained a mix of SUCCEEDED and
TERMINAL.

See `onFailureStages()` on `CreateServerGroupStage`.
