### PR TITLE
fix(execution): a stage with redirect tasks gets marked terminal

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -230,7 +230,7 @@ class CompleteStageHandler(
       allStatuses.contains(STOPPED)            -> STOPPED
       allStatuses.contains(CANCELED)           -> CANCELED
       allStatuses.contains(FAILED_CONTINUE)    -> FAILED_CONTINUE
-      allStatuses.all { it == SUCCEEDED }      -> SUCCEEDED
+      allStatuses.all { it == SUCCEEDED || it == REDIRECT }      -> SUCCEEDED
       afterStageStatuses.contains(NOT_STARTED) -> RUNNING // after stages were planned but not run yet
       else                                     -> {
         log.error("Unhandled condition for stage $id of $execution.id, marking as TERMINAL. syntheticStatuses=$syntheticStatuses, taskStatuses=$taskStatuses, planningStatus=$planningStatus, afterStageStatuses=$afterStageStatuses")


### PR DESCRIPTION
The logic for determining stage status seems overly strict.
The redirect execution status is used in a task loop. Without counting that as success how would something like RollingPushStage ever succeed? Or do the redirect statuses get modified somehow?
I could also make an argument that skipped tasks should not kick the stage out of opportunity to be a success.
