### PR TITLE
fix(pipelines): allow access to evaluation result attributes

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionEvaluationSummary.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionEvaluationSummary.java
@@ -80,7 +80,7 @@ public class ExpressionEvaluationSummary {
     );
   }
 
-  static class Result {
+  public static class Result {
     private String description;
     private Class<?> exceptionType;
     private long timestamp;


### PR DESCRIPTION
ExpressionEvaluationSummary.Result attributes have some useful information like description and exceptionType. It would be nice to be able to access these from other packages or other projects. ExpressionEvaluationSummary is public and it publicly exposes Result through getExpressionResult so it makes sense to have access all the way down.

