### PR TITLE
fix(targeting): Adds autoscaling policy getter.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -85,6 +85,14 @@ class TargetServerGroup {
     return serverGroup?.moniker ? objectMapper.convertValue(serverGroup?.moniker, Moniker) : null
   }
 
+  /**
+   * Used in UpsertGceAutoscalingPolicy, which is Java, which doesn't play nice with @Delegate
+   * @return
+   */
+  Map<String, Object> getAutoscalingPolicy() {
+    return (Map<String, Object>) serverGroup.autoscalingPolicy
+  }
+
   Map toClouddriverOperationPayload(String account) {
     //TODO(cfieber) - add an endpoint on Clouddriver to do provider appropriate conversion of a TargetServerGroup
     def op = [


### PR DESCRIPTION
We access autoscaling policy fields when synthesizing
dynamic stages if the server group is autoscaled.
We have to explicitly add the getter for java-groovy interop.

This is a port of the relevant parts of https://github.com/spinnaker/orca/pull/2488.