### PR TITLE
feat(pipeline): Support conditional disabling of `ServerGroupCacheForceRefreshTask`

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/BulkDestroyServerGroupStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/BulkDestroyServerGroupStage.java
@@ -37,7 +37,6 @@ public class BulkDestroyServerGroupStage implements StageDefinitionBuilder, Name
     this.dynamicConfigService = dynamicConfigService;
   }
 
-
   @Override
   public void taskGraph(Stage stage, TaskNode.Builder builder) {
     //TODO(cfieber): how to do locking here...

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheStatusService
 import retrofit.client.Response
@@ -36,8 +37,16 @@ import static java.net.HttpURLConnection.HTTP_OK
 
 class ServerGroupCacheForceRefreshTaskSpec extends Specification {
 
+  def cacheStatusService = Mock(CloudDriverCacheStatusService)
+  def cacheService = Mock(CloudDriverCacheService)
+
   @Subject
-  def task = new ServerGroupCacheForceRefreshTask(objectMapper: new ObjectMapper())
+  def task = new ServerGroupCacheForceRefreshTask(
+    cacheStatusService,
+    cacheService,
+    new ObjectMapper(),
+    new NoopRegistry()
+  )
   def stage = stage()
 
   def deployConfig = [
@@ -49,8 +58,6 @@ class ServerGroupCacheForceRefreshTaskSpec extends Specification {
   def setup() {
     stage.context.putAll(deployConfig)
     stage.startTime = 0
-    task.cacheService = Mock(CloudDriverCacheService)
-    task.cacheStatusService = Mock(CloudDriverCacheStatusService)
   }
 
   void "should force cache refresh server groups via clouddriver"() {


### PR DESCRIPTION
Added the `isForceCacheRefreshEnabled()` in a few more stages.

A new `tasks.serverGroupCacheForceRefresh` metric can be used to track
down which stages are still using server group force cache refresh.
(metric should be removable in the future)
