### PR TITLE
fix(tests): Use JUnit vintage engine so Spock tests still run

### DIFF
--- a/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca-clouddriver/orca-clouddriver.gradle
@@ -17,7 +17,9 @@
 apply from: "$rootDir/gradle/groovy.gradle"
 
 test {
-  useJUnitPlatform()
+  useJUnitPlatform {
+    includeEngines "junit-vintage", "junit-jupiter"
+  }
 }
 
 dependencies {
@@ -39,4 +41,5 @@ dependencies {
   testCompile "org.mockito:mockito-core:2.25.0"
 
   testRuntime spinnaker.dependency("junitJupiterEngine")
+  testRuntime "org.junit.vintage:junit-vintage-engine:${spinnaker.version('jupiter')}"
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/PollerSupport.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/PollerSupport.java
@@ -26,18 +26,18 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 
-class PollerSupport {
+public class PollerSupport {
   private final ObjectMapper objectMapper;
   private final RetrySupport retrySupport;
   private final OortService oortService;
 
-  PollerSupport(ObjectMapper objectMapper, RetrySupport retrySupport, OortService oortService) {
+  public PollerSupport(ObjectMapper objectMapper, RetrySupport retrySupport, OortService oortService) {
     this.objectMapper = objectMapper;
     this.retrySupport = retrySupport;
     this.oortService = oortService;
   }
 
-  Optional<ServerGroup> fetchServerGroup(String account, String region, String name) {
+  public Optional<ServerGroup> fetchServerGroup(String account, String region, String name) {
     return retrySupport.retry(() -> {
       try {
         Response response = oortService.getServerGroup(account, region, name);

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPoller.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPoller.java
@@ -50,7 +50,7 @@ import static java.lang.String.format;
 @Slf4j
 @Component
 @ConditionalOnExpression(value = "${pollers.restorePinnedServerGroups.enabled:false}")
-class RestorePinnedServerGroupsPoller extends AbstractPollingNotificationAgent {
+public class RestorePinnedServerGroupsPoller extends AbstractPollingNotificationAgent {
   private static final Logger log = LoggerFactory.getLogger(RestorePinnedServerGroupsPoller.class);
 
   private final ObjectMapper objectMapper;
@@ -89,7 +89,7 @@ class RestorePinnedServerGroupsPoller extends AbstractPollingNotificationAgent {
   }
 
   @VisibleForTesting
-  RestorePinnedServerGroupsPoller(NotificationClusterLock notificationClusterLock,
+  public RestorePinnedServerGroupsPoller(NotificationClusterLock notificationClusterLock,
                                   ObjectMapper objectMapper,
                                   OortService oortService,
                                   RetrySupport retrySupport,
@@ -184,7 +184,7 @@ class RestorePinnedServerGroupsPoller extends AbstractPollingNotificationAgent {
     }
   }
 
-  List<PinnedServerGroupTag> fetchPinnedServerGroupTags() {
+  public List<PinnedServerGroupTag> fetchPinnedServerGroupTags() {
     List<EntityTags> allEntityTags = retrySupport.retry(() -> objectMapper.convertValue(
       oortService.getEntityTags(ImmutableMap.<String, String>builder()
         .put("tag:" + PINNED_CAPACITY_TAG, "*")
@@ -211,7 +211,7 @@ class RestorePinnedServerGroupsPoller extends AbstractPollingNotificationAgent {
       .collect(Collectors.toList());
   }
 
-  boolean hasCompletedExecution(PinnedServerGroupTag pinnedServerGroupTag) {
+  public boolean hasCompletedExecution(PinnedServerGroupTag pinnedServerGroupTag) {
     try {
       Execution execution = executionRepository.retrieve(
         pinnedServerGroupTag.executionType, pinnedServerGroupTag.executionId
@@ -276,7 +276,7 @@ class RestorePinnedServerGroupsPoller extends AbstractPollingNotificationAgent {
       .build();
   }
 
-  private static class PinnedServerGroupTag {
+  public static class PinnedServerGroupTag {
     public String id;
 
     public String cloudProvider;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
@@ -139,7 +139,7 @@ public class SpinnakerMetadataServerGroupTagGenerator implements ServerGroupEnti
     }, 10, 3000, false); // retry for up to 30 seconds
   }
 
-  Map<String, Object> getPreviousServerGroupFromClusterByTarget(String application,
+  public Map<String, Object> getPreviousServerGroupFromClusterByTarget(String application,
                                                                 String account,
                                                                 String cluster,
                                                                 String cloudProvider,


### PR DESCRIPTION
It's not clear to me why Spock's selection of JDK dynamic proxies for tests like `SpinnakerMetadataServerGroupTagGeneratorSpec` and `RestorePinnedServerGroupsPollerSpec` used to work without the correct visibility modifiers, but they seem to be necessary now?