### PR TITLE
feat(MPTv2): Adds separate v2 plan endpoint.

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
@@ -16,11 +16,12 @@
 
 package com.netflix.spinnaker.orca.pipeline.expressions;
 
-import java.util.*;
 import com.netflix.spinnaker.orca.pipeline.util.ContextFunctionConfiguration;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.util.Map;
 
 public class PipelineExpressionEvaluator extends ExpressionsSupport implements ExpressionEvaluator {
   public static final String SUMMARY = "expressionEvaluationSummary";

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v2schema/model/V2PipelineTemplate.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v2schema/model/V2PipelineTemplate.java
@@ -28,7 +28,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Data
 public class V2PipelineTemplate implements VersionedSchema {
@@ -121,7 +120,9 @@ public class V2PipelineTemplate implements VersionedSchema {
   }
 
   public void setStages(List<V2StageDefinition> stages) {
-    pipeline.put("stages", stages);
+    ObjectMapper oj = new ObjectMapper();
+    TypeReference mapTypeRef = new TypeReference<List<Map<String, Object>>>() {};
+    pipeline.put("stages", oj.convertValue(stages, mapTypeRef));
   }
 
   public void accept(V2PipelineTemplateVisitor visitor) {

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -146,7 +146,7 @@ class OperationsController {
     }
   }
 
-  private Map parseAndValidatePipeline(Map pipeline) {
+  public Map parseAndValidatePipeline(Map pipeline) {
     parsePipelineTrigger(executionRepository, buildService, pipeline)
 
     for (PipelinePreprocessor preprocessor : (pipelinePreprocessors ?: [])) {

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/V2PipelineTemplateController.java
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/V2PipelineTemplateController.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.controllers;
+
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping(value = "/v2/pipelineTemplates")
+@ConditionalOnExpression("${pipelineTemplates.enabled:true}")
+@Slf4j
+public class V2PipelineTemplateController {
+
+  @Autowired
+  private OperationsController operationsController;
+
+  @Autowired
+  ContextParameterProcessor contextParameterProcessor;
+
+  @RequestMapping(value = "/plan", method = RequestMethod.POST)
+  Map<String, Object> orchestrate(@RequestBody Map<String, Object> pipeline) {
+    pipeline = operationsController.parseAndValidatePipeline(pipeline);
+
+    Map<String, Object> augmentedContext = new HashMap<>();
+    augmentedContext.put("trigger", pipeline.get("trigger"));
+    augmentedContext.put("templateVariables", pipeline.getOrDefault("templateVariables", Collections.EMPTY_MAP));
+    return contextParameterProcessor.process(pipeline, augmentedContext, false);
+  }
+}


### PR DESCRIPTION
Also fixes SpEL rendering for /orchestrate - was broken due to model changes in a previous PR. Maintains backwards compatibility for v1 plan. @jervi @gardleopard may be interested in this as well.