### PR TITLE
 test(ci): Add tests to JenkinsStage and ScriptStage

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/CIStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/CIStageDefinition.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.orca.igor.tasks;
+package com.netflix.spinnaker.orca.igor.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
@@ -22,7 +22,7 @@ import lombok.Getter;
 import java.util.Optional;
 
 @Getter
-public class CIJobRequest {
+public class CIStageDefinition {
   private final String master;
   private final String job;
   private final String propertyFile;
@@ -31,7 +31,7 @@ public class CIJobRequest {
 
   // There does not seem to be a way to auto-generate a constructor using our current version of Lombok (1.16.20) that
   // Jackson can use to deserialize.
-  public CIJobRequest(
+  public CIStageDefinition(
     @JsonProperty("master") String master,
     @JsonProperty("job") String job,
     @JsonProperty("property") String propertyFile,

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/CIStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/CIStageDefinition.java
@@ -17,8 +17,11 @@
 package com.netflix.spinnaker.orca.igor.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import lombok.Getter;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 @Getter
@@ -27,6 +30,8 @@ public class CIStageDefinition {
   private final String job;
   private final String propertyFile;
   private final Integer buildNumber;
+  private final boolean waitForCompletion;
+  private final List<ExpectedArtifact> expectedArtifacts;
   private final int consecutiveErrors;
 
   // There does not seem to be a way to auto-generate a constructor using our current version of Lombok (1.16.20) that
@@ -36,12 +41,18 @@ public class CIStageDefinition {
     @JsonProperty("job") String job,
     @JsonProperty("property") String propertyFile,
     @JsonProperty("buildNumber") Integer buildNumber,
+    @JsonProperty("waitForCompletion") Boolean waitForCompletion,
+    @JsonProperty("expectedArtifacts") List<ExpectedArtifact> expectedArtifacts,
     @JsonProperty("consecutiveErrors") Integer consecutiveErrors
   ) {
     this.master = master;
     this.job = job;
     this.propertyFile = propertyFile;
     this.buildNumber = buildNumber;
+    this.waitForCompletion = Optional.ofNullable(waitForCompletion).orElse(true);
+    this.expectedArtifacts = Collections.unmodifiableList(
+      Optional.ofNullable(expectedArtifacts).orElse(Collections.emptyList())
+    );
     this.consecutiveErrors = Optional.ofNullable(consecutiveErrors).orElse(0);
   }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/CIStage.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/CIStage.java
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.orca.igor.pipeline;
 
 import com.netflix.spinnaker.orca.CancellableStage;
 import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.igor.model.CIStageDefinition;
 import com.netflix.spinnaker.orca.igor.tasks.*;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode;
@@ -37,31 +38,20 @@ public abstract class CIStage implements StageDefinitionBuilder, CancellableStag
 
   @Override
   public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
+    CIStageDefinition stageDefinition = stage.mapTo(CIStageDefinition.class);
     String jobType = StringUtils.capitalize(getType());
     builder
       .withTask(String.format("start%sJob", jobType), StartJenkinsJobTask.class)
       .withTask(String.format("waitFor%sJobStart", jobType), waitForJobStartTaskClass());
 
-    if (waitForCompletion(stage)) {
+    if (stageDefinition.isWaitForCompletion()) {
       builder.withTask(String.format("monitor%sJob", jobType), MonitorJenkinsJobTask.class);
       builder.withTask("getBuildProperties", GetBuildPropertiesTask.class);
       builder.withTask("getBuildArtifacts", GetBuildArtifactsTask.class);
     }
-    if (stage.getContext().containsKey("expectedArtifacts")) {
+    if (stageDefinition.getExpectedArtifacts().size() > 0) {
       builder.withTask(BindProducedArtifactsTask.TASK_NAME, BindProducedArtifactsTask.class);
     }
-  }
-
-  private boolean waitForCompletion(Stage stage) {
-    Object contextValue = stage.getContext().get("waitForCompletion");
-    Boolean waitForCompletion = true;
-    if (contextValue instanceof String) {
-      String contextValueString = (String) contextValue;
-      waitForCompletion = !contextValueString.equalsIgnoreCase("false");
-    } else if (contextValue instanceof Boolean) {
-      waitForCompletion = (Boolean) contextValue;
-    }
-    return waitForCompletion;
   }
 
   protected Class<? extends Task> waitForJobStartTaskClass() {

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTask.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.igor.BuildService;
+import com.netflix.spinnaker.orca.igor.model.CIStageDefinition;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -37,12 +38,12 @@ public class GetBuildArtifactsTask extends RetryableIgorTask {
   private final BuildService buildService;
 
   @Override
-  protected @Nonnull TaskResult tryExecute(@Nonnull CIJobRequest jobRequest) {
-    if (StringUtils.isEmpty(jobRequest.getPropertyFile())) {
+  protected @Nonnull TaskResult tryExecute(@Nonnull CIStageDefinition stageDefinition) {
+    if (StringUtils.isEmpty(stageDefinition.getPropertyFile())) {
       return TaskResult.SUCCEEDED;
     }
     List<Artifact> artifacts = buildService.getArtifacts(
-      jobRequest.getBuildNumber(), jobRequest.getPropertyFile(), jobRequest.getMaster(), jobRequest.getJob()
+      stageDefinition.getBuildNumber(), stageDefinition.getPropertyFile(), stageDefinition.getMaster(), stageDefinition.getJob()
     );
     Map<String, List<Artifact>> outputs = Collections.singletonMap("artifacts", artifacts);
     return new TaskResult(ExecutionStatus.SUCCEEDED, Collections.emptyMap(), outputs);

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildPropertiesTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildPropertiesTask.java
@@ -19,14 +19,13 @@ package com.netflix.spinnaker.orca.igor.tasks;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.igor.BuildService;
-import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.igor.model.CIStageDefinition;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,14 +36,14 @@ public class GetBuildPropertiesTask extends RetryableIgorTask {
   private final BuildService buildService;
 
   @Override
-  protected @Nonnull TaskResult tryExecute(@Nonnull CIJobRequest jobRequest) {
-    if (StringUtils.isEmpty(jobRequest.getPropertyFile())) {
+  protected @Nonnull TaskResult tryExecute(@Nonnull CIStageDefinition stageDefinition) {
+    if (StringUtils.isEmpty(stageDefinition.getPropertyFile())) {
       return TaskResult.SUCCEEDED;
     }
 
-    Map<String, Object> properties = buildService.getPropertyFile(jobRequest.getBuildNumber(), jobRequest.getPropertyFile(), jobRequest.getMaster(), jobRequest.getJob());
+    Map<String, Object> properties = buildService.getPropertyFile(stageDefinition.getBuildNumber(), stageDefinition.getPropertyFile(), stageDefinition.getMaster(), stageDefinition.getJob());
     if (properties.size() == 0) {
-      throw new IllegalStateException(String.format("Expected properties file %s but it was either missing, empty or contained invalid syntax", jobRequest.getPropertyFile()));
+      throw new IllegalStateException(String.format("Expected properties file %s but it was either missing, empty or contained invalid syntax", stageDefinition.getPropertyFile()));
     }
     HashMap<String, Object> outputs = new HashMap<>(properties);
     outputs.put("propertyFileContents", properties);

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/pipeline/JenkinsStageSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/pipeline/JenkinsStageSpec.groovy
@@ -1,7 +1,9 @@
 package com.netflix.spinnaker.orca.igor.pipeline
 
+import com.netflix.spinnaker.orca.igor.tasks.MonitorJenkinsJobTask
 import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
@@ -59,5 +61,120 @@ class JenkinsStageSpec extends Specification {
     tasks.findAll {
       it.implementingClass == BindProducedArtifactsTask
     }.size() == 0
+  }
+
+  @Unroll
+  def "should wait for completion if set in the stage context"() {
+    given:
+    def jenkinsStage = new JenkinsStage()
+
+    def stage = stage {
+      type = "jenkins"
+      context = [
+        master: "builds",
+        job: "orca",
+        buildNumber: 4,
+        propertyFile: "sample.properties",
+        waitForCompletion: waitForCompletion
+      ]
+    }
+
+    when:
+    def tasks = jenkinsStage.buildTaskGraph(stage)
+    def result = tasks.findAll {
+      it.implementingClass == MonitorJenkinsJobTask
+    }.size() == 1
+
+    then:
+    result == didWaitForCompletion
+
+    where:
+    waitForCompletion  | didWaitForCompletion
+    true               | true
+    "true"             | true
+    false              | false
+    "false"            | false
+  }
+
+  def "should wait for completion when waitForCompletion is absent"() {
+    given:
+    def jenkinsStage = new JenkinsStage()
+
+    def stage = stage {
+      type = "jenkins"
+      context = [
+        master: "builds",
+        job: "orca",
+        buildNumber: 4,
+        propertyFile: "sample.properties"
+      ]
+    }
+
+    when:
+    def tasks = jenkinsStage.buildTaskGraph(stage)
+
+    then:
+    tasks.findAll {
+      it.implementingClass == MonitorJenkinsJobTask
+    }.size() == 1
+  }
+
+  def "should not bind artifacts if no expected artifacts were defined"() {
+    given:
+    def jenkinsStage = new JenkinsStage()
+
+    def stage = stage {
+      type = "jenkins"
+      context = [
+        master: "builds",
+        job: "orca",
+        buildNumber: 4,
+        propertyFile: "sample.properties"
+      ]
+    }
+
+    when:
+    def tasks = jenkinsStage.buildTaskGraph(stage)
+
+    then:
+    tasks.findAll {
+      it.implementingClass == BindProducedArtifactsTask
+    }.size() == 0
+  }
+
+  def "should bind artifacts if expected artifacts are defined"() {
+    given:
+    def jenkinsStage = new JenkinsStage()
+
+    def stage = stage {
+      type = "jenkins"
+      context = [
+        master: "builds",
+        job: "orca",
+        buildNumber: 4,
+        propertyFile: "sample.properties",
+        expectedArtifacts: [
+          [
+            defaultArtifact: [
+              customKind: true,
+              id: "1d3af620-1a63-4063-882d-ea05eb185b1d",
+            ],
+            displayName: "my-favorite-artifact",
+            id: "547ac2ac-a646-4b8f-8ab4-d7337678b6b6",
+            name: "gcr.io/my-registry/my-container",
+            useDefaultArtifact: false,
+            usePriorArtifact: false,
+          ]
+        ]
+      ]
+    }
+
+    when:
+    def tasks = jenkinsStage.buildTaskGraph(stage)
+
+    then:
+    tasks.findAll {
+      it.implementingClass == BindProducedArtifactsTask
+    }.size() == 1
   }
 }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/pipeline/ScriptStageSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/pipeline/ScriptStageSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.pipeline
+
+import com.netflix.spinnaker.orca.igor.tasks.GetBuildPropertiesTask
+import spock.lang.Specification
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class ScriptStageSpec extends Specification {
+  def "should fetch properties after running the script"() {
+    given:
+    def scriptStage = new ScriptStage()
+
+    def stage = stage {
+      type = "script"
+      context = [
+        command: "echo hello",
+      ]
+    }
+
+    when:
+    def tasks = scriptStage.buildTaskGraph(stage)
+
+    then:
+    tasks.findAll {
+      it.implementingClass == GetBuildPropertiesTask
+    }.size() == 1
+  }
+}

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/RetryableIgorTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/RetryableIgorTaskSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.igor.tasks
 
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.igor.model.CIStageDefinition
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import retrofit.RetrofitError
 import retrofit.client.Response
@@ -25,9 +26,9 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 class RetryableIgorTaskSpec extends Specification {
-  CIJobRequest jobRequest = Stub(CIJobRequest)
+  CIStageDefinition jobRequest = Stub(CIStageDefinition)
   Stage stage = Mock(Stage) {
-    mapTo(CIJobRequest.class) >> jobRequest
+    mapTo(CIStageDefinition.class) >> jobRequest
   }
 
   @Subject


### PR DESCRIPTION
Improve some things around the Jenkins code that broke last week.

* test(ci): Add tests to JenkinsStage and ScriptStage 

  There are no tests that waitForCompletion is properly read when starting a Jenkins stage; this functionality recently broke, so add some tests to it.  Also add some tests to verify that binding of artifacts works correctly.

  The ScriptStage has no tests at all; add a simple test that it fetches the properties after the script finishes.

* refactor(ci): Move CIJobRequest and rename it CIStageDefinition 

  This definition was originally only used one specific task, but it really represents the full stage definition of a CIStage, so rename it and move it to a more appropriate location.

* refactor(ci): Remove explicit casting from CIStage 

  In order to quickly fix a bug, I explicitly added some code to coerce waitForCompletion to a boolean. Let Jackson handle this by adding it to the CIStageDefinition model, and also do the same with the pre-existing expectedArtifacts field.
