### PR TITLE
fix(artifacts): Use client error return code for missing artifacts

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import com.netflix.spinnaker.orca.pipeline.model.StageContext;
@@ -241,7 +242,7 @@ public class ArtifactResolver {
       }
 
       if (resolved == null) {
-        throw new IllegalStateException(format("Unmatched expected artifact %s could not be resolved.", expectedArtifact));
+        throw new InvalidRequestException(format("Unmatched expected artifact %s could not be resolved.", expectedArtifact));
       } else {
         resolvedArtifacts.add(resolved);
       }


### PR DESCRIPTION
When a pipeline is missing artifacts on startup, we currently throw an IllegalStateException, which eventually returns a 500 code to the client.  As this is a problem with the request, and it should not be retried, let's be more clear by making it an IllegalArgumentException, which returns a 400 code.