### PR TITLE
fix(triggers): Handle explicitly null container fields in triggers

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
@@ -110,7 +110,7 @@ internal class TriggerDeserializer
           get("strategy")?.booleanValue() == true
         )
       }.apply {
-        other = mapValue(parser)
+        other = mapValue(parser) ?: mutableMapOf()
         resolvedExpectedArtifacts = get("resolvedExpectedArtifacts")?.listValue(parser) ?: mutableListOf()
       }
     }
@@ -131,10 +131,10 @@ internal class TriggerDeserializer
     customTriggerSuppliers.any { it.predicate.invoke(this) }
 
   private fun <E> JsonNode.listValue(parser: JsonParser) =
-    parser.codec.treeToValue(this, List::class.java) as List<E>
+    parser.codec.treeToValue(this, List::class.java) as? List<E>
 
   private fun <K, V> JsonNode.mapValue(parser: JsonParser) =
-    parser.codec.treeToValue(this, Map::class.java) as Map<K, V>
+    parser.codec.treeToValue(this, Map::class.java) as? Map<K, V>
 
   private inline fun <reified T> JsonNode.parseValue(parser: JsonParser): T =
     parser.codec.treeToValue(this, T::class.java)

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/TriggerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/TriggerSpec.groovy
@@ -137,6 +137,29 @@ class TriggerSpec extends Specification {
     }'''
   }
 
+  def "defaults properties for explicitly null container types"() {
+    given:
+    def trigger = mapper.readValue(triggerJson, Trigger)
+
+    expect:
+    with(trigger) {
+      type == "webhook"
+      user == "[anonymous]"
+      parameters == [:]
+      notifications == []
+      artifacts == []
+    }
+
+    where:
+    triggerJson = '''
+    {
+      "type": "webhook",
+      "parameters": null,
+      "notifications": null,
+      "artifacts": null
+    }'''
+  }
+
   def "serializing a trigger flattens payload data"() {
     given:
     def asJson = new StringWriter().withCloseable {
@@ -540,24 +563,24 @@ class TriggerSpec extends Specification {
 """
   }
 
-def "a Wercker trigger works just like a Jenkins one"() {
-	given:
-	def trigger = mapper.readValue(triggerJson, Trigger)
+  def "a Wercker trigger works just like a Jenkins one"() {
+    given:
+    def trigger = mapper.readValue(triggerJson, Trigger)
 
-	expect:
-	trigger instanceof JenkinsTrigger
-	with(trigger) {
-	  master == "staging"
-	  job == "mytest"
-	  buildNumber == 123
-	  propertyFile == null
-	  buildInfo.name == "test-build"
-	  buildInfo.number == 123
-	  buildInfo.url == "https://testurl"
-	}
+    expect:
+    trigger instanceof JenkinsTrigger
+    with(trigger) {
+      master == "staging"
+      job == "mytest"
+      buildNumber == 123
+      propertyFile == null
+      buildInfo.name == "test-build"
+      buildInfo.number == 123
+      buildInfo.url == "https://testurl"
+    }
 
-	where:
-	triggerJson = """{
+    where:
+    triggerJson = """{
   "buildInfo": {
     "name": "test-build",
     "number": 123,


### PR DESCRIPTION
Upgrading from 1.8 to 1.10, I noticed that our webhook triggers were no longer working. Digging into the orca logs, there was an exception being thrown
```
c.n.s.k.w.e.GenericExceptionHandlers     : Internal Server Error
kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.List<E>
```
originating at [this line](https://github.com/spinnaker/orca/blob/release-1.10.x/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt#L134), as a result of trying to deserialize the `notifications` field [here](https://github.com/spinnaker/orca/blob/release-1.10.x/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt#L107).

The line of code responsible for deserializing that field -`get("notifications")?.listValue(parser) ?: mutableListOf()` - tries to account for when the `notifications` field is unset by using the safe call operator. However, this only works when `get("notifications")` returns null. 

I believe as a result of [this change](https://github.com/spinnaker/echo/pull/341) in 1.10, which added a `notifications` field to the Trigger model in echo [here](https://github.com/spinnaker/echo/pull/341/files#diff-e20a0caf38ea03da9bce335e6e49a6e0R111), the JSON getting sent from echo to orca when triggering pipelines now includes an explicitly null `notifications` field (e.g. `notifications: null`) instead of an absent one. This results in the `get("notifications")` call returning a `NullNode` instead of null. Ultimately this results in the listValue call throwing that cast exception, since it's trying to cast null to a List instead of short circuiting via the safe call operator.

This change introduces a safe cast in the `listValue` and `mapValue` calls to handle this case. My assumption is that there isn't a meaningful distinction between an absent container field vs. an explicitly null one being sent by echo to orca.
