### PR TITLE
 fix(pipelines): Allow caller to specify whether to resolve artifacts

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -39,6 +39,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
+import retrofit.http.Query
 
 import javax.servlet.http.HttpServletResponse
 
@@ -87,17 +88,22 @@ class OperationsController {
     planOrOrchestratePipeline(pipeline)
   }
 
+  @RequestMapping(value = "/plan", method = RequestMethod.POST)
+  Map<String, Object> plan(@RequestBody Map pipeline, @Query("resolveArtifacts") boolean resolveArtifacts, HttpServletResponse response) {
+    planPipeline(pipeline, resolveArtifacts)
+  }
+
   private Map planOrOrchestratePipeline(Map pipeline) {
     if (pipeline.plan) {
-      planPipeline(pipeline)
+      planPipeline(pipeline, false)
     } else {
       orchestratePipeline(pipeline)
     }
   }
 
-  private Map<String, Object> planPipeline(Map pipeline) {
+  private Map<String, Object> planPipeline(Map pipeline, boolean resolveArtifacts) {
     log.info('Not starting pipeline (plan: true): {}', value("pipelineId", pipeline.id))
-    return parseAndValidatePipeline(pipeline)
+    return parseAndValidatePipeline(pipeline, resolveArtifacts)
   }
 
   private Map<String, Object> orchestratePipeline(Map pipeline) {
@@ -120,7 +126,11 @@ class OperationsController {
   }
 
   private Map parseAndValidatePipeline(Map pipeline) {
-    parsePipelineTrigger(executionRepository, buildService, pipeline)
+    return parseAndValidatePipeline(pipeline, true)
+  }
+
+  private Map parseAndValidatePipeline(Map pipeline, boolean resolveArtifacts) {
+    parsePipelineTrigger(executionRepository, buildService, pipeline, resolveArtifacts)
 
     for (PipelinePreprocessor preprocessor : (pipelinePreprocessors ?: [])) {
       pipeline = preprocessor.process(pipeline)
@@ -144,7 +154,7 @@ class OperationsController {
     return pipeline
   }
 
-  private void parsePipelineTrigger(ExecutionRepository executionRepository, BuildService buildService, Map pipeline) {
+  private void parsePipelineTrigger(ExecutionRepository executionRepository, BuildService buildService, Map pipeline, boolean resolveArtifacts) {
     if (!(pipeline.trigger instanceof Map)) {
       pipeline.trigger = [:]
       if (pipeline.plan && pipeline.type == "templatedPipeline" && pipelineTemplateService != null) {
@@ -194,7 +204,9 @@ class OperationsController {
       }
     }
 
-    artifactResolver?.resolveArtifacts(pipeline)
+    if (resolveArtifacts) {
+      artifactResolver?.resolveArtifacts(pipeline)
+    }
   }
 
   private void getBuildInfo(Map trigger) {
@@ -224,14 +236,14 @@ class OperationsController {
   @RequestMapping(value = "/ops", method = RequestMethod.POST)
   Map<String, String> ops(@RequestBody List<Map> input) {
     def execution = [application: null, name: null, stages: input]
-    parsePipelineTrigger(executionRepository, buildService, execution)
+    parsePipelineTrigger(executionRepository, buildService, execution, true)
     startTask(execution)
   }
 
   @RequestMapping(value = "/ops", consumes = "application/context+json", method = RequestMethod.POST)
   Map<String, String> ops(@RequestBody Map input) {
     def execution = [application: input.application, name: input.description, stages: input.job, trigger: input.trigger ?: [:]]
-    parsePipelineTrigger(executionRepository, buildService, execution)
+    parsePipelineTrigger(executionRepository, buildService, execution, true)
     startTask(execution)
   }
 


### PR DESCRIPTION
Create a new '/plan' endpoint that allows callers to request a plan for a pipeline template. Any calls to '/orchestrate' with pipeline.plan set to true can be migrated to this endpoint, but the '/orchestrate' endpoint will continue to work.

This new endpoint has a new feature, the flag 'resolveArtifacts' that allows the caller to toggle whether to resolve artifacts when making the plan.