### PR TITLE
refactor(mort): add getAllAccountDetails access via Clouddriver

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingMortService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingMortService.java
@@ -51,7 +51,12 @@ public class DelegatingMortService
   }
 
   @Override
-  public Map getAccountDetails(String account) {
+  public AccountDetails getAccountDetails(String account) {
     return getService().getAccountDetails(account);
+  }
+
+  @Override
+  public List<AccountDetails> getAllAccountDetails() {
+    return getService().getAllAccountDetails();
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/MortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/MortService.groovy
@@ -17,6 +17,10 @@
 
 package com.netflix.spinnaker.orca.clouddriver
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonRawValue
 import com.fasterxml.jackson.annotation.JsonSetter
 import com.fasterxml.jackson.databind.JsonNode
@@ -50,7 +54,37 @@ interface MortService {
                                       @Query("type") String type)
 
   @GET("/credentials/{account}")
-  Map getAccountDetails(@Path("account") String account)
+  AccountDetails getAccountDetails(@Path("account") String account)
+
+  @GET("/credentials?expand=true")
+  List<AccountDetails> getAllAccountDetails()
+
+  @JsonIgnoreProperties(ignoreUnknown = false)
+  static class AccountDetails {
+    String name
+    String accountId
+    String type
+    String providerVersion
+    Collection<String> requiredGroupMembership = []
+    String skin
+    Map<String, Collection<String>> permissions
+    String accountType
+    String environment
+    Boolean challengeDestructiveActions
+    Boolean primaryAccount
+    String cloudProvider
+    private Map<String, Object> details = new HashMap<String, Object>()
+
+    @JsonAnyGetter
+    public Map<String,Object> details() {
+      return details
+    }
+
+    @JsonAnySetter
+    public void set(String name, Object value) {
+      details.put(name, value)
+    }
+  }
 
   static class SearchResult {
     int totalMatches

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -23,9 +23,6 @@ import retrofit.client.Response
 import retrofit.http.*
 
 interface Front50Service {
-  @GET("/credentials")
-  List<Front50Credential> getCredentials()
-
   @GET("/v2/applications/{applicationName}")
   Application get(@Path("applicationName") String applicationName)
 


### PR DESCRIPTION
The front50 endpoint doesn't work and is unused.

This mort endpoint is great and I would like this data in a task in our internal build.