### PR TITLE
fix(locking): more guards around locking

### DIFF
--- a/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca-clouddriver/orca-clouddriver.gradle
@@ -27,4 +27,5 @@ dependencies {
   testCompile project(":orca-test")
   testCompile project(":orca-test-groovy")
   testCompile "com.github.tomakehurst:wiremock:2.15.0"
+  testCompile spinnaker.dependency('springTest')
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/DisableClusterStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/DisableClusterStage.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractWaitForClust
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.DisableClusterTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.WaitForClusterDisableTask;
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard;
+import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -30,8 +31,8 @@ public class DisableClusterStage extends AbstractClusterWideClouddriverOperation
   public static final String STAGE_TYPE = "disableCluster";
 
   @Autowired
-  public DisableClusterStage(TrafficGuard trafficGuard) {
-    super(trafficGuard);
+  public DisableClusterStage(TrafficGuard trafficGuard, LockingConfigurationProperties lockingConfigurationProperties) {
+    super(trafficGuard, lockingConfigurationProperties);
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ScaleDownClusterStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ScaleDownClusterStage.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractWaitForClust
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.ScaleDownClusterTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.WaitForScaleDownClusterTask;
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard;
+import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -28,8 +29,8 @@ import org.springframework.stereotype.Component;
 public class ScaleDownClusterStage extends AbstractClusterWideClouddriverOperationStage {
 
   @Autowired
-  public ScaleDownClusterStage(TrafficGuard trafficGuard) {
-    super(trafficGuard);
+  public ScaleDownClusterStage(TrafficGuard trafficGuard, LockingConfigurationProperties lockingConfigurationProperties) {
+    super(trafficGuard, lockingConfigurationProperties);
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ShrinkClusterStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ShrinkClusterStage.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractWaitForClust
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.ShrinkClusterTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.WaitForClusterShrinkTask;
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard;
+import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties;
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,8 +40,8 @@ public class ShrinkClusterStage extends AbstractClusterWideClouddriverOperationS
   private final DisableClusterStage disableClusterStage;
 
   @Autowired
-  public ShrinkClusterStage(TrafficGuard trafficGuard, DisableClusterStage disableClusterStage) {
-    super(trafficGuard);
+  public ShrinkClusterStage(TrafficGuard trafficGuard, LockingConfigurationProperties lockingConfigurationProperties, DisableClusterStage disableClusterStage) {
+    super(trafficGuard, lockingConfigurationProperties);
     this.disableClusterStage = disableClusterStage;
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTa
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.kato.pipeline.CopyLastAsgStage
 import com.netflix.spinnaker.orca.kato.pipeline.DeployStage
+import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/RollbackClusterStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/RollbackClusterStageSpec.groovy
@@ -16,11 +16,14 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.cluster
 
+import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
+import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.springframework.mock.env.MockEnvironment
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -29,9 +32,15 @@ import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 class RollbackClusterStageSpec extends Specification {
 
   def trafficGuard = Mock(TrafficGuard)
+  def env = new MockEnvironment()
+  def lockingConfig = new LockingConfigurationProperties(new SpringDynamicConfigService(environment: env))
 
   @Subject
-  def stageBuilder = new RollbackClusterStage(trafficGuard)
+  def stageBuilder = new RollbackClusterStage(trafficGuard, lockingConfig)
+
+  def setup() {
+    env.setProperty('locking.enabled', 'true')
+  }
 
   def "should not build any aroundStages()"() {
     expect:

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
@@ -16,11 +16,14 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
+import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.AwsDeployStagePreProcessor
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.DeployStagePreProcessor
+import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
+import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.model.Task
+import org.springframework.mock.env.MockEnvironment
 
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.RollbackClusterStage
@@ -32,10 +35,13 @@ import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
 class CreateServerGroupStageSpec extends Specification {
   def deployStagePreProcessor = Mock(DeployStagePreProcessor)
+  def trafficGuard = Stub(TrafficGuard)
+  def env = new MockEnvironment()
+  def lockingConfig = new LockingConfigurationProperties(new SpringDynamicConfigService(environment: env))
 
   @Subject
   def createServerGroupStage = new CreateServerGroupStage(
-    rollbackClusterStage: new RollbackClusterStage(),
+    rollbackClusterStage: new RollbackClusterStage(trafficGuard, lockingConfig),
     destroyServerGroupStage: new DestroyServerGroupStage(),
     deployStagePreProcessors: [ deployStagePreProcessor ]
   )

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/HighlanderStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/HighlanderStrategySpec.groovy
@@ -16,20 +16,25 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies
 
+import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.DisableClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.ShrinkClusterStage
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
+import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner
+import org.springframework.mock.env.MockEnvironment
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class HighlanderStrategySpec extends Specification {
 
   def trafficGuard = Stub(TrafficGuard)
-  def disableClusterStage = new DisableClusterStage(trafficGuard)
-  def shrinkClusterStage = new ShrinkClusterStage(trafficGuard, disableClusterStage)
+  def env = new MockEnvironment()
+  def lockingConfig = new LockingConfigurationProperties(new SpringDynamicConfigService(environment: env))
+  def disableClusterStage = new DisableClusterStage(trafficGuard, lockingConfig)
+  def shrinkClusterStage = new ShrinkClusterStage(trafficGuard, lockingConfig, disableClusterStage)
 
   @Unroll
   def "should compose flow"() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategySpec.groovy
@@ -16,23 +16,28 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies
 
+import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.DisableClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.ScaleDownClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.ShrinkClusterStage
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
+import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties
 import com.netflix.spinnaker.orca.pipeline.WaitStage
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner
+import org.springframework.mock.env.MockEnvironment
 import spock.lang.Specification
 
 class RedBlackStrategySpec extends Specification {
 
   def trafficGuard = Stub(TrafficGuard)
-  def disableClusterStage = new DisableClusterStage(trafficGuard)
-  def shrinkClusterStage = new ShrinkClusterStage(trafficGuard, disableClusterStage)
-  def scaleDownClusterStage = new ScaleDownClusterStage(trafficGuard)
+  def env = new MockEnvironment()
+  def config = new LockingConfigurationProperties(new SpringDynamicConfigService(environment: env))
+  def disableClusterStage = new DisableClusterStage(trafficGuard, config)
+  def shrinkClusterStage = new ShrinkClusterStage(trafficGuard, config, disableClusterStage)
+  def scaleDownClusterStage = new ScaleDownClusterStage(trafficGuard, config)
   def waitStage = new WaitStage()
 
   def "should compose flow"() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupLinearStageSupportSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupLinearStageSupportSpec.groovy
@@ -16,8 +16,11 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support
 
+import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
+import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder
+import org.springframework.core.env.StandardEnvironment
 import spock.lang.Specification
 import spock.lang.Unroll
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
@@ -27,11 +30,13 @@ class TargetServerGroupLinearStageSupportSpec extends Specification {
 
   def resolver = Stub(TargetServerGroupResolver)
   def trafficGuard = Stub(TrafficGuard)
+  def lockingConfig = new LockingConfigurationProperties(new SpringDynamicConfigService(environment: new StandardEnvironment()))
   def supportStage = new TestSupport()
 
   def setup() {
     supportStage.resolver = resolver
     supportStage.trafficGuard = trafficGuard
+    supportStage.lockingConfigurationProperties = lockingConfig
   }
 
   @Unroll

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/DetermineLockTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/DetermineLockTaskSpec.groovy
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.orca.pipeline.tasks
 
-import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.locks.LockingConfigurationProperties


### PR DESCRIPTION
Originally the locking.enabled flag would cause the locking tasks to
no-op. This change guards the wiring of locking synthetic stages
as well, as a means of ensuring there are no extra unexpected stages
present when locking is disabled, and to better allow vetting the
feature
