### PR TITLE
test(core): Remove front50 bean from startup test

### DIFF
--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/MainSpec.java
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/MainSpec.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca;
 
-import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.locks.LockManager;
 import com.netflix.spinnaker.orca.notifications.NotificationClusterLock;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
@@ -33,9 +32,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration(classes = {StartupTestConfiguration.class})
 @TestPropertySource(properties = {"spring.config.location=classpath:orca-test.yml"})
 public class MainSpec {
-  @MockBean
-  Front50Service front50Service;
-
   @MockBean
   ExecutionRepository executionRepository;
 

--- a/orca-web/src/test/resources/orca-test.yml
+++ b/orca-web/src/test/resources/orca-test.yml
@@ -1,5 +1,5 @@
 front50:
-  baseUrl: http://localhost:8080
+  enabled: false
 
 igor:
   enabled: false


### PR DESCRIPTION
When deploying to Kubernetes, halyard uses a bootstrap orca that doesn't have front50 enabled. This means that we need to keep orca starting without front50 around; set it to false in the test and remove the mock bean.