### PR TITLE
fix(artifacts): Fix successful filter for find artifacts

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
@@ -73,13 +73,13 @@ public class FindArtifactFromExecutionTask implements Task {
 
   @Data
   private static class ExecutionOptions {
-    boolean succeeded;
+    boolean successful;
     boolean terminal;
     boolean running;
 
     ExecutionCriteria toCriteria() {
       List<String> statuses = new ArrayList<>();
-      if (succeeded) {
+      if (successful) {
         statuses.add("SUCCEEDED");
       }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
@@ -73,13 +73,18 @@ public class FindArtifactFromExecutionTask implements Task {
 
   @Data
   private static class ExecutionOptions {
+    // Accept either 'succeeded' or 'successful' in the stage config. The front-end sets 'successful', but due to a bug
+    // this class was only looking for 'succeeded'. Fix this by accepting 'successful' but to avoid breaking anyone who
+    // discovered this bug and manually edited their stage to set 'succeeded', continue to accept 'succeeded'.
+    boolean succeeded;
     boolean successful;
+
     boolean terminal;
     boolean running;
 
     ExecutionCriteria toCriteria() {
       List<String> statuses = new ArrayList<>();
-      if (successful) {
+      if (succeeded || successful) {
         statuses.add("SUCCEEDED");
       }
 


### PR DESCRIPTION
When filtering to only include successful executions, the front-end sets the flag 'successful' in the stage config. Orca is incorrectly looking for a value 'succeeded', and thus ignores the value that was set on the front-end.

While 'succeeded' is slightly better named as it matches the execution status, changing this on the backend means that existing pipelines will work automatically.  (Whereas changing it on the front-end would require either a pipeline migrator or for anyone affected to re-configure the stage.)