### PR TITLE
feat(bake): pass owner as application owner

### DIFF
--- a/orca-bakery/orca-bakery.gradle
+++ b/orca-bakery/orca-bakery.gradle
@@ -18,6 +18,7 @@ apply from: "$rootDir/gradle/groovy.gradle"
 
 dependencies {
   compile project(":orca-retrofit")
+  compile project(":orca-front50")
   spinnaker.group('jackson')
   compile spinnaker.dependency('jacksonGuava')
   compileOnly spinnaker.dependency('lombok')


### PR DESCRIPTION
We use the owner field in the bake stage to tag images with their owner.
Right now, we just pull this from the stage.

This PR adds a lookup to front50 to find the application, and if that application exists and the owner exists it updates the owner to be that value.