### PR TITLE
fix(pubsub): Make manual judgement notifications work with pubsub

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
@@ -144,6 +144,7 @@ class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage 
     String address
     String cc
     String type
+    String publisherName
     List<String> when
     Map<String, Map> message
 
@@ -173,7 +174,7 @@ class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage 
     void notify(EchoService echoService, Stage stage, String notificationState) {
       echoService.create(new EchoService.Notification(
         notificationType: EchoService.Notification.Type.valueOf(type.toUpperCase()),
-        to: address ? [address] : null,
+        to: address ? [address] : (publisherName ? [publisherName] : null),
         cc: cc ? [cc] : null,
         templateGroup: notificationState,
         severity: EchoService.Notification.Severity.HIGH,

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
@@ -111,7 +111,11 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
         appNotification = contextParameterProcessor.process(appNotification, executionMap, true)
 
         Map<String, Object> targetMatch = pipeline.notifications.find { pipelineNotification ->
-          pipelineNotification.address == appNotification.address && pipelineNotification.type == appNotification.type
+          def addressMatches = pipelineNotification.address == appNotification.address
+          def publisherMatches = pipelineNotification.publisherName == appNotification.publisherName
+          def typeMatches = pipelineNotification.type == appNotification.type
+
+          return (addressMatches || publisherMatches) && typeMatches
         }
         if (!targetMatch) {
           pipeline.notifications.push(appNotification)

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
@@ -57,14 +57,15 @@ class ManualJudgmentStageSpec extends Specification {
       new Notification(type: "email", address: "test@netflix.com"),
       new Notification(type: "hipchat", address: "Hipchat Channel"),
       new Notification(type: "sms", address: "11122223333"),
-      new Notification(type: "unknown", address: "unknown")
+      new Notification(type: "unknown", address: "unknown"),
+      new Notification(type: "pubsub", publisherName: "foobar")
     ]]))
 
     then:
     result.status == ExecutionStatus.RUNNING
     result.context.notifications.findAll {
       it.lastNotifiedByNotificationState["manualJudgment"]
-    }*.type == ["email", "hipchat", "sms"]
+    }*.type == ["email", "hipchat", "sms", "pubsub"]
   }
 
   @Unroll


### PR DESCRIPTION
Manual judgement notifications are weirdly different from all other notifications, so this extra bit of change is needed on top of the stuff from yesterday.

tag: https://github.com/spinnaker/spinnaker/issues/2784