### PR TITLE
fix(metrics): Correctly handle potentially empty account tag

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/MetricsTagHelper.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/MetricsTagHelper.kt
@@ -2,8 +2,8 @@ package com.netflix.spinnaker.orca.q.metrics
 
 import com.netflix.spectator.api.BasicTag
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
+import com.netflix.spinnaker.orca.pipeline.model.Stage
 
 class MetricsTagHelper : CloudProviderAware {
   companion object {
@@ -14,17 +14,26 @@ class MetricsTagHelper : CloudProviderAware {
         BasicTag("status", status.toString()),
         BasicTag("executionType", stage.execution.type.name.capitalize()),
         BasicTag("isComplete", status.isComplete.toString()),
-        BasicTag("cloudProvider", helper.getCloudProvider(stage) ?: "n_a"))
+        BasicTag("cloudProvider", helper.getCloudProvider(stage).valueOrNa())
+      )
 
     fun detailedTaskTags(stage: Stage, taskModel: com.netflix.spinnaker.orca.pipeline.model.Task, status: ExecutionStatus): Iterable<BasicTag> =
       arrayListOf(
         BasicTag("taskType", taskModel.implementingClass),
-        BasicTag("account", helper.getCredentials(stage) ?: "n_a"),
+        BasicTag("account", helper.getCredentials(stage).valueOrNa()),
 
         // sorting regions to reduce the metrics cardinality
         BasicTag("region", helper.getRegions(stage).let {
           if (it.isEmpty()) { "n_a" }
           else { it.sorted().joinToString(",") }
         }))
+
+    private fun String?.valueOrNa(): String {
+      return if (this == null || isBlank()) {
+        "n_a"
+      } else {
+        this
+      }
+    }
   }
 }


### PR DESCRIPTION
At long last, we know exactly where we had that bad metric.

An example of the invalid measurements (there's a ton of these):

```
invalid measurement: Measurement(task.invocations.duration.withType:account=:atlas.dstype=rate:cloudProvider=aws:executionType=PIPELINE:isComplete=true:region=n_a:statistic=totalOfSquares:status=SUCCEEDED:taskType=com.netflix.spinnaker.orca.igor.tasks.StartScriptTask,1537820460000,0.0)
```