### PR TITLE
feat(core): add support for batch updating pipelines

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -59,6 +59,9 @@ interface Front50Service {
   @POST("/pipelines")
   Response savePipeline(@Body Map pipeline)
 
+  @POST("/pipelines/batchUpdate")
+  Response batchUpdatePipelines(@Body List<Map<String, Object>> pipelines)
+
   @PUT("/pipelines/{pipelineId}")
   Response updatePipeline(@Path("pipelineId") String pipelineId, @Body Map pipeline)
 

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/BatchUpdatePipelinesStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/BatchUpdatePipelinesStage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.pipeline;
+
+import com.netflix.spinnaker.orca.front50.tasks.BatchUpdatePipelinesTask;
+import com.netflix.spinnaker.orca.front50.tasks.MonitorFront50Task;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BatchUpdatePipelinesStage implements StageDefinitionBuilder {
+  @Override
+  public void taskGraph(Stage stage, TaskNode.Builder builder) {
+    builder
+      .withTask("batchUpdatePipelines", BatchUpdatePipelinesTask.class)
+      .withTask("waitForPipelineSave", MonitorFront50Task.class);
+  }
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/BatchUpdatePipelinesTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/BatchUpdatePipelinesTask.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.RetryableTask;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.front50.PipelineModelMutator;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class BatchUpdatePipelinesTask implements RetryableTask {
+
+  private Logger log = LoggerFactory.getLogger(getClass());
+
+  @Autowired(required = false)
+  private Front50Service front50Service;
+
+  @Autowired(required = false)
+  private List<PipelineModelMutator> pipelineModelMutators = new ArrayList<>();
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public TaskResult execute(Stage stage) {
+    if (front50Service == null) {
+      throw new UnsupportedOperationException("Front50 is not enabled, no way to save pipeline. Fix this by setting front50.enabled: true");
+    }
+
+    if (!stage.getContext().containsKey("pipelines")) {
+      throw new IllegalArgumentException("pipeline contexts must be provided");
+    }
+
+    if (!(stage.getContext().get("pipelines") instanceof String)) {
+      throw new IllegalArgumentException("'pipelines' context key must be a base64-encoded string: Ensure you're on the most recent version of gate");
+    }
+
+    List<Map<String, Object>> pipelines;
+    try {
+      pipelines = (List<Map<String, Object>>) stage.decodeBase64("/pipelines", List.class);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("'pipelines' context key must be a base64-encoded string: Ensure you're on the most recent version of gate", e);
+    }
+
+    for (Map<String, Object> pipeline : pipelines) {
+      pipelineModelMutators.stream().filter(m -> m.supports(pipeline)).forEach(m -> m.mutate(pipeline));
+    }
+
+    Response response = front50Service.batchUpdatePipelines(pipelines);
+
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put("notification.type", "batchupdatepipelines");
+    outputs.put("application", pipelines.get(0).get("application"));
+
+    return new TaskResult(
+      (response.getStatus() == HttpStatus.OK.value()) ? ExecutionStatus.SUCCEEDED : ExecutionStatus.TERMINAL,
+      outputs
+    );
+  }
+
+  @Override
+  public long getBackoffPeriod() {
+    return 1000;
+  }
+
+  @Override
+  public long getTimeout() {
+    return TimeUnit.SECONDS.toMillis(30);
+  }
+}


### PR DESCRIPTION
Previously, Deck made one request per pipeline to be re-indexed after re-ordering or deleting a pipeline, which could flood the Tasks panel when an application contained many pipelines. This change enables support for batch updating pipelines.

Deck PR: [spinnaker/deck#6519](https://github.com/spinnaker/deck/pull/6519)
Gate PR: https://github.com/spinnaker/gate/pull/723