### PR TITLE
fix(clouddriver): Avoid NPE in terminate and decrement server group task

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/TerminateInstanceAndDecrementServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/TerminateInstanceAndDecrementServerGroupTask.groovy
@@ -52,7 +52,7 @@ class TerminateInstanceAndDecrementServerGroupTask extends AbstractCloudProvider
 
     List<String> instanceIds = remainingInstances*.id
 
-    def ctx = stage.context + [
+    def ctx = [
             "notification.type"                                       : "terminateinstanceanddecrementservergroup",
             "terminate.account.name"                                  : account,
             "terminate.region"                                        : stage.context.region,


### PR DESCRIPTION
`stage.context` contained a `null` value that was subsequently failing
with:

```
java.lang.NullPointerException: null value in entry: scmInfo=null
...
at com.netflix.spinnaker.orca.clouddriver.tasks.instance.TerminateInstanceAndDecrementServerGroupTask.execute(TerminateInstanceAndDecrementServerGroupTask.groovy:80)
```
