### PR TITLE
chore(redis): Upgrade Keiko to v2.9.7 to resolve error on non-US locales

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ junitVersion=1.2.0
 jupiterVersion=5.0.2
 junitLegacyVersion=4.12.0
 spekVersion=1.1.5
-keikoVersion=2.9.6
+keikoVersion=2.9.7


### PR DESCRIPTION
Contains this fix: https://github.com/spinnaker/keiko/pull/50