### PR TITLE
test(core): Basic startup test

### DIFF
--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -59,6 +59,7 @@ dependencies {
 
   spinnaker.group('test')
   testCompile project(":orca-test-groovy")
+  testCompile "com.netflix.spinnaker.keiko:keiko-mem:$keikoVersion"
 
   //this brings in the jetty GzipFilter which boot will autoconfigure
   runtime 'org.eclipse.jetty:jetty-servlets:9.2.11.v20150529'

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/MainSpec.java
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/MainSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.orca;
 
 import com.netflix.spinnaker.orca.front50.Front50Service;

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/MainSpec.java
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/MainSpec.java
@@ -1,9 +1,9 @@
 package com.netflix.spinnaker.orca;
 
-import com.netflix.spinnaker.orca.bakery.api.BakeryService;
-import com.netflix.spinnaker.orca.echo.EchoService;
 import com.netflix.spinnaker.orca.front50.Front50Service;
-import com.netflix.spinnaker.orca.igor.IgorService;
+import com.netflix.spinnaker.orca.locks.LockManager;
+import com.netflix.spinnaker.orca.notifications.NotificationClusterLock;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,13 +21,13 @@ public class MainSpec {
   Front50Service front50Service;
 
   @MockBean
-  IgorService igorService;
+  ExecutionRepository executionRepository;
 
   @MockBean
-  BakeryService bakeryService;
+  LockManager lockManager;
 
   @MockBean
-  EchoService echoService;
+  NotificationClusterLock notificationClusterLock;
 
   @Test
   public void startupTest() {

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/MainSpec.java
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/MainSpec.java
@@ -1,0 +1,35 @@
+package com.netflix.spinnaker.orca;
+
+import com.netflix.spinnaker.orca.bakery.api.BakeryService;
+import com.netflix.spinnaker.orca.echo.EchoService;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.igor.IgorService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {Main.class})
+@ContextConfiguration(classes = {StartupTestConfiguration.class})
+@TestPropertySource(properties = {"spring.config.location=classpath:orca-test.yml"})
+public class MainSpec {
+  @MockBean
+  Front50Service front50Service;
+
+  @MockBean
+  IgorService igorService;
+
+  @MockBean
+  BakeryService bakeryService;
+
+  @MockBean
+  EchoService echoService;
+
+  @Test
+  public void startupTest() {
+  }
+}

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/StartupTestConfiguration.java
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/StartupTestConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca;
+
+import com.netflix.spinnaker.q.Queue;
+import com.netflix.spinnaker.q.memory.InMemoryQueue;
+import com.netflix.spinnaker.q.metrics.EventPublisher;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Collections;
+
+@TestConfiguration
+class StartupTestConfiguration {
+  @Bean
+  @Primary
+  Queue queue(Clock clock, EventPublisher publisher) {
+    return new InMemoryQueue(clock, Duration.ofMinutes(1), Collections.emptyList(), publisher);
+  }
+}

--- a/orca-web/src/test/resources/orca-test.yml
+++ b/orca-web/src/test/resources/orca-test.yml
@@ -1,14 +1,19 @@
-redis:
-  connection: redis://localhost:6379
-
 front50:
   baseUrl: http://localhost:8080
 
 igor:
-  baseUrl: http://localhost:8088
+  enabled: false
 
 bakery:
-  baseUrl: http://localhost:8087
+  enabled: false
 
 echo:
-  baseUrl: http://localhost:8089
+  enabled: false
+
+monitor:
+  activeExecutions:
+    redis: false
+
+executionRepository:
+  redis:
+    enabled: false

--- a/orca-web/src/test/resources/orca-test.yml
+++ b/orca-web/src/test/resources/orca-test.yml
@@ -1,0 +1,14 @@
+redis:
+  connection: redis://localhost:6379
+
+front50:
+  baseUrl: http://localhost:8080
+
+igor:
+  baseUrl: http://localhost:8088
+
+bakery:
+  baseUrl: http://localhost:8087
+
+echo:
+  baseUrl: http://localhost:8089


### PR DESCRIPTION
Test that orca starts up with a very basic config, with just the baseUrl for each dependent service defined, and an in-memory execution queue.