### PR TITLE
fix(rollingPush): reset start time

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/CheckForRemainingTerminationsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/CheckForRemainingTerminationsTask.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import javafx.util.Duration
 import org.springframework.stereotype.Component
 
 import java.time.Instant
@@ -37,8 +38,7 @@ class CheckForRemainingTerminationsTask implements Task {
 
     return new TaskResult(ExecutionStatus.REDIRECT, [
       skipRemainingWait: false,
-      waitTaskState: [:],
-      startTime: Instant.MIN
+      startTime: Instant.EPOCH
     ])
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/CheckForRemainingTerminationsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/CheckForRemainingTerminationsTask.groovy
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.stereotype.Component
 
+import java.time.Instant
+
 @Component
 class CheckForRemainingTerminationsTask implements Task {
 
@@ -35,7 +37,8 @@ class CheckForRemainingTerminationsTask implements Task {
 
     return new TaskResult(ExecutionStatus.REDIRECT, [
       skipRemainingWait: false,
-      waitTaskState: [:]
+      waitTaskState: [:],
+      startTime: Instant.MIN
     ])
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/tasks/image/RollingPushTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/tasks/image/RollingPushTaskSpec.groovy
@@ -1,0 +1,34 @@
+package com.netflix.spinnaker.orca.tasks.image
+
+import com.netflix.spinnaker.orca.kato.tasks.rollingpush.CheckForRemainingTerminationsTask
+import com.netflix.spinnaker.orca.time.MutableClock
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.Instant
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class RollingPushTaskSpec extends Specification {
+  def clock = new MutableClock()
+  @Subject
+  terminateTask = new CheckForRemainingTerminationsTask()
+
+
+  void "should wait correctly in rolling push"() {
+    setup:
+    def stage = stage {
+      refId = "1"
+      type = "wait"
+      context["waitTime"] = 300
+      context["startTime"] = clock.instant().toEpochMilli()
+      context["terminationInstanceIds"] = ["1111", "2222"]
+    }
+
+    when:
+    def result = terminateTask.execute(stage)
+
+    then:
+    result.context.startTime == Instant.EPOCH
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitTask.java
@@ -55,7 +55,7 @@ public class WaitTask implements RetryableTask {
 
     if (context.isSkipRemainingWait()) {
       return new TaskResult(SUCCEEDED);
-    } else if (context.getStartTime() == null || context.getStartTime() == Instant.MIN) {
+    } else if (context.getStartTime() == null || context.getStartTime() == Instant.EPOCH) {
       return new TaskResult(RUNNING, singletonMap("startTime", now));
     } else if (context.getStartTime().plus(context.getWaitDuration()).isBefore(now)) {
       return new TaskResult(SUCCEEDED);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitTask.java
@@ -55,7 +55,7 @@ public class WaitTask implements RetryableTask {
 
     if (context.isSkipRemainingWait()) {
       return new TaskResult(SUCCEEDED);
-    } else if (context.getStartTime() == null) {
+    } else if (context.getStartTime() == null || context.getStartTime() == Instant.MIN) {
       return new TaskResult(RUNNING, singletonMap("startTime", now));
     } else if (context.getStartTime().plus(context.getWaitDuration()).isBefore(now)) {
       return new TaskResult(SUCCEEDED);


### PR DESCRIPTION
We've seen that with rolling push + a specified wait time, this stage is only waiting after the first termination. It _seems_ like start time is never getting reset, and therefore all following wait stages immediately complete because they think they started at the same time as the first wait stage.

This PR resets start time to the lowest time possible. If it sees that time in the running stage, it resets the time to the current time.

@robfletcher - does this seem like a reasonable fix? I'd like to remove the variable from the context entirely (that seems preferable to `Instant.MIN`), but I'm not sure if that's possible.