### PR TITLE
fix(authz): Fix copying pipelines with managed service accounts

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
@@ -91,6 +91,9 @@ public class SavePipelineTask implements RetryableTask {
 
     if (stage.getContext().get("pipeline.id") != null && pipeline.get("id") == null) {
       pipeline.put("id", stage.getContext().get("pipeline.id"));
+
+      // We need to tell front50 to regenerate cron trigger id's
+      pipeline.put("regenerateCronTriggerIds", true);
     }
 
     pipelineModelMutators.stream().filter(m -> m.supports(pipeline)).forEach(m -> m.mutate(pipeline));
@@ -145,7 +148,12 @@ public class SavePipelineTask implements RetryableTask {
     }
 
     // Managed Service account exists and roles are set; Update triggers
-    triggers.forEach(t -> t.putIfAbsent("runAsUser", serviceAccount));
+    triggers.stream()
+      .filter(t -> {
+        String runAsUser = (String) t.get("runAsUser");
+        return runAsUser == null || runAsUser.endsWith("@managed-service-account");
+      })
+      .forEach(t -> t.put("runAsUser", serviceAccount));
   }
 
   private Map<String, Object> fetchExistingPipeline(Map<String, Object> newPipeline) {

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
@@ -89,6 +89,10 @@ public class SavePipelineTask implements RetryableTask {
       updateServiceAccount(pipeline, serviceAccount);
     }
 
+    if (stage.getContext().get("pipeline.id") != null && pipeline.get("id") == null) {
+      pipeline.put("id", stage.getContext().get("pipeline.id"));
+    }
+
     pipelineModelMutators.stream().filter(m -> m.supports(pipeline)).forEach(m -> m.mutate(pipeline));
 
     Response response = front50Service.savePipeline(pipeline);

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTaskSpec.groovy
@@ -192,4 +192,40 @@ class SaveServiceAccountTaskSpec extends Specification {
     result.context == ImmutableMap.of('pipeline.serviceAccount', expectedServiceAccount.name)
   }
 
+  def "should generate a pipeline id if not already present"() {
+    given:
+    def pipeline = [
+      application: 'orca',
+      name: 'My pipeline',
+      stages: [],
+      roles: ['foo']
+    ]
+    def stage = stage {
+      context = [
+        pipeline: Base64.encoder.encodeToString(objectMapper.writeValueAsString(pipeline).bytes)
+      ]
+    }
+    def uuid = null
+    def expectedServiceAccountName = null
+
+    when:
+    stage.getExecution().setTrigger(new DefaultTrigger('manual', null, 'abc@somedomain.io'))
+    def result = task.execute(stage)
+
+    then:
+    1 * fiatPermissionEvaluator.getPermission('abc@somedomain.io') >> {
+      new UserPermission().addResources([new Role('foo')]).view
+    }
+
+    1 * front50Service.saveServiceAccount({ it.name != null }) >> { ServiceAccount serviceAccount ->
+      uuid = serviceAccount.name - "@managed-service-account"
+      expectedServiceAccountName = serviceAccount.name
+      new Response('http://front50', 200, 'OK', [], null)
+    }
+
+    result.status == ExecutionStatus.SUCCEEDED
+    result.context == ImmutableMap.of(
+      'pipeline.id', uuid,
+      'pipeline.serviceAccount', expectedServiceAccountName)
+  }
 }


### PR DESCRIPTION
Copying pipelines currently fails when managed service accounts are enabled. This commit fixes that by generating a pipeline id (UUID) in Orca before generating the managed service account.