### PR TITLE
fix(locking): fixes locking in strategies / child pipelines

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/CustomStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/CustomStrategy.groovy
@@ -27,14 +27,9 @@ import org.springframework.stereotype.Component
 import static com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.newStage
 
 @Component
-class CustomStrategy implements Strategy, ApplicationContextAware {
+class CustomStrategy implements Strategy {
 
   final String name = "custom"
-
-  @Autowired(required = false)
-  PipelineStage pipelineStage
-
-  ApplicationContext applicationContext
 
   @Override
   List<Stage> composeFlow(Stage stage) {
@@ -68,7 +63,7 @@ class CustomStrategy implements Strategy, ApplicationContextAware {
     return [
       newStage(
         stage.execution,
-        pipelineStage.type,
+        PipelineStage.PIPELINE_CONFIG_TYPE,
         "pipeline",
         modifyCtx,
         stage,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
@@ -173,7 +173,8 @@ public class TrafficGuard {
     try {
       application = front50Service.get(clusterMoniker.getApp());
     } catch (RetrofitError e) {
-      if (e.getResponse() != null && e.getResponse().getStatus() == 404) {
+      //ignore an unknown (404) or unauthorized (403) application
+      if (e.getResponse() != null && Arrays.asList(404, 403).contains(e.getResponse().getStatus())) {
         application = null;
       } else {
         throw e;

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/ParallelDeployStageSpec.groovy
@@ -114,15 +114,15 @@ class ParallelDeployStageSpec extends Specification {
           [
             name   : "Deploy in us-west-1",
             cluster: [
-              account                  : "prod",
-              availabilityZones        : ["us-west-1": []],
-              cloudProvider            : "aws",
-              restrictedExecutionWindow: [:],
-              strategy                 : "none",
               amiName                  : "ami-1234",
+              restrictedExecutionWindow: [:],
+              cloudProvider            : "aws",
+              availabilityZones        : ["us-west-1": []],
+              strategy                 : "none",
+              account                  : "prod"
             ],
+            account: "prod",
             type   : "createServerGroup",
-            account: "prod"
           ]
         ]
       ],
@@ -130,8 +130,7 @@ class ParallelDeployStageSpec extends Specification {
         scenario                : "inherit traffic options from parent",
         parentStageContext      : [
           amiName           : "ami-1234",
-          trafficOptions    : "enable",
-          suspendedProcesses: [],
+          suspendedProcesses: ['AddToLoadBalancer'],
         ],
         stageContext            : [
           trafficOptions: "inherit"
@@ -141,26 +140,24 @@ class ParallelDeployStageSpec extends Specification {
           [
             name          : "Deploy in us-west-1",
             cluster       : [
-              account                  : "prod",
-              availabilityZones        : ["us-west-1": []],
-              cloudProvider            : "aws",
-              restrictedExecutionWindow: [:],
-              strategy                 : "none",
               amiName                  : "ami-1234",
-              trafficOptions           : "enable",
-              suspendedProcesses       : [],
+              restrictedExecutionWindow: [:],
+              cloudProvider            : "aws",
+              availabilityZones        : ["us-west-1": []],
+              suspendedProcesses       : ['AddToLoadBalancer'],
+              strategy                 : "none",
+              account                  : "prod"
             ],
-            trafficOptions: "inherit",
             type          : "createServerGroup",
+            trafficOptions: "inherit",
             account       : "prod"
           ]
         ]
       ],
       [
-        scenario                : "override traffic options in parent",
+        scenario                : "override traffic options in parent to enable cluster",
         parentStageContext      : [
           amiName           : "ami-1234",
-          trafficOptions    : "disable",
           suspendedProcesses: ['AddToLoadBalancer'],
         ],
         stageContext            : [
@@ -171,18 +168,45 @@ class ParallelDeployStageSpec extends Specification {
           [
             name          : "Deploy in us-west-1",
             cluster       : [
-              account                  : "prod",
-              availabilityZones        : ["us-west-1": []],
-              cloudProvider            : "aws",
-              restrictedExecutionWindow: [:],
-              strategy                 : "none",
               amiName                  : "ami-1234",
-              trafficOptions           : "disable",
-              suspendedProcesses       : []
+              restrictedExecutionWindow: [:],
+              cloudProvider            : "aws",
+              availabilityZones        : ["us-west-1": []],
+              suspendedProcesses       : [],
+              strategy                 : "none",
+              account                  : "prod"
             ],
-            account       : "prod",
-            trafficOptions: "enable",
             type          : "createServerGroup",
+            trafficOptions: "enable",
+            account       : "prod"
+          ]
+        ]
+      ],
+      [
+        scenario                : "override traffic options in parent to disable cluster",
+        parentStageContext      : [
+          amiName           : "ami-1234",
+          suspendedProcesses: [],
+        ],
+        stageContext            : [
+          trafficOptions: "disable"
+        ],
+        triggerParams           : [:],
+        expectedParallelContexts: [
+          [
+            name          : "Deploy in us-west-1",
+            cluster: [
+              amiName                  : "ami-1234",
+              restrictedExecutionWindow: [:],
+              cloudProvider            : "aws",
+              availabilityZones        : ["us-west-1": []],
+              suspendedProcesses       : ['AddToLoadBalancer'],
+              strategy                 : "none",
+              account                  : "prod"
+            ],
+            type          : "createServerGroup",
+            trafficOptions: "disable",
+            account: "prod"
           ]
         ]
       ]

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockContext.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockContext.java
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.orca.locks;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.PipelineTrigger;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 
 import java.util.Objects;
@@ -54,12 +55,23 @@ public class LockContext {
             .map(Execution.ExecutionType::toString)
             .orElse(null));
 
-        //TODO(cfieber): lockValue.id:
-        // if we are a child pipeline / strategy we probably need to use the parent execution id
-        final String id = Optional.ofNullable(this.id).orElseGet(() ->
-          execution
-            .map(Execution::getId)
-            .orElse(null));
+        final String id = Optional.ofNullable(this.id).orElseGet(() -> {
+          if (!execution.isPresent()) {
+            return null;
+          }
+
+          Optional<Execution> next = execution;
+          Execution rootExecution;
+          do {
+            rootExecution = next.get();
+            next = next
+              .filter(e -> e.getTrigger() instanceof PipelineTrigger)
+              .map(e -> ((PipelineTrigger) e.getTrigger()).getParentStage())
+              .map(Stage::getExecution);
+          } while (next.isPresent());
+
+          return rootExecution.getId();
+        });
 
         return new LockManager.LockValue(application, type, id);
       }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/locks/LockContextSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/locks/LockContextSpec.groovy
@@ -1,0 +1,124 @@
+package com.netflix.spinnaker.orca.locks
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.PipelineTrigger
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.test.model.ExecutionBuilder
+import spock.lang.Specification
+
+class LockContextSpec extends Specification {
+
+  def "builder uses explicitly provided id in when present"() {
+    given:
+    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, type, explicitId, stage)
+
+    expect:
+    builder.build() == expected
+
+    where:
+    application = 'app'
+    type = 'pipeline'
+    explicitId = 'bacon'
+
+    stage = ExecutionBuilder.stage {
+      context = [:]
+    }
+
+    expectedId = explicitId
+    expected = new LockManager.LockValue(application, type, expectedId)
+  }
+
+  def "builder uses execution id in simple execution"() {
+    given:
+    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, type, explicitId, stage)
+
+    expect:
+    builder.build() == expected
+
+    where:
+    application = 'app'
+    type = 'pipeline'
+    explicitId = null
+
+    stage = ExecutionBuilder.stage {
+      context = [:]
+    }
+
+    expectedId = stage.execution.id
+    expected = new LockManager.LockValue(application, type, expectedId)
+  }
+
+  def "builder traverses up the hierarchy when execution is triggered by a PipelineTrigger"() {
+    given:
+    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, type, explicitId, stage)
+
+    expect:
+    builder.build() == expected
+
+    where:
+    application = 'app'
+    type = 'pipeline'
+    explicitId = null
+
+    parentStage = ExecutionBuilder.stage {
+      type = 'pipeline'
+    }
+
+
+    exec = ExecutionBuilder.pipeline {
+      trigger = makeTrigger(parentStage)
+      ExecutionBuilder.stage {
+        type = 'acquireLock'
+      }
+    }
+
+    stage = exec.stages[0]
+
+    expectedId = parentStage.execution.id
+    expected = new LockManager.LockValue(application, type, expectedId)
+
+  }
+
+  def "builder traverses up the hierarchy multiple levels when execution is triggered by a PipelineTrigger"() {
+    given:
+    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, type, explicitId, stage)
+
+    expect:
+    builder.build() == expected
+
+    where:
+    application = 'app'
+    type = 'pipeline'
+    explicitId = null
+
+
+
+    grandParentStage = ExecutionBuilder.stage {
+      type = 'pipeline'
+    }
+
+    parentExec = childExec(grandParentStage)
+
+    exec = childExec(parentExec.stages[0], 'acquireLock')
+    stage = exec.stages[0]
+
+    expectedId = grandParentStage.execution.id
+    expected = new LockManager.LockValue(application, type, expectedId)
+
+  }
+
+  private PipelineTrigger makeTrigger(Stage parentStage) {
+    return new PipelineTrigger('pipeline', null, '[anonymous', [:], [], [], false, false, false, parentStage.execution, parentStage.id)
+  }
+
+  private Execution childExec(Stage parentStage, String stageType = 'pipeline') {
+    return ExecutionBuilder.pipeline {
+      trigger = makeTrigger(parentStage)
+      ExecutionBuilder.stage {
+        type = stageType
+      }
+    }
+
+
+  }
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
@@ -35,7 +35,7 @@ class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
   @Autowired
   ExecutionRepository executionRepository
 
-  long backoffPeriod = 1000
+  long backoffPeriod = TimeUnit.SECONDS.toMillis(15)
   long timeout = TimeUnit.HOURS.toMillis(12)
 
   @Override


### PR DESCRIPTION
fix for a couple items broken by #2420 :

* locking in strategies and child pipelines will now use the parent pipeline id 
* traffic guard getting a 403 on an application lookup is non fatal (treated as application not existing)
* also increases the poll interval for monitoring child pipelines from 1s -> 15s