### PR TITLE
fix(search): execution results < limit == no more matches

### DIFF
--- a/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -78,7 +78,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     repository.store(runningExecution)
     repository.store(succeededExecution)
     def pipelines = repository.retrievePipelinesForPipelineConfigId(
-      "pipeline-1", new ExecutionCriteria(limit: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"])
+      "pipeline-1", new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
     then:
@@ -86,7 +86,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
 
     when:
     pipelines = repository.retrievePipelinesForPipelineConfigId(
-      "pipeline-1", new ExecutionCriteria(limit: 5, statuses: ["RUNNING"])
+      "pipeline-1", new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
     then:
@@ -94,7 +94,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
 
     when:
     pipelines = repository.retrievePipelinesForPipelineConfigId(
-      "pipeline-1", new ExecutionCriteria(limit: 5, statuses: ["TERMINAL"])
+      "pipeline-1", new ExecutionCriteria(pageSize: 5, statuses: ["TERMINAL"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
     then:
@@ -119,7 +119,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     repository.store(runningExecution)
     repository.store(succeededExecution)
     def orchestrations = repository.retrieveOrchestrationsForApplication(
-      runningExecution.application, new ExecutionCriteria(limit: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"])
+      runningExecution.application, new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
     then:
@@ -127,7 +127,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
 
     when:
     orchestrations = repository.retrieveOrchestrationsForApplication(
-      runningExecution.application, new ExecutionCriteria(limit: 5, statuses: ["RUNNING"])
+      runningExecution.application, new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
     then:
@@ -135,7 +135,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
 
     when:
     orchestrations = repository.retrieveOrchestrationsForApplication(
-      runningExecution.application, new ExecutionCriteria(limit: 5, statuses: ["TERMINAL"])
+      runningExecution.application, new ExecutionCriteria(pageSize: 5, statuses: ["TERMINAL"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
     then:
@@ -160,7 +160,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     repository.store(succeededExecution)
     def orchestrations = repository.retrieveOrchestrationsForApplication(
       runningExecution.application,
-      new ExecutionCriteria(limit: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"]),
+      new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"]),
       NATURAL
     )
 
@@ -172,7 +172,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     when:
     orchestrations = repository.retrieveOrchestrationsForApplication(
       runningExecution.application,
-      new ExecutionCriteria(limit: 5, statuses: ["RUNNING"]),
+      new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING"]),
       NATURAL
     )
 
@@ -182,7 +182,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     when:
     orchestrations = repository.retrieveOrchestrationsForApplication(
       runningExecution.application,
-      new ExecutionCriteria(limit: 5, statuses: ["TERMINAL"]),
+      new ExecutionCriteria(pageSize: 5, statuses: ["TERMINAL"]),
       NATURAL
     )
 
@@ -613,7 +613,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     and:
     def criteria = new ExecutionCriteria()
       .setStatuses(statuses.collect { it.toString() })
-      .setLimit(limit)
+      .setPageSize(limit)
 
     expect:
     with(repository.retrieve(type, criteria).toList().toBlocking().single()) {

--- a/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
+++ b/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepositoryTck.groovy
@@ -35,7 +35,7 @@ import static com.netflix.spinnaker.orca.ExecutionStatus.*
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
-import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.NATURAL
+import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.NATURAL_ASC
 import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.START_TIME_OR_ID
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.*
 import static java.time.ZoneOffset.UTC
@@ -161,7 +161,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     def orchestrations = repository.retrieveOrchestrationsForApplication(
       runningExecution.application,
       new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"]),
-      NATURAL
+      NATURAL_ASC
     )
 
     then:
@@ -173,7 +173,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     orchestrations = repository.retrieveOrchestrationsForApplication(
       runningExecution.application,
       new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING"]),
-      NATURAL
+      NATURAL_ASC
     )
 
     then:
@@ -183,7 +183,7 @@ abstract class ExecutionRepositoryTck<T extends ExecutionRepository> extends Spe
     orchestrations = repository.retrieveOrchestrationsForApplication(
       runningExecution.application,
       new ExecutionCriteria(pageSize: 5, statuses: ["TERMINAL"]),
-      NATURAL
+      NATURAL_ASC
     )
 
     then:

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgent.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgent.java
@@ -111,7 +111,7 @@ public class TopApplicationExecutionCleanupPollingNotificationAgent extends Abst
         log.info("Cleaning up orchestration executions (application: {}, threshold: {})", app, threshold);
 
         ExecutionCriteria executionCriteria = new ExecutionCriteria();
-        executionCriteria.setLimit(Integer.MAX_VALUE);
+        executionCriteria.setPageSize(Integer.MAX_VALUE);
         cleanup(executionRepository.retrieveOrchestrationsForApplication(app, executionCriteria), app, "orchestration");
       });
     } catch (Exception e) {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
@@ -181,7 +181,7 @@ class DualExecutionRepository(
   }
 
   override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-    pipelineConfigIds: MutableList<String>,
+    pipelineConfigIds: List<String>,
     buildTimeStartBoundary: Long,
     buildTimeEndBoundary: Long,
     executionCriteria: ExecutionCriteria,
@@ -208,7 +208,7 @@ class DualExecutionRepository(
   }
 
   override fun retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-    pipelineConfigIds: MutableList<String>,
+    pipelineConfigIds: List<String>,
     buildTimeStartBoundary: Long,
     buildTimeEndBoundary: Long,
     executionCriteria: ExecutionCriteria

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
@@ -180,24 +180,51 @@ class DualExecutionRepository(
     )
   }
 
-  override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(pipelineConfigIds: MutableList<String>,
-                                                                             buildTimeStartBoundary: Long,
-                                                                             buildTimeEndBoundary: Long,
-                                                                             limit: Int): Observable<Execution> {
-    return Observable.merge(
-      primary.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+  override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+    pipelineConfigIds: MutableList<String>,
+    buildTimeStartBoundary: Long,
+    buildTimeEndBoundary: Long,
+    executionCriteria: ExecutionCriteria,
+    offset: Int,
+    limit: Int
+  ): List<Execution> {
+    return primary
+      .retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
         pipelineConfigIds,
         buildTimeStartBoundary,
         buildTimeEndBoundary,
-        limit
-      ),
-      previous.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-        pipelineConfigIds,
-        buildTimeStartBoundary,
-        buildTimeEndBoundary,
+        executionCriteria,
+        offset,
         limit
       )
-    )
+      .plus(previous.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+        pipelineConfigIds,
+        buildTimeStartBoundary,
+        buildTimeEndBoundary,
+        executionCriteria,
+        offset,
+        limit)
+      )
+  }
+
+  override fun retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+    pipelineConfigIds: MutableList<String>,
+    buildTimeStartBoundary: Long,
+    buildTimeEndBoundary: Long,
+    executionCriteria: ExecutionCriteria
+  ): List<Execution> {
+    return primary
+      .retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+        pipelineConfigIds,
+        buildTimeStartBoundary,
+        buildTimeEndBoundary,
+        executionCriteria
+      ).plus(previous.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+        pipelineConfigIds,
+        buildTimeStartBoundary,
+        buildTimeEndBoundary,
+        executionCriteria)
+      )
   }
 
   override fun retrieveOrchestrationsForApplication(application: String,

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
@@ -181,29 +181,23 @@ class DualExecutionRepository(
   }
 
   override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-    pipelineConfigIds: List<String>,
+    pipelineConfigIds: MutableList<String>,
     buildTimeStartBoundary: Long,
     buildTimeEndBoundary: Long,
-    executionCriteria: ExecutionCriteria,
-    offset: Int,
-    limit: Int
+    executionCriteria: ExecutionCriteria
   ): List<Execution> {
     return primary
       .retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
         pipelineConfigIds,
         buildTimeStartBoundary,
         buildTimeEndBoundary,
-        executionCriteria,
-        offset,
-        limit
+        executionCriteria
       )
       .plus(previous.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
         pipelineConfigIds,
         buildTimeStartBoundary,
         buildTimeEndBoundary,
-        executionCriteria,
-        offset,
-        limit)
+        executionCriteria)
       )
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -152,7 +152,7 @@ public interface ExecutionRepository {
       return setStatuses(
         statuses
           .stream()
-          .map(ExecutionStatus::valueOf)
+          .map(it -> ExecutionStatus.valueOf(it.toUpperCase()))
           .collect(toList())
           .toArray(new ExecutionStatus[statuses.size()])
       );
@@ -206,14 +206,14 @@ public interface ExecutionRepository {
 
   enum ExecutionComparator implements Comparator<Execution> {
 
-    NATURAL {
+    NATURAL_ASC {
       @Override
       public int compare(Execution a, Execution b) {
         return b.getId().compareTo(a.getId());
       }
     },
 
-    REVERSE_NATURAL {
+    NATURAL_DESC {
       @Override
       public int compare(Execution a, Execution b) {
         return a.getId().compareTo(b.getId());
@@ -244,7 +244,7 @@ public interface ExecutionRepository {
       }
     },
 
-    REVERSE_BUILD_TIME {
+    BUILD_TIME_DESC {
       @Override
       public int compare(Execution a, Execution b) {
         Long aBuildTime = Optional.ofNullable(a.getBuildTime()).orElse(0L);
@@ -258,7 +258,7 @@ public interface ExecutionRepository {
       }
     },
 
-    BUILD_TIME {
+    BUILD_TIME_ASC {
       @Override
       public int compare(Execution a, Execution b) {
         Long aBuildTime = Optional.ofNullable(a.getBuildTime()).orElse(0L);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -71,21 +71,27 @@ public interface ExecutionRepository {
   Observable<Execution> retrievePipelinesForPipelineConfigId(@Nonnull String pipelineConfigId,
                                                              @Nonnull ExecutionCriteria criteria);
 
+  /**
+   * Returns executions in the time boundary. Redis impl does not respect pageSize or offset params,
+   *  and returns all executions. Sql impl respects these params.
+   * @param executionCriteria use this param to specify:
+   *  if there are statuses, only those will be returned
+   *  if there is a sort type that will be used to sort the results
+   *  use pageSize and page to control pagination
+   */
   @Nonnull
   List<Execution> retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
     @Nonnull List<String> pipelineConfigIds,
     long buildTimeStartBoundary,
     long buildTimeEndBoundary,
-    ExecutionCriteria executionCriteria,
-    int offset,
-    int limit
+    ExecutionCriteria executionCriteria
   );
 
   /**
    * Returns all executions in the time boundary
    * @param executionCriteria
    *  if there are statuses, only those will be returned
-   *  if there is a limit, that will be used as the page size
+   *  if there is a pageSize, that will be used as the page size
    *  if there is a sort type that will be used to sort the results
    */
   @Nonnull
@@ -123,18 +129,18 @@ public interface ExecutionRepository {
   List<String> retrieveAllExecutionIds(@Nonnull ExecutionType type);
 
   final class ExecutionCriteria {
-    private int limit = 3500;
+    private int pageSize = 3500;
     private Collection<ExecutionStatus> statuses = new ArrayList<>();
     private int page;
     private Instant startTimeCutoff;
     private ExecutionComparator sortType;
 
-    public int getLimit() {
-      return limit;
+    public int getPageSize() {
+      return pageSize;
     }
 
-    public @Nonnull ExecutionCriteria setLimit(int limit) {
-      this.limit = limit;
+    public @Nonnull ExecutionCriteria setPageSize(int pageSize) {
+      this.pageSize = pageSize;
       return this;
     }
 
@@ -188,13 +194,13 @@ public interface ExecutionRepository {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       ExecutionCriteria that = (ExecutionCriteria) o;
-      return limit == that.limit &&
+      return pageSize == that.pageSize &&
         Objects.equals(statuses, that.statuses) &&
         page == that.page;
     }
 
     @Override public int hashCode() {
-      return Objects.hash(limit, statuses, page);
+      return Objects.hash(pageSize, statuses, page);
     }
   }
 

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionComparatorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionComparatorSpec.groovy
@@ -19,8 +19,8 @@ import com.netflix.spinnaker.orca.pipeline.model.Execution
 import spock.lang.Specification
 
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.*
-import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.NATURAL
-import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.REVERSE_BUILD_TIME
+import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.NATURAL_ASC
+import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.BUILD_TIME_DESC
 import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.START_TIME_OR_ID
 
 class ExecutionComparatorSpec extends Specification {
@@ -34,7 +34,7 @@ class ExecutionComparatorSpec extends Specification {
     ]
 
     when:
-    executions.sort(NATURAL)
+    executions.sort(NATURAL_ASC)
 
     then:
     assert executions*.id == ["3", "2", "1"]
@@ -66,7 +66,7 @@ class ExecutionComparatorSpec extends Specification {
     ]
 
     when:
-    executions.sort(REVERSE_BUILD_TIME)
+    executions.sort(BUILD_TIME_DESC)
 
     then:
     assert executions*.id == ["2", "3", "1", "4"]

--- a/orca-migration/src/main/kotlin/com/netflix/spinnaker/orca/pipeline/persistence/migration/OrchestrationMigrationAgent.kt
+++ b/orca-migration/src/main/kotlin/com/netflix/spinnaker/orca/pipeline/persistence/migration/OrchestrationMigrationAgent.kt
@@ -41,7 +41,7 @@ class OrchestrationMigrationAgent(
     val previouslyMigratedOrchestrationIds = dualExecutionRepository.primary.retrieveAllExecutionIds(ORCHESTRATION)
 
     val executionCriteria = ExecutionRepository.ExecutionCriteria().apply {
-      limit = 3500
+      pageSize = 3500
       setStatuses(ExecutionStatus.COMPLETED.map { it.name })
     }
 

--- a/orca-migration/src/main/kotlin/com/netflix/spinnaker/orca/pipeline/persistence/migration/PipelineMigrationAgent.kt
+++ b/orca-migration/src/main/kotlin/com/netflix/spinnaker/orca/pipeline/persistence/migration/PipelineMigrationAgent.kt
@@ -40,7 +40,7 @@ class PipelineMigrationAgent(
     val previouslyMigratedPipelineIds = dualExecutionRepository.primary.retrieveAllExecutionIds(PIPELINE)
 
     val executionCriteria = ExecutionRepository.ExecutionCriteria().apply {
-      limit = 50
+      pageSize = 50
       setStatuses(ExecutionStatus.COMPLETED.map { it.name })
     }
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
@@ -84,7 +84,7 @@ public class PipelineTemplateService {
       return executionRepository.retrieve(PIPELINE, executionId);
     } else if (pipelineConfigId != null) {
       // No executionId set - use last execution
-      ExecutionRepository.ExecutionCriteria criteria = new ExecutionRepository.ExecutionCriteria().setLimit(1);
+      ExecutionRepository.ExecutionCriteria criteria = new ExecutionRepository.ExecutionCriteria().setPageSize(1);
       try {
         return executionRepository.retrievePipelinesForPipelineConfigId(pipelineConfigId, criteria)
           .toSingle()

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/OrcaMessageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/OrcaMessageHandler.kt
@@ -92,7 +92,7 @@ internal interface OrcaMessageHandler<M : Message> : MessageHandler<M> {
       !isLimitConcurrent -> false
       configId == null   -> false
       else               -> {
-        val criteria = ExecutionCriteria().setLimit(2).setStatuses(RUNNING)
+        val criteria = ExecutionCriteria().setPageSize(2).setStatuses(RUNNING)
         repository
           .retrievePipelinesForPipelineConfigId(configId, criteria)
           .filter { it.id != id }

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
@@ -207,17 +207,37 @@ class RedisInstrumentedExecutionRepository(
     }
   }
 
-  override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(pipelineConfigIds: MutableList<String>,
-                                                                             buildTimeStartBoundary: Long,
-                                                                             buildTimeEndBoundary: Long,
-                                                                             limit: Int): Observable<Execution> {
+  override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+    pipelineConfigIds: MutableList<String>,
+    buildTimeStartBoundary: Long,
+    buildTimeEndBoundary: Long,
+    executionCriteria: ExecutionRepository.ExecutionCriteria,
+    offset: Int,
+    limit: Int
+  ): List<Execution> {
     return withMetrics("retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary") {
       executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
         pipelineConfigIds,
         buildTimeStartBoundary,
         buildTimeEndBoundary,
-        limit
-      )
+        executionCriteria,
+        offset,
+        limit)
+    }
+  }
+
+  override fun retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+    pipelineConfigIds: MutableList<String>,
+    buildTimeStartBoundary: Long,
+    buildTimeEndBoundary: Long,
+    executionCriteria: ExecutionRepository.ExecutionCriteria
+  ): List<Execution> {
+    return withMetrics("retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary") {
+      executionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+        pipelineConfigIds,
+        buildTimeStartBoundary,
+        buildTimeEndBoundary,
+        executionCriteria)
     }
   }
 

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
@@ -208,7 +208,7 @@ class RedisInstrumentedExecutionRepository(
   }
 
   override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-    pipelineConfigIds: MutableList<String>,
+    pipelineConfigIds: List<String>,
     buildTimeStartBoundary: Long,
     buildTimeEndBoundary: Long,
     executionCriteria: ExecutionRepository.ExecutionCriteria,
@@ -227,7 +227,7 @@ class RedisInstrumentedExecutionRepository(
   }
 
   override fun retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-    pipelineConfigIds: MutableList<String>,
+    pipelineConfigIds: List<String>,
     buildTimeStartBoundary: Long,
     buildTimeEndBoundary: Long,
     executionCriteria: ExecutionRepository.ExecutionCriteria

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
@@ -208,21 +208,17 @@ class RedisInstrumentedExecutionRepository(
   }
 
   override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-    pipelineConfigIds: List<String>,
+    pipelineConfigIds: MutableList<String>,
     buildTimeStartBoundary: Long,
     buildTimeEndBoundary: Long,
-    executionCriteria: ExecutionRepository.ExecutionCriteria,
-    offset: Int,
-    limit: Int
+    executionCriteria: ExecutionRepository.ExecutionCriteria
   ): List<Execution> {
     return withMetrics("retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary") {
       executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
         pipelineConfigIds,
         buildTimeStartBoundary,
         buildTimeEndBoundary,
-        executionCriteria,
-        offset,
-        limit)
+        executionCriteria)
     }
   }
 

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
@@ -339,7 +339,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
       11L,
       new ExecutionCriteria()
     )
-    retrieved.sort(BUILD_TIME)
+    retrieved.sort(BUILD_TIME_ASC)
 
     then:
     retrieved*.buildTime == [9L, 11L]

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
@@ -22,9 +22,9 @@ import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.orca.pipeline.model.DefaultTrigger
+import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepositoryTck
 import redis.clients.jedis.Jedis
 import redis.clients.util.Pool
@@ -41,6 +41,8 @@ import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_AFTER
 import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAGE_BEFORE
+import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.*
+import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.*
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.*
 import static java.util.concurrent.TimeUnit.SECONDS
 
@@ -144,7 +146,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     }
 
     when:
-    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionRepository.ExecutionCriteria(limit: limit))
+    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(limit: limit))
       .toList().toBlocking().first()
 
     then:
@@ -255,7 +257,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     // TODO-AJ limits are current applied to each backing redis
-    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionRepository.ExecutionCriteria(limit: 2))
+    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(limit: 2))
       .toList().toBlocking().first()
 
     then:
@@ -280,7 +282,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     repository.delete(orchestration1.type, orchestration1.id)
-    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionRepository.ExecutionCriteria(limit: 2))
+    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(limit: 2))
       .toList().toBlocking().first()
 
     then:
@@ -288,7 +290,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     repository.delete(orchestration2.type, orchestration2.id)
-    retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionRepository.ExecutionCriteria(limit: 2))
+    retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(limit: 2))
       .toList().toBlocking().first()
 
     then:
@@ -331,14 +333,15 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     })
 
     when:
-    def retrieved = repository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+    List<Execution> retrieved = repository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
       Arrays.asList("pipeline-2", "pipeline-3"),
       9L,
       11L,
+      new ExecutionCriteria(),
+      1,
       10
     )
-      .sorted({ a, b -> a.buildTime <=> b.buildTime })
-      .toList().toBlocking().first()
+    retrieved.sort(BUILD_TIME)
 
     then:
     retrieved*.buildTime == [9L, 11L]
@@ -405,7 +408,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     // TODO-AJ limits are current applied to each backing redis
-    def retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionRepository.ExecutionCriteria(limit: 2))
+    def retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionCriteria(limit: 2))
       .toList().toBlocking().first()
 
     then:
@@ -432,7 +435,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     repository.delete(pipeline1.type, pipeline1.id)
-    def retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionRepository.ExecutionCriteria(limit: 2))
+    def retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionCriteria(limit: 2))
       .toList().toBlocking().first()
 
     then:
@@ -440,7 +443,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     repository.delete(pipeline2.type, pipeline2.id)
-    retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionRepository.ExecutionCriteria(limit: 2))
+    retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionCriteria(limit: 2))
       .toList().toBlocking().first()
 
     then:

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
@@ -146,7 +146,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     }
 
     when:
-    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(limit: limit))
+    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(pageSize: limit))
       .toList().toBlocking().first()
 
     then:
@@ -257,7 +257,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     // TODO-AJ limits are current applied to each backing redis
-    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(limit: 2))
+    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(pageSize: 2))
       .toList().toBlocking().first()
 
     then:
@@ -282,7 +282,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     repository.delete(orchestration1.type, orchestration1.id)
-    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(limit: 2))
+    def retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(pageSize: 2))
       .toList().toBlocking().first()
 
     then:
@@ -290,7 +290,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     repository.delete(orchestration2.type, orchestration2.id)
-    retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(limit: 2))
+    retrieved = repository.retrieveOrchestrationsForApplication("orca", new ExecutionCriteria(pageSize: 2))
       .toList().toBlocking().first()
 
     then:
@@ -337,9 +337,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
       Arrays.asList("pipeline-2", "pipeline-3"),
       9L,
       11L,
-      new ExecutionCriteria(),
-      1,
-      10
+      new ExecutionCriteria()
     )
     retrieved.sort(BUILD_TIME)
 
