### PR TITLE
fix(pipeline_templates): Fix expected artifacts when templated pipeline is triggered by a parent pipeline

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -98,6 +98,7 @@ class DependentPipelineStarter implements ApplicationContextAware {
 
     def trigger = pipelineConfig.trigger
     //keep the trigger as the preprocessor removes it.
+    def expectedArtifacts = pipelineConfig.expectedArtifacts
 
     for (PipelinePreprocessor preprocessor : (pipelinePreprocessors ?: [])) {
       pipelineConfig = preprocessor.process(pipelineConfig)
@@ -110,6 +111,7 @@ class DependentPipelineStarter implements ApplicationContextAware {
     }
 
     pipelineConfig.trigger = trigger
+    pipelineConfig.expectedArtifacts = expectedArtifacts
 
     def artifactError = null
     try {


### PR DESCRIPTION
(kind of similar to this one https://github.com/spinnaker/orca/pull/2406 )

When a templated pipeline has `expectedArtifacts`, and said pipeline is triggered by another pipeline (parent), the expectedartifacts value is not kept after the the process done by `PipelineProcessors`