### PR TITLE
(fix): Possible NPE with `WaitForManifestStableTask`

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTask.java
@@ -91,7 +91,7 @@ public class WaitForManifestStableTask implements OverridableTimeoutRetryableTas
         Status status = manifest.getStatus();
         if (status.getStable() == null || !status.getStable().isState()) {
           allStable = false;
-          messages.add(identifier + ": " + status.getStable().getMessage());
+          messages.add(identifier + ": waiting for manifest to stabilize");
         }
 
         Map<String, String> manifestNameAndLocation = ImmutableMap.<String, String>builder().


### PR DESCRIPTION
In the event that `status.getStable() == null` then `status.getStable().getMessage()` will throw an NPE

We ran into this in a production setting. Happy to discuss other alternatives.