### PR TITLE
fix(MPT): Propagate notifications from pipeline config

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequest.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequest.java
@@ -17,7 +17,9 @@ package com.netflix.spinnaker.orca.pipelinetemplate;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.NamedHashMap;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +32,7 @@ public class TemplatedPipelineRequest {
   Map<String, Object> trigger = new HashMap<>();
   Map<String, Object> config;
   Map<String, Object> template;
+  List<NamedHashMap> notifications = new ArrayList<>();
   String executionId;
   Boolean plan = false;
   boolean limitConcurrent = true;
@@ -90,6 +93,14 @@ public class TemplatedPipelineRequest {
 
   public Map<String, Object> getTemplate() {
     return template;
+  }
+
+  public void setNotifications(List<NamedHashMap> notifications) {
+    this.notifications = notifications;
+  }
+
+  public List<NamedHashMap> getNotifications() {
+    return notifications;
   }
 
   public void setTemplate(Map<String, Object> template) {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/V1TemplateLoaderHandler.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/V1TemplateLoaderHandler.kt
@@ -37,6 +37,7 @@ class V1TemplateLoaderHandler(
 
   override fun handle(chain: HandlerChain, context: PipelineTemplateContext) {
     val config = objectMapper.convertValue(context.getRequest().config, TemplateConfiguration::class.java)
+    config.configuration.notifications.addAll(context.getRequest().notifications)
 
     // Allow template inlining to perform plans without publishing the template
     if (context.getRequest().plan && context.getRequest().template != null) {


### PR DESCRIPTION
One can specify notification on the pipeline in deck (even if pipeline is templated)
However, those notifications are not respected because they don't end up in the
pipeline config. Copy them there so notifications work as expected.
