### PR TITLE
chore(jinja): Upgrade jinjava

### DIFF
--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -7,8 +7,6 @@ dependencies {
   compile project(":orca-front50")
   compile project(":orca-clouddriver")
 
-  compile('com.hubspot.jinjava:jinjava:2.2.3')
-
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${spinnaker.version('jackson')}"
   compile "com.fasterxml.jackson.module:jackson-module-kotlin:${spinnaker.version("jackson")}"
   compile('com.jayway.jsonpath:json-path:2.2.0')
@@ -17,6 +15,7 @@ dependencies {
   compile spinnaker.dependency("bootAutoConfigure")
   compile spinnaker.dependency("springContext")
   compile spinnaker.dependency("jacksonDatabind")
+  compile spinnaker.dependency("jinjava")
   compile spinnaker.dependency("spectatorApi")
   compile spinnaker.dependency("frigga")
   compile spinnaker.dependency('korkExceptions')

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/ModuleTagSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/render/tags/ModuleTagSpec.groovy
@@ -58,7 +58,7 @@ class ModuleTagSpec extends Specification {
     context.variables.put("m", [myKey: 'myValue'])
 
     when:
-    def result = renderer.render("{% module myModule myOtherVar=world, subject=testerName, job=trigger.job, concat=m['my' + 'Key'], filtered=trigger.nonExist|default('hello', True) %}", context)
+    def result = renderer.render("{% module myModule myOtherVar=world, subject=testerName, job=trigger.job, concat=m['my' + 'Key'], filtered=trigger.nonExist|default('hello', true) %}", context)
 
     then:
     result == 'hello world, Mr. Tester Testington. You triggered myJob myValue hello'


### PR DESCRIPTION
The ModuleTag class breaks with jinjava >= 2.2.8 because of a fix in failsOnUnknownTokens.  We need to catch this error in cases where we expect that a token may be unknown. The test also uses True as a literal which should be true (ie, lowercase) which worked before but breaks with the upgrade.
