### PR TITLE
fix(kubernetes): Don't fail deploy for SpEL errors in manifest artifacts

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
@@ -125,10 +125,6 @@ public class DeployManifestTask extends AbstractCloudProviderAwareTask implement
               true
           );
 
-          if (manifestWrapper.containsKey("expressionEvaluationSummary")) {
-            throw new IllegalStateException("Failure evaluating manifest expressions: " + manifestWrapper.get("expressionEvaluationSummary"));
-          }
-
           return manifestWrapper.get("manifests");
         } catch (Exception e) {
           log.warn("Failure fetching/parsing manifests from {}", manifestArtifact, e);


### PR DESCRIPTION
Fixes spinnaker/spinnaker#3644
This will still display a warning to in the pipeline UI, just as when an evaluation error happens in a manifest in the stage as text. It allows the successful deployment of manifests that contain "expressions" that are intended to evaluated by the pod and not the pipeline (e.g. configmaps with Spring config, bash scripts with `${}` style environment variables, etc )
