### PR TITLE
fix(webhooks): Add enabled flag for webhook trust

### DIFF
--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
@@ -127,7 +127,7 @@ public class WebhookConfiguration {
 
   private Optional<KeyStore> getCustomKeyStore() {
     WebhookProperties.TrustSettings trustSettings = webhookProperties.getTrust();
-    if (trustSettings == null || StringUtils.isEmpty(trustSettings.getTrustStore())) {
+    if (trustSettings == null || !trustSettings.isEnabled() || StringUtils.isEmpty(trustSettings.getTrustStore())) {
       return Optional.empty();
     }
 

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -43,6 +43,7 @@ public class WebhookProperties {
   @Data
   @NoArgsConstructor
   public static class TrustSettings {
+    private boolean enabled;
     private String trustStore;
     private String trustStorePassword;
   }


### PR DESCRIPTION
A minor change to the recent ability to configure webhook; add an explicit enabled flag so the functionality can be toggled without nulling out the trust store location.