### PR TITLE
feat(stage): evaluate variables stage

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/EvaluateVariablesStage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/EvaluateVariablesStage.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.tasks.EvaluateVariablesTask;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Component
+public class EvaluateVariablesStage implements StageDefinitionBuilder {
+
+  public static String STAGE_TYPE = "evaluateVariables";
+
+  @Override
+  public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
+    builder.withTask("evaluateVariables", EvaluateVariablesTask.class);
+  }
+
+  public static final class EvaluateVariablesStageContext {
+    private final List<Variable> vars;
+
+    @JsonCreator
+    public EvaluateVariablesStageContext(
+      @JsonProperty("variables") @Nullable List<Variable> variables
+    ) {
+      this.vars = variables;
+    }
+
+    public @Nullable List<Variable> getVariables() {
+      return vars;
+    }
+  }
+
+  public static class Variable {
+    private String key;
+    private String value;
+
+    @JsonCreator
+    public Variable(@JsonProperty("key") String key, @JsonProperty("value") String value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    public void setKey(String key) {
+      this.key = key;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTask.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.tasks;
+
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.pipeline.EvaluateVariablesStage;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class EvaluateVariablesTask implements Task {
+
+  @Autowired
+  public EvaluateVariablesTask() {
+  }
+
+  @Nonnull
+  @Override
+  public TaskResult execute(@Nonnull Stage stage) {
+    EvaluateVariablesStage.EvaluateVariablesStageContext context =
+      stage.mapTo(EvaluateVariablesStage.EvaluateVariablesStageContext.class);
+
+    Map<String, String> outputs = new HashMap<>();
+    for (EvaluateVariablesStage.Variable v : context.getVariables()) {
+      outputs.put(v.getKey(), v.getValue());
+    }
+
+    return new TaskResult(ExecutionStatus.SUCCEEDED, stage.mapTo(Map.class), outputs);
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTaskSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.tasks
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class EvaluateVariablesTaskSpec extends Specification {
+
+  @Subject
+  task = new EvaluateVariablesTask()
+
+  void "Should correctly evaulate variables"() {
+    setup:
+    def stage = stage {
+      refId = "1"
+      type = "evaluateVariables"
+      context["variables"] = [
+        ["key": "myKey1", "value": "ohWow"],
+        ["key": "myKey2", "value": "myMy"]
+      ]
+    }
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.outputs.get("myKey1") == "ohWow"
+    result.outputs.get("myKey2") == "myMy"
+  }
+}


### PR DESCRIPTION
We have people that use the comments or parameters fields combined with spel expressions to create 'variables' in the spinnaker context. This is brittle and somewhat hard to reason about.

Specifically, we have someone who needs to create a GUID and have that value stay the same throughout the pipeline. If you create an expression for that GUID, it gets evaluated every time it is used (and produces a different GUID).

This stage allows them to perform that logic and create a variable in the context. It can then be referred to in any downstream stages by using `"${ myVariableName }"`