### PR TITLE
feat(clouddriver): Consider target capacity if supplied from `clouddriver`

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
@@ -122,15 +122,16 @@ abstract class AbstractInstancesCheckTask extends AbstractCloudProviderAwareTask
         def isComplete = hasSucceeded(stage, serverGroup, serverGroup.instances ?: [], interestingHealthProviderNames)
         if (!isComplete) {
           Map newContext = getAdditionalRunningStageContext(stage, serverGroup)
-          if (seenServerGroup && !stage.context.capacitySnapshot) {
-            newContext.zeroDesiredCapacityCount = 0
-            newContext.capacitySnapshot = [
-              minSize        : serverGroup.capacity.min,
-              desiredCapacity: serverGroup.capacity.desired,
-              maxSize        : serverGroup.capacity.max
-            ]
-          }
           if (seenServerGroup) {
+            if (!stage.context.capacitySnapshot) {
+              newContext.zeroDesiredCapacityCount = 0
+              newContext.capacitySnapshot = newContext.capacitySnapshot ?: [
+                  minSize        : serverGroup.capacity.min,
+                  desiredCapacity: serverGroup.capacity.desired,
+                  maxSize        : serverGroup.capacity.max
+              ]
+            }
+
             if (serverGroup.capacity.desired == 0) {
               newContext.zeroDesiredCapacityCount = (stage.context.zeroDesiredCapacityCount ?: 0) + 1
             } else {


### PR DESCRIPTION
AWS deployments are somewhat special in that they create an initial
asg of size 0/0/0 and then subsequently resize it to the target
capacity.

This PR protects against premature success by favoring the
clouddriver-supplied capacity if we see a 0/0/0 asg but expect a
non-0/0/0 asg.

The edge case only appears when the `ForceCacheRefresh` task is dropped
from the deploy stages in `orca`.

relates to spinnaker/clouddriver#3356
