### PR TITLE
 feat(traffic-guards): consider capacity ratio

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.clouddriver.utils;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
@@ -37,20 +38,25 @@ import static java.lang.String.format;
 
 @Component
 public class TrafficGuard {
-
+  private final static String MIN_CAPACITY_RATIO = "trafficGuards.minCapacityRatio";
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final OortHelper oortHelper;
   private final Front50Service front50Service;
   private final Registry registry;
+  private final DynamicConfigService dynamicConfigService;
 
   private final Id savesId;
 
   @Autowired
-  public TrafficGuard(OortHelper oortHelper, Optional<Front50Service> front50Service, Registry registry) {
+  public TrafficGuard(OortHelper oortHelper,
+                      Optional<Front50Service> front50Service,
+                      Registry registry,
+                      DynamicConfigService dynamicConfigService) {
     this.oortHelper = oortHelper;
     this.front50Service = front50Service.orElse(null);
     this.registry = registry;
+    this.dynamicConfigService = dynamicConfigService;
     this.savesId = registry.createId("trafficGuard.saves");
   }
 
@@ -116,11 +122,15 @@ public class TrafficGuard {
     verifyOtherServerGroupsAreTakingTraffic(serverGroupName, serverGroupMoniker, location, account, cloudProvider, operationDescriptor);
   }
 
-  private void verifyOtherServerGroupsAreTakingTraffic(String serverGroupName, Moniker serverGroupMoniker, Location location, String account, String cloudProvider, String operationDescriptor) {
+  private void verifyOtherServerGroupsAreTakingTraffic(String serverGroupName, Moniker serverGroupMoniker,
+                                                       Location location, String account, String cloudProvider,
+                                                       String operationDescriptor) {
     // TODO rz - Expose traffic guards endpoint in clouddriver
-    Optional<Map> cluster = oortHelper.getCluster(serverGroupMoniker.getApp(), account, serverGroupMoniker.getCluster(), cloudProvider);
+    Optional<Map> cluster = oortHelper.getCluster(serverGroupMoniker.getApp(), account,
+      serverGroupMoniker.getCluster(), cloudProvider);
     if (!cluster.isPresent()) {
-      throw new TrafficGuardException(format("Could not find cluster '%s' in %s/%s with traffic guard configured.", serverGroupMoniker.getCluster(), account, location.getValue()));
+      throw new TrafficGuardException(format("Could not find cluster '%s' in %s/%s with traffic guard configured.",
+        serverGroupMoniker.getCluster(), account, location.getValue()));
     }
 
     List<TargetServerGroup> targetServerGroups = ((List<Map<String, Object>>) cluster.get().get("serverGroups"))
@@ -144,11 +154,12 @@ public class TrafficGuard {
     }
 
     double futureCapacityRatio = ((double) futureCapacity) / currentCapacity;
-    if (futureCapacityRatio < 0.4) {
+    if (futureCapacityRatio <= getMinCapacityRatio()) {
       String message = format("This cluster ('%s' in %s/%s) has traffic guards enabled. %s %s would leave the cluster ",
         serverGroupMoniker.getCluster(), account, location.getValue(), operationDescriptor, serverGroupName);
 
-      message += (futureCapacity == 0) ? "with no instances taking traffic."
+      message += (futureCapacity == 0)
+        ? "with no instances taking traffic."
         : format("with %d instances up (%.2f%% of %d instances currently up)",
             futureCapacity, futureCapacityRatio * 100, currentCapacity);
 
@@ -161,6 +172,16 @@ public class TrafficGuard {
 
       throw new TrafficGuardException(message);
     }
+  }
+
+  private double getMinCapacityRatio() {
+    Double minCapacityRatio = dynamicConfigService.getConfig(Double.class, MIN_CAPACITY_RATIO, 0d);
+    if (minCapacityRatio == null || minCapacityRatio < 0 || 0.5 <= minCapacityRatio) {
+      log.error("Expecting a double value in range [0, 0.5) for {} but got {}", MIN_CAPACITY_RATIO, minCapacityRatio);
+      return 0;
+    }
+
+    return minCapacityRatio;
   }
 
   private List<Map> generateContext(List<TargetServerGroup> targetServerGroups) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
@@ -59,7 +59,8 @@ class TrafficGuardSpec extends Specification {
       account: "test",
       region : "us-east-1",
       name   : "app-foo-v001",
-      moniker: [app: "app", stack: "foo", sequence: 1, cluster: "app-foo"]
+      moniker: [app: "app", stack: "foo", sequence: 1, cluster: "app-foo"],
+      isDisabled: false
     ]
     otherServerGroup = [
       account   : "test",

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
@@ -85,6 +85,24 @@ class TrafficGuardSpec extends Specification {
     ]
   }
 
+  void "should throw exception when target server group holds most of the capacity"() {
+    given:
+    addGuard([account: "test", location: "us-east-1", stack: "foo"])
+
+    when:
+    trafficGuard.verifyTrafficRemoval(targetName, moniker, "test", location, "aws", "x")
+
+    then:
+    thrown(TrafficGuardException)
+    1 * front50Service.get("app") >> application
+    1 * oortHelper.getCluster("app", "test", "app-foo", "aws") >> [
+      serverGroups: [
+        makeServerGroup(targetName, 2),
+        makeServerGroup(otherName, 1)
+      ]
+    ]
+  }
+
   void "should throw exception when target server group is the only one in cluster"() {
     given:
     addGuard([account: "test", location: "us-east-1", stack: "foo"])

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
@@ -117,6 +117,21 @@ class TrafficGuardSpec extends Specification {
     ]
   }
 
+  void "should not throw exception when cluster has no active instances"() {
+    given:
+    addGuard([account: "test", location: "us-east-1", stack: "foo"])
+
+    when:
+    trafficGuard.verifyTrafficRemoval(targetName, moniker, "test", location, "aws", "x")
+
+    then:
+    noExceptionThrown()
+    1 * front50Service.get("app") >> application
+    1 * oortHelper.getCluster("app", "test", "app-foo", "aws") >> [
+      serverGroups: [makeServerGroup(targetName, 0, 1)]
+    ]
+  }
+
   void "should validate existence of cluster"() {
     given:
     addGuard([account: "test", location: "us-east-1", stack: "foo"])


### PR DESCRIPTION
Instead of just enforcing capacity > 0, we want to compare the current
capacity and the future capacity. This is meant to prevent incidents where
a production cluster could accidentally go from 200 to 3 instances for
example.
