### PR TITLE
feat(kubernetes): add expression evaluation options to bake and deplo…

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.bakery.tasks.manifests;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class BakeManifestContext {
+  private final List<CreateBakeManifestTask.InputArtifactPair> inputArtifacts;
+  private final List<ExpectedArtifact> expectedArtifacts;
+  private final Map<String, Object> overrides;
+  private final Boolean evaluateOverrideExpressions;
+  private final String templateRenderer;
+  private final String outputName;
+  private final String namespace;
+
+  // There does not seem to be a way to auto-generate a constructor using our current version of Lombok (1.16.20) that
+  // Jackson can use to deserialize.
+  public BakeManifestContext(
+    @JsonProperty("inputArtifacts") List<CreateBakeManifestTask.InputArtifactPair> inputArtifacts,
+    @JsonProperty("expectedArtifacts") List<ExpectedArtifact> expectedArtifacts,
+    @JsonProperty("overrides") Map<String, Object> overrides,
+    @JsonProperty("evaluateOverrideExpressions") Boolean evaluateOverrideExpressions,
+    @JsonProperty("templateRenderer") String templateRenderer,
+    @JsonProperty("outputName") String outputName,
+    @JsonProperty("namespace") String namespace
+  ) {
+    this.inputArtifacts = inputArtifacts;
+    this.expectedArtifacts = expectedArtifacts;
+    this.overrides = overrides;
+    this.evaluateOverrideExpressions = evaluateOverrideExpressions;
+    this.templateRenderer = templateRenderer;
+    this.outputName = outputName;
+    this.namespace = namespace;
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestContext.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Getter
+public class DeployManifestContext extends HashMap<String, Object> {
+  private final String source;
+  private final String manifestArtifactId;
+  private final String manifestArtifactAccount;
+  private final Boolean skipExpressionEvaluation;
+  private final List<String> requiredArtifactIds;
+
+  // There does not seem to be a way to auto-generate a constructor using our current version of Lombok (1.16.20) that
+  // Jackson can use to deserialize.
+  public DeployManifestContext(
+    @JsonProperty("source") String source,
+    @JsonProperty("manifestArtifactId") String manifestArtifactId,
+    @JsonProperty("manifestArtifactAccount") String manifestArtifactAccount,
+    @JsonProperty("skipExpressionEvaluation") Boolean skipExpressionEvaluation,
+    @JsonProperty("requiredArtifactIds") List<String> requiredArtifactIds
+  ){
+    this.source = source;
+    this.manifestArtifactId = manifestArtifactId;
+    this.manifestArtifactAccount = manifestArtifactAccount;
+    this.skipExpressionEvaluation = skipExpressionEvaluation;
+    this.requiredArtifactIds = requiredArtifactIds;
+  }
+}


### PR DESCRIPTION
…y manifest stages

Corresponding Deck PR: https://github.com/spinnaker/deck/pull/6696

The primary purpose of this change is to prevent Deploy Manifest stage failure for users attempting to deploy third-party Helm manifests that include `${}`-wrapped expressions, while allowing SpEL overrides to be explicitly evaluated just prior to baking. These options should probably be deprecated when expression evaluation is refactored in Spinnaker (see this [proposal](https://github.com/spinnaker/spinnaker/issues/3500)).

- Adds `evaluateOverrideExpressions` option to Bake Manifest stage. This defaults to false. When it is set to true, SpEL expressions evaluation of manifest overrides will occur during the Bake stage.
- Adds `skipExpressionEvaluation` option to Deploy Manifest stage for manifest artifacts. This defaults to false. When it is set to true, SpEL expression of the manifest artifact will not occur during the Deploy stage.
- Important caveat: Orca attempts to evaluate expressions in the entire pipeline context multiple times in logic that does not belong to these stages (for example, [here](https://github.com/spinnaker/orca/blob/master/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy#L167)). Therefore, there will still be "failed to evaluate" warnings for all `${}`-wrapped expressions not intended for Spinnaker.

Related issues:
- https://github.com/spinnaker/spinnaker/issues/2809
- https://github.com/spinnaker/spinnaker/issues/3028
- https://github.com/spinnaker/spinnaker/issues/3939
- https://github.com/spinnaker/spinnaker/issues/4109
- https://github.com/spinnaker/spinnaker/issues/3644
- https://github.com/spinnaker/spinnaker/issues/3335

Before:
![2kX9K7zFvuJ](https://user-images.githubusercontent.com/15936279/54393281-26124300-4680-11e9-9fec-dd9f9c492dda.png)

After:
![2N55McgwoEf](https://user-images.githubusercontent.com/15936279/54393295-2d395100-4680-11e9-84eb-ee212fcb6d77.png)
