### PR TITLE
feat(artifacts): Add stage artifact resolver

### DIFF
--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
@@ -43,7 +43,7 @@ class DependentPipelineStarterSpec extends Specification {
 
   ObjectMapper mapper = OrcaObjectMapper.newInstance()
   ExecutionRepository executionRepository = Mock(ExecutionRepository)
-  ArtifactResolver artifactResolver = Spy(ArtifactResolver, constructorArgs: [mapper, executionRepository])
+  ArtifactResolver artifactResolver = Spy(ArtifactResolver, constructorArgs: [mapper, executionRepository, new ContextParameterProcessor()])
 
   def "should only propagate credentials when explicitly provided"() {
     setup:

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTaskSpec.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import retrofit.RetrofitError
 import retrofit.client.Response
 import spock.lang.Shared
@@ -35,7 +36,7 @@ import spock.lang.Unroll
 
 class MonitorJenkinsJobTaskSpec extends Specification {
   def executionRepository = Mock(ExecutionRepository)
-  def artifactResolver = new ArtifactResolver(new ObjectMapper(), executionRepository)
+  def artifactResolver = new ArtifactResolver(new ObjectMapper(), executionRepository, new ContextParameterProcessor())
 
   @Subject
   MonitorJenkinsJobTask task = new MonitorJenkinsJobTask()

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -481,7 +481,7 @@ class OperationsControllerSpec extends Specification {
       startedPipeline
     }
     executionRepository.retrievePipelinesForPipelineConfigId(*_) >> Observable.empty()
-    ArtifactResolver realArtifactResolver = new ArtifactResolver(mapper, executionRepository)
+    ArtifactResolver realArtifactResolver = new ArtifactResolver(mapper, executionRepository, new ContextParameterProcessor())
 
     // can't use @subject, since we need to test the behavior of otherwise mocked-out 'artifactResolver'
     def tempController = new OperationsController(


### PR DESCRIPTION
The new method is used to fully resolve a bound artifact on a stage that can either select an expected artifact ID for an expected artifact defined in a prior stage or as a trigger constraint OR define an inline expression-evaluable default artifact.