### PR TITLE
fix(pipelines): Add expected artifacts to pipeline template spec

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequest.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequest.java
@@ -16,14 +16,17 @@
 package com.netflix.spinnaker.orca.pipelinetemplate;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class TemplatedPipelineRequest {
   String id;
   String schema;
   String type;
+  List<ExpectedArtifact> expectedArtifacts;
   Map<String, Object> trigger = new HashMap<>();
   Map<String, Object> config;
   Map<String, Object> template;
@@ -115,5 +118,13 @@ public class TemplatedPipelineRequest {
 
   public boolean isKeepWaitingPipelines() {
     return keepWaitingPipelines;
+  }
+
+  public void setExpectedArtifacts(List<ExpectedArtifact> expectedArtifacts) {
+    this.expectedArtifacts = expectedArtifacts;
+  }
+
+  public List<ExpectedArtifact> getExpectedArtifacts() {
+    return this.expectedArtifacts;
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
@@ -77,6 +77,9 @@ public class V1SchemaExecutionGenerator implements ExecutionGenerator {
     if (request.getTrigger() != null && !request.getTrigger().isEmpty()) {
       pipeline.put("trigger", request.getTrigger());
     }
+    if (request.getExpectedArtifacts() != null) {
+      pipeline.put("expectedArtifacts", request.getExpectedArtifacts());
+    }
 
     return pipeline;
   }


### PR DESCRIPTION
Expected artifacts are not being returned from template plan requests as they are not in the spec; this is breaking display of templated pipelines with expected artifacts.