### PR TITLE
feat(core): Support pipeline correlation ids

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -41,7 +41,6 @@ import java.util.Optional;
 
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.AuthenticationDetails;
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
-import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION;
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
@@ -127,10 +126,6 @@ public class ExecutionLauncher {
   }
 
   private Execution checkForCorrelatedExecution(Execution execution) {
-    if (execution.getType() != ORCHESTRATION) {
-      return null;
-    }
-
     if (execution.getTrigger().getCorrelationId() == null) {
       return null;
     }
@@ -138,10 +133,11 @@ public class ExecutionLauncher {
     Trigger trigger = execution.getTrigger();
 
     try {
-      Execution o = executionRepository.retrieveOrchestrationForCorrelationId(
+      Execution o = executionRepository.retrieveByCorrelationId(
+        execution.getType(),
         trigger.getCorrelationId()
       );
-      log.info("Found pre-existing Orchestration by correlation id (id: " +
+      log.info("Found pre-existing " + execution.getType() + " by correlation id (id: " +
         o.getId() + ", correlationId: " +
         trigger.getCorrelationId() +
         ")");
@@ -149,6 +145,7 @@ public class ExecutionLauncher {
     } catch (ExecutionNotFoundException e) {
       // Swallow
     }
+
     return null;
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
@@ -244,11 +244,27 @@ class DualExecutionRepository(
     }
   }
 
+  override fun retrieveByCorrelationId(executionType: Execution.ExecutionType, correlationId: String): Execution {
+    return try {
+      primary.retrieveByCorrelationId(executionType, correlationId)
+    } catch (e: ExecutionNotFoundException) {
+      previous.retrieveByCorrelationId(executionType, correlationId)
+    }
+  }
+
   override fun retrieveOrchestrationForCorrelationId(correlationId: String): Execution {
     return try {
       primary.retrieveOrchestrationForCorrelationId(correlationId)
     } catch (e: ExecutionNotFoundException) {
       previous.retrieveOrchestrationForCorrelationId(correlationId)
+    }
+  }
+
+  override fun retrievePipelineForCorrelationId(correlationId: String): Execution {
+    return try {
+      primary.retrievePipelineForCorrelationId(correlationId)
+    } catch (e: ExecutionNotFoundException) {
+      previous.retrievePipelineForCorrelationId(correlationId)
     }
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -113,7 +113,16 @@ public interface ExecutionRepository {
                                                        @Nullable ExecutionComparator sorter);
 
   @Nonnull
+  Execution retrieveByCorrelationId(@Nonnull ExecutionType executionType,
+                                    @Nonnull String correlationId) throws ExecutionNotFoundException;
+
+  @Deprecated
+  @Nonnull
   Execution retrieveOrchestrationForCorrelationId(@Nonnull String correlationId) throws ExecutionNotFoundException;
+
+  @Deprecated
+  @Nonnull
+  Execution retrievePipelineForCorrelationId(@Nonnull String correlationId) throws ExecutionNotFoundException;
 
   @Nonnull
   List<Execution> retrieveBufferedExecutions();

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
@@ -189,9 +189,21 @@ class RedisInstrumentedExecutionRepository(
     }
   }
 
+  override fun retrieveByCorrelationId(executionType: Execution.ExecutionType, correlationId: String): Execution {
+    return withMetrics("retrieveByCorrelationId") {
+      executionRepository.retrieveByCorrelationId(executionType, correlationId)
+    }
+  }
+
   override fun retrieveOrchestrationForCorrelationId(correlationId: String): Execution {
     return withMetrics("retrieveOrchestrationForCorrelationId") {
       executionRepository.retrieveOrchestrationForCorrelationId(correlationId)
+    }
+  }
+
+  override fun retrievePipelineForCorrelationId(correlationId: String): Execution {
+    return withMetrics("retrievePipelineForCorrelationId") {
+      executionRepository.retrievePipelineForCorrelationId(correlationId)
     }
   }
 

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisExecutionRepositorySpec.groovy
@@ -216,7 +216,7 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
 
   }
 
-  def "can retrieve running orchestration in previousRedis by correlation id"() {
+  def "can retrieve running execution in previousRedis by correlation id"() {
     given:
     def execution = orchestration {
       trigger = new DefaultTrigger("manual", "covfefe")
@@ -225,14 +225,14 @@ class JedisExecutionRepositorySpec extends ExecutionRepositoryTck<RedisExecution
     previousRepository.updateStatus(execution.type, execution.id, RUNNING)
 
     when:
-    def result = repository.retrieveOrchestrationForCorrelationId('covfefe')
+    def result = repository.retrieveByCorrelationId(ORCHESTRATION, 'covfefe')
 
     then:
     result.id == execution.id
 
     when:
     repository.updateStatus(execution.type, execution.id, SUCCEEDED)
-    repository.retrieveOrchestrationForCorrelationId('covfefe')
+    repository.retrieveByCorrelationId(ORCHESTRATION, 'covfefe')
 
     then:
     thrown(ExecutionNotFoundException)

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
@@ -193,9 +193,21 @@ class SqlInstrumentedExecutionRepository(
     }
   }
 
+  override fun retrieveByCorrelationId(executionType: Execution.ExecutionType, correlationId: String): Execution {
+    return withMetrics("retrieveByCorrelationId") {
+      executionRepository.retrieveByCorrelationId(executionType, correlationId)
+    }
+  }
+
   override fun retrieveOrchestrationForCorrelationId(correlationId: String): Execution {
     return withMetrics("retrieveOrchestrationForCorrelationId") {
       executionRepository.retrieveOrchestrationForCorrelationId(correlationId)
+    }
+  }
+
+  override fun retrievePipelineForCorrelationId(correlationId: String): Execution {
+    return withMetrics("retrievePipelineForCorrelationId") {
+      executionRepository.retrievePipelineForCorrelationId(correlationId)
     }
   }
 


### PR DESCRIPTION
This is to support de-duplicating pipelines from an internal tool (Gutenberg) which sends a ton of pipeline requests to us with a low timeout/retry cycle.