### PR TITLE
fix(findImage): make both find image task timeouts overridable

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -43,7 +43,8 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
 
   final long backoffPeriod = 10000
 
-  final long timeout = 600000
+  @Value('${tasks.findImageFromClusterTimeoutMillis:600000}')
+  long timeout
 
   static enum SelectionStrategy {
     /**

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -42,6 +43,9 @@ public class FindImageFromTagsTask extends AbstractCloudProviderAwareTask implem
 
   @Autowired
   List<ImageFinder> imageFinders;
+
+  @Value("${tasks.findImageFromTagsTimeoutMillis:600000}")
+  private Long findImageFromTagsTimeoutMillis;
 
   @Override
   public TaskResult execute(Stage stage) {
@@ -101,7 +105,7 @@ public class FindImageFromTagsTask extends AbstractCloudProviderAwareTask implem
 
   @Override
   public long getTimeout() {
-    return 600000;
+    return this.findImageFromTagsTimeoutMillis;
   }
 
   static class StageData {


### PR DESCRIPTION
The current timeouts are just fine most of the time, but we've been accumulating a lot of images and temporarily have very elevated image lookup times. We'd like to be lenient with those lookups until the times come back down.