### PR TITLE
fix(artifacts/trigger/buildInfo): This makes rpms supported

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.java
@@ -282,12 +282,21 @@ public class PackageInfo {
 
   private String extractPackageVersion(Map<String, Object> artifact, String filePrefix, String fileExtension) {
     String fileName = artifact.get("fileName").toString();
+    if (packageType.equals("rpm")) {
+      return extractRpmVersion(fileName);
+    }
     String version = fileName.substring(fileName.indexOf(filePrefix) + filePrefix.length(), fileName.lastIndexOf(fileExtension));
     if (version.contains(versionDelimiter)) {
       // further strip in case of _all is in the file name
       version = version.substring(0, version.indexOf(versionDelimiter));
     }
     return version;
+  }
+
+  private String extractRpmVersion(String fileName) {
+    String[] parts = fileName.split(versionDelimiter);
+    String suffix = parts[parts.length - 1].replaceAll(".rpm", "");
+    return parts[parts.length - 2] + versionDelimiter + suffix;
   }
 
   private Map<String, Object> filterArtifacts(List<Map<String, Object>> artifacts, String prefix, String fileExtension) {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
@@ -745,4 +745,44 @@ class PackageInfoSpec extends Specification {
     triggerFilename                            | buildFilename                                | requestPackage     | result
     [["fileName": "test-package_1.0.0.deb"]]   | [["fileName": "test-package_1.0.0.deb"]]     | "test-package"     | "test-package_1.0.0"
   }
+
+  def "should work if the same RPM artifact is present in different places"() {
+    given:
+    Stage bakeStage = new Stage()
+    PackageType packageType = RPM
+    boolean extractBuildDetails = false
+
+    Artifact artifact1 = new Artifact.ArtifactBuilder()
+            .type("rpm")
+            .name("test-package")
+            .version("1539516142-1.x86_64")
+            .reference("test-package-1539516142-1.x86_64.rpm")
+            .provenance("https://jenkins/test-package-build-master")
+            .build()
+    List<Artifact> artifacts = new ArrayList<>()
+    artifacts.add(artifact1)
+
+    PackageInfo packageInfo = new PackageInfo(bakeStage,
+            artifacts,
+            packageType.packageType,
+            packageType.versionDelimiter,
+            extractBuildDetails,
+            false,
+            mapper)
+    def allowMissingPackageInstallation = true
+
+    Map trigger = ["buildInfo": ["artifacts": triggerFilename], "artifacts": artifacts]
+    Map buildInfo = ["artifacts": buildFilename]
+    Map stageContext = ["package": requestPackage]
+
+    when:
+    Map returnedStageContext = packageInfo.createAugmentedRequest(trigger, buildInfo, stageContext, allowMissingPackageInstallation)
+
+    then:
+    returnedStageContext.package == result
+
+    where:
+    triggerFilename                            | buildFilename                                | requestPackage     | result
+    [["fileName": "test-package-1539516142-1.x86_64.rpm"]]   | [["fileName": "test-package-1539516142-1.x86_64.rpm"]]     | "test-package"     | "test-package-1539516142-1.x86_64"
+  }
 }


### PR DESCRIPTION
RPM versions cannot be extracted in the same way as deb versions.
