### PR TITLE
fix(rrb): pass targetHealthyDeployPercentage to resize tasks

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
@@ -137,7 +137,8 @@ class RollingRedBlackStrategy implements Strategy, ApplicationContextAware {
         scalePct            : p,
         pinCapacity         : p < 100,  // if p < 100, capacity should be pinned (min == max == desired)
         unpinMinimumCapacity: p == 100, // if p == 100, min capacity should be restored to the original unpinned value from source
-        useNameAsLabel      : true      // hint to deck that it should _not_ override the name
+        useNameAsLabel      : true,     // hint to deck that it should _not_ override the name
+        targetHealthyDeployPercentage: stage.context.targetHealthyDeployPercentage
       ]
 
       if (source) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategySpec.groovy
@@ -48,7 +48,8 @@ class RollingRedBlackStrategySpec extends Specification {
       region           : "north",
       availabilityZones: [ north: ["pole-1a"] ],
       source           : [:],  // pretend there is no pre-existing server group
-      capacity         : fallbackCapacity
+      capacity         : fallbackCapacity,
+      targetHealthyDeployPercentage: 90
     ]
 
     def stage = new Stage(Execution.newPipeline("orca"), "whatever", ctx)
@@ -99,9 +100,13 @@ class RollingRedBlackStrategySpec extends Specification {
     afterStages.get(1).context.action == ResizeStrategy.ResizeAction.scale_exact
     afterStages.get(1).context.capacity == fallbackCapacity
 
+    // also verify that targetHealthyDeployPercentage from the base stage context percolates down to the resize context
+    afterStages.get(1).context.targetHealthyDeployPercentage == ctx.targetHealthyDeployPercentage
+
     afterStages.get(2).type == resizeServerGroupStage.type
     afterStages.get(2).name == "Grow to 100% of Desired Size"
     afterStages.get(2).context.action == ResizeStrategy.ResizeAction.scale_exact
     afterStages.get(2).context.capacity == fallbackCapacity
+
   }
 }


### PR DESCRIPTION
Fixes an issue where a single instance starting to fail in one of the
RRB `Grow to X%` tasks would fail the whole deployment.
