### PR TITLE
fix(locking): determine lock should not fail when locking is disabled

### DIFF
--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/DetermineLockTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/DetermineLockTaskSpec.groovy
@@ -1,23 +1,35 @@
 package com.netflix.spinnaker.orca.pipeline.tasks
 
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties
 import com.netflix.spinnaker.orca.pipeline.AcquireLockStage
 import com.netflix.spinnaker.orca.pipeline.ReleaseLockStage
 import com.netflix.spinnaker.orca.pipeline.WaitStage
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
+import org.springframework.core.env.StandardEnvironment
 import spock.lang.Specification
 import spock.lang.Subject
 
 class DetermineLockTaskSpec extends Specification {
+
+  def config = new LockingConfigurationProperties(new SpringDynamicConfigService(environment: new StandardEnvironment()))
 
   @Subject DetermineLockTask task = new DetermineLockTask(
     new StageNavigator(
       Arrays.asList(
         new WaitStage(),
         new AcquireLockStage(),
-        new ReleaseLockStage())))
+        new ReleaseLockStage())),
+      config)
+
+  def setup() {
+    config.setEnabled(true)
+    config.setLearningMode(false)
+  }
 
   def "should determine the lock when lock values explicitly provided"() {
     given:
@@ -81,5 +93,56 @@ class DetermineLockTaskSpec extends Specification {
     lockName = 'lock'
     lockId = 'fooLock'
     lockHolder = 'holder'
+  }
+
+  def "should fail if unable to determine lock from a previous stage"() {
+    given:
+    def exec = new Execution(Execution.ExecutionType.PIPELINE, app)
+
+    def release = new Stage(exec, ReleaseLockStage.PIPELINE_TYPE, [
+      refId: 'releaseLock',
+    ])
+    exec.stages.addAll(Arrays.asList(release))
+
+    when:
+    task.execute(release)
+
+    then:
+    thrown(IllegalStateException)
+
+    where:
+    app = 'fooapp'
+  }
+
+  def "should ignore failure to determine the lock from a previous stage when locking disabled or in learning mode"() {
+    given:
+    config.learningMode = learningMode
+    config.enabled = lockingEnabled
+    def exec = new Execution(Execution.ExecutionType.PIPELINE, app)
+
+    def release = new Stage(exec, ReleaseLockStage.PIPELINE_TYPE, [
+      refId: 'releaseLock'
+    ])
+    exec.stages.addAll(Arrays.asList(release))
+
+    when:
+    def result = task.execute(release)
+
+    then:
+    result.status == ExecutionStatus.SUCCEEDED
+    result.context.lock.lockName == 'unknown'
+    result.context.lock.lockHolder == 'unknown'
+    result.context.lock.lockValue.application == app
+    result.context.lock.lockValue.type == exec.type.toString()
+    result.context.lock.lockValue.id == exec.id
+
+
+    where:
+    app = 'fooapp'
+
+    lockingEnabled | learningMode
+    false | false
+    false | true
+    true | true
   }
 }


### PR DESCRIPTION
Rolling in the locking code to an existing system running pipelines can cause a new node to plan a disable lock stage when the corresponding acquire lock stage was not planned. If locking is not enabled, the determine lock failure becomes non fatal and just generates a stubbed out lock context.
