### PR TITLE
 feat(artifacts): SpEL evaluable expected artifact inputs

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -70,11 +70,11 @@ public class ArtifactResolver {
   public @Nonnull
   List<Artifact> getArtifacts(@Nonnull Stage stage) {
     if (stage.getContext() instanceof StageContext) {
-      return (List<Artifact>) Optional.ofNullable((List) ((StageContext) stage.getContext()).getAll("artifacts"))
+      return Optional.ofNullable((List<?>) ((StageContext) stage.getContext()).getAll("artifacts"))
         .map(list -> list.stream()
           .filter(Objects::nonNull)
-          .flatMap(it -> ((List) it).stream())
-          .map(a -> a instanceof Map ? objectMapper.convertValue(a, Artifact.class) : a)
+          .flatMap(it -> ((List<?>) it).stream())
+          .map(a -> a instanceof Map ? objectMapper.convertValue(a, Artifact.class) : (Artifact) a)
           .collect(Collectors.toList()))
         .orElse(emptyList());
     } else {
@@ -91,9 +91,9 @@ public class ArtifactResolver {
     List<Artifact> emittedArtifacts = Stage.topologicalSort(execution.getStages())
       .filter(s -> s.getOutputs().containsKey("artifacts"))
       .flatMap(
-        s -> (Stream<Artifact>) ((List) s.getOutputs().get("artifacts"))
+        s -> ((List<?>) s.getOutputs().get("artifacts"))
             .stream()
-            .map(a -> a instanceof Map ? objectMapper.convertValue(a, Artifact.class) : a)
+            .map(a -> a instanceof Map ? objectMapper.convertValue(a, Artifact.class) : (Artifact) a)
       ).collect(Collectors.toList());
     Collections.reverse(emittedArtifacts);
 
@@ -115,11 +115,11 @@ public class ArtifactResolver {
 
     List<ExpectedArtifact> expectedArtifacts;
     if (stage.getContext() instanceof StageContext) {
-      expectedArtifacts = (List<ExpectedArtifact>) Optional.ofNullable((List) ((StageContext) stage.getContext()).getAll("resolvedExpectedArtifacts"))
+      expectedArtifacts = Optional.ofNullable((List<?>) ((StageContext) stage.getContext()).getAll("resolvedExpectedArtifacts"))
         .map(list -> list.stream()
           .filter(Objects::nonNull)
-          .flatMap(it -> ((List) it).stream())
-          .map(a -> a instanceof Map ? objectMapper.convertValue(a, ExpectedArtifact.class) : a)
+          .flatMap(it -> ((List<?>) it).stream())
+          .map(a -> a instanceof Map ? objectMapper.convertValue(a, ExpectedArtifact.class) : (ExpectedArtifact) a)
           .collect(Collectors.toList()))
         .orElse(emptyList());
     } else {
@@ -155,13 +155,13 @@ public class ArtifactResolver {
 
   public void resolveArtifacts(@Nonnull Map pipeline) {
     Map<String, Object> trigger = (Map<String, Object>) pipeline.get("trigger");
-    List<ExpectedArtifact> expectedArtifacts = (List<ExpectedArtifact>) Optional.ofNullable((List) pipeline.get("expectedArtifacts"))
+    List<ExpectedArtifact> expectedArtifacts = Optional.ofNullable((List<?>) pipeline.get("expectedArtifacts"))
       .map(list -> list.stream().map(it -> objectMapper.convertValue(it, ExpectedArtifact.class)).collect(toList()))
       .orElse(emptyList());
-    List<Artifact> receivedArtifactsFromPipeline = (List<Artifact>) Optional.ofNullable((List) pipeline.get("receivedArtifacts"))
+    List<Artifact> receivedArtifactsFromPipeline = Optional.ofNullable((List<?>) pipeline.get("receivedArtifacts"))
       .map(list -> list.stream().map(it -> objectMapper.convertValue(it, Artifact.class)).collect(toList()))
       .orElse(emptyList());
-    List<Artifact> artifactsFromTrigger = (List<Artifact>) Optional.ofNullable((List) trigger.get("artifacts"))
+    List<Artifact> artifactsFromTrigger = Optional.ofNullable((List<?>) trigger.get("artifacts"))
       .map(list -> list.stream().map(it -> objectMapper.convertValue(it, Artifact.class)).collect(toList()))
       .orElse(emptyList());
     List<Artifact> receivedArtifacts = Stream.concat(receivedArtifactsFromPipeline.stream(), artifactsFromTrigger.stream()).collect(toList());
@@ -252,10 +252,6 @@ public class ArtifactResolver {
   }
 
   private static class ArtifactResolutionException extends RuntimeException {
-    ArtifactResolutionException(String message) {
-      super(message);
-    }
-
     ArtifactResolutionException(String message, Throwable cause) {
       super(message, cause);
     }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import retrofit.RetrofitError
 import retrofit.client.Response
 import spock.lang.Shared
@@ -35,7 +36,7 @@ import spock.lang.Unroll
 
 class MonitorJenkinsJobTaskSpec extends Specification {
   def executionRepository = Mock(ExecutionRepository)
-  def artifactResolver = new ArtifactResolver(new ObjectMapper(), executionRepository)
+  def artifactResolver = new ArtifactResolver(new ObjectMapper(), executionRepository, new ContextParameterProcessor())
 
   @Subject
   MonitorJenkinsJobTask task = new MonitorJenkinsJobTask()

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -481,7 +481,7 @@ class OperationsControllerSpec extends Specification {
       startedPipeline
     }
     executionRepository.retrievePipelinesForPipelineConfigId(*_) >> Observable.empty()
-    ArtifactResolver realArtifactResolver = new ArtifactResolver(mapper, executionRepository)
+    ArtifactResolver realArtifactResolver = new ArtifactResolver(mapper, executionRepository, new ContextParameterProcessor())
 
     // can't use @subject, since we need to test the behavior of otherwise mocked-out 'artifactResolver'
     def tempController = new OperationsController(


### PR DESCRIPTION
Resolve expected artifact expressions in `ArtifactResolver` before attempting to match against incoming artifacts.

This PR also contains a polish commit that handles generics better in `ArtifactResolver`, resulting in fewer unchecked casts.