### PR TITLE
feat(gce): Adds stage for modifying autoscaling policies.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/ModifyGceAutoscalingPolicyStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/ModifyGceAutoscalingPolicyStage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.gce;
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport;
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.gce.autoscaling.UpsertGceAutoscalingPolicyTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask;
+import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ModifyGceAutoscalingPolicyStage extends TargetServerGroupLinearStageSupport {
+
+  @Override
+  protected void taskGraphInternal(Stage stage, TaskNode.Builder builder) {
+    builder
+      .withTask("upsert", UpsertGceAutoscalingPolicyTask.class)
+      .withTask("monitor", MonitorKatoTask.class)
+      .withTask("forceCacheRefresh", ServerGroupCacheForceRefreshTask.class)
+      .withTask("waitForScalingProcesses", WaitForGceAutoscalingPolicyTask.class);
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/WaitForGceAutoscalingPolicyTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/WaitForGceAutoscalingPolicyTask.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.gce;
+
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+@Component
+public class WaitForGceAutoscalingPolicyTask implements RetryableTask {
+  @Autowired
+  private OortHelper oortHelper;
+
+  @Override
+  public long getBackoffPeriod() {
+    return 20000;
+  }
+
+  @Override
+  public long getTimeout() {
+    return 1200000;
+  }
+
+  @Nonnull
+  @Override
+  public TaskResult execute(@Nonnull Stage stage) {
+    StageData data = stage.mapTo(StageData.class);
+    String autoscalingMode = (String) getTargetGroupForLocation(data, data.getRegion())
+      .getAutoscalingPolicy()
+      .get("mode");
+    return AutoscalingMode.valueOf(autoscalingMode) == data.getMode() ?
+      new TaskResult(ExecutionStatus.SUCCEEDED) :
+      new TaskResult(ExecutionStatus.RUNNING);
+  }
+
+  private TargetServerGroup getTargetGroupForLocation(StageData data, String location) {
+    Optional<TargetServerGroup> maybeTargetServerGroup = oortHelper.getTargetServerGroup(
+      data.getAccountName(), data.getServerGroupName(), location, "gce");
+
+    if (!maybeTargetServerGroup.isPresent()) {
+      throw new IllegalStateException(String.format("No server group found (serverGroupName: %s:%s)",
+        location, data.getServerGroupName()));
+    }
+    return maybeTargetServerGroup.get();
+  }
+
+  enum AutoscalingMode {
+    ON, OFF, ONLY_DOWN, ONLY_UP
+  }
+
+  @Data
+  public static class StageData {
+    String accountName;
+    String serverGroupName;
+    String region;
+    AutoscalingMode mode;
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -85,6 +85,14 @@ class TargetServerGroup {
     return serverGroup?.moniker ? objectMapper.convertValue(serverGroup?.moniker, Moniker) : null
   }
 
+  /**
+   * Used in UpsertGceAutoscalingPolicy, which is Java, which doesn't play nice with @Delegate
+   * @return
+   */
+  Map<String, Object> getAutoscalingPolicy() {
+    return (Map<String, Object>) serverGroup.autoscalingPolicy
+  }
+
   Map toClouddriverOperationPayload(String account) {
     //TODO(cfieber) - add an endpoint on Clouddriver to do provider appropriate conversion of a TargetServerGroup
     def op = [

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/autoscaling/UpsertGceAutoscalingPolicyTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/autoscaling/UpsertGceAutoscalingPolicyTask.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.gce.autoscaling;
+
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.KatoService;
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver;
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.netflix.spinnaker.orca.clouddriver.pipeline.providers.gce.WaitForGceAutoscalingPolicyTask.StageData;
+
+@Slf4j
+@Component
+public class UpsertGceAutoscalingPolicyTask extends AbstractCloudProviderAwareTask implements Task {
+  @Autowired
+  private KatoService katoService;
+
+  @Autowired
+  private TargetServerGroupResolver resolver;
+
+  public String getType() {
+    return "upsertScalingPolicy";
+  }
+
+  @Override
+  public TaskResult execute(Stage stage) {
+    StageData stageData = stage.mapTo(StageData.class);
+    TargetServerGroup targetServerGroup;
+    if (TargetServerGroup.isDynamicallyBound(stage)) {
+      // Dynamically resolved server groups look back at previous stages to find the name
+      // of the server group based on *this task's region*
+      targetServerGroup = TargetServerGroupResolver.fromPreviousStage(stage);
+    } else {
+      // Statically resolved server groups should only resolve to a single server group at all times,
+      // because each region desired should have been spun off its own ScalingProcess for that region.
+      List<TargetServerGroup> resolvedServerGroups = resolver.resolve(stage);
+      if (resolvedServerGroups == null || resolvedServerGroups.size() != 1) {
+        throw new IllegalStateException(
+          String.format("Could not resolve exactly one server group for autoscaling policy upsert for %s in %s",
+            stageData.getAccountName(), stageData.getRegion()));
+      }
+
+      targetServerGroup = resolvedServerGroups.get(0);
+    }
+
+    Map<String, Object> autoscalingPolicy = targetServerGroup.getAutoscalingPolicy();
+    String serverGroupName = targetServerGroup.getName();
+
+    Map<String, Object> stageContext = new HashMap<>(stage.getContext());
+    stageContext.put("serverGroupName", serverGroupName);
+
+    stageData.setServerGroupName(serverGroupName);
+
+    Map<String, Object> stageOutputs = new HashMap<>();
+    stageOutputs.put("notification.type", getType().toLowerCase());
+    stageOutputs.put("serverGroupName", serverGroupName);
+
+    Map<String, Map> op = new HashMap<>();
+    // NOTE: stage only supports modifying autoscaling policy mode.
+    autoscalingPolicy.put("mode", stageData.getMode());
+    stageContext.put("autoscalingPolicy", autoscalingPolicy);
+    op.put(getType(), stageContext);
+
+    TaskId taskId = katoService.requestOperations(getCloudProvider(stage), Collections.singletonList(op))
+      .toBlocking()
+      .first();
+    stageOutputs.put("kato.last.task.id", taskId);
+
+    return new TaskResult(ExecutionStatus.SUCCEEDED, stageOutputs);
+  }
+}


### PR DESCRIPTION
There's no UI for this stage yet, but you can still configure it as a custom stage. The config is as follows:

```
{
  "accountName": "spin-jtk54", # gce account name
  "cloudProvider": "gce",
  "cluster": "app-cluster-name",
  "credentials": "spin-jtk54", # gce account name for synthesized stages
  "mode": "OFF", # autoscaling mode
  "moniker": {
    "app": "app",
    "cluster": "app-cluster-name",
    "detail": "name",
    "stack": "cluster"
  },
  "regions": [
    "us-central1",
    "us-east1"
  ],
  "serverGroupName": "app-cluster-name-v000", # specify one of serverGroupName or target
  "target": "current_asg_dynamic", # specify one of serverGroupName or target
  "type": "modifyGceAutoscalingPolicy"
}
```

[Target enum is defined here.](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy#L180)