### PR TITLE
fix(imagetagging): retry for missing namedImages

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/ImageTagger.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/ImageTagger.java
@@ -63,11 +63,13 @@ public abstract class ImageTagger {
   }
 
   protected Collection findImages(Collection<String> imageNames, Collection<String> consideredStageRefIds, Stage stage, Class matchedImageType) {
+    List<String> upstreamImageIds = new ArrayList<>();
+
     if (imageNames == null || imageNames.isEmpty()) {
       imageNames = new HashSet<>();
 
       // attempt to find upstream images in the event that one was not explicitly provided
-      Collection<String> upstreamImageIds = upstreamImageIds(stage, consideredStageRefIds, getCloudProvider());
+      upstreamImageIds.addAll(upstreamImageIds(stage, consideredStageRefIds, getCloudProvider()));
       if (upstreamImageIds.isEmpty()) {
         throw new IllegalStateException("Unable to determine source image(s)");
       }
@@ -93,7 +95,9 @@ public abstract class ImageTagger {
       Map matchedImage = allMatchedImages.stream()
         .filter(image -> image.get("imageName").equals(targetImageName))
         .findFirst()
-        .orElseThrow(() -> new ImageNotFound(format("No image found (imageName: %s)", targetImageName), false));
+        .orElseThrow(() ->
+          new ImageNotFound(format("No image found (imageName: %s)", targetImageName), !upstreamImageIds.isEmpty())
+        );
 
       foundImages.add(objectMapper.convertValue(matchedImage, matchedImageType));
     }


### PR DESCRIPTION
`ImageTagger` already retries fetching images by id, but not when subsequently fetching by image name. This poses a race condition for `UpsertImageTagsStage` due to the fact that clouddriver's `ImageCachingAgent` stores image metadata and image -> name mappings as distinct objects which are not updated atomically, at least in the case of the AWS provider.

If `UpsertImageTagsStage` executes in the narrow window where a newly baked image's `image` object has been stored but `imageName` has not, it will go terminal without retries. This PR enables retries for the lookup by name when that name was derived from a successful lookup by id. When `ImageTagger.findImages()` is called with image names, the existing behavior is preserved and the first lookup failure remains terminal.