### PR TITLE
fix(authz): Use pipeline ids for managed service account names.

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTask.java
@@ -135,12 +135,8 @@ public class SaveServiceAccountTask implements RetryableTask {
     if (pipeline.containsKey("serviceAccount")) {
       return (String) pipeline.get("serviceAccount");
     }
-
-    String pipelineName = (String) pipeline.get("name");
-    // Pipeline name can have spaces. Replace them with "-"
-    pipelineName= pipelineName.replaceAll("\\s", "-") + SERVICE_ACCOUNT_SUFFIX;
-    // Fiat service account names are always lower case.
-    return pipelineName.toLowerCase();
+    String pipelineName = (String) pipeline.get("id");
+    return pipelineName.toLowerCase() + SERVICE_ACCOUNT_SUFFIX;
   }
 
   private boolean isUserAuthorized(String user, List<String> pipelineRoles) {

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTaskSpec.groovy
@@ -69,6 +69,7 @@ class SaveServiceAccountTaskSpec extends Specification {
     given:
     def pipeline = [
       application: 'orca',
+      id: 'pipeline-id',
       name: 'My pipeline',
       stages: [],
       roles: ['foo']
@@ -79,7 +80,7 @@ class SaveServiceAccountTaskSpec extends Specification {
       ]
     }
 
-    def expectedServiceAccount = new ServiceAccount(name: 'my-pipeline@managed-service-account', memberOf: ['foo'])
+    def expectedServiceAccount = new ServiceAccount(name: 'pipeline-id@managed-service-account', memberOf: ['foo'])
 
     when:
     stage.getExecution().setTrigger(new DefaultTrigger('manual', null, 'abc@somedomain.io'))
@@ -102,6 +103,7 @@ class SaveServiceAccountTaskSpec extends Specification {
     given:
     def pipeline = [
       application: 'orca',
+      id: 'pipeline-id',
       name: 'my pipeline',
       stages: [],
       roles: ['foo', 'bar']


### PR DESCRIPTION
This was causing service accounts to be overwritten when two pipelines in different applications had the same name in https://github.com/spinnaker/spinnaker/issues/3562