### PR TITLE
fix(webhook): using okhttp configs instead of defaults

### DIFF
--- a/orca-webhook/orca-webhook.gradle
+++ b/orca-webhook/orca-webhook.gradle
@@ -20,6 +20,7 @@ apply from: "$rootDir/gradle/groovy.gradle"
 dependencies {
   compile project(':orca-core')
   compile spinnaker.dependency('kork')
+  compile spinnaker.dependency('korkWeb')
   compile spinnaker.dependency('bootAutoConfigure')
   compile spinnaker.dependency('lombok')
   compile('com.jayway.jsonpath:json-path:2.2.0')

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.orca.webhook.config;
 
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import com.netflix.spinnaker.orca.webhook.util.UnionX509TrustManager;
 import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.StringUtils;
@@ -70,11 +71,16 @@ public class WebhookConfiguration {
   }
 
   @Bean
-  public ClientHttpRequestFactory webhookRequestFactory() {
+  public ClientHttpRequestFactory webhookRequestFactory(
+    OkHttpClientConfigurationProperties okHttpClientConfigurationProperties
+  ) {
     X509TrustManager trustManager = webhookX509TrustManager();
     SSLSocketFactory sslSocketFactory = getSSLSocketFactory(trustManager);
     OkHttpClient client = new OkHttpClient.Builder().sslSocketFactory(sslSocketFactory, trustManager).build();
-    return new OkHttp3ClientHttpRequestFactory(client);
+    OkHttp3ClientHttpRequestFactory requestFactory = new OkHttp3ClientHttpRequestFactory(client);
+    requestFactory.setReadTimeout(Math.toIntExact(okHttpClientConfigurationProperties.getReadTimeoutMs()));
+    requestFactory.setConnectTimeout(Math.toIntExact(okHttpClientConfigurationProperties.getConnectTimeoutMs()));
+    return requestFactory;
   }
 
   private X509TrustManager webhookX509TrustManager() {

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.orca.webhook.service
 
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions
 import com.netflix.spinnaker.orca.webhook.config.WebhookProperties
 import com.netflix.spinnaker.orca.webhook.config.WebhookConfiguration
@@ -42,10 +43,13 @@ class WebhookServiceSpec extends Specification {
   def webhookProperties = new WebhookProperties()
 
   @Shared
+  def okHttpClientConfigurationProperties = new OkHttpClientConfigurationProperties()
+
+  @Shared
   def webhookConfiguration = new WebhookConfiguration(webhookProperties)
 
   @Shared
-  def requestFactory = webhookConfiguration.webhookRequestFactory()
+  def requestFactory = webhookConfiguration.webhookRequestFactory(okHttpClientConfigurationProperties)
 
   @Shared
   def restTemplate = webhookConfiguration.restTemplate(requestFactory)


### PR DESCRIPTION
The webhook okhttp wasn't using the defaults we have in the config. We were seeing requests time out after 10 seconds (which is not consistent with previous behavior). This PR updates okhttp to use the config values for read and connect timeout.

@ajordens let me know if you'd do this a different way, happy to make changes.