### PR TITLE
refactor(core): Allow registering custom SpEL expression functions

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -29,10 +29,10 @@ import com.netflix.spinnaker.orca.listeners.*;
 import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory;
+import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionFunctionProvider;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.orca.pipeline.util.ContextFunctionConfiguration;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
-import java.util.Arrays;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -51,13 +51,15 @@ import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import rx.Notification;
 import rx.Scheduler;
 import rx.schedulers.Schedulers;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.springframework.context.annotation.AnnotationConfigUtils.EVENT_LISTENER_FACTORY_BEAN_NAME;
@@ -122,9 +124,13 @@ public class OrcaConfiguration {
 
   @Bean
   public ContextFunctionConfiguration contextFunctionConfiguration(UserConfiguredUrlRestrictions userConfiguredUrlRestrictions,
-                                                                   @Value("${spelEvaluator:v2}")
-                                                                     String spelEvaluator) {
-    return new ContextFunctionConfiguration(userConfiguredUrlRestrictions, spelEvaluator);
+                                                                   Optional<List<ExpressionFunctionProvider>> expressionFunctionProviders,
+                                                                   @Value("${spelEvaluator:v2}") String spelEvaluator) {
+    return new ContextFunctionConfiguration(
+      userConfiguredUrlRestrictions,
+      expressionFunctionProviders.orElse(Collections.emptyList()),
+      spelEvaluator
+    );
   }
 
   @Bean

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionFunctionProvider.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionFunctionProvider.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipeline.expressions
+
+interface ExpressionFunctionProvider {
+  val namespace: String?
+  val functions: Collection<FunctionDefinition>
+
+  data class FunctionDefinition(
+    val name: String,
+    val parameters: List<FunctionParameter>
+  )
+
+  data class FunctionParameter(
+    val type: Class<*>,
+    val name: String,
+    val description: String
+  )
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/DeployedServerGroupsExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/DeployedServerGroupsExpressionFunctionProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipeline.expressions.functions;
+
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionFunctionProvider;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.function.Predicate;
+
+@Component
+public class DeployedServerGroupsExpressionFunctionProvider implements ExpressionFunctionProvider {
+
+  private static List<String> DEPLOY_STAGE_NAMES = Arrays.asList(
+    "deploy", "createServerGroup", "cloneServerGroup", "rollingPush"
+  );
+
+  @Nullable
+  @Override
+  public String getNamespace() {
+    return null;
+  }
+
+  @NotNull
+  @Override
+  public Collection<FunctionDefinition> getFunctions() {
+    return Collections.singletonList(
+      new FunctionDefinition("deployedServerGroups", Arrays.asList(
+        new FunctionParameter(Object.class, "execution", "The execution to search for stages within"),
+        new FunctionParameter(String[].class, "ids", "A list of stage name or stage IDs to search")
+      ))
+    );
+  }
+
+  public static List<Map<String, Object>> deployedServerGroups(Object obj, String... id) {
+    if (obj instanceof Execution) {
+      List<Map<String, Object>> deployedServerGroups = new ArrayList<>();
+      ((Execution) obj).getStages()
+        .stream()
+        .filter(matchesDeployedStage(id))
+        .forEach(stage -> {
+          String region = (String) stage.getContext().get("region");
+          if (region == null) {
+            Map<String, Object> availabilityZones = (Map<String, Object>) stage.getContext().get("availabilityZones");
+            if (availabilityZones != null) {
+              region = availabilityZones.keySet().iterator().next();
+            }
+          }
+
+          if (region != null) {
+            Map<String, Object> deployDetails = new HashMap<>();
+            deployDetails.put("account", stage.getContext().get("account"));
+            deployDetails.put("capacity", stage.getContext().get("capacity"));
+            deployDetails.put("parentStage", stage.getContext().get("parentStage"));
+            deployDetails.put("region", region);
+            List<Map> existingDetails = (List<Map>) stage.getContext().get("deploymentDetails");
+            if (existingDetails != null) {
+              existingDetails
+                .stream()
+                .filter(d -> deployDetails.get("region").equals(d.get("region")))
+                .forEach(deployDetails::putAll);
+            }
+
+            List<Map> serverGroups = (List<Map>) ((Map) stage.getContext().get("deploy.server.groups")).get(region);
+            if (serverGroups != null) {
+              deployDetails.put("serverGroup", serverGroups.get(0));
+            }
+
+            deployedServerGroups.add(deployDetails);
+          }
+        });
+
+      return deployedServerGroups;
+    }
+
+    throw new IllegalArgumentException("An execution is required for this function");
+  }
+
+  private static Predicate<Stage> matchesDeployedStage(String... id) {
+    List<String> idsOrNames = Arrays.asList(id);
+    if (!idsOrNames.isEmpty()){
+      return stage -> DEPLOY_STAGE_NAMES.contains(stage.getType()) &&
+        stage.getContext().containsKey("deploy.server.groups") &&
+        stage.getStatus() == ExecutionStatus.SUCCEEDED &&
+        (idsOrNames.contains(stage.getName()) || idsOrNames.contains(stage.getId()));
+    } else {
+      return stage -> DEPLOY_STAGE_NAMES.contains(stage.getType()) &&
+        stage.getContext().containsKey("deploy.server.groups") && stage.getStatus() == ExecutionStatus.SUCCEEDED;
+    }
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/ManifestLabelValueExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/ManifestLabelValueExpressionFunctionProvider.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipeline.expressions.functions;
+
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionFunctionProvider;
+import com.netflix.spinnaker.orca.pipeline.expressions.SpelHelperFunctionException;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+import static java.lang.String.format;
+
+@Component
+public class ManifestLabelValueExpressionFunctionProvider implements ExpressionFunctionProvider {
+  @Nullable
+  @Override
+  public String getNamespace() {
+    return null;
+  }
+
+  @NotNull
+  @Override
+  public Collection<FunctionDefinition> getFunctions() {
+    return Collections.singletonList(
+      new FunctionDefinition("manifestLabelValue", Arrays.asList(
+        new FunctionParameter(Object.class, "execution", "The execution to search for stages within"),
+        new FunctionParameter(String.class, "stageName", "Name of a deployManifest stage to find"),
+        new FunctionParameter(String.class, "kind", "The kind of manifest to find"),
+        new FunctionParameter(String.class, "labelKey", "The key of the label to find")
+      ))
+    );
+  }
+
+  /**
+   * Gets value of given label key in manifest of given kind deployed by stage of given name
+   * @param obj #root.execution
+   * @param stageName the name of a `deployManifest` stage to find
+   * @param kind the kind of manifest to find
+   * @param labelKey the key of the label to find
+   * @return the label value
+   */
+  public static String manifestLabelValue(Object obj, String stageName, String kind, String labelKey) {
+    if (!(obj instanceof Execution)) {
+      throw new IllegalArgumentException("An execution is required for this function");
+    }
+
+    List<String> validKinds = Arrays.asList("Deployment", "ReplicaSet");
+    if (!validKinds.contains(kind)) {
+      throw new IllegalArgumentException("Only Deployments and ReplicaSets are valid kinds for this function");
+    }
+
+    if (labelKey == null) {
+      throw new IllegalArgumentException("A labelKey is required for this function");
+    }
+
+    Optional<Stage> stage = ((Execution) obj).getStages()
+      .stream()
+      .filter(s -> s.getName().equals(stageName) && s.getType().equals("deployManifest") && s.getStatus() == ExecutionStatus.SUCCEEDED)
+      .findFirst();
+
+    if (!stage.isPresent()) {
+      throw new SpelHelperFunctionException("A valid Deploy Manifest stage name is required for this function");
+    }
+
+    List<Map> manifests = (List<Map>) stage.get().getContext().get("manifests");
+
+    if (manifests == null || manifests.size() == 0) {
+      throw new SpelHelperFunctionException("No manifest could be found in the context of the specified stage");
+    }
+
+    Optional<Map> manifestOpt = manifests.stream()
+      .filter(m -> m.get("kind").equals(kind))
+      .findFirst();
+
+    if (!manifestOpt.isPresent()) {
+      throw new SpelHelperFunctionException(format("No manifest of kind %s could be found on the context of the specified stage", kind));
+    }
+
+    Map manifest = manifestOpt.get();
+    String labelPath = format("$.spec.template.metadata.labels.%s", labelKey);
+    String labelValue;
+
+    try {
+      labelValue = JsonPath.read(manifest, labelPath);
+    } catch (PathNotFoundException e) {
+      throw new SpelHelperFunctionException("No label of specified key found on matching manifest spec.template.metadata.labels");
+    }
+
+    return labelValue;
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextFunctionConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextFunctionConfiguration.java
@@ -17,23 +17,36 @@
 package com.netflix.spinnaker.orca.pipeline.util;
 
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
+import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionFunctionProvider;
+
+import java.util.List;
+
 import static com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator.ExpressionEvaluationVersion.V2;
 
 public class ContextFunctionConfiguration {
   private final UserConfiguredUrlRestrictions urlRestrictions;
+  private final List<ExpressionFunctionProvider> expressionFunctionProviders;
   private final String spelEvaluator;
 
-  public ContextFunctionConfiguration(UserConfiguredUrlRestrictions urlRestrictions, String spelEvaluator) {
+  public ContextFunctionConfiguration(UserConfiguredUrlRestrictions urlRestrictions,
+                                      List<ExpressionFunctionProvider> expressionFunctionProviders,
+                                      String spelEvaluator) {
     this.urlRestrictions = urlRestrictions;
+    this.expressionFunctionProviders = expressionFunctionProviders;
     this.spelEvaluator = spelEvaluator;
   }
 
-  public ContextFunctionConfiguration(UserConfiguredUrlRestrictions urlRestrictions) {
-    this(urlRestrictions, V2);
+  public ContextFunctionConfiguration(UserConfiguredUrlRestrictions urlRestrictions,
+                                      List<ExpressionFunctionProvider> expressionFunctionProviders) {
+    this(urlRestrictions, expressionFunctionProviders, V2);
   }
 
   public UserConfiguredUrlRestrictions getUrlRestrictions() {
     return urlRestrictions;
+  }
+
+  public List<ExpressionFunctionProvider> getExpressionFunctionProviders() {
+    return expressionFunctionProviders;
   }
 
   public String getSpelEvaluator() {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
@@ -23,6 +23,8 @@ import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
 import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionEvaluationSummary;
 import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionEvaluator;
 import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator;
+import com.netflix.spinnaker.orca.pipeline.expressions.functions.DeployedServerGroupsExpressionFunctionProvider;
+import com.netflix.spinnaker.orca.pipeline.expressions.functions.ManifestLabelValueExpressionFunctionProvider;
 import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger;
 import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.BuildInfo;
 import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.SourceControl;
@@ -31,10 +33,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Trigger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator.ExpressionEvaluationVersion.V2;
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE;
@@ -54,7 +53,14 @@ public class ContextParameterProcessor {
   private ExpressionEvaluator expressionEvaluator;
 
   public ContextParameterProcessor() {
-    this(new ContextFunctionConfiguration(new UserConfiguredUrlRestrictions.Builder().build(), V2));
+    this(new ContextFunctionConfiguration(
+      new UserConfiguredUrlRestrictions.Builder().build(),
+      Arrays.asList(
+        new DeployedServerGroupsExpressionFunctionProvider(),
+        new ManifestLabelValueExpressionFunctionProvider()
+      ),
+      V2
+    ));
   }
 
   public ContextParameterProcessor(ContextFunctionConfiguration contextFunctionConfiguration) {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/DeployedServerGroupsExpressionFunctionProviderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/DeployedServerGroupsExpressionFunctionProviderSpec.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipeline.expressions.functions
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
+import static com.netflix.spinnaker.orca.pipeline.expressions.functions.DeployedServerGroupsExpressionFunctionProvider.deployedServerGroups
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class DeployedServerGroupsExpressionFunctionProviderSpec extends Specification {
+  @Shared
+  def pipeline = pipeline {
+    stage {
+      id = "1"
+      name = "My First Stage"
+      context = [
+        "region": "us-east-1",
+      ]
+    }
+
+    stage {
+      id = "2"
+      name = "My Second Stage"
+      context = [
+        "region": "us-west-1",
+      ]
+    }
+
+    stage {
+      id = "3"
+      status = SUCCEEDED
+      type = "createServerGroup"
+      name = "Deploy in us-east-1"
+      context.putAll(
+        "account": "test",
+        "deploy.account.name": "test",
+        "availabilityZones": [
+          "us-east-1": [
+            "us-east-1c",
+            "us-east-1d",
+            "us-east-1e"
+          ]
+        ],
+        "capacity": [
+          "desired": 1,
+          "max"    : 1,
+          "min"    : 1
+        ],
+        "deploy.server.groups": [
+          "us-east-1": [
+            "app-test-v001"
+          ]
+        ]
+      )
+    }
+
+    stage {
+      id = "4"
+      status = SUCCEEDED
+      type = "disableServerGroup"
+      name = "disable server group"
+      context.putAll(
+        "account": "test",
+        "deploy.account.name": "test",
+        "availabilityZones": [
+          "us-east-1": [
+            "us-east-1c",
+            "us-east-1d",
+            "us-east-1e"
+          ]
+        ],
+        "capacity": [
+          "desired": 1,
+          "max"    : 1,
+          "min"    : 1
+        ],
+        "deploy.server.groups": [
+          "us-west-2": [
+            "app-test-v002"
+          ]
+        ]
+      )
+    }
+  }
+
+  def "deployedServerGroup should resolve for valid stage type"() {
+    when:
+    def map = deployedServerGroups(pipeline)
+
+    then: "(deploy|createServerGroup|cloneServerGroup|rollingPush)"
+    map.serverGroup == ["app-test-v001"]
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/ManifestLabelValueExpressionFunctionProviderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/ManifestLabelValueExpressionFunctionProviderSpec.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipeline.expressions.functions
+
+
+import com.netflix.spinnaker.orca.pipeline.expressions.SpelHelperFunctionException
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
+import static com.netflix.spinnaker.orca.pipeline.expressions.functions.ManifestLabelValueExpressionFunctionProvider.manifestLabelValue
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class ManifestLabelValueExpressionFunctionProviderSpec extends Specification {
+
+  @Shared
+  def deployManifestPipeline = pipeline {
+    stage {
+      id = "1"
+      name = "Deploy ReplicaSet"
+      context.putAll(
+        "manifests": [
+          [
+            "kind": "ReplicaSet",
+            "spec": [
+              "template": [
+                "metadata": [
+                  "labels": [
+                    "my-label-key": "my-label-value",
+                    "my-other-label-key": "my-other-label-value"
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      )
+      status = SUCCEEDED
+      type = "deployManifest"
+    }
+  }
+
+  @Unroll
+  def "manifestLabelValue should resolve label value for manifest of given kind deployed by stage of given name"() {
+    expect:
+    manifestLabelValue(deployManifestPipeline, "Deploy ReplicaSet", "ReplicaSet", labelKey) == expectedLabelValue
+
+    where:
+    labelKey             || expectedLabelValue
+    "my-label-key"       || "my-label-value"
+    "my-other-label-key" || "my-other-label-value"
+  }
+
+  def "manifestLabelValue should raise exception if stage, manifest, or label not found"() {
+    when:
+    manifestLabelValue(deployManifestPipeline, "Non-existent Stage", "ReplicaSet", "my-label-key")
+
+    then:
+    thrown(SpelHelperFunctionException)
+
+    when:
+    manifestLabelValue(deployManifestPipeline, "Deploy ReplicaSet", "Deployment", "my-label-key")
+
+    then:
+    thrown(SpelHelperFunctionException)
+
+    when:
+    manifestLabelValue(deployManifestPipeline, "Deploy ReplicaSet", "ReplicaSet", "non-existent-label")
+
+    then:
+    thrown(SpelHelperFunctionException)
+  }
+}


### PR DESCRIPTION
Provides a strategy for extending Orca's SpEL expression language with new helper functions.
Additionally offers a more strongly typed and documented method of building these helpers, as
well as namespacing capabilities in case an organization wants to provide a canned group of
helper functions.

Moved `deployedServerGroups` and `manifestLabelValue` to use this new format.

Largely stolen from @ajordens prior art that was never merged.