### PR TITLE
fix(queue): only push ContinueParentStage message if not in unacked

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/OrcaMessageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/OrcaMessageHandler.kt
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.Execu
 import com.netflix.spinnaker.orca.q.*
 import com.netflix.spinnaker.q.Message
 import com.netflix.spinnaker.q.MessageHandler
+import java.time.Duration
 
 internal interface OrcaMessageHandler<M : Message> : MessageHandler<M> {
   val repository: ExecutionRepository
@@ -78,7 +79,7 @@ internal interface OrcaMessageHandler<M : Message> : MessageHandler<M> {
           queue.push(StartStage(it))
         }
       } else if (phase != null) {
-        queue.push(ContinueParentStage(parent(), phase))
+        queue.ensure(ContinueParentStage(parent(), phase), Duration.ZERO)
       } else {
         queue.push(CompleteExecution(execution))
       }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
@@ -46,6 +46,8 @@ import org.jetbrains.spek.api.dsl.*
 import org.jetbrains.spek.api.lifecycle.CachingMode.GROUP
 import org.jetbrains.spek.subject.SubjectSpek
 import org.springframework.context.ApplicationEventPublisher
+import java.time.Duration
+import java.time.Duration.*
 
 object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
 
@@ -637,7 +639,7 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
                   assertThat(parentStageId).isEqualTo(message.stageId)
                   assertThat(name).isEqualTo("After Stage")
                 }
-                else          ->
+                else ->
                   fail("Expected a StartStage message but got a ${capturedMessage.javaClass.simpleName}")
               }
             }
@@ -886,10 +888,10 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
           }
 
           it("signals the parent stage to run") {
-            verify(queue).push(ContinueParentStage(
+            verify(queue).ensure(ContinueParentStage(
               pipeline.stageByRef("1"),
               STAGE_BEFORE
-            ))
+            ), ZERO)
           }
         }
       }
@@ -956,10 +958,10 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
 
           it("tells the parent stage to continue") {
             verify(queue)
-              .push(ContinueParentStage(
+              .ensure(ContinueParentStage(
                 pipeline.stageById(message.stageId).parent!!,
                 STAGE_AFTER
-              ))
+              ), ZERO)
           }
         }
       }
@@ -1068,7 +1070,7 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
 
         it("signals the parent stage to try to run") {
           verify(queue)
-            .push(ContinueParentStage(pipeline.stageByRef("1"), STAGE_BEFORE))
+            .ensure(ContinueParentStage(pipeline.stageByRef("1"), STAGE_BEFORE), ZERO)
         }
       }
 
@@ -1105,7 +1107,7 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
 
         it("signals the parent stage to try to run") {
           verify(queue)
-            .push(ContinueParentStage(pipeline.stageByRef("1"), STAGE_BEFORE))
+            .ensure(ContinueParentStage(pipeline.stageByRef("1"), STAGE_BEFORE), ZERO)
         }
       }
     }


### PR DESCRIPTION
Addresses[1] a race condition triggered by the final two or more synthetic BEFORE stages completing close together in time, where duplicate ContinueParentStageMessage B is queued while ContinueParentStageMessage A is being executed (and in the unack'd queue), potentially resulting in duplicate execution of downstream tasks and pipeline failure.

[1] Keiko's ensure method isn't currently atomic; until that changes this only makes the race condition less likely. 