### PR TITLE
feat(core): add save pipelines stage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/pipeline/SavePipelinesFromArtifactStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/pipeline/SavePipelinesFromArtifactStage.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
-public class SavePipelinesStage implements StageDefinitionBuilder {
+public class SavePipelinesFromArtifactStage implements StageDefinitionBuilder {
 
   @Override
   public void taskGraph(Stage stage, Builder builder) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/pipeline/SavePipelinesStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/pipeline/SavePipelinesStage.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.clouddriver.pipeline.pipeline;
+
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.tasks.pipeline.CheckForRemainingPipelinesTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.pipeline.GetPipelinesFromArtifactTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.pipeline.PreparePipelineToSaveTask;
+import com.netflix.spinnaker.orca.front50.tasks.MonitorFront50Task;
+import com.netflix.spinnaker.orca.front50.tasks.SavePipelineTask;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode.Builder;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SavePipelinesStage implements StageDefinitionBuilder {
+
+  @Override
+  public void taskGraph(Stage stage, Builder builder) {
+
+    builder
+      .withTask("getPipelinesFromArtifact", GetPipelinesFromArtifactTask.class)
+      .withLoop(subGraph -> {
+        subGraph
+          .withTask("preparePipelineToSaveTask", PreparePipelineToSaveTask.class)
+          .withTask("savePipeline", SavePipelineTask.class)
+          .withTask("waitForPipelineSave", MonitorFront50Task.class)
+          .withTask("checkForRemainingPipelines", CheckForRemainingPipelinesTask.class);
+      })
+      .withTask("savePipelinesCompleteTask", SavePipelinesCompleteTask.class);
+  }
+
+  @Component
+  public static class SavePipelinesCompleteTask implements com.netflix.spinnaker.orca.Task {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @Override public TaskResult execute(Stage stage) {
+      log.info("Save Pipelines completed");
+      return TaskResult.SUCCEEDED;
+    }
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/CheckForRemainingPipelinesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/CheckForRemainingPipelinesTask.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.clouddriver.tasks.pipeline;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CheckForRemainingPipelinesTask implements Task {
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Override
+  public TaskResult execute(Stage stage) {
+    final SavePipelinesData input = stage.mapTo(SavePipelinesData.class);
+    if (input.getPipelinesToSave() == null || input.getPipelinesToSave().isEmpty()) {
+      return new TaskResult(ExecutionStatus.SUCCEEDED);
+    }
+    return new TaskResult(ExecutionStatus.REDIRECT);
+  }
+
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/GetPipelinesFromArtifactTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/GetPipelinesFromArtifactTask.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.clouddriver.tasks.pipeline;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class GetPipelinesFromArtifactTask implements Task {
+
+  private Logger log = LoggerFactory.getLogger(getClass());
+
+  @Autowired
+  private Front50Service front50Service;
+
+  @Autowired
+  private OortService oort;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Autowired
+  ArtifactResolver artifactResolver;
+
+  RetrySupport retrySupport = new RetrySupport();
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class PipelinesArtifactData {
+    @JsonProperty("pipelinesArtifactId") private String id;
+    @JsonProperty("pipelinesArtifact") private Artifact inline;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public TaskResult execute(Stage stage) {
+    final PipelinesArtifactData pipelinesArtifact = stage.mapTo(PipelinesArtifactData.class);
+    Artifact resolvedArtifact = artifactResolver
+      .getBoundArtifactForStage(stage, pipelinesArtifact.getId(), pipelinesArtifact.getInline());
+    if (resolvedArtifact == null) {
+      throw new IllegalArgumentException("No artifact could be bound to '" + pipelinesArtifact.getId() + "'");
+    }
+    log.info("Using {} as the pipelines to be saved", pipelinesArtifact);
+
+    String pipelinesText = getPipelinesArtifactContent(resolvedArtifact);
+
+    Map<String, List<Map>> pipelinesFromArtifact = null;
+    try {
+      pipelinesFromArtifact = objectMapper.readValue(pipelinesText, new TypeReference<Map<String, List<Map>>>() {});
+    } catch (IOException e) {
+      log.warn("Failure parsing pipelines from {}", pipelinesArtifact, e);
+      throw new IllegalStateException(e); // forces a retry
+    }
+    final Map<String, List<Map>> finalPipelinesFromArtifact = pipelinesFromArtifact;
+    final Set<String> appNames = pipelinesFromArtifact.keySet();
+    final List newAndUpdatedPipelines = appNames.stream().flatMap(appName -> {
+      final List<Map<String, Object>> existingAppPipelines = front50Service.getPipelines(appName);
+      final List<Map> specifiedAppPipelines = finalPipelinesFromArtifact.get(appName);
+      return specifiedAppPipelines.stream().map(p -> {
+        final Map<String, Object> pipeline = p;
+        pipeline.put("application", appName);
+        final Optional<Map<String, Object>> matchedExistingPipeline = existingAppPipelines
+          .stream().filter(existingPipeline -> existingPipeline.get("name").equals(pipeline.get("name"))).findFirst();
+        matchedExistingPipeline.ifPresent(matchedPipeline -> {
+          pipeline.put("id", matchedPipeline.get("id"));
+        });
+        return pipeline;
+      }).filter(pipeline -> !pipeline.isEmpty());
+    }).collect(Collectors.toList());
+    final SavePipelinesData output = new SavePipelinesData(null, newAndUpdatedPipelines);
+    return new TaskResult(ExecutionStatus.SUCCEEDED,
+      objectMapper.convertValue(output, new TypeReference<Map<String, Object>>() {}));
+  }
+
+  private String getPipelinesArtifactContent(Artifact artifact) {
+    return retrySupport.retry(() -> {
+      Response response = oort.fetchArtifact(artifact);
+      InputStream artifactInputStream;
+      try {
+        artifactInputStream = response.getBody().in();
+      } catch (IOException e) {
+        log.warn("Failure fetching pipelines from {}", artifact, e);
+        throw new IllegalStateException(e); // forces a retry
+      }
+      try (BufferedReader rd = new BufferedReader(new InputStreamReader(artifactInputStream))) {
+        String line;
+        StringBuilder result = new StringBuilder();
+        while ((line = rd.readLine()) != null) {
+          result.append(line);
+        }
+        return result.toString();
+      } catch (IOException e) {
+        log.warn("Failure reading pipelines from {}", artifact, e);
+        throw new IllegalStateException(e); // forces a retry
+      }
+    }, 10, 200, true);
+  }
+
+}
+

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/PreparePipelineToSaveTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/PreparePipelineToSaveTask.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.clouddriver.tasks.pipeline;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class PreparePipelineToSaveTask implements Task {
+
+  private Logger log = LoggerFactory.getLogger(getClass());
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Override
+  public TaskResult execute(Stage stage) {
+    final SavePipelinesData input = stage.mapTo(SavePipelinesData.class);
+    if (input.getPipelinesToSave() == null || input.getPipelinesToSave().isEmpty()) {
+      log.info("There are no pipelines to save.");
+      return new TaskResult(ExecutionStatus.TERMINAL);
+    }
+    final Map pipelineData = input.getPipelinesToSave().get(0);
+    final String pipelineString;
+    try {
+      pipelineString = objectMapper.writeValueAsString(pipelineData);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(e);
+    }
+    final String encodedPipeline = Base64.getEncoder().encodeToString(pipelineString.getBytes());
+    final List<Map> remainingPipelinesToSave = input.getPipelinesToSave().subList(1, input.getPipelinesToSave().size());
+    final SavePipelinesData output = new SavePipelinesData(encodedPipeline, remainingPipelinesToSave);
+    return new TaskResult(ExecutionStatus.SUCCEEDED,
+      objectMapper.convertValue(output, new TypeReference<Map<String, Object>>() {}));
+  }
+
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/SavePipelinesData.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/SavePipelinesData.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.clouddriver.tasks.pipeline;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SavePipelinesData {
+  private String pipeline;
+  private List<Map> pipelinesToSave;
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/GetPipelinesFromArtifactTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/GetPipelinesFromArtifactTaskSpec.groovy
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.clouddriver.tasks.pipeline
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver
+import retrofit.client.Response
+import retrofit.mime.TypedString
+import spock.lang.Specification
+import spock.lang.Subject
+
+class GetPipelinesFromArtifactTaskSpec extends Specification {
+
+  @Subject
+  final task = new GetPipelinesFromArtifactTask()
+
+  Front50Service front50Service = Mock()
+  OortService oortService = Mock()
+  ArtifactResolver artifactResolver = Mock()
+
+  void setup() {
+    task.front50Service = front50Service
+    task.oort = oortService
+    task.artifactResolver = artifactResolver
+    task.objectMapper = OrcaObjectMapper.newInstance()
+  }
+
+  void 'extract pipelines JSON from artifact'() {
+    when:
+    def context = [
+      pipelinesArtifactId: '123'
+    ]
+    def result = task.execute(new Stage(Execution.newPipeline("orca"), "whatever", context))
+
+    then:
+    1 * artifactResolver.getBoundArtifactForStage(_, '123', _) >> new Artifact().builder().type('http/file')
+      .reference('url1').build()
+    1 * oortService.fetchArtifact(_) >> new Response("url1", 200, "reason1", [],
+      new TypedString(pipelineJson))
+    front50Service.getPipelines(_) >> []
+    result.status == ExecutionStatus.SUCCEEDED
+    final pipelinesToSave = ((List<Map>) result.context.get("pipelinesToSave"))
+    pipelinesToSave.size() == 3
+    pipelinesToSave.every { !it.containsKey("id") }
+  }
+
+  void 'extract pipelines JSON from artifact with existing pipeline'() {
+    when:
+    def context = [
+      pipelinesArtifactId: '123'
+    ]
+    def result = task.execute(new Stage(Execution.newPipeline("orca"), "whatever", context))
+
+    then:
+    1 * artifactResolver.getBoundArtifactForStage(_, '123', _) >> new Artifact().builder().type('http/file')
+      .reference('url1').build()
+    1 * oortService.fetchArtifact(_) >> new Response("url1", 200, "reason1", [],
+      new TypedString(pipelineJson))
+    front50Service.getPipelines("app1") >> []
+    front50Service.getPipelines("app2") >> [
+      [name: "just judging", id: "exitingPipelineId"]
+    ]
+    result.status == ExecutionStatus.SUCCEEDED
+    final pipelinesToSave = ((List<Map>) result.context.get("pipelinesToSave"))
+    pipelinesToSave.size() == 3
+    pipelinesToSave.find { it.name == "just judging"}.containsKey("id")
+    pipelinesToSave.findAll { !it.name == "just judging"}.every { !it.containsKey("id") }
+  }
+
+  void 'fail to extract pipelines JSON from artifact without bound artifact'() {
+    when:
+    def context = [
+      pipelinesArtifactId: '123'
+    ]
+    def result = task.execute(new Stage(Execution.newPipeline("orca"), "whatever", context))
+
+    then:
+    1 * artifactResolver.getBoundArtifactForStage(_, '123', _) >> null
+    IllegalArgumentException ex = thrown()
+    ex.message == "No artifact could be bound to '123'"
+  }
+
+  final pipelineJson = '''
+{
+  "app1": [{
+    "name": "just waiting",
+    "description": "",
+    "parameterConfig": [],
+    "notifications": [],
+    "triggers": [],
+    "stages": [{
+      "refId": "wait1",
+      "requisiteStageRefIds": [],
+      "type": "wait",
+      "waitTime": "420"
+    }],
+    "expectedArtifacts": [],
+    "keepWaitingPipelines": false,
+    "limitConcurrent": true
+  }],
+  "app2": [{
+      "name": "just judging",
+      "description": "",
+      "parameterConfig": [],
+      "notifications": [],
+      "triggers": [],
+      "stages": [{
+        "refId": "manualJudgment1",
+        "requisiteStageRefIds": [],
+        "instructions": "Judge me.",
+        "judgmentInputs": [],
+        "type": "manualJudgment"
+      }],
+      "expectedArtifacts": [],
+      "keepWaitingPipelines": false,
+      "limitConcurrent": true
+    },
+    {
+      "name": "waiting then judging",
+      "description": "",
+      "parameterConfig": [],
+      "notifications": [],
+      "triggers": [],
+      "stages": [{
+          "refId": "wait1",
+          "requisiteStageRefIds": [],
+          "type": "wait",
+          "waitTime": "420",
+          "comments": "Wait before judging me."
+        },
+        {
+          "refId": "manualJudgment2",
+          "requisiteStageRefIds": [
+            "wait1"
+          ],
+          "instructions": "Okay, Judge me now.",
+          "judgmentInputs": [],
+          "type": "manualJudgment"
+        }
+      ],
+      "expectedArtifacts": [],
+      "keepWaitingPipelines": false,
+      "limitConcurrent": true
+    }
+  ]
+}
+
+'''
+
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/PreparePipelineToSaveTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/PreparePipelineToSaveTaskSpec.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.clouddriver.tasks.pipeline
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import spock.lang.Specification
+import spock.lang.Subject
+
+class PreparePipelineToSaveTaskSpec extends Specification {
+
+  @Subject
+  final task = new PreparePipelineToSaveTask()
+
+  void setup() {
+    task.objectMapper = OrcaObjectMapper.newInstance()
+  }
+
+  void 'prepare pipeline for save pipeline task'() {
+    when:
+    def context = [
+      pipelinesToSave: [
+        [ name: "pipeline1" ]
+      ]
+    ]
+    def result = task.execute(new Stage(Execution.newPipeline("orca"), "whatever", context))
+
+    then:
+    result.status == ExecutionStatus.SUCCEEDED
+    result.context.get("pipeline") == "eyJuYW1lIjoicGlwZWxpbmUxIn0="
+    result.context.get("pipelinesToSave") == []
+  }
+
+  void 'prepare pipeline for save pipeline task with multiple pipelines'() {
+    when:
+    def context = [
+      pipelinesToSave: [
+        [ name: "pipeline1" ],
+        [ name: "pipeline2" ]
+      ]
+    ]
+    def result = task.execute(new Stage(Execution.newPipeline("orca"), "whatever", context))
+
+    then:
+    result.status == ExecutionStatus.SUCCEEDED
+    result.context.get("pipeline") == "eyJuYW1lIjoicGlwZWxpbmUxIn0="
+    result.context.get("pipelinesToSave") == [ [name: "pipeline2"] ]
+  }
+
+  void 'fail to prepare pipeline for save pipeline task with no pipelines'() {
+    when:
+    def context = [:]
+    def result = task.execute(new Stage(Execution.newPipeline("orca"), "whatever", context))
+
+    then:
+    result.status == ExecutionStatus.TERMINAL
+  }
+
+}


### PR DESCRIPTION
This stage will be used to extract pipelines from an artifact and save them. Spinnaker is a tool for deploying code, so when we treat pipelines as code it makes sense to use Spinnaker to deploy them.
Imagine you have your pipelines in a GitHub repo, and on each build you create an artifact that describes your pipelines. This CircleCI build is an example:
https://circleci.com/gh/claymccoy/canal_example/14#artifacts/containers/0

You can now create a pipleine that is triggered by that build, grab the artifact produced, and (with this new stage) extract the pipelines and save them.
It performs an upsert, where it looks for existing pipelines by app and name and uses the id to update in that case.

The format of the artifact is a JSON object where the top level keys are application names with values that are a list of pipelines for the app. The nested pipeline JSON is standard pipeline JSON. Here is an example:
https://14-171799544-gh.circle-artifacts.com/0/pipelines/pipelines.json

For now this simply upserts every pipeline in the artifact, but in the future it could allow you to specify a subset of apps and pipelines and effectively test and increase the scope of pipeline roll out. It (or a similar stage) could also save pipeline templates in the future as well.
