### PR TITLE
fix(queue): remove max attempts from CompleteExecution

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
@@ -93,15 +93,8 @@ class CompleteExecutionHandler(
         block.invoke(if (execution.shouldOverrideSuccess()) TERMINAL else SUCCEEDED)
       } else {
         val attempts = getAttribute<AttemptsAttribute>()?.attempts ?: 0
-        if (attempts <= 10) {
-          log.warn("Re-queuing $this as the execution is not yet complete (attempts: $attempts)")
-
-          // no need to re-queue continuously as the RUNNING stages will also emit a `CompleteExecution` message
-          setAttribute(MaxAttemptsAttribute(11))
-          queue.push(this, retryDelay)
-        } else {
-          log.warn("Max attempts reached (10), $this will not be re-queued")
-        }
+        log.warn("Re-queuing $this as the execution is not yet complete (attempts: $attempts)")
+        queue.push(this, retryDelay)
       }
     }
   }


### PR DESCRIPTION
No longer setting MaxAttemptsAttribute on CompleteExecution messages due to a potential race condition when a pipeline has many parallel end branches completing within a close window.