### PR TITLE
fix(FindImageFromCluster): infer regions from deploy stages

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
-import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.RegionCollector
 import retrofit.RetrofitError
 import retrofit.client.Response
 import retrofit.mime.TypedString
@@ -33,12 +33,16 @@ import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 class FindImageFromClusterTaskSpec extends Specification {
 
   @Subject
-    task = new FindImageFromClusterTask()
+  task = new FindImageFromClusterTask()
   OortService oortService = Mock(OortService)
+  RegionCollector regionCollector = Mock(RegionCollector)
 
   def setup() {
+    regionCollector.getRegionsFromChildStages(_ as Stage) >> { stage -> new HashSet<String>() }
+
     task.oortService = oortService
     task.objectMapper = new ObjectMapper()
+    task.regionCollector = regionCollector
   }
 
   @Unroll
@@ -98,7 +102,11 @@ class FindImageFromClusterTaskSpec extends Specification {
 
   def "should be RUNNING if summary does not include imageId"() {
     given:
-    def stage = new Stage(Execution.newPipeline("orca"), "findImage", [
+    def pipe = pipeline {
+      application = "orca" // Should be ignored.
+    }
+
+    def stage = new Stage(pipe, "findImage", [
       cloudProvider    : "cloudProvider",
       cluster          : "foo-test",
       account          : "test",
@@ -186,7 +194,10 @@ class FindImageFromClusterTaskSpec extends Specification {
       account                : "test",
       selectionStrategy      : "LARGEST",
       onlyEnabled            : "false",
-      regions                : [location1.value, location2.value]
+      regions                : [
+        location1.value
+        //Note: location2.value will come from regionCollectorResponse below
+      ]
     ])
 
     when:
@@ -200,6 +211,8 @@ class FindImageFromClusterTaskSpec extends Specification {
       throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), null, Map)
     }
     1 * oortService.findImage("cloudProvider", "ami-012-name-ebs*", "test", null, null) >> imageSearchResult
+    1 * regionCollector.getRegionsFromChildStages(stage) >> regionCollectorResponse
+
     assertNorth(result.outputs?.deploymentDetails?.find {
       it.region == "north"
     } as Map, [imageName: "ami-012-name-ebs"])
@@ -220,6 +233,8 @@ class FindImageFromClusterTaskSpec extends Specification {
                     buildInfo      : [job: "foo-build", buildNumber: 1]
                   ]]
     ]
+
+    regionCollectorResponse = [location2.value]
 
     imageSearchResult = [
       [
@@ -366,7 +381,11 @@ class FindImageFromClusterTaskSpec extends Specification {
 
   def "should parse fail strategy error message"() {
     given:
-    def stage = new Stage(Execution.newPipeline("orca"), "whatever", [
+    def pipe = pipeline {
+      application = "orca" // Should be ignored.
+    }
+
+    def stage = new Stage(pipe, "whatever", [
       cloudProvider    : "cloudProvider",
       cluster          : "foo-test",
       account          : "test",
@@ -402,7 +421,10 @@ class FindImageFromClusterTaskSpec extends Specification {
   @Unroll
   'cluster with name "#cluster" and moniker "#moniker" should have application name "#expected"'() {
     given:
-    def stage = new Stage(Execution.newPipeline("orca"), 'findImageFromCluster', [
+    def pipe = pipeline {
+      application = "orca" // Should be ignored.
+    }
+    def stage = new Stage(pipe, 'findImageFromCluster', [
       cluster: cluster,
       moniker: moniker,
     ])

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -423,6 +423,41 @@ public class Stage implements Serializable {
   }
 
   /**
+   * Recursively get all stages that are children of the current one
+   */
+  public List<Stage> allDownstreamStages() {
+    if (execution != null) {
+      HashSet<String> visited = new HashSet<>();
+      LinkedList<Stage> queue = new LinkedList<>();
+      List<Stage> children = new ArrayList<>();
+
+      queue.push(this);
+      boolean first = true;
+
+      while (!queue.isEmpty()) {
+        Stage stage = queue.pop();
+        if (!first) {
+          children.add(stage);
+        }
+
+        first = false;
+        visited.add(stage.refId);
+
+        List<Stage> childStages = stage.downstreamStages();
+
+        childStages
+          .stream()
+          .filter(s -> !visited.contains(s.refId))
+          .forEach(s -> queue.add(s));
+      }
+
+      return children;
+    }
+
+    return emptyList();
+  }
+
+  /**
    * Maps the stage's context to a typed object
    */
   public <O> O mapTo(Class<O> type) {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/RegionCollector.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/RegionCollector.java
@@ -1,0 +1,71 @@
+package com.netflix.spinnaker.orca.pipeline.util;
+
+import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+/**
+ * Collects relevant regions from stages
+ *
+ * Used by e.g. FindImageFromClusterTask and BakeTask
+ */
+public class RegionCollector {
+  /**
+   * Traverses all descendant stages of a given stage looking for deploy/deploy canary stages
+   * When found, extracts the regions those stages deploy to.
+   *
+   * @param stage Stage for which to traverse the regions for
+   * @return union of all regions or an empty set
+   */
+  public @NotNull
+  Set<String> getRegionsFromChildStages(Stage stage) {
+    Set<String> deployRegions = new HashSet<>();
+    Map<String, Object> context = stage.getContext();
+    String stageCloudProviderType = (String)context.getOrDefault(
+      "cloudProviderType",
+      context.getOrDefault("cloudProvider", CloudProviderAware.DEFAULT_CLOUD_PROVIDER));
+
+    List<Stage> childStages = stage.allDownstreamStages();
+
+    childStages
+      .stream()
+      .filter(it -> "deploy".equals(it.getType()))
+      .forEach(deployStage -> {
+        List<Map> clusters = (List<Map>) deployStage.getContext().getOrDefault("clusters", new ArrayList<>());
+        for (Map cluster : clusters) {
+          if (stageCloudProviderType.equals(cluster.get("cloudProvider"))) {
+            deployRegions.addAll(((Map) cluster.getOrDefault("availabilityZones", new HashMap())).keySet());
+          }
+        }
+
+        Map clusterMap = (Map) deployStage.getContext().getOrDefault("cluster", new HashMap<>());
+        if (stageCloudProviderType.equals(clusterMap.get("cloudProvider"))) {
+          deployRegions.addAll(((Map) clusterMap.getOrDefault("availabilityZones", new HashMap())).keySet());
+        }
+      });
+
+    // TODO(duftler): Also filter added canary regions once canary supports multiple platforms.
+    childStages
+      .stream()
+      .filter(it -> "canary".equals(it.getType()))
+      .forEach(canaryStage -> {
+        List<Map> clusterPairs = (List<Map>)canaryStage.getContext().getOrDefault("clusterPairs", new ArrayList<>());
+
+        for (Map clusterPair : clusterPairs) {
+          Map baseline = ((Map)clusterPair.getOrDefault("baseline", new HashMap()));
+          Map availabilityZones = ((Map)baseline.getOrDefault("availabilityZones", new HashMap()));
+          deployRegions.addAll(availabilityZones.keySet());
+
+          Map canary = ((Map)clusterPair.getOrDefault("canary", new HashMap()));
+          availabilityZones = ((Map)canary.getOrDefault("availabilityZones", new HashMap()));
+          deployRegions.addAll(availabilityZones.keySet());
+        }
+      });
+
+    return deployRegions;
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/RegionCollectorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/RegionCollectorSpec.groovy
@@ -1,0 +1,96 @@
+package com.netflix.spinnaker.orca.pipeline.util
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class RegionCollectorSpec extends Specification {
+  @Subject
+  def regionCollector = new RegionCollector()
+
+  def "should find all regions from subsequent deploys"() {
+    given:
+    def execution = pipeline {
+      stage {
+        name = "findImage"
+        type = "findImage"
+        refId = "1"
+        context = [ cloudProvider: "aws"]
+      }
+
+      stage {
+        name = "deploy"
+        type = "deploy"
+        context = [
+          clusters: deployClusters
+        ]
+        requisiteStageRefIds = ["1"]
+      }
+    }
+
+    when:
+    def regionSet = regionCollector.getRegionsFromChildStages(execution.stageByRef("1"))
+
+    then:
+    regionSet == ["region1", "region2", "region3"] as Set
+
+    where:
+    deployClusters = [
+      makeCluster(["region1", "region2"]),
+      makeCluster(["region3"])
+    ]
+  }
+
+  def "should find all regions from subsequent canary deploys"() {
+    given:
+    def execution = pipeline {
+      stage {
+        name = "findImage"
+        type = "findImage"
+        refId = "1"
+        context = [cloudProvider: "aws"]
+      }
+
+      stage {
+        name = "canary"
+        type = "canary"
+        context = [
+          clusterPairs: [[
+                           baseline: deployCluster1,
+                           canary  : deployCluster2
+                         ],
+                         [
+                           baseline: deployCluster3
+                         ]
+          ]
+        ]
+        requisiteStageRefIds = ["1"]
+      }
+    }
+
+    when:
+    def regionSet = regionCollector.getRegionsFromChildStages(execution.stageByRef("1"))
+
+    then:
+    regionSet == ["region1", "region2", "region3", "region4"] as Set
+
+    where:
+    deployCluster1 = makeCluster(["region1", "region2"])
+    deployCluster2 = makeCluster(["region3"])
+    deployCluster3 = makeCluster(["region4"])
+  }
+
+  private makeCluster(List regions) {
+    def aZones = new HashMap()
+    regions.each { it -> aZones.put(it, []) }
+
+    return [
+            cloudProvider: "aws",
+            availabilityZones: aZones
+    ]
+  }
+}
+
+


### PR DESCRIPTION
FindImageFromClusterTask now looks ahead to find all regions from subsequent deploy stages
This moves the failure point of a pipeline up when an image isn't found.
E.g. FindImage specifies to look for images in `us-east`, but a deploy right after was modified to
deploy to `us-east` AND `us-west`. Thus FindImage will locate the `us-east` image,
the deploy for that image will start but the deploy for `us-west` will fail.
This failure can cause regions to have different versions deployed.
To prevent this, we now will fail in the FindImage task before any deploy starts
