### PR TITLE
feat(pipelines): if saving multiple pipelines, continue on failure

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/SavePipelinesCompleteTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/SavePipelinesCompleteTask.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.orca.clouddriver.tasks.pipeline;
 
+import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.Task;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
@@ -35,7 +36,10 @@ public class SavePipelinesCompleteTask implements Task {
     logResults(savePipelineResults.getPipelinesFailedToSave(), "Failed to save pipelines: ");
     logResults(savePipelineResults.getPipelinesCreated(), "Created pipelines: ");
     logResults(savePipelineResults.getPipelinesUpdated(), "Updated pipelines: ");
-    return TaskResult.SUCCEEDED;
+    if (savePipelineResults.getPipelinesFailedToSave().isEmpty()) {
+      return TaskResult.SUCCEEDED;
+    }
+    return new TaskResult(ExecutionStatus.TERMINAL);
   }
 
   private void logResults(List<PipelineReferenceData> savePipelineSuccesses, String s) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/SavePipelinesData.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/SavePipelinesData.java
@@ -28,4 +28,5 @@ import java.util.Map;
 public class SavePipelinesData {
   private String pipeline;
   private List<Map> pipelinesToSave;
+  private final Boolean isSavingMultiplePipelines = true;
 }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
@@ -31,11 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import retrofit.client.Response;
 
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -111,10 +107,19 @@ public class SavePipelineTask implements RetryableTask {
       }
     }
 
-    return new TaskResult(
-      (response.getStatus() == HttpStatus.OK.value()) ? ExecutionStatus.SUCCEEDED : ExecutionStatus.TERMINAL,
-      outputs
-    );
+    final ExecutionStatus status;
+    if (response.getStatus() == HttpStatus.OK.value()) {
+      status = ExecutionStatus.SUCCEEDED;
+    } else {
+      final Boolean isSavingMultiplePipelines = (Boolean) Optional
+        .ofNullable(stage.getContext().get("isSavingMultiplePipelines")).orElse(false);
+      if (isSavingMultiplePipelines) {
+        status = ExecutionStatus.FAILED_CONTINUE;
+      } else {
+        status = ExecutionStatus.TERMINAL;
+      }
+    }
+    return new TaskResult(status, outputs);
   }
 
   @Override


### PR DESCRIPTION
This is a minor change to SavePipelineTask. By default it will still fail with a TERMINAL status exactly as before. I’ve added a unit test for this original behavior. But if it detects that multiple pipelines are being saved, then the failure status will be FAILED_CONTINUE instead. This allows the SavePipelinesFromArtifactStage to attempt to save all the pipelines from the artifact and then give a summary of the results.
