### PR TITLE
feat(waitUntil): add waitUntil stage for internal use

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/WaitUntilStage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/WaitUntilStage.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.tasks.WaitUntilTask;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+@Component
+public class WaitUntilStage implements StageDefinitionBuilder {
+
+  public static String STAGE_TYPE = "waitUntil";
+
+  @Override
+  public void taskGraph(Stage stage, TaskNode.Builder builder) {
+    builder.withTask("waitUntil", WaitUntilTask.class);
+  }
+
+  public static final class WaitUntilStageContext {
+    private final Long epochMillis;
+    private final Instant startTime;
+
+    @JsonCreator
+    public WaitUntilStageContext(
+      @JsonProperty("epochMillis") @Nullable Long epochMillis,
+      @JsonProperty("startTime") @Nullable Instant startTime
+    ) {
+      this.epochMillis = epochMillis;
+      this.startTime = startTime;
+    }
+
+    public WaitUntilStageContext(@Nonnull Long epochMillis) {
+      this(epochMillis, null);
+    }
+
+    public @Nullable Long getEpochMillis() {
+      return epochMillis;
+    }
+
+    public @Nullable Instant getStartTime() {
+      return startTime;
+    }
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitUntilTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitUntilTask.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.tasks;
+
+import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.pipeline.WaitUntilStage;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+import static com.netflix.spinnaker.orca.ExecutionStatus.RUNNING;
+import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED;
+import static java.util.Collections.singletonMap;
+
+@Component
+public class WaitUntilTask implements RetryableTask {
+
+  private final Clock clock;
+
+  @Autowired
+  public WaitUntilTask(Clock clock) {
+    this.clock = clock;
+  }
+
+  @Override
+  public @Nonnull
+  TaskResult execute(@Nonnull Stage stage) {
+    WaitUntilStage.WaitUntilStageContext context = stage.mapTo(WaitUntilStage.WaitUntilStageContext.class);
+
+    if (context.getEpochMillis() == null) {
+      return new TaskResult(SUCCEEDED);
+    }
+
+    Instant now = clock.instant();
+
+    if (context.getStartTime() == null || context.getStartTime() == Instant.EPOCH) {
+      return new TaskResult(RUNNING, singletonMap("startTime", now));
+    } else if (context.getEpochMillis() <= now.toEpochMilli()) {
+      return new TaskResult(SUCCEEDED);
+    } else {
+      return new TaskResult(RUNNING);
+    }
+  }
+
+  @Override
+  public long getBackoffPeriod() {
+    return 1_000;
+  }
+
+  @Override
+  public long getDynamicBackoffPeriod(Stage stage, Duration taskDuration) {
+    WaitUntilStage.WaitUntilStageContext context = stage.mapTo(WaitUntilStage.WaitUntilStageContext.class);
+
+    // Return a backoff time that reflects the requested target time.
+    if (context.getStartTime() != null && context.getEpochMillis() != null) {
+      Instant now = clock.instant();
+      Instant completion = Instant.ofEpochMilli(context.getEpochMillis());
+
+      if (completion.isAfter(now)) {
+        return completion.toEpochMilli() - now.toEpochMilli();
+      }
+    }
+    return getBackoffPeriod();
+  }
+
+  @Override
+  public long getTimeout() {
+    return Integer.MAX_VALUE;
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/WaitUntilTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/WaitUntilTaskSpec.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.tasks
+
+import com.netflix.spinnaker.orca.time.MutableClock
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.Duration
+
+import static com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
+import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class WaitUntilTaskSpec extends Specification {
+  def clock = new MutableClock()
+  @Subject
+    task = new WaitUntilTask(clock)
+
+  void "should wait for a configured period"() {
+    setup:
+    def stage = stage {
+      refId = "1"
+      type = "epochMillis"
+      context["epochMillis"] = 5
+    }
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.status == RUNNING
+    result.context.startTime != null
+    stage.context.putAll(result.context)
+
+    when:
+    clock.incrementBy(Duration.ofSeconds(10))
+
+    and:
+    result = task.execute(stage)
+
+    then:
+    result.status == SUCCEEDED
+    result.context.startTime == null
+  }
+
+  void "should return backoff based on epochMillis"() {
+    def waitTimeSeconds = 300
+    def epochMillis = clock.instant().plusSeconds(waitTimeSeconds)
+    def stage = stage {
+      refId = "1"
+      type = "epochMillis"
+      context["epochMillis"] = epochMillis
+    }
+
+    when:
+    def result = task.execute(stage)
+
+    and:
+    stage.context.putAll(result.context)
+    def backOff = task.getDynamicBackoffPeriod(stage, null)
+
+    then:
+    result.status == RUNNING
+    backOff == waitTimeSeconds * 1000
+  }
+
+}


### PR DESCRIPTION
This adds a `waitUntil` stage which will be used in the kayenta pipeline to accurately schedule when to run canary reports in a sequence on a pre-computed schedule.  `waitUntil` waits for an absolute time in milliseconds.

Kayenta sets up a schedule, which is visible in the UI, of when it will run analysis stages.  It spaces these apart by a fixed amount, and it is nice to see the times they are scheduled to run.  The current Kayenta stage uses `wait` stages with a fixed amount to do this, but if the report takes seconds to run, it will drift and end up running the canary longer than it should.  `waitUntil` removes this drift.