### PR TITLE
feat(swabbie): do not monitor delete image

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/image/DeleteImageStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/image/DeleteImageStage.java
@@ -31,8 +31,7 @@ public class DeleteImageStage implements StageDefinitionBuilder {
   @Override
   public void taskGraph(@NotNull Stage stage, @NotNull TaskNode.Builder builder) {
     builder
-      .withTask("deleteImage", DeleteImageTask.class)
-      .withTask("monitorDelete", MonitorDeleteImageTask.class);
+      .withTask("deleteImage", DeleteImageTask.class);
   }
 
   public static class DeleteImageRequest {


### PR DESCRIPTION
Removing the monitor task from delete image. 

If the image does not actually get deleted due to a transient error, Swabbie will try again in the future.
