### PR TITLE
fix(cloudformation): template should be a string

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTask.java
@@ -80,13 +80,14 @@ public class DeployCloudFormationTask extends AbstractCloudProviderAwareTask imp
       try {
         String template = CharStreams.toString(new InputStreamReader(response.getBody().in()));
         log.debug("Fetched template from artifact {}: {}", artifact.getReference(), template);
-        task.put("templateBody", objectMapper.readValue(template, Map.class));
+        task.put("templateBody", template);
       } catch (IOException e) {
-        throw new IllegalArgumentException("Failed to read template from artifact definition "+ artifact, e);
+        throw new IllegalArgumentException("Failed to read template from artifact definition " + artifact, e);
       }
     }
 
-    Map templateBody = (Map) task.get("templateBody");
+
+    String templateBody = (String) task.get("templateBody");
     if (templateBody == null || templateBody.isEmpty()) {
       throw new IllegalArgumentException(
         "Invalid stage format, missing artifact or templateBody field: " + templateBody + ", " + stage.getContext());


### PR DESCRIPTION
previously cloudformation assumed that the template text would only be
JSON so it attempted to deserialize the artifact to a map.
cloudformation supports YAML or JSON templates so we should just pass
the template as a string all the way to the cloudformation tasks and let
any failures come from the aws sdk.