### PR TITLE
fix(pipelines): Fix rendering of templated pipelines

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.kork.web.exceptions.ValidationException
 import com.netflix.spinnaker.orca.clouddriver.service.JobService
 import com.netflix.spinnaker.orca.extensionpoint.pipeline.PipelinePreprocessor
 import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.PipelineModelMutator
 import com.netflix.spinnaker.orca.igor.BuildService
 import com.netflix.spinnaker.orca.pipeline.ExecutionLauncher
 import com.netflix.spinnaker.orca.pipeline.model.Execution
@@ -75,6 +76,9 @@ class OperationsController {
 
   @Autowired(required = false)
   List<PipelinePreprocessor> pipelinePreprocessors
+
+  @Autowired(required = false)
+  private List<PipelineModelMutator> pipelineModelMutators = new ArrayList<>();
 
   @Autowired(required = false)
   WebhookService webhookService
@@ -140,6 +144,7 @@ class OperationsController {
 
   private Map<String, Object> planPipeline(Map pipeline, boolean resolveArtifacts) {
     log.info('Not starting pipeline (plan: true): {}', value("pipelineId", pipeline.id))
+    pipelineModelMutators.stream().filter({m -> m.supports(pipeline)}).forEach({m -> m.mutate(pipeline)})
     return parseAndValidatePipeline(pipeline, resolveArtifacts)
   }
 


### PR DESCRIPTION
When a templated pipeline is first configured, we call the plan endpoint to generate the pipeline for display in the UI. This rendered pipeline doesn't have the inherited fields included; these are only inherited on a save operation. In order to properly show the rendered pipeline after a plan request, also process any inherited fields when requesting a plan.

As this code is run on any save operation, it is already required to be idempotent (so subsequent saves without a change in the UI are no-ops); it is thus safe to run it after configuring the pipeline as well.