### PR TITLE
fix(triggers): surface error if build not found

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -266,7 +266,16 @@ class OperationsController {
 
   private void decorateBuildInfo(Map trigger) {
     if (trigger.master && trigger.job && trigger.buildNumber) {
-      def buildInfo = buildService.getBuild(trigger.buildNumber, trigger.master, trigger.job)
+      def buildInfo
+      try {
+        buildInfo = buildService.getBuild(trigger.buildNumber, trigger.master, trigger.job)
+      } catch (RetrofitError e) {
+        if (e.response?.status == 404) {
+          throw new IllegalStateException("Build " + trigger.buildNumber + " for " + trigger.master + "/" + trigger.job + " not found")
+        } else {
+          throw e
+        }
+      }
       if (buildInfo?.artifacts) {
         if (trigger.type == "manual") {
           trigger.artifacts = buildInfo.artifacts

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
 import com.netflix.spinnaker.kork.web.exceptions.ValidationException
 import com.netflix.spinnaker.orca.clouddriver.service.JobService
+import com.netflix.spinnaker.orca.exceptions.OperationFailedException
 import com.netflix.spinnaker.orca.extensionpoint.pipeline.PipelinePreprocessor
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.front50.PipelineModelMutator
@@ -271,9 +272,9 @@ class OperationsController {
         buildInfo = buildService.getBuild(trigger.buildNumber, trigger.master, trigger.job)
       } catch (RetrofitError e) {
         if (e.response?.status == 404) {
-          throw new IllegalStateException("Build " + trigger.buildNumber + " for " + trigger.master + "/" + trigger.job + " not found")
+          throw new IllegalStateException("Build ${trigger.buildNumber} of ${trigger.master}/${trigger.job} not found")
         } else {
-          throw e
+          throw new OperationFailedException("Failed to get build ${trigger.buildNumber} of ${trigger.master}/${trigger.job}", e)
         }
       }
       if (buildInfo?.artifacts) {
@@ -294,7 +295,7 @@ class OperationsController {
           if (e.response?.status == 404) {
             throw new IllegalStateException("Expected properties file " + trigger.propertyFile + " (configured on trigger), but it was missing")
           } else {
-            throw e
+            throw new OperationFailedException("Failed to get properties file ${trigger.propertyFile}", e)
           }
         }
       }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/exceptions/OperationFailedException.java
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/exceptions/OperationFailedException.java
@@ -1,0 +1,7 @@
+package com.netflix.spinnaker.orca.exceptions;
+
+public class OperationFailedException extends RuntimeException {
+  public OperationFailedException(String message) { super(message);}
+
+  public OperationFailedException(String message, Throwable cause) { super(message, cause);}
+}


### PR DESCRIPTION
If a user tries to start a pipeline manually from a jenkins trigger and the build is not found we fail super silently. Let's at least throw a new exception with the cause. 

This message will show up in a tiny tool tip in the UI. Not a great experience, but better than not showing the error at all.