### PR TITLE
fix(traffic-guards): bypass the traffic guard capacity check during RRB

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTaskSpec.groovy
@@ -78,6 +78,20 @@ class AbstractClusterWideClouddriverTaskSpec extends Specification {
   }
 
   @Unroll
+  def "shouldSkipTrafficGuardCheck=#skip for katoOps with #description"() {
+    expect:
+    AbstractClusterWideClouddriverTask.shouldSkipTrafficGuardCheck(katoOps) == skip
+
+    where:
+    skip  || description                  | katoOps
+    false || "no desiredPercentage"       | [[destroyServerGroup:[credentials:"test", accountName:"test", serverGroupName:"test-v468", asgName:"test-v468", cloudProvider:"cloud", region:"region"]]]
+    false || "a null desiredPercentage"   | [[disableServerGroup:[credentials:"test", accountName:"test", serverGroupName:"test-v468", asgName:"test-v468", cloudProvider:"cloud", region:"region", desiredPercentage:null]]]
+    false || "a desiredPercentage at 100" | [[disableServerGroup:[credentials:"test", accountName:"test", serverGroupName:"test-v468", asgName:"test-v468", cloudProvider:"cloud", region:"region", desiredPercentage:100]]]
+    true  || "a desiredPercentage at 50"  | [[disableServerGroup:[credentials:"test", accountName:"test", serverGroupName:"test-v468", asgName:"test-v468", cloudProvider:"cloud", region:"region", desiredPercentage:50]]]
+    true  || "only one partial disable"   | [[disableServerGroup:[credentials:"test", accountName:"test", serverGroupName:"test-v468", asgName:"test-v468", cloudProvider:"cloud", region:"region"]], [disableServerGroup:[credentials:"test", accountName:"test", serverGroupName:"test-v468", asgName:"test-v468", cloudProvider:"cloud", region:"region", desiredPercentage:50]]]
+  }
+
+  @Unroll
   def "should filter out server groups that are newer than parent deploys"() {
     when:
     def targetServerGroups = AbstractClusterWideClouddriverTask.filterParentAndNewerThanParentDeploys(


### PR DESCRIPTION
The capacity check in TrafficGuard assumes entire server groups are going
away, which is not necessarily true in the case of rolling red/blacks.

In the RRB case, AbstractClusterWideClouddriverTask generates katoOps
for operations like disableServerGroup with a desiredPercentage property
and clouddriver is responsible for selecting which instances to disable.
