### PR TITLE
fix(triggers): Add Jenkins and Concourse build info types to allowed …

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/ReturnTypeRestrictor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/ReturnTypeRestrictor.java
@@ -59,6 +59,8 @@ public interface ReturnTypeRestrictor extends InstantiationTypeRestrictor {
         Trigger.class,
         BuildInfo.class,
         JenkinsArtifact.class,
+        JenkinsBuildInfo.class,
+        ConcourseBuildInfo.class,
         SourceControl.class,
         ExecutionStatus.class,
         Execution.AuthenticationDetails.class,


### PR DESCRIPTION
@emjburns This solves the immediate problem you reported, but I'm not exactly sure what the second pipeline looked like. Would you mind testing this in your env?

> Failed to evaluate ${trigger.parentExecution.trigger.buildInfo.url}, returning raw value EL1021E: A problem occurred whilst attempting to access the property 'buildInfo': 'found getter for requested buildInfo but rejected due to return type class com.netflix.spinnaker.orca.pipeline.model.JenkinsBuildInfo'"
,
"logger_name":"com.netflix.spinnaker.orca.pipeline.expressions.ExpressionTransform"