### PR TITLE
feat(core): add support for reordering pipelines

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -68,6 +68,12 @@ interface Front50Service {
   @GET("/pipelines?restricted=false")
   List<Map<String, Object>> getAllPipelines()
 
+  @POST('/actions/pipelines/reorder')
+  Response reorderPipelines(@Body ReorderPipelinesCommand reorderPipelinesCommand)
+
+  @POST('/actions/strategies/reorder')
+  Response reorderPipelineStrategies(@Body ReorderPipelinesCommand reorderPipelinesCommand)
+
   // pipeline template related
   @GET("/pipelineTemplates")
   List<Map<String, Object>> getPipelineTemplates(@Query("scopes") List<String> scopes)
@@ -136,6 +142,16 @@ interface Front50Service {
     static class PipelineConfig {
       String application
       String pipelineConfigId
+    }
+  }
+
+  static class ReorderPipelinesCommand {
+    Map<String, Integer> idsToIndices
+    String application
+
+    ReorderPipelinesCommand(Map<String, Integer> idsToIndices, String application) {
+      this.idsToIndices = idsToIndices
+      this.application = application
     }
   }
 }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/ReorderPipelinesStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/ReorderPipelinesStage.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.pipeline;
+
+import com.netflix.spinnaker.orca.front50.tasks.ReorderPipelinesTask;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReorderPipelinesStage implements StageDefinitionBuilder {
+  @Override
+  public void taskGraph(Stage stage, TaskNode.Builder builder) {
+    builder
+      .withTask("reorderPipelines", ReorderPipelinesTask.class);
+  }
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/ReorderPipelinesTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/ReorderPipelinesTask.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class ReorderPipelinesTask implements Task {
+  @Autowired(required = false)
+  private Front50Service front50Service;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public TaskResult execute(Stage stage) {
+    validateTask(stage);
+
+    Map<String, Integer> idsToIndices;
+    try {
+      idsToIndices = (Map<String, Integer>) stage.decodeBase64("/idsToIndices", Map.class);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("`idsToIndices` context key must be a base64-encoded string: Ensure you're on the most recent version of gate", e);
+    }
+
+    String application;
+    try {
+      application = stage.decodeBase64("/application", String.class);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("`application` context key must be a base64-encoded string: Ensure you're on the most recent version of gate", e);
+    }
+
+    Boolean isStrategy;
+    try {
+      isStrategy = stage.decodeBase64("/isStrategy", Boolean.class);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("`isStrategy` context key must be a base64-encoded string: Ensure you're on the most recent version of gate", e);
+    }
+
+    Front50Service.ReorderPipelinesCommand reorderPipelinesCommand = new Front50Service.ReorderPipelinesCommand(idsToIndices, application);
+
+    Response response = isStrategy ?
+      front50Service.reorderPipelineStrategies(reorderPipelinesCommand) :
+      front50Service.reorderPipelines(reorderPipelinesCommand);
+
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put("notification.type", "reorderpipelines");
+    outputs.put("application", application);
+
+    return new TaskResult(
+      (response.getStatus() == HttpStatus.OK.value()) ? ExecutionStatus.SUCCEEDED : ExecutionStatus.TERMINAL,
+      outputs
+    );
+  }
+
+  private void validateTask(Stage stage) {
+    if (front50Service == null) {
+      throw new UnsupportedOperationException("Front50 is not enabled, no way to reorder pipeline. Fix this by setting front50.enabled: true");
+    }
+
+    if (!stage.getContext().containsKey("idsToIndices")) {
+      throw new IllegalArgumentException("`idsToIndices` context key must be provided");
+    }
+
+    if (!(stage.getContext().get("idsToIndices") instanceof String)) {
+      throw new IllegalArgumentException("`idsToIndices` context key must be a base64-encoded string: Ensure you're on the most recent version of gate");
+    }
+
+    if (!stage.getContext().containsKey("application")) {
+      throw new IllegalArgumentException("`application` context key must be provided");
+    }
+
+    if (!(stage.getContext().get("application") instanceof String)) {
+      throw new IllegalArgumentException("`application` context key must be a base64-encoded string: Ensure you're on the most recent version of gate");
+    }
+
+    if (!stage.getContext().containsKey("isStrategy")) {
+      throw new IllegalArgumentException("`isStrategy` context key must be provided");
+    }
+
+    if (!(stage.getContext().get("isStrategy") instanceof String)) {
+      throw new IllegalArgumentException("`isStrategy` context key must be a base64-encoded string: Ensure you're on the most recent version of gate");
+    }
+  }
+}


### PR DESCRIPTION
Adds a reordering task for pipelines and pipeline strategies so that we don't need to kick of a save task for each pipeline in an application after they are reordered or one is removed.

Corresponding PRs:
Deck: https://github.com/spinnaker/deck/pull/6519
Gate: https://github.com/spinnaker/gate/pull/723
Front50: https://github.com/spinnaker/front50/pull/448