### PR TITLE
feat(cloudformation): support YAML templates

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTask.java
@@ -15,7 +15,6 @@
  */
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.cloudformation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
@@ -32,6 +31,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.parser.ParserException;
 import retrofit.client.Response;
 
 import javax.annotation.Nonnull;
@@ -48,9 +49,6 @@ public class DeployCloudFormationTask extends AbstractCloudProviderAwareTask imp
 
   @Autowired
   OortService oortService;
-
-  @Autowired
-  ObjectMapper objectMapper;
 
   @Autowired
   ArtifactResolver artifactResolver;
@@ -80,9 +78,13 @@ public class DeployCloudFormationTask extends AbstractCloudProviderAwareTask imp
       try {
         String template = CharStreams.toString(new InputStreamReader(response.getBody().in()));
         log.debug("Fetched template from artifact {}: {}", artifact.getReference(), template);
-        task.put("templateBody", objectMapper.readValue(template, Map.class));
+        // attempt to deserialize template body to a map. supports YAML or JSON formatted templates.
+        Map<String, Object> templateBody = (Map<String, Object>) new Yaml().load(template);
+        task.put("templateBody", templateBody);
       } catch (IOException e) {
         throw new IllegalArgumentException("Failed to read template from artifact definition "+ artifact, e);
+      } catch (ParserException e) {
+        throw new IllegalArgumentException("Template body must be valid JSON or YAML.", e);
       }
     }
 


### PR DESCRIPTION
adds support for YAML templates by attempting to deserialize using
snakeyaml instead of object mapper. since YAML is a superset of JSON
snakeyaml can process either format properly.