### PR TITLE
feat(pipeline): Support conditional disabling of `ServerGroupCacheForceRefreshTask`

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/DisableClusterStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/DisableClusterStage.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.cluster;
 
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideClouddriverTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractWaitForClusterWideClouddriverTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.DisableClusterTask;
@@ -31,8 +32,10 @@ public class DisableClusterStage extends AbstractClusterWideClouddriverOperation
   public static final String STAGE_TYPE = "disableCluster";
 
   @Autowired
-  public DisableClusterStage(TrafficGuard trafficGuard, LockingConfigurationProperties lockingConfigurationProperties) {
-    super(trafficGuard, lockingConfigurationProperties);
+  public DisableClusterStage(TrafficGuard trafficGuard,
+                             LockingConfigurationProperties lockingConfigurationProperties,
+                             DynamicConfigService dynamicConfigService) {
+    super(trafficGuard, lockingConfigurationProperties, dynamicConfigService);
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ScaleDownClusterStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ScaleDownClusterStage.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.cluster;
 
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideClouddriverTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractWaitForClusterWideClouddriverTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.ScaleDownClusterTask;
@@ -29,8 +30,10 @@ import org.springframework.stereotype.Component;
 public class ScaleDownClusterStage extends AbstractClusterWideClouddriverOperationStage {
 
   @Autowired
-  public ScaleDownClusterStage(TrafficGuard trafficGuard, LockingConfigurationProperties lockingConfigurationProperties) {
-    super(trafficGuard, lockingConfigurationProperties);
+  public ScaleDownClusterStage(TrafficGuard trafficGuard,
+                               LockingConfigurationProperties lockingConfigurationProperties,
+                               DynamicConfigService dynamicConfigService) {
+    super(trafficGuard, lockingConfigurationProperties, dynamicConfigService);
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ShrinkClusterStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ShrinkClusterStage.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.cluster;
 
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideClouddriverTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractWaitForClusterWideClouddriverTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.ShrinkClusterTask;
@@ -40,8 +41,11 @@ public class ShrinkClusterStage extends AbstractClusterWideClouddriverOperationS
   private final DisableClusterStage disableClusterStage;
 
   @Autowired
-  public ShrinkClusterStage(TrafficGuard trafficGuard, LockingConfigurationProperties lockingConfigurationProperties, DisableClusterStage disableClusterStage) {
-    super(trafficGuard, lockingConfigurationProperties);
+  public ShrinkClusterStage(TrafficGuard trafficGuard,
+                            LockingConfigurationProperties lockingConfigurationProperties,
+                            DynamicConfigService dynamicConfigService,
+                            DisableClusterStage disableClusterStage) {
+    super(trafficGuard, lockingConfigurationProperties, dynamicConfigService);
     this.disableClusterStage = disableClusterStage;
   }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/AbstractClusterWideClouddriverOperationStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/AbstractClusterWideClouddriverOperationStageSpec.groovy
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.cluster
 
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
@@ -23,7 +24,9 @@ class AbstractClusterWideClouddriverOperationStageSpec extends Specification {
   def guard = Mock(TrafficGuard)
   def env = new MockEnvironment()
   def config = new LockingConfigurationProperties(new SpringDynamicConfigService(environment: env))
-  def stageBuilder = new TestStage(guard, config)
+  def dynamicConfigService = Mock(DynamicConfigService)
+
+  def stageBuilder = new TestStage(guard, config, dynamicConfigService)
 
   @Unroll
   def "should #desc1 inject #expectedType for #desc2 traffic guard protected cluster"() {
@@ -68,8 +71,10 @@ class AbstractClusterWideClouddriverOperationStageSpec extends Specification {
 
 
   static class TestStage extends AbstractClusterWideClouddriverOperationStage {
-    TestStage(TrafficGuard trafficGuard, LockingConfigurationProperties config) {
-      super(trafficGuard, config)
+    TestStage(TrafficGuard trafficGuard,
+              LockingConfigurationProperties config,
+              DynamicConfigService dynamicConfigService) {
+      super(trafficGuard, config, dynamicConfigService)
     }
 
     @Override

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/HighlanderStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/HighlanderStrategySpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies
 
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.DisableClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.ShrinkClusterStage
@@ -33,8 +34,11 @@ class HighlanderStrategySpec extends Specification {
   def trafficGuard = Stub(TrafficGuard)
   def env = new MockEnvironment()
   def lockingConfig = new LockingConfigurationProperties(new SpringDynamicConfigService(environment: env))
-  def disableClusterStage = new DisableClusterStage(trafficGuard, lockingConfig)
-  def shrinkClusterStage = new ShrinkClusterStage(trafficGuard, lockingConfig, disableClusterStage)
+
+  def dynamicConfigService = Mock(DynamicConfigService)
+
+  def disableClusterStage = new DisableClusterStage(trafficGuard, lockingConfig, dynamicConfigService)
+  def shrinkClusterStage = new ShrinkClusterStage(trafficGuard, lockingConfig, dynamicConfigService, disableClusterStage)
 
   @Unroll
   def "should compose flow"() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategySpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies
 
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.DisableClusterStage
@@ -35,9 +36,12 @@ class RedBlackStrategySpec extends Specification {
   def trafficGuard = Stub(TrafficGuard)
   def env = new MockEnvironment()
   def config = new LockingConfigurationProperties(new SpringDynamicConfigService(environment: env))
-  def disableClusterStage = new DisableClusterStage(trafficGuard, config)
-  def shrinkClusterStage = new ShrinkClusterStage(trafficGuard, config, disableClusterStage)
-  def scaleDownClusterStage = new ScaleDownClusterStage(trafficGuard, config)
+
+  def dynamicConfigService = Mock(DynamicConfigService)
+
+  def disableClusterStage = new DisableClusterStage(trafficGuard, config, dynamicConfigService)
+  def shrinkClusterStage = new ShrinkClusterStage(trafficGuard, config, dynamicConfigService, disableClusterStage)
+  def scaleDownClusterStage = new ScaleDownClusterStage(trafficGuard, config, dynamicConfigService)
   def waitStage = new WaitStage()
 
   def "should compose flow"() {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.pipeline;
 
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.orca.pipeline.TaskNode.TaskGraph;
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
@@ -168,5 +169,21 @@ public interface StageDefinitionBuilder {
    */
   default boolean canManuallySkip() {
     return false;
+  }
+
+  default boolean isForceCacheRefreshEnabled(DynamicConfigService dynamicConfigService) {
+    String className = getClass().getSimpleName();
+
+    try {
+      return dynamicConfigService.isEnabled(
+        String.format(
+          "stages.%s.forceCacheRefresh",
+          Character.toLowerCase(className.charAt(0)) + className.substring(1)
+        ),
+        true
+      );
+    } catch (Exception e) {
+      return true;
+    }
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilderSpec.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class StageDefinitionBuilderSpec extends Specification {
+  def dynamicConfigService = Mock(DynamicConfigService)
+
+  @Subject
+  def stageDefinitionBuilder = new MyStageDefinitionBuilder()
+
+  @Unroll
+  def "should check dynamic config property"() {
+    when:
+    def isForceCacheRefreshEnabled = stageDefinitionBuilder.isForceCacheRefreshEnabled(dynamicConfigService)
+
+    then:
+    1 * dynamicConfigService.isEnabled("stages.myStageDefinitionBuilder.forceCacheRefresh", true) >> {
+      return response()
+    }
+    0 * _
+
+    isForceCacheRefreshEnabled == expectedForceCacheRefreshEnabled
+
+    where:
+    response << [{ return true }, { return false }, { throw new NullPointerException() }]
+    expectedForceCacheRefreshEnabled << [true, false, true]
+  }
+
+  private static class MyStageDefinitionBuilder implements StageDefinitionBuilder {
+
+  }
+}


### PR DESCRIPTION
```
stages.cloneServerGroupStage.forceCacheRefresh.enabled: false
```

Current belief is that `ServerGroupCacheForceRefreshTask` is being used
in a few spots unnecessarily and causing pipelines/stages to run longer
than needed.

We will test in our environment, if the belief holds true we'll either:
(a) remove the `ServerGroupCacheForceRefreshTask` or
(b) make it easier to disable `ServerGroupCacheForceRefreshTask` across the board
