### PR TITLE
fix(core): Avoid revisiting stages when traversing ancestors (#2349)

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support
 
+import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -70,7 +71,7 @@ class TargetServerGroupSpec extends Specification {
   def "dynamically bound stage"() {
 
     when:
-      def stage = new Stage(context: context)
+      def stage = new Stage(context: context, execution: new Execution(Execution.ExecutionType.PIPELINE, "app"))
 
     then:
       TargetServerGroup.isDynamicallyBound(stage) == want
@@ -95,7 +96,7 @@ class TargetServerGroupSpec extends Specification {
         target         : target,
         zones          : zones,
       ]
-      def stage = new Stage(context: context)
+      def stage = new Stage(context: context, execution: new Execution(Execution.ExecutionType.PIPELINE, "app"))
       def p = TargetServerGroup.Params.fromStage(stage)
 
     then:

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/StageSpec.groovy
@@ -183,6 +183,36 @@ class StageSpec extends Specification {
     syntheticAfterStageAncestors*.refId == ["1<2", "1<1", "1"]
   }
 
+  def "ancestors should not include duplicate stages"() {
+    given:
+    def pipeline = pipeline {
+      stage {
+        refId = "1"
+        requisiteStageRefIds = []
+      }
+      stage {
+        refId = "2"
+        requisiteStageRefIds = ["1"]
+      }
+      stage {
+        refId = "3"
+        requisiteStageRefIds = ["1"]
+      }
+      stage {
+        refId = "4"
+        requisiteStageRefIds = ["2", "3"]
+      }
+    }
+
+    def stage4 = pipeline.stages.find { it.refId == "4" }
+
+    when:
+    def ancestors = stage4.ancestors()
+
+    then:
+    ancestors*.refId == ["4", "2", "3", "1"]
+  }
+
   @Unroll
   def "should fetch stageTimeoutMs for a synthetic stage from the closest parent with it overridden"() {
     given:


### PR DESCRIPTION
This is a port of https://github.com/spinnaker/orca/pull/2349 to 1.8.x