### PR TITLE
feat(kubernetes): ManifestForceCacheRefreshTask Metrics

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTaskSpec.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheStatusService
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+
+class ManifestForceCacheRefreshTaskSpec extends Specification {
+  def now = Instant.now()
+
+  def registry = new DefaultRegistry()
+  @Subject task = new ManifestForceCacheRefreshTask(
+    registry,
+    Mock(CloudDriverCacheService),
+    Mock(CloudDriverCacheStatusService),
+    Mock(ObjectMapper),
+    Clock.fixed(now, ZoneId.of("UTC"))
+  )
+
+  def "auto Succeed from timeout increments counter"() {
+    given:
+    def stage = new Stage(Execution.newPipeline("orca"), "whatever")
+    stage.setStartTime(now.minusMillis(TimeUnit.MINUTES.toMillis(13)).toEpochMilli())
+    def taskResult = task.execute(stage)
+
+    expect:
+    taskResult.getStatus().isSuccessful()
+    registry.timer("manifestForceCacheRefreshTask.duration", "success", "true", "outcome", "autoSucceed").count() == 1
+  }
+}


### PR DESCRIPTION
This adds the spectator registry to ManifestForceCacheRefreshTask as an initial start to getting more detailed metrics from the Kubernetes manifest tasks. In particular this will give us detailed timing emitted directly from this task on completion and, more importantly, a specific metric when the Force Cache Refresh has been "autoSucceeded" based on the 12 minute timeout. I followed the pattern [here](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy#L52-L60) to make testing a bit easier.

Fixes https://github.com/spinnaker/spinnaker/issues/3605