### PR TITLE
fix(clouddriver): Reduce jardiff connect/read timeouts

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTask.groovy
@@ -113,10 +113,18 @@ class JarDiffsTask implements DiffTask {
   }
 
   InstanceService createInstanceService(String address) {
+    def okHttpClient = new OkHttpClient(retryOnConnectionFailure: false)
+
+    // short circuit as quickly as possible security groups don't allow ingress to <instance>:8077
+    // (spinnaker applications don't allow this)
+    okHttpClient.setConnectTimeout(2, TimeUnit.SECONDS)
+    okHttpClient.setReadTimeout(2, TimeUnit.SECONDS)
+
     RestAdapter restAdapter = new RestAdapter.Builder()
       .setEndpoint(address)
-      .setClient(new OkClient(new OkHttpClient(retryOnConnectionFailure: false)))
+      .setClient(new OkClient(okHttpClient))
       .build()
+
     return restAdapter.create(InstanceService.class)
   }
 


### PR DESCRIPTION
This handles situations where a security group may prevent ingress
and otherwise timeout after the default (10s).

We automatically retry 5 times so our deployments are taking _at least_
50s longer than they need to.

This isn't perfect but that 50s will be lowered to 10s.
