### PR TITLE
fix(dependencies): update minutest dependency in orca-sql to fix build

### DIFF
--- a/orca-sql/orca-sql.gradle
+++ b/orca-sql/orca-sql.gradle
@@ -36,7 +36,7 @@ dependencies {
   testCompile "io.strikt:strikt-core:0.11.5"
   testCompile "org.assertj:assertj-core:3.9.0"
   testCompile "org.junit.jupiter:junit-jupiter-api:$jupiterVersion"
-  testCompile "com.oneeyedmen:minutest:0.34.0"
+  testCompile "dev.minutest:minutest:0.45.0"
   testCompile "com.nhaarman:mockito-kotlin:1.5.0"
 
   testRuntime "org.junit.jupiter:junit-jupiter-engine:$jupiterVersion"

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/PagedIterator.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/PagedIterator.kt
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.orca.sql.pipeline.persistence
 /**
  * An iterator that can fetch paginated data transparently to clients.
  */
-internal class PagedIterator<T, C>(
+class PagedIterator<T, C>(
   private val pageSize: Int,
   private val toCursor: (T) -> C,
   private val nextPage: (Int, C?) -> Iterable<T>

--- a/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/SqlHealthcheckQueueActivatorTest.kt
+++ b/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/SqlHealthcheckQueueActivatorTest.kt
@@ -22,17 +22,17 @@ import com.nhaarman.mockito_kotlin.isA
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.whenever
-import com.oneeyedmen.minutest.junit.JupiterTests
-import com.oneeyedmen.minutest.junit.context
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
 import org.jooq.DSLContext
 import org.jooq.DeleteWhereStep
 import org.jooq.Table
 import strikt.api.expect
 import strikt.assertions.isEqualTo
 
-class SqlHealthcheckQueueActivatorTest : JupiterTests {
+class SqlHealthcheckQueueActivatorTest : JUnit5Minutests {
 
-  override val tests = context<Unit> {
+  override val tests = rootContext<Unit> {
 
     val dslContext = mock<DSLContext>()
     val query = mock<DeleteWhereStep<*>>()

--- a/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/PagedIteratorTest.kt
+++ b/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/PagedIteratorTest.kt
@@ -16,15 +16,15 @@
 package com.netflix.spinnaker.orca.sql.pipeline.persistence
 
 import com.nhaarman.mockito_kotlin.mock
-import com.oneeyedmen.minutest.junit.JupiterTests
-import com.oneeyedmen.minutest.junit.context
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 
-class PagedIteratorTest : JupiterTests {
+class PagedIteratorTest : JUnit5Minutests {
 
-  override val tests = context<PagedIterator<String, String>> {
+  override val tests = rootContext<PagedIterator<String, String>> {
 
     val pageSize = 3
     val nextPage = mock<(Int, String?) -> Iterable<String>>()
@@ -37,8 +37,8 @@ class PagedIteratorTest : JupiterTests {
         }
 
         test("won't return anything") {
-          Assertions.assertThat(it.hasNext()).isFalse()
-          Assertions.assertThatThrownBy { it.next() }
+          Assertions.assertThat(this.hasNext()).isFalse()
+          Assertions.assertThatThrownBy { this.next() }
             .isInstanceOf<NoSuchElementException>()
         }
       }
@@ -54,10 +54,10 @@ class PagedIteratorTest : JupiterTests {
         }
 
         test("iterates over available elements") {
-          assertThat(it.hasNext()).isTrue()
+          assertThat(this.hasNext()).isTrue()
 
           val results = mutableListOf<String>()
-          it.forEachRemaining { results.add(it) }
+          this.forEachRemaining { results.add(it) }
 
           assertThat(results).containsExactly("ONE", "TWO")
         }
@@ -74,10 +74,10 @@ class PagedIteratorTest : JupiterTests {
         }
 
         test("iterates over available elements") {
-          assertThat(it.hasNext()).isTrue()
+          assertThat(this.hasNext()).isTrue()
 
           val results = mutableListOf<String>()
-          it.forEachRemaining { results.add(it) }
+          this.forEachRemaining { results.add(it) }
 
           assertThat(results).containsExactly("ONE", "TWO", "THREE")
         }
@@ -96,10 +96,10 @@ class PagedIteratorTest : JupiterTests {
         }
 
         test("iterates over the available elements") {
-          assertThat(it.hasNext()).isTrue()
+          assertThat(this.hasNext()).isTrue()
 
           val results = mutableListOf<String>()
-          it.forEachRemaining { results.add(it) }
+          this.forEachRemaining { results.add(it) }
 
           assertThat(results).containsExactly("ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN")
         }


### PR DESCRIPTION
This kept Orca from building. I’m guessing that it wasn’t caught because everyone else (including travis) have a com.oneeyedmen:minutest:0.34.0 sitting in their .m2 cache.
It is described here (https://github.com/dmcg/minutest) that the group for the minutest project changed from ‘com.oneeyedmen’ to ‘dev.minutest’ and com.oneeyedmen:minutest:0.34.0 can no longer be referenced. The minor code changes are just what was needed when updating the dep.