@@ -408,7 +406,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     // TODO-AJ limits are current applied to each backing redis
-    def retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionCriteria(limit: 2))
+    def retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionCriteria(pageSize: 2))
       .toList().toBlocking().first()
 
     then:
@@ -435,7 +433,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     repository.delete(pipeline1.type, pipeline1.id)
-    def retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionCriteria(limit: 2))
+    def retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionCriteria(pageSize: 2))
       .toList().toBlocking().first()
 
     then:
@@ -443,7 +441,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
     when:
     repository.delete(pipeline2.type, pipeline2.id)
-    retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionCriteria(limit: 2))
+    retrieved = repository.retrievePipelinesForPipelineConfigId("pipeline-1", new ExecutionCriteria(pageSize: 2))
       .toList().toBlocking().first()
 
     then:

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -406,7 +406,7 @@ class SqlExecutionRepository(
   }
 
   override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-    pipelineConfigIds: MutableList<String>,
+    pipelineConfigIds: List<String>,
     buildTimeStartBoundary: Long,
     buildTimeEndBoundary: Long,
     executionCriteria: ExecutionCriteria,
@@ -442,7 +442,7 @@ class SqlExecutionRepository(
   }
 
   override fun retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-    pipelineConfigIds: MutableList<String>,
+    pipelineConfigIds: List<String>,
     buildTimeStartBoundary: Long,
     buildTimeEndBoundary: Long,
     executionCriteria: ExecutionCriteria

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -33,8 +33,8 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.NATURAL
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.REVERSE_BUILD_TIME
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.NATURAL_ASC
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.BUILD_TIME_DESC
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.START_TIME_OR_ID
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionCriteria
 import com.netflix.spinnaker.orca.pipeline.persistence.UnpausablePipelineException
@@ -270,7 +270,7 @@ class SqlExecutionRepository(
     application: String,
     criteria: ExecutionCriteria
   ): Observable<Execution> {
-    return Observable.from(retrieveOrchestrationsForApplication(application, criteria, NATURAL))
+    return Observable.from(retrieveOrchestrationsForApplication(application, criteria, NATURAL_ASC))
   }
 
   override fun retrieveOrchestrationsForApplication(
@@ -298,7 +298,7 @@ class SqlExecutionRepository(
       seek = {
         val ordered = when (sorter) {
           START_TIME_OR_ID -> it.orderBy(field("start_time").desc().nullsFirst(), field("id").desc())
-          REVERSE_BUILD_TIME -> it.orderBy(field("build_time").asc(), field("id").asc())
+          BUILD_TIME_DESC -> it.orderBy(field("build_time").asc(), field("id").asc())
           else -> it.orderBy(field("id").desc())
         }
 
@@ -426,10 +426,10 @@ class SqlExecutionRepository(
       },
       seek = {
         val seek = when (executionCriteria.sortType) {
-          ExecutionComparator.BUILD_TIME -> it.orderBy(field("build_time").asc())
-          ExecutionComparator.REVERSE_BUILD_TIME -> it.orderBy(field("build_time").desc())
+          ExecutionComparator.BUILD_TIME_ASC -> it.orderBy(field("build_time").asc())
+          ExecutionComparator.BUILD_TIME_DESC -> it.orderBy(field("build_time").desc())
           ExecutionComparator.START_TIME_OR_ID -> it.orderBy(field("start_time").desc())
-          ExecutionComparator.NATURAL -> it.orderBy(field("id").desc())
+          ExecutionComparator.NATURAL_ASC -> it.orderBy(field("id").desc())
           else -> it.orderBy(field("id").asc())
         }
         seek

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
@@ -218,21 +218,17 @@ class SqlInstrumentedExecutionRepository(
   }
 
   override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-    pipelineConfigIds: List<String>,
+    pipelineConfigIds: MutableList<String>,
     buildTimeStartBoundary: Long,
     buildTimeEndBoundary: Long,
-    executionCriteria: ExecutionCriteria,
-    offset: Int,
-    limit: Int
+    executionCriteria: ExecutionCriteria
   ): List<Execution> {
     return withMetrics("retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary") {
       executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
         pipelineConfigIds,
         buildTimeStartBoundary,
         buildTimeEndBoundary,
-        executionCriteria,
-        offset,
-        limit)
+        executionCriteria)
     }
   }
 

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
@@ -217,17 +217,37 @@ class SqlInstrumentedExecutionRepository(
     }
   }
 
-  override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(pipelineConfigIds: MutableList<String>,
-                                                                             buildTimeStartBoundary: Long,
-                                                                             buildTimeEndBoundary: Long,
-                                                                             limit: Int): Observable<Execution> {
+  override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+    pipelineConfigIds: MutableList<String>,
+    buildTimeStartBoundary: Long,
+    buildTimeEndBoundary: Long,
+    executionCriteria: ExecutionCriteria,
+    offset: Int,
+    limit: Int
+  ): List<Execution> {
     return withMetrics("retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary") {
       executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
         pipelineConfigIds,
         buildTimeStartBoundary,
         buildTimeEndBoundary,
-        limit
-      )
+        executionCriteria,
+        offset,
+        limit)
+    }
+  }
+
+  override fun retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+    pipelineConfigIds: MutableList<String>,
+    buildTimeStartBoundary: Long,
+    buildTimeEndBoundary: Long,
+    executionCriteria: ExecutionCriteria
+  ): List<Execution> {
+    return withMetrics("retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary") {
+      executionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+        pipelineConfigIds,
+        buildTimeStartBoundary,
+        buildTimeEndBoundary,
+        executionCriteria)
     }
   }
 

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
@@ -218,7 +218,7 @@ class SqlInstrumentedExecutionRepository(
   }
 
   override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-    pipelineConfigIds: MutableList<String>,
