### PR TITLE
fix(pipelines): make String and List expression transforms public

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
@@ -80,7 +80,7 @@ public class ExpressionTransform {
     return result;
   }
 
-  private List transformList(List source,
+  public List transformList(List source,
                              EvaluationContext evaluationContext,
                              ExpressionEvaluationSummary summary,
                              Map<String, Object> additionalContext) {
@@ -104,7 +104,7 @@ public class ExpressionTransform {
     return result;
   }
 
-  private Object transformString(Object source,
+  public Object transformString(Object source,
                                  EvaluationContext evaluationContext,
                                  ExpressionEvaluationSummary summary,
                                  Map<String, Object> additionalContext) {


### PR DESCRIPTION
ExpressionTransform.transformString and .transformList are useful, not just transformMap.

Check out this construction of a Map, and the need to ensure a consistent key between controller and the processor just to evaluate a String.

https://github.com/spinnaker/orca/blob/1931bd1a43c978f945866587f68897082409577c/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy#L490

https://github.com/spinnaker/orca/blob/d7c223a14a44af61d827c680203b45aebc825b4e/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java#L64

Things like this could be simpler without the need to artificially construct a Map.
