### PR TITLE
fix(pipelines): make evaluation context and transform public

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
@@ -43,7 +43,7 @@ public class ExpressionTransform {
   private final ParserContext parserContext;
   private final ExpressionParser parser;
 
-  ExpressionTransform(ParserContext parserContext, ExpressionParser parser) {
+  public ExpressionTransform(ParserContext parserContext, ExpressionParser parser) {
     this.parserContext = parserContext;
     this.parser = parser;
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionsSupport.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionsSupport.java
@@ -80,7 +80,7 @@ public class ExpressionsSupport {
    * @param allowUnknownKeys flag to control what helper functions are available
    * @return an evaluation context hooked with helper functions and correct ACL via whitelisting
    */
-  static StandardEvaluationContext newEvaluationContext(Object rootObject, boolean allowUnknownKeys) {
+  public static StandardEvaluationContext newEvaluationContext(Object rootObject, boolean allowUnknownKeys) {
     StandardEvaluationContext evaluationContext = new StandardEvaluationContext(rootObject);
     evaluationContext.setTypeLocator(new WhitelistTypeLocator());
     evaluationContext.setMethodResolvers(Collections.singletonList(new FilteredMethodResolver()));


### PR DESCRIPTION
Currently one has to use PipelineExpressionEvaluator.evaluate outside of this package, but that has a lot of limitations. It might be useful to keep an evaluationContext around and run multiple transforms against it or use a different ExpressionParser. I see PipelineExpressionEvaluator as an example of how expressions can be evaluated, but not an abstraction that shouldn’t be opened. Allowing context and transform creation from outside the package makes sense.
