### PR TITLE
fix(orca) fix force cache refresh sometimes taking 12 minutes (#3366)

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
@@ -122,7 +122,11 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
             .findAny();
 
         if (pendingRefresh.isPresent()) {
-          if (!pendingRefreshProcessed(pendingRefresh.get(), refreshedManifests, startTime)) {
+          if (pendingRefreshProcessed(pendingRefresh.get(), refreshedManifests, startTime)) {
+            log.debug("Pending manifest refresh of {} in {} completed", id, account);
+            processedManifests.add(id);
+          } else {
+            log.debug("Pending manifest refresh of {} in {} still pending", id, account);
             allProcessed = false;
           }
         } else {


### PR DESCRIPTION
Sometimes the "Force Cache Refresh" task of deploying a v2 manifest would take
up to 12 minutes to complete. This would occur as result of a timing issue
between when Orca submits the refresh requests to the cloud driver and when the
cloud driver processes the requests.

The fix is to handle the scenario where Orca "forgets" pending requests that
have been previously completed if not all the pending requests are completed
when it queries the cloud driver.

This is to fix issue spinnaker/spinnaker#3366