### PR TITLE
fix(execution): Ensure that synthetic stages respect execution strategy

### DIFF
--- a/orca-kotlin/orca-kotlin.gradle
+++ b/orca-kotlin/orca-kotlin.gradle
@@ -15,7 +15,11 @@
  */
 
 apply from: "$rootDir/gradle/kotlin.gradle"
+apply from: "$rootDir/gradle/spek.gradle"
 
 dependencies {
   compile project(":orca-core")
+
+  testCompile project(":orca-test-kotlin")
+  testCompile "org.assertj:assertj-core:3.9.0"
 }

--- a/orca-kotlin/src/test/kotlin/com/netflix/spinnaker/orca/ext/StageTest.kt
+++ b/orca-kotlin/src/test/kotlin/com/netflix/spinnaker/orca/ext/StageTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.ext.failureStatus
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import com.netflix.spinnaker.orca.fixture.*
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.it
+
+class StageTest : Spek({
+  describe("parent stage context is empty") {
+    val pipeline = pipeline {
+      application = "test"
+      stage {
+        refId = "1"
+        type = "parent"
+        status = ExecutionStatus.SUCCEEDED
+        stage {
+          type = "child"
+          status = ExecutionStatus.TERMINAL
+        }
+      }
+    }
+
+    it("looks up execution options from parent") {
+      assertThat(pipeline.stages[1].failureStatus()).isEqualTo(ExecutionStatus.TERMINAL)
+    }
+  }
+
+  describe("parent stage context is empty but child is set") {
+    val pipeline = pipeline {
+      application = "test"
+      stage {
+        refId = "1"
+        type = "parent"
+        status = ExecutionStatus.SUCCEEDED
+        context = mapOf(
+          "failPipeline" to false,
+          "continuePipeline" to true
+        )
+        stage {
+          type = "child"
+          status = ExecutionStatus.TERMINAL
+        }
+      }
+    }
+
+    it("looks up execution options from parent") {
+      assertThat(pipeline.stages[1].failureStatus()).isEqualTo(ExecutionStatus.FAILED_CONTINUE)
+    }
+  }
+
+  describe("parent stage context dictates stop this branch") {
+    val pipeline = pipeline {
+      application = "test"
+      stage {
+        refId = "1"
+        type = "parent"
+        status = ExecutionStatus.SUCCEEDED
+        context = mapOf(
+          "failPipeline" to false,
+          "continuePipeline" to false
+        )
+        stage {
+          type = "child"
+          status = ExecutionStatus.TERMINAL
+        }
+      }
+    }
+
+    it("looks up execution options from parent") {
+      assertThat(pipeline.stages[1].failureStatus()).isEqualTo(ExecutionStatus.STOPPED)
+    }
+  }
+})


### PR DESCRIPTION
Synthetic stages don't (always) get the parent context. Since the user
might set execution options (e.g. whether to fail or not the pipeline) on
the parent stage, those directives should be respected by synthetic stages.
With this change, recursively look up these directives on synthetic stages'
parent if they aren't explicitly passed down.

An example here is the deploy stages: if a synthetic generated by one of the
deploy strategies fails but the deploy stage specified to ignore failure, the
ignore behavior will not be respected.