### PR TITLE
fix(appDelete): Handle retrofit exceptions with no response object.

### DIFF
--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/VerifyApplicationHasNoDependenciesTask.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/VerifyApplicationHasNoDependenciesTask.groovy
@@ -59,7 +59,10 @@ class VerifyApplicationHasNoDependenciesTask implements Task {
         existingDependencyTypes << "security groups"
       }
     } catch (RetrofitError e) {
-      if (e.response?.status != 404) {
+      if (!e.response) {
+        def exception = [operation: stage.tasks[-1].name, reason: e.message]
+        return new TaskResult(ExecutionStatus.TERMINAL, [exception: exception])
+      } else if (e.response && e.response.status && e.response.status != 404) {
         def resp = e.response
         def exception = [statusCode: resp.status, operation: stage.tasks[-1].name, url: resp.url, reason: resp.reason]
         try {


### PR DESCRIPTION
See https://github.com/spinnaker/spinnaker/issues/3857 for context, we NPEd in the error handling so we couldn't even see the proper exception from Retrofit.