### PR TITLE
fix(moniker): handle Monikers without cluster

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/AbstractClusterWideClouddriverOperationStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/AbstractClusterWideClouddriverOperationStage.java
@@ -119,7 +119,7 @@ public abstract class AbstractClusterWideClouddriverOperationStage implements St
       @JsonProperty("cloudProvider") String cloudProvider,
       @JsonProperty("credentials") String credentials) {
       if (cluster == null) {
-        if (moniker == null) {
+        if (moniker == null || moniker.getCluster() == null) {
           throw new NullPointerException("At least one of 'cluster' and 'moniker' is required");
         } else {
           this.cluster = moniker.getCluster();
@@ -128,7 +128,7 @@ public abstract class AbstractClusterWideClouddriverOperationStage implements St
         this.cluster = cluster;
       }
 
-      if (moniker == null) {
+      if (moniker == null || moniker.getCluster() == null) {
         this.moniker = MonikerHelper.friggaToMoniker(this.cluster);
       } else {
         this.moniker = moniker;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
@@ -93,7 +93,7 @@ class ApplySourceServerGroupCapacityTask extends AbstractServerGroupTask {
   @Override
   Moniker convertMoniker(Stage stage) {
     // Used in AbstractServerGroupTask.execute() but not needed here.
-    return null;
+    return null
   }
 
   /**

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
@@ -111,7 +111,7 @@ abstract class AbstractDeployStrategyStage extends AbstractCloudProviderAwareSta
     def preProcessors = deployStagePreProcessors.findAll { it.supports(stage) }
     def stageData = stage.mapTo(StageData)
     def stages = []
-    def moniker = stageData.moniker ?: MonikerHelper.friggaToMoniker(stageData.cluster)
+    def moniker = stageData.moniker?.cluster ? stageData.moniker : MonikerHelper.friggaToMoniker(stageData.cluster)
     def location = TargetServerGroup.Support.locationFromStageData(stageData)
     def lockName = ClusterLockHelper.clusterLockName(moniker, stageData.account, location)
     boolean addLocking = trafficGuard.hasDisableLock(moniker, stageData.account, location)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
@@ -34,7 +34,6 @@ import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.front50.model.Application;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
-import com.thoughtworks.xstream.mapper.Mapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobUtils.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobUtils.java
@@ -21,7 +21,6 @@ import com.netflix.frigga.Names;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.clouddriver.KatoRestService;
-import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractBulkServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractBulkServerGroupTask.java
@@ -105,7 +105,7 @@ public abstract class AbstractBulkServerGroupTask extends AbstractCloudProviderA
       Map<String , Map> tmp = new HashMap<>();
       Map operation = targetServerGroup.toClouddriverOperationPayload(request.getCredentials());
       Moniker moniker = targetServerGroup.getMoniker();
-      if (moniker == null) {
+      if (moniker == null || moniker.getCluster() == null) {
         moniker = MonikerHelper.friggaToMoniker(targetServerGroup.getName());
       }
       validateClusterStatus(operation, moniker);

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
@@ -126,8 +126,8 @@ abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask im
 
   Moniker convertMoniker(Stage stage) {
     if (TargetServerGroup.isDynamicallyBound(stage)) {
-      TargetServerGroup tsg = TargetServerGroupResolver.fromPreviousStage(stage);
-      return  tsg.getMoniker() == null ? MonikerHelper.friggaToMoniker(tsg.getName()) : tsg.getMoniker();
+      TargetServerGroup tsg = TargetServerGroupResolver.fromPreviousStage(stage)
+      return tsg.getMoniker()?.getCluster() == null ? MonikerHelper.friggaToMoniker(tsg.getName()) : tsg.getMoniker()
     }
     String serverGroupName = (String) stage.context.serverGroupName;
     String asgName = (String) stage.context.asgName;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/ClusterLockHelper.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/ClusterLockHelper.java
@@ -20,6 +20,6 @@ public class ClusterLockHelper {
       Objects.requireNonNull(account),
       loc.map(Location::getType).orElse(null),
       loc.map(Location::getValue).orElse(null),
-      Objects.requireNonNull(clusterMoniker).getCluster());
+      Optional.ofNullable(clusterMoniker).map(Moniker::getCluster).orElseThrow(NullPointerException::new));
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/MonikerHelper.java
@@ -62,7 +62,7 @@ public class MonikerHelper {
 
   static public Moniker monikerFromStage(Stage stage, String fallbackFriggaName) {
     Moniker moniker = monikerFromStage(stage);
-    return moniker == null ? friggaToMoniker(fallbackFriggaName) : moniker;
+    return (moniker == null || moniker.getCluster() == null) ? friggaToMoniker(fallbackFriggaName) : moniker;
   }
 
   static public Moniker friggaToMoniker(String friggaName) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTaskSpec.groovy
@@ -163,7 +163,7 @@ class AbstractClusterWideClouddriverTaskSpec extends Specification {
 
     where:
     cluster       | moniker            | expected
-    'clustername' | ['app': 'appname'] | 'appname'
+    'clustername' | ['app': 'appname', cluster:'clustername'] | 'appname'
     'app-stack'   | null               | 'app'
 
   }


### PR DESCRIPTION
Cluster is not a required field on Moniker, and in a number of cases where we are working with a Moniker from pipeline configuration or a submitted execution the cluster can be absent. For TrafficGuard, locking, and cluster status checking purposes we want to programmatically rely on the Moniker object holding the cluster to check. This adds a few more checks and fallbacks to the serverGroupName to build the Moniker object if there is no cluster available