+    pipelineConfigIds: List<String>,
     buildTimeStartBoundary: Long,
     buildTimeEndBoundary: Long,
     executionCriteria: ExecutionCriteria,
@@ -237,7 +237,7 @@ class SqlInstrumentedExecutionRepository(
   }
 
   override fun retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
-    pipelineConfigIds: MutableList<String>,
+    pipelineConfigIds: List<String>,
     buildTimeStartBoundary: Long,
     buildTimeEndBoundary: Long,
     executionCriteria: ExecutionCriteria

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositorySpec.groovy
@@ -470,14 +470,14 @@ class SqlExecutionRepositorySpec extends ExecutionRepositoryTck<SqlExecutionRepo
       ["foo1", "foo2"],
       0L,
       5L,
-      new ExecutionCriteria().setPageSize(1).setSortType(BUILD_TIME)
+      new ExecutionCriteria().setPageSize(1).setSortType(BUILD_TIME_ASC)
     )
     List<Execution> backwardsResults = repository
       .retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
       ["foo1", "foo2"],
       0L,
       5L,
-      new ExecutionCriteria().setPageSize(1).setSortType(REVERSE_BUILD_TIME)
+      new ExecutionCriteria().setPageSize(1).setSortType(BUILD_TIME_DESC)
     )
 
     then:

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositorySpec.groovy
@@ -282,7 +282,7 @@ class SqlExecutionRepositorySpec extends ExecutionRepositoryTck<SqlExecutionRepo
 
   def "no specified page retrieves first page"() {
     given:
-    def criteria = new ExecutionCriteria().setLimit(limit)
+    def criteria = new ExecutionCriteria().setPageSize(limit)
 
     and:
     (limit + 1).times { i ->
@@ -304,7 +304,7 @@ class SqlExecutionRepositorySpec extends ExecutionRepositoryTck<SqlExecutionRepo
 
     then:
     with(results) {
-      size() == criteria.limit
+      size() == criteria.pageSize
       first().name == "Orchestration #${limit + 1}"
       last().name == "Orchestration #2"
     }
@@ -315,7 +315,7 @@ class SqlExecutionRepositorySpec extends ExecutionRepositoryTck<SqlExecutionRepo
 
   def "out of range page retrieves empty result set"() {
     given:
-    def criteria = new ExecutionCriteria().setLimit(limit).setPage(3)
+    def criteria = new ExecutionCriteria().setPageSize(limit).setPage(3)
 
     and:
     (limit + 1).times { i ->
@@ -342,7 +342,7 @@ class SqlExecutionRepositorySpec extends ExecutionRepositoryTck<SqlExecutionRepo
 
   def "page param > 1 retrieves the relevant page"() {
     given:
-    def criteria = new ExecutionCriteria().setLimit(limit).setPage(2)
+    def criteria = new ExecutionCriteria().setPageSize(limit).setPage(2)
 
     and:
     (limit + 1).times { i ->
@@ -375,7 +375,7 @@ class SqlExecutionRepositorySpec extends ExecutionRepositoryTck<SqlExecutionRepo
   @Unroll
   def "page size param restricts the number of results"() {
     given:
-    def criteria = new ExecutionCriteria().setLimit(limit).setPage(page)
+    def criteria = new ExecutionCriteria().setPageSize(limit).setPage(page)
 
     and:
     executions.times { i ->
@@ -433,9 +433,7 @@ class SqlExecutionRepositorySpec extends ExecutionRepositoryTck<SqlExecutionRepo
       ["foo1", "foo2"],
       0L,
       6L,
-      new ExecutionCriteria(),
-      0,
-      retrieveLimit * 2
+      new ExecutionCriteria()
     )
 
     then:
@@ -472,14 +470,14 @@ class SqlExecutionRepositorySpec extends ExecutionRepositoryTck<SqlExecutionRepo
       ["foo1", "foo2"],
       0L,
       5L,
-      new ExecutionCriteria().setLimit(1).setSortType(BUILD_TIME)
+      new ExecutionCriteria().setPageSize(1).setSortType(BUILD_TIME)
     )
     List<Execution> backwardsResults = repository
       .retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
       ["foo1", "foo2"],
       0L,
       5L,
-      new ExecutionCriteria().setLimit(1).setSortType(REVERSE_BUILD_TIME)
+      new ExecutionCriteria().setPageSize(1).setSortType(REVERSE_BUILD_TIME)
     )
 
     then:

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/ProjectController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/ProjectController.groovy
@@ -59,7 +59,7 @@ class ProjectController {
 
     statuses = statuses ?: ExecutionStatus.values()*.toString().join(",")
     def executionCriteria = new ExecutionRepository.ExecutionCriteria(
-      limit: limit,
+      pageSize: limit,
       statuses: (statuses.split(",") as Collection)
     )
 

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -313,6 +313,11 @@ class TaskController {
   ) {
     validateSearchForPipelinesByTriggerParameters(triggerTimeStartBoundary, triggerTimeEndBoundary, startIndex, size)
 
+    ExecutionComparator sortType = BUILD_TIME_DESC
+    if (reverse) {
+      sortType = BUILD_TIME_ASC
+    }
+
     // Returned map will be empty if encodedTriggerParams is null
     final Map triggerParams = decodeTriggerParams(encodedTriggerParams)
 
@@ -337,7 +342,7 @@ class TaskController {
     }
 
     ExecutionCriteria executionCriteria =  new ExecutionCriteria()
-      .setSortType( reverse ? REVERSE_BUILD_TIME : BUILD_TIME )
+      .setSortType( sortType )
     if (statuses != null && statuses != "") {
       executionCriteria.setStatuses(statuses.split(",").toList())
     }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -59,7 +59,8 @@ import java.util.stream.Collectors
 
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
-import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.START_TIME_OR_ID
+import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.*
+import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.*
 
 @Slf4j
 @RestController
@@ -105,7 +106,7 @@ class TaskController {
     @RequestParam(value = "statuses", required = false) String statuses
   ) {
     statuses = statuses ?: ExecutionStatus.values()*.toString().join(",")
-    def executionCriteria = new ExecutionRepository.ExecutionCriteria()
+    def executionCriteria = new ExecutionCriteria()
       .setPage(page)
       .setLimit(limit)
       .setStatuses(statuses.split(",") as Collection)
@@ -202,7 +203,7 @@ class TaskController {
     @RequestParam(value = "expand", defaultValue = "true") boolean expand) {
     statuses = statuses ?: ExecutionStatus.values()*.toString().join(",")
     limit = limit ?: 1
-    ExecutionRepository.ExecutionCriteria executionCriteria = new ExecutionRepository.ExecutionCriteria(
+    ExecutionCriteria executionCriteria = new ExecutionCriteria(
       limit: limit,
       statuses: (statuses.split(",") as Collection)
     )
@@ -312,29 +313,47 @@ class TaskController {
   ) {
     validateSearchForPipelinesByTriggerParameters(triggerTimeStartBoundary, triggerTimeEndBoundary, startIndex, size)
 
-    final Map triggerParams = decodeTriggerParams(encodedTriggerParams) // Returned map will be empty if encodedTriggerParams is null
+    // Returned map will be empty if encodedTriggerParams is null
+    final Map triggerParams = decodeTriggerParams(encodedTriggerParams)
 
-    Set<String> triggerTypesAsSet = (triggerTypes && triggerTypes != "*") ? triggerTypes.split(",") as Set : null // null means all trigger types
-    Set<String> statusesAsSet = (statuses && statuses != "*") ? statuses.split(",") as Set : null // null means all statuses
+    Set<String> triggerTypesAsSet = (triggerTypes && triggerTypes != "*")
+      ? triggerTypes.split(",") as Set
+      : null // null means all trigger types
 
-    // Filter by application
-    List<String> pipelineConfigIds = application == "*" ?
-    getPipelineConfigIdsOfReadableApplications() :
-    front50Service.getPipelines(application, false)*.id as List<String>
-
-    List<Execution> pipelineExecutions = executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(pipelineConfigIds, triggerTimeStartBoundary, triggerTimeEndBoundary, size)
-      .subscribeOn(Schedulers.io())
-      .filter{
-        // Filter by pipeline name
-        if (pipelineName && pipelineName != it.name) {
-          return false
+    // Filter by application (and pipeline name, if that parameter has been given in addition to application name)
+    List<String> pipelineConfigIds
+    if (application == "*") {
+      pipelineConfigIds = getPipelineConfigIdsOfReadableApplications()
+    } else {
+      List<Map<String, Object>> pipelines = front50Service.getPipelines(application, false)
+      pipelines = pipelines.stream().filter({ pipeline ->
+        if (pipelineName != null && pipelineName != "") {
+          return pipeline.get("name") == pipelineName
+        } else {
+          return true
         }
+      }).collect(Collectors.toList())
+      pipelineConfigIds = pipelines*.id as List<String>
+    }
+
+    ExecutionCriteria executionCriteria =  new ExecutionCriteria()
+      .setSortType( reverse ? REVERSE_BUILD_TIME : BUILD_TIME )
+    if (statuses != null && statuses != "") {
+      executionCriteria.setStatuses(statuses.split(",").toList())
+    }
+
+    List<Execution> allExecutions = executionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+      pipelineConfigIds,
+      triggerTimeStartBoundary,
+      triggerTimeEndBoundary,
+      executionCriteria
+    )
+
+    List<Execution> matchingExecutions = allExecutions
+      .stream()
+      .filter({
         // Filter by trigger type
         if (triggerTypesAsSet && !triggerTypesAsSet.contains(it.getTrigger().type)) {
-          return false
-        }
-        // Filter by statuses
-        if (statusesAsSet && !statusesAsSet.contains(it.getStatus().toString())) {
           return false
         }
         // Filter by event ID
@@ -343,21 +362,14 @@ class TaskController {
         }
         // Filter by trigger params
         return compareTriggerWithTriggerSubset(it.getTrigger(), triggerParams)
-      }
-      .toList()
-      .toBlocking()
-      .single()
-      .sort(reverseBuildTime)
-
-    if (reverse) {
-      pipelineExecutions.reverse(true)
-    }
+      })
+      .collect(Collectors.toList())
 
     List<Execution> rval
-    if (startIndex >= pipelineExecutions.size()) {
+    if (startIndex >= matchingExecutions.size()) {
       rval = []
     } else {
-      rval = pipelineExecutions.subList(startIndex, Math.min(pipelineExecutions.size(), startIndex + size))
+      rval = matchingExecutions.subList(startIndex, Math.min(matchingExecutions.size(), startIndex + size))
     }
 
     if (!expand) {
@@ -527,7 +539,7 @@ class TaskController {
     }
 
     statuses = statuses ?: ExecutionStatus.values()*.toString().join(",")
-    def executionCriteria = new ExecutionRepository.ExecutionCriteria(
+    def executionCriteria = new ExecutionCriteria(
       limit: limit,
       statuses: (statuses.split(",") as Collection)
     )

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -108,7 +108,7 @@ class TaskController {
     statuses = statuses ?: ExecutionStatus.values()*.toString().join(",")
     def executionCriteria = new ExecutionCriteria()
       .setPage(page)
-      .setLimit(limit)
+      .setPageSize(limit)
       .setStatuses(statuses.split(",") as Collection)
       .setStartTimeCutoff(
         clock
@@ -204,7 +204,7 @@ class TaskController {
     statuses = statuses ?: ExecutionStatus.values()*.toString().join(",")
     limit = limit ?: 1
     ExecutionCriteria executionCriteria = new ExecutionCriteria(
-      limit: limit,
+      pageSize: limit,
       statuses: (statuses.split(",") as Collection)
     )
 
@@ -540,7 +540,7 @@ class TaskController {
 
     statuses = statuses ?: ExecutionStatus.values()*.toString().join(",")
     def executionCriteria = new ExecutionCriteria(
-      limit: limit,
+      pageSize: limit,
       statuses: (statuses.split(",") as Collection)
     )
 

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -36,6 +36,7 @@ import java.time.Clock
 import java.time.Instant
 
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION
+import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionComparator.*
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.*
 import static java.time.ZoneOffset.UTC
 import static java.time.temporal.ChronoUnit.DAYS
@@ -159,7 +160,7 @@ class TaskControllerSpec extends Specification {
     def response = mockMvc.perform(get("/applications/$app/tasks")).andReturn().response
 
     then:
-    1 * executionRepository.retrieveOrchestrationsForApplication(app, _, _) >> []
+    1 * executionRepository.retrieveOrchestrationsForApplication(app, _, START_TIME_OR_ID) >> []
 
     where:
     app = "test"


### PR DESCRIPTION
A user discovered a situation where SQL behaves differently than Redis:
```
$ SIZE=100
$ curl -s "https://spinnaker/applications/my_app/executions/search?application=my_app&pipelineName=DEPLOY&triggerTimeStartBoundary=1539846060000&triggerTimeEndBoundary=1539964800000&reverse=true&size=$SIZE" | jq '. | length'
27

$ SIZE=1000
$ curl -s "https://spinnaker/applications/my_app/executions/search?application=my_app&pipelineName=DEPLOY&triggerTimeStartBoundary=1539846060000&triggerTimeEndBoundary=1539964800000&reverse=true&size=$SIZE" | jq '. | length'
98
```

This happens because with redis, we'd get all the executions and then filter down to the matching ones. In sql, we are only getting `limit` number of executions and then filtering them down to the matching ones. This is unexpected.

This PR does a couple of things:
 - removes `Observables` from this endpoint, since we immediately block.
 - creates a new execution repository endpoint which returns all executions in a time period, sorted how you specify. This allows each executionRepositoryImpl to handle pagination and sorting however it would like.
- fixed the problem stated above.

