### PR TITLE
fix(sql): Pin minutest dependency

### DIFF
--- a/orca-sql/orca-sql.gradle
+++ b/orca-sql/orca-sql.gradle
@@ -36,7 +36,7 @@ dependencies {
   testCompile "io.strikt:strikt-core:0.11.5"
   testCompile "org.assertj:assertj-core:3.9.0"
   testCompile "org.junit.jupiter:junit-jupiter-api:$jupiterVersion"
-  testCompile "com.oneeyedmen:minutest:+"
+  testCompile "com.oneeyedmen:minutest:0.34.0"
   testCompile "com.nhaarman:mockito-kotlin:1.5.0"
 
   testRuntime "org.junit.jupiter:junit-jupiter-engine:$jupiterVersion"


### PR DESCRIPTION
Orca tests are not compiling because gradle is pulling the latest version of minutest, which removed some classes we depend on. Pin the version to the latest version before this breaking change.