### PR TITLE
fix(templated-pipelines): handle a missing notifications field

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/V1TemplateLoaderHandler.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/V1TemplateLoaderHandler.kt
@@ -37,7 +37,7 @@ class V1TemplateLoaderHandler(
 
   override fun handle(chain: HandlerChain, context: PipelineTemplateContext) {
     val config = objectMapper.convertValue(context.getRequest().config, TemplateConfiguration::class.java)
-    config.configuration.notifications.addAll(context.getRequest().notifications)
+    config.configuration.notifications.addAll(context.getRequest().notifications.orEmpty())
 
     // Allow template inlining to perform plans without publishing the template
     if (context.getRequest().plan && context.getRequest().template != null) {


### PR DESCRIPTION
This change should handle the case where notifications should not be null, but was in an existing template.