### PR TITLE
fix(webhooks): use error field consistently

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
@@ -67,7 +67,7 @@ class CreateWebhookTask implements RetryableTask {
       if ((stageData.failFastStatusCodes != null) &&
         (stageData.failFastStatusCodes.contains(statusCode.value()))) {
         String webhookMessage = "Received a status code configured to fail fast, terminating stage."
-        outputs.webhook << [errorMessage: webhookMessage]
+        outputs.webhook << [error: webhookMessage]
 
         return new TaskResult(ExecutionStatus.TERMINAL, outputs)
       }
@@ -76,7 +76,7 @@ class CreateWebhookTask implements RetryableTask {
         String errorMessage = "error submitting webhook for pipeline ${stage.execution.id} to ${stageData.url}, will retry."
         log.warn(errorMessage, e)
 
-        outputs.webhook << [errorMessage: errorMessage]
+        outputs.webhook << [error: errorMessage]
 
         return new TaskResult(ExecutionStatus.RUNNING, outputs)
       }

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
@@ -182,7 +182,7 @@ class CreateWebhookTaskSpec extends Specification {
       webhook: [
         statusCode: HttpStatus.TOO_MANY_REQUESTS,
         statusCodeValue: HttpStatus.TOO_MANY_REQUESTS.value(),
-        errorMessage: errorMessage
+        error: errorMessage
       ]
     ]
   }
@@ -214,7 +214,7 @@ class CreateWebhookTaskSpec extends Specification {
     result.status == ExecutionStatus.TERMINAL
     result.context as Map == [
       webhook: [
-        errorMessage: "Received a status code configured to fail fast, terminating stage.",
+        error: "Received a status code configured to fail fast, terminating stage.",
         statusCode: HttpStatus.SERVICE_UNAVAILABLE,
         statusCodeValue: HttpStatus.SERVICE_UNAVAILABLE.value(),
         body: bodyString


### PR DESCRIPTION
Always use `error` (never `errorMessage`) to report errors from webhooks stage
This is what UI looks for (improvements in that area will be PR'd shortly)

