### PR TITLE
feat(rollback): Support wait before disable during an orchestrated rollback

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollback.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollback.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.orca.clouddriver.FeaturesService
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.CloneServerGroupStage
+import com.netflix.spinnaker.orca.pipeline.WaitStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner
 import org.springframework.beans.factory.annotation.Autowired
@@ -33,6 +34,7 @@ class PreviousImageRollback implements Rollback {
   String imageName
   String imageId
   Integer targetHealthyRollbackPercentage
+  Integer delayBeforeDisableSeconds
 
   @Autowired
   @JsonIgnore
@@ -94,6 +96,7 @@ class PreviousImageRollback implements Rollback {
       region                       : parentStageContext.region,
       credentials                  : parentStageContext.credentials,
       cloudProvider                : parentStageContext.cloudProvider,
+      delayBeforeDisableSec        : delayBeforeDisableSeconds ?: 0,
       source                       : [
         asgName          : rollbackServerGroupName,
         serverGroupName  : rollbackServerGroupName,

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollbackSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/PreviousImageRollbackSpec.groovy
@@ -64,6 +64,7 @@ class PreviousImageRollbackSpec extends Specification {
     rollback.rollbackServerGroupName = "application-v002"
     rollback.targetHealthyRollbackPercentage = 95
     rollback.imageName = imageName
+    rollback.delayBeforeDisableSeconds = delay
 
     when:
     def allStages = rollback.buildStages(stage)
@@ -105,6 +106,7 @@ class PreviousImageRollbackSpec extends Specification {
       region                       : "us-west-1",
       credentials                  : "test",
       cloudProvider                : "aws",
+      delayBeforeDisableSec : expectedDelay,
       source                       : [
         asgName          : "application-v002",
         serverGroupName  : "application-v002",
@@ -116,9 +118,9 @@ class PreviousImageRollbackSpec extends Specification {
     ]
 
     where:
-    imageName        | imageSource                                          || expectedImageName                 || expectedImageId
-    "explicit_image" | "explicitly provided image"                          || "explicit_image"                  || null
-    null             | "image fetched from `spinnaker:metadata` entity tag" || "previous_image_from_entity_tags" || "previous_image_from_entity_tags_id"
+    imageName        | imageSource                                          | delay || expectedImageName                 || expectedImageId                      || expectedDelay
+    "explicit_image" | "explicitly provided image"                          | null  || "explicit_image"                  || null                                 || 0
+    null             | "image fetched from `spinnaker:metadata` entity tag" | 100   || "previous_image_from_entity_tags" || "previous_image_from_entity_tags_id" || 100
   }
 
   @Unroll


### PR DESCRIPTION
A new `delayBeforeDisableSeconds` property has been added to both the
`ExplicitRollback` and `PreviousImageRollback` strategies.
