### PR TITLE
fix(evaluateVariables): enable EvaluateVariables stage to run in dryRun

### DIFF
--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunStageDefinitionBuilderFactory.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunStageDefinitionBuilderFactory.kt
@@ -37,7 +37,13 @@ class DryRunStageDefinitionBuilderFactory(
     }
 
   private val Stage.shouldExecuteNormallyInDryRun: Boolean
-    get() = isManualJudgment || isPipeline || isExpressionPrecondition || isFindImage || isDetermineTargetServerGroup || isRollbackCluster
+    get() = isManualJudgment ||
+      isPipeline ||
+      isExpressionPrecondition ||
+      isFindImage ||
+      isDetermineTargetServerGroup ||
+      isRollbackCluster ||
+      isEvalVariables
 
   private val Stage.isManualJudgment: Boolean
     get() = type == "manualJudgment"
@@ -68,4 +74,7 @@ class DryRunStageDefinitionBuilderFactory(
 
   private val Stage.isRollbackCluster: Boolean
     get() = type == "rollbackCluster"
+
+  private val Stage.isEvalVariables: Boolean
+    get() = type == "evaluateVariables"
 }


### PR DESCRIPTION
Variables are hard to get right, hence the EvaluateVariables stage, but
if it doesn't run in `dryRun` it makes quickly iterating on it harder.
