### PR TITLE
fix(webhook): ignore empty expectedArtifacts list in webhook stage response

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
@@ -109,7 +109,7 @@ class CreateWebhookTask implements RetryableTask {
         outputs.webhook << [statusEndpoint: statusUrl]
         return new TaskResult(ExecutionStatus.SUCCEEDED, outputsDeprecated + outputs)
       }
-      if (stage.context.containsKey("expectedArtifacts")) {
+      if (stage.context.containsKey("expectedArtifacts") && !((List) stage.context.get("expectedArtifacts")).isEmpty()) {
         try {
           def artifacts = new JsonContext().parse(response.body).read("artifacts")
           outputs << [artifacts: artifacts]


### PR DESCRIPTION
Before: An empty `expectedArtifacts` array in a webhook stage definition results in a failed pipeline with no explanation provided, and an error in Orca related to missing artifacts.

After: The pipeline is allowed to continue when the webhook response doesn't contain any artifacts.

Closes https://github.com/spinnaker/spinnaker/issues/3354