### PR TITLE
feat(spel): add manifestLabelValue helper function

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -42,6 +42,7 @@ dependencies {
   compile "org.apache.commons:commons-lang3:3.7"
   compile "de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.1.1"
   compile "javax.servlet:javax.servlet-api:4.0.1"
+  compile('com.jayway.jsonpath:json-path:2.2.0')
 
   compileOnly spinnaker.dependency("lombok")
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionTransform.java
@@ -37,7 +37,7 @@ import static java.util.stream.Collectors.toSet;
 public class ExpressionTransform {
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  private static final List<String> EXECUTION_AWARE_FUNCTIONS = Arrays.asList("judgment", "judgement", "stage", "stageExists", "deployedServerGroups");
+  private static final List<String> EXECUTION_AWARE_FUNCTIONS = Arrays.asList("judgment", "judgement", "stage", "stageExists", "deployedServerGroups", "manifestLabelValue");
   private static final List<String> EXECUTION_AWARE_ALIASES = Collections.singletonList("deployedServerGroups");
   private static final List<Class> STRINGIFYABLE_TYPES = Collections.singletonList(ExecutionStatus.class);
   private final ParserContext parserContext;


### PR DESCRIPTION
@duftler proof of concept for using a helper function to resolve label values to enable blue/green deployments in which labels are dynamically patched into Services:

Used in patch manifest stage...

![ez1g017frzr](https://user-images.githubusercontent.com/15936279/53669033-b8a7f080-3c43-11e9-80b3-8f3cec138044.png)

...and resolved in pipeline execution:

![ytgjism0dip](https://user-images.githubusercontent.com/15936279/53669068-cf4e4780-3c43-11e9-9b45-ee10a4d08387.png)

Would you recommend creating some sort of helper class for a ReplicaSet/Deployment manifest spec rather than checking each step of spec --> template --> metadata -->labels? This seems pretty verbose.