### PR TITLE
feat(retrofit): Support registering custom interceptors

### DIFF
--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
@@ -21,11 +21,8 @@ import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.config.OkHttpClientConfiguration
-import com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor
-import com.netflix.spinnaker.okhttp.OkHttpMetricsInterceptor
 import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler
 import groovy.transform.CompileStatic
-import okhttp3.ConnectionPool
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
@@ -42,33 +39,41 @@ import org.springframework.core.annotation.Order
 import retrofit.RestAdapter.LogLevel
 import retrofit.client.OkClient
 
-import java.util.concurrent.TimeUnit
-
 @Configuration
 @CompileStatic
 @Import(OkHttp3ClientConfiguration)
 @EnableConfigurationProperties
 class RetrofitConfiguration {
-   @Bean(name = ["retrofitClient"])
-   @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
-   Ok3Client ok3Client(Registry registry, OkHttp3ClientConfiguration okHttpClientConfig) {
-     final String userAgent = "Spinnaker-${System.getProperty('spring.application.name', 'unknown')}/${getClass().getPackage().implementationVersion ?: '1.0'}"
-     OkHttpClient.Builder builder = okHttpClientConfig.create()
-     builder.addNetworkInterceptor(
-       new Interceptor() {
-         @Override
-         Response intercept(Interceptor.Chain chain) throws IOException {
-           def req = chain.request().newBuilder().header('User-Agent', userAgent).build()
-           chain.proceed(req)
-         }
-       })
+  @Bean(name = ["retrofitClient"])
+  @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+  Ok3Client ok3Client(Registry registry,
+                      OkHttp3ClientConfiguration okHttpClientConfig,
+                      Optional<List<RetrofitInterceptorProvider>> retrofitInterceptorProviders) {
+    final String userAgent = "Spinnaker-${System.getProperty('spring.application.name', 'unknown')}/${getClass().getPackage().implementationVersion ?: '1.0'}"
+    OkHttpClient.Builder builder = okHttpClientConfig.create()
+    builder.addNetworkInterceptor(
+      new Interceptor() {
+        @Override
+        Response intercept(Interceptor.Chain chain) throws IOException {
+          def req = chain.request().newBuilder().header('User-Agent', userAgent).build()
+          chain.proceed(req)
+        }
+      })
 
-     new Ok3Client(builder.build())
+    (retrofitInterceptorProviders.orElse([])).each { provider ->
+      provider.interceptors.each { interceptor ->
+        builder.addInterceptor(interceptor);
+      }
+    }
+
+    new Ok3Client(builder.build())
   }
 
   @Bean
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-  OkClient okClient(Registry registry, @Qualifier("okHttpClientConfiguration") OkHttpClientConfiguration okHttpClientConfig) {
+  OkClient okClient(Registry registry,
+                    @Qualifier("okHttpClientConfiguration") OkHttpClientConfiguration okHttpClientConfig,
+                    Optional<List<RetrofitInterceptorProvider>> retrofitInterceptorProviders) {
     final String userAgent = "Spinnaker-${System.getProperty('spring.application.name', 'unknown')}/${getClass().getPackage().implementationVersion ?: '1.0'}"
     def cfg = okHttpClientConfig.create()
     cfg.networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
@@ -79,15 +84,23 @@ class RetrofitConfiguration {
       }
     })
 
+    (retrofitInterceptorProviders.orElse([])).each { provider ->
+      provider.legacyInterceptors.each { interceptor ->
+        cfg.interceptors().add(interceptor)
+      }
+    }
+
     new OkClient(cfg)
   }
 
-  @Bean LogLevel retrofitLogLevel(@Value('${retrofit.logLevel:BASIC}') String retrofitLogLevel) {
+  @Bean
+  LogLevel retrofitLogLevel(@Value('${retrofit.logLevel:BASIC}') String retrofitLogLevel) {
     return LogLevel.valueOf(retrofitLogLevel)
   }
 
-  @Bean @Order(Ordered.HIGHEST_PRECEDENCE) RetrofitExceptionHandler retrofitExceptionHandler() {
+  @Bean
+  @Order(Ordered.HIGHEST_PRECEDENCE)
+  RetrofitExceptionHandler retrofitExceptionHandler() {
     new RetrofitExceptionHandler()
   }
-
 }

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitInterceptorProvider.java
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitInterceptorProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.retrofit;
+
+import java.util.List;
+
+public interface RetrofitInterceptorProvider {
+  List<okhttp3.Interceptor> getInterceptors();
+  List<com.squareup.okhttp.Interceptor> getLegacyInterceptors();
+}


### PR DESCRIPTION
The `RetrofitInterceptorProvider` interface provides an extension point
through which additional okhttp/okhttp3 interceptors can be registered.
