### PR TITLE
feat(bake): if base name is empty string, remove from bake request

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -186,6 +186,10 @@ class CreateBakeTask implements RetryableTask {
       requestMap.remove("baseOs")
     }
 
+    if (requestMap.baseName == "") {
+      requestMap.remove("baseName")
+    }
+
     def request = mapper.convertValue(requestMap, BakeRequest)
     if (!roscoApisEnabled) {
       request.other.clear()


### PR DESCRIPTION
We have a user who is using SpEL to conditionally set the `baseName` in the bake. If the parameter of the pipeline has a value for baseName, it's set in the stage. If the parameter is empty, they send us empty string because there is no way to conditionally set a field in the UI. 

`"baseName": "${ parameters['customBaseName'] ?: '' }",`

It feels like the right behavior to remove this parameter from what gets turned into the BakeRequest. This shouldn't break anything because right now if you send an empty string for baseName our bakery errors out.