### PR TITLE
feat(core): Add support for Concourse triggers

### DIFF
--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -21,8 +21,10 @@ import com.netflix.spinnaker.orca.bakery.api.BakeRequest
 import com.netflix.spinnaker.orca.bakery.api.BakeStatus
 import com.netflix.spinnaker.orca.bakery.api.BakeryService
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
+import com.netflix.spinnaker.orca.pipeline.model.BuildInfo
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger
+import com.netflix.spinnaker.orca.pipeline.model.SourceControl
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.model.Trigger
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver
@@ -36,7 +38,7 @@ import spock.lang.Subject
 import spock.lang.Unroll
 import static com.netflix.spinnaker.orca.bakery.api.BakeStatus.State.COMPLETED
 import static com.netflix.spinnaker.orca.bakery.api.BakeStatus.State.RUNNING
-import static com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.*
+import static com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.JenkinsArtifact
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND
@@ -121,7 +123,7 @@ class CreateBakeTaskSpec extends Specification {
     new JenkinsArtifact("hodor_1.1_all.deb", "."),
     new JenkinsArtifact("hodor-1.1.noarch.rpm", "."),
     new JenkinsArtifact("hodor.1.1.nupkg", ".")
-  ], [], false, "SUCCESS"
+  ], [], false, "SUCCESS", 'name#0'
   )
 
   @Shared
@@ -131,7 +133,7 @@ class CreateBakeTaskSpec extends Specification {
       new JenkinsArtifact("hodor_1.1_all.deb", "."),
       new JenkinsArtifact("hodor-1.1.noarch.rpm", "."),
       new JenkinsArtifact("hodor.1.1.nupkg", ".")
-    ], [], false, "SUCCESS"
+    ], [], false, "SUCCESS", 'name#0'
   )
 
   @Shared
@@ -141,7 +143,7 @@ class CreateBakeTaskSpec extends Specification {
       new JenkinsArtifact("hodor_1.1_all.deb", "."),
       new JenkinsArtifact("hodor-1.1.noarch.rpm", "."),
       new JenkinsArtifact("hodor.1.1.nupkg", ".")
-    ], [], false, "SUCCESS"
+    ], [], false, "SUCCESS", 'name#0'
   )
 
   @Shared
@@ -153,7 +155,7 @@ class CreateBakeTaskSpec extends Specification {
       new JenkinsArtifact("hodor.1.1.nupkg", ".")
     ], [
     new SourceControl("refs/remotes/origin/master", "master", "f83a447f8d02a40fa84ec9d4d0dccd263d51782d")
-  ], false, "SUCCESS"
+  ], false, "SUCCESS", 'name#0'
   )
 
   @Shared
@@ -166,7 +168,7 @@ class CreateBakeTaskSpec extends Specification {
     ], [
     new SourceControl("refs/remotes/origin/master", "master", "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"),
     new SourceControl("refs/remotes/origin/some-feature", "some-feature", "1234567f8d02a40fa84ec9d4d0dccd263d51782d")
-  ], false, "SUCCESS"
+  ], false, "SUCCESS", 'name#0'
   )
 
   @Shared
@@ -179,7 +181,7 @@ class CreateBakeTaskSpec extends Specification {
     ], [
     new SourceControl("refs/remotes/origin/master", "master", "f83a447f8d02a40fa84ec9d4d0dccd263d51782d"),
     new SourceControl("refs/remotes/origin/develop", "develop", "1234567f8d02a40fa84ec9d4d0dccd263d51782d")
-  ], false, "SUCCESS"
+  ], false, "SUCCESS", 'name#0'
   )
 
   @Shared
@@ -188,7 +190,7 @@ class CreateBakeTaskSpec extends Specification {
     new JenkinsArtifact("hodornodor_1.1_all.deb", "."),
     new JenkinsArtifact("hodor-1.1.noarch.rpm", "."),
     new JenkinsArtifact("hodor.1.1.nupkg", ".")
-  ], [], false, "SUCCESS"
+  ], [], false, "SUCCESS", 'name#0'
   )
 
   @Shared

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineBranchFinderSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineBranchFinderSpec.groovy
@@ -16,11 +16,11 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.appengine
 
+import com.netflix.spinnaker.orca.pipeline.model.BuildInfo
 import com.netflix.spinnaker.orca.pipeline.model.GitTrigger
 import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger
 import spock.lang.Specification
 import spock.lang.Unroll
-import static com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.BuildInfo
 
 class AppEngineBranchFinderSpec extends Specification {
   @Unroll
@@ -74,7 +74,7 @@ class AppEngineBranchFinderSpec extends Specification {
   def "(jenkins trigger) should resolve branch, using regex (if provided) to narrow down options"() {
     given:
     def trigger = new JenkinsTrigger("Jenkins", "poll_git_repo", 1, null)
-    trigger.buildInfo = new BuildInfo("poll_git_repo", 1, "http://jenkins", [], scm, false, "SUCCESS")
+    trigger.buildInfo = new BuildInfo("poll_git_repo", 1, "http://jenkins", [], scm, false, "SUCCESS", "poll_git_repo#1")
 
     def operation = [
       trigger: [
@@ -97,7 +97,7 @@ class AppEngineBranchFinderSpec extends Specification {
   def "(jenkins trigger) should throw appropriate error if method cannot resolve exactly one branch"() {
     given:
     def trigger = new JenkinsTrigger("Jenkins", "poll_git_repo", 1, null)
-    trigger.buildInfo = new BuildInfo("poll_git_repo", 1, "http://jenkins", [], scm, false, "SUCCESS")
+    trigger.buildInfo = new BuildInfo("poll_git_repo", 1, "http://jenkins", [], scm, false, "SUCCESS", "poll_git_repo#1")
 
     def operation = [
       trigger      : [

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/ReturnTypeRestrictor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/ReturnTypeRestrictor.java
@@ -17,10 +17,7 @@
 package com.netflix.spinnaker.orca.pipeline.expressions.whitelisting;
 
 import com.netflix.spinnaker.orca.ExecutionStatus;
-import com.netflix.spinnaker.orca.pipeline.model.Execution;
-import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger;
-import com.netflix.spinnaker.orca.pipeline.model.Stage;
-import com.netflix.spinnaker.orca.pipeline.model.Trigger;
+import com.netflix.spinnaker.orca.pipeline.model.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,9 +57,9 @@ public interface ReturnTypeRestrictor extends InstantiationTypeRestrictor {
         Execution.class,
         Stage.class,
         Trigger.class,
-        JenkinsTrigger.BuildInfo.class,
+        BuildInfo.class,
         JenkinsTrigger.JenkinsArtifact.class,
-        JenkinsTrigger.SourceControl.class,
+        SourceControl.class,
         ExecutionStatus.class,
         Execution.AuthenticationDetails.class,
         Execution.PausedDetails.class

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/BuildInfo.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/BuildInfo.kt
@@ -1,0 +1,16 @@
+package com.netflix.spinnaker.orca.pipeline.model
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class BuildInfo<A>
+@JsonCreator constructor(
+        @param:JsonProperty("name") val name: String,
+        @param:JsonProperty("number") val number: Int,
+        @param:JsonProperty("url") val url: String,
+        @JsonProperty("artifacts") val artifacts: List<A>? = emptyList(),
+        @JsonProperty("scm") val scm: List<SourceControl>? = emptyList(),
+        @param:JsonProperty("building") val isBuilding: Boolean,
+        @param:JsonProperty("result") val result: String?,
+        @param:JsonProperty("fullDisplayName") val fullDisplayName: String = "$name#$number"
+)

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/ConcourseTrigger.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/ConcourseTrigger.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,12 @@
 
 package com.netflix.spinnaker.orca.pipeline.model
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
 
-data class JenkinsTrigger
+data class ConcourseTrigger
 @JvmOverloads constructor(
-  override val type: String = "jenkins",
+  override val type: String = "artifactory",
   override val correlationId: String? = null,
   override val user: String? = "[anonymous]",
   override val parameters: Map<String, Any> = mutableMapOf(),
@@ -32,21 +29,10 @@ data class JenkinsTrigger
   override val notifications: List<Map<String, Any>> = mutableListOf(),
   override var isRebake: Boolean = false,
   override var isDryRun: Boolean = false,
-  override var isStrategy: Boolean = false,
-  val master: String,
-  val job: String,
-  val buildNumber: Int,
-  val propertyFile: String?
+  override var isStrategy: Boolean = false
 ) : Trigger {
-
   override var other: Map<String, Any> = mutableMapOf()
   override var resolvedExpectedArtifacts: List<ExpectedArtifact> = mutableListOf()
-  var buildInfo: BuildInfo<JenkinsArtifact>? = null
+  var buildInfo: BuildInfo<Any>? = null
   var properties: Map<String, Any> = mutableMapOf()
-
-  data class JenkinsArtifact
-  @JsonCreator constructor(
-    @param:JsonProperty("fileName") val fileName: String,
-    @param:JsonProperty("relativePath") val relativePath: String
-  )
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/SourceControl.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/SourceControl.kt
@@ -1,0 +1,11 @@
+package com.netflix.spinnaker.orca.pipeline.model
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class SourceControl
+@JsonCreator constructor(
+        @param:JsonProperty("name") val name: String,
+        @param:JsonProperty("branch") val branch: String,
+        @param:JsonProperty("sha1") val sha1: String
+)

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
@@ -46,6 +46,20 @@ internal class TriggerDeserializer
           get("repository").textValue(),
           get("tag").textValue()
         )
+        looksLikeConcourse() -> ConcourseTrigger(
+                get("type").textValue(),
+                get("correlationId")?.textValue(),
+                get("user")?.textValue() ?: "[anonymous]",
+                get("parameters")?.mapValue(parser) ?: mutableMapOf(),
+                get("artifacts")?.listValue(parser) ?: mutableListOf(),
+                get("notifications")?.listValue(parser) ?: mutableListOf(),
+                get("rebake")?.booleanValue() == true,
+                get("dryRun")?.booleanValue() == true,
+                get("strategy")?.booleanValue() == true
+        ).apply {
+          buildInfo = get("buildInfo")?.parseValue(parser)
+          properties = get("properties")?.parseValue(parser) ?: mutableMapOf()
+        }
         looksLikeJenkins() -> JenkinsTrigger(
           get("type").textValue(),
           get("correlationId")?.textValue(),
@@ -135,6 +149,8 @@ internal class TriggerDeserializer
 
   private fun JsonNode.looksLikeJenkins() =
     hasNonNull("master") && hasNonNull("job") && hasNonNull("buildNumber")
+
+  private fun JsonNode.looksLikeConcourse() = get("type")?.textValue() == "concourse"
 
   private fun JsonNode.looksLikePipeline() =
     hasNonNull("parentExecution")

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractor.java
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.orca.pipeline.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
-import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.BuildInfo;
-import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.SourceControl;
+import com.netflix.spinnaker.orca.pipeline.model.BuildInfo;
+import com.netflix.spinnaker.orca.pipeline.model.SourceControl;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
@@ -59,7 +59,7 @@ public class BuildDetailExtractor {
   private static class LegacyJenkinsUrlDetailExtractor implements DetailExtractor {
 
     @Override
-    public boolean tryToExtractBuildDetails(BuildInfo buildInfo, Map<String, Object> request) {
+    public boolean tryToExtractBuildDetails(BuildInfo<?> buildInfo, Map<String, Object> request) {
       if (buildInfo == null || request == null) {
         return false;
       }
@@ -104,7 +104,7 @@ public class BuildDetailExtractor {
   private static class DefaultDetailExtractor implements DetailExtractor {
 
     @Override
-    public boolean tryToExtractBuildDetails(BuildInfo buildInfo, Map<String, Object> request) {
+    public boolean tryToExtractBuildDetails(BuildInfo<?> buildInfo, Map<String, Object> request) {
 
       if (buildInfo == null || request == null) {
         return false;
@@ -133,9 +133,9 @@ public class BuildDetailExtractor {
   //Common trait for DetailExtractor
   private interface DetailExtractor {
 
-    boolean tryToExtractBuildDetails(BuildInfo buildInfo, Map<String, Object> request);
+    boolean tryToExtractBuildDetails(BuildInfo<?> buildInfo, Map<String, Object> request);
 
-    default void extractCommitHash(BuildInfo buildInfo, Map<String, Object> request) {
+    default void extractCommitHash(BuildInfo<?> buildInfo, Map<String, Object> request) {
       // buildInfo.scm contains a list of maps. Each map contains these keys: name, sha1, branch.
       // If the list contains more than one entry, prefer the first one that is not master and is not develop.
       String commitHash = null;

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
@@ -25,11 +25,7 @@ import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionEvaluator;
 import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator;
 import com.netflix.spinnaker.orca.pipeline.expressions.functions.DeployedServerGroupsExpressionFunctionProvider;
 import com.netflix.spinnaker.orca.pipeline.expressions.functions.ManifestLabelValueExpressionFunctionProvider;
-import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger;
-import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.BuildInfo;
-import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.SourceControl;
-import com.netflix.spinnaker.orca.pipeline.model.Stage;
-import com.netflix.spinnaker.orca.pipeline.model.Trigger;
+import com.netflix.spinnaker.orca.pipeline.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,6 +140,9 @@ public class ContextParameterProcessor {
 
     if (context.get("scmInfo") == null && trigger instanceof JenkinsTrigger) {
       context.put("scmInfo", Optional.ofNullable(((JenkinsTrigger) trigger).getBuildInfo()).map(BuildInfo::getScm).orElse(emptyList()));
+    }
+    if (context.get("scmInfo") == null && trigger instanceof ConcourseTrigger) {
+      context.put("scmInfo", Optional.ofNullable(((ConcourseTrigger) trigger).getBuildInfo()).map(BuildInfo::getScm).orElse(emptyList()));
     }
     if (context.get("scmInfo") != null && ((List) context.get("scmInfo")).size() >= 2) {
       List<SourceControl> scmInfos = (List<SourceControl>) context.get("scmInfo");

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
@@ -22,17 +22,13 @@ import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionEvaluationSumma
 import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionTransform
 import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionsSupport
 import com.netflix.spinnaker.orca.pipeline.expressions.SpelHelperFunctionException
-import com.netflix.spinnaker.orca.pipeline.model.DefaultTrigger
-import com.netflix.spinnaker.orca.pipeline.model.Execution
-import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger
+import com.netflix.spinnaker.orca.pipeline.model.*
 import org.springframework.expression.spel.SpelEvaluationException
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
 import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
-import static com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.BuildInfo
-import static com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.SourceControl
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
@@ -306,7 +302,7 @@ class ContextParameterProcessorSpec extends Specification {
   @Unroll
   def "correctly compute scmInfo attribute"() {
     given:
-    context.trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [], scm, false, "SUCCESS")
+    context.trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [], scm, false, "SUCCESS", 'name#1')
 
     def source = ['branch': '${scmInfo.branch}']
 

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
@@ -15,10 +15,9 @@
  */
 package com.netflix.spinnaker.orca.pipeline.util
 
-import com.netflix.spinnaker.kork.artifacts.model.Artifact
-
-import java.util.regex.Pattern
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.orca.pipeline.model.BuildInfo
 import com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger
 import com.netflix.spinnaker.orca.pipeline.model.PipelineTrigger
 import com.netflix.spinnaker.orca.pipeline.model.Stage
@@ -26,7 +25,9 @@ import com.netflix.spinnaker.orca.test.model.ExecutionBuilder
 import org.springframework.beans.factory.annotation.Autowired
 import spock.lang.Specification
 import spock.lang.Unroll
-import static com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.BuildInfo
+
+import java.util.regex.Pattern
+
 import static com.netflix.spinnaker.orca.pipeline.model.JenkinsTrigger.JenkinsArtifact
 import static com.netflix.spinnaker.orca.pipeline.util.PackageType.DEB
 import static com.netflix.spinnaker.orca.pipeline.util.PackageType.RPM
@@ -65,7 +66,7 @@ class PackageInfoSpec extends Specification {
     given:
     def execution = pipeline {
       trigger = new JenkinsTrigger("master", "job", 1, null)
-      trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("testFileName", ".")], [], false, "SUCCESS")
+      trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("testFileName", ".")], [], false, "SUCCESS", 'name#1')
       stage {
         context = [buildInfo: [name: "someName"], package: "testPackageName"]
       }
@@ -395,7 +396,7 @@ class PackageInfoSpec extends Specification {
     given:
     def pipeline = pipeline {
       trigger = new JenkinsTrigger("master", "job", 1, null)
-      trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], false, "SUCCESS")
+      trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], false, "SUCCESS", 'name#1')
       stage {
         refId = "1"
         context["package"] = "another_package"
@@ -431,7 +432,7 @@ class PackageInfoSpec extends Specification {
     given:
     def pipeline = pipeline {
       trigger = new JenkinsTrigger("master", "job", 1, null)
-      trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_2.2.2-h02.sha321_all.deb", ".")], [], false, "SUCCESS")
+      trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_2.2.2-h02.sha321_all.deb", ".")], [], false, "SUCCESS", 'name#1')
       stage {
         context = [package: 'api']
       }
@@ -518,10 +519,10 @@ class PackageInfoSpec extends Specification {
     pipelineTrigger << [
       new PipelineTrigger(ExecutionBuilder.pipeline {
         trigger = new JenkinsTrigger("master", "job", 1, null)
-        trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], false, "SUCCESS")
+        trigger.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], false, "SUCCESS", 'name#1')
       }),
       new JenkinsTrigger("master", "job", 1, null).with {
-        it.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], false, "SUCCESS")
+        it.buildInfo = new BuildInfo("name", 1, "http://jenkins", [new JenkinsArtifact("api_1.1.1-h01.sha123_all.deb", ".")], [], false, "SUCCESS", 'name#1')
         it
       }
     ]
@@ -530,7 +531,7 @@ class PackageInfoSpec extends Specification {
   def "should fetch artifacts from upstream stage when not specified on pipeline trigger"() {
     given:
     def jenkinsTrigger = new JenkinsTrigger("master", "job", 1, "propertyFile")
-    jenkinsTrigger.buildInfo = new BuildInfo("name", 0, "url", [], [], false, "result")
+    jenkinsTrigger.buildInfo = new BuildInfo("name", 0, "url", [], [], false, "result", 'name#1')
 
     def pipeline = pipeline {
       trigger = jenkinsTrigger    // has no artifacts!


### PR DESCRIPTION
Reopening this after having messed up the source branch on this prior PR: https://github.com/spinnaker/orca/pull/2758.

This should have been merged last week and is needed for 1.13 as it collaborates with Concourse features in other Spinnaker services.

![image](https://user-images.githubusercontent.com/1697736/54567095-b7dfc000-49a0-11e9-93d4-63b5fc585b84.png)

![image](https://user-images.githubusercontent.com/1697736/54567098-badab080-49a0-11e9-8030-adcde5f1021f.png)
