### PR TITLE
feat(gcb): Add Google Cloud Build stage

### DIFF
--- a/orca-igor/orca-igor.gradle
+++ b/orca-igor/orca-igor.gradle
@@ -22,7 +22,7 @@ dependencies {
   compile project(":orca-front50")
   compile spinnaker.dependency('kork')
   compile spinnaker.dependency('bootAutoConfigure')
-  compile 'com.google.apis:google-api-services-cloudbuild:v1-rev836-1.25.0'
+  compile spinnaker.dependency('googleCloudBuild')
   testCompile project(":orca-test-groovy")
   testCompile spinnaker.dependency("springTest")
 }

--- a/orca-igor/orca-igor.gradle
+++ b/orca-igor/orca-igor.gradle
@@ -22,6 +22,7 @@ dependencies {
   compile project(":orca-front50")
   compile spinnaker.dependency('kork')
   compile spinnaker.dependency('bootAutoConfigure')
+  compile 'com.google.apis:google-api-services-cloudbuild:v1-rev836-1.25.0'
   testCompile project(":orca-test-groovy")
   testCompile spinnaker.dependency("springTest")
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.orca.igor;
 
+import com.google.api.services.cloudbuild.v1.model.Build;
+import com.google.api.services.cloudbuild.v1.model.Operation;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import retrofit.http.*;
 
@@ -68,4 +70,9 @@ public interface IgorService {
     @Query("propertyFile") String propertyFile,
     @Path("master") String master,
     @Path(value = "job", encode = false) String job);
+
+  @POST("/gcb/builds/create/{account}")
+  Operation createGoogleCloudBuild(
+    @Path("account") String account,
+    @Body Build job);
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.api.services.cloudbuild.v1.model.Build;
+import lombok.Getter;
+
+@Getter
+public class GoogleCloudBuildStageDefinition {
+  private final String account;
+  private final Build buildDefinition;
+
+  // There does not seem to be a way to auto-generate a constructor using our current version of Lombok (1.16.20) that
+  // Jackson can use to deserialize.
+  public GoogleCloudBuildStageDefinition(
+    @JsonProperty("account") String account,
+    @JsonProperty("buildDefinition") Build buildDefinition
+  ) {
+    this.account = account;
+    this.buildDefinition = buildDefinition;
+  }
+}

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/GoogleCloudBuildStage.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/GoogleCloudBuildStage.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.igor.pipeline;
+
+import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildStageDefinition;
+import com.netflix.spinnaker.orca.igor.tasks.StartGoogleCloudBuildTask;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleCloudBuildStage implements StageDefinitionBuilder {
+  @Override
+  public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
+    GoogleCloudBuildStageDefinition stageDefinition = stage.mapTo(GoogleCloudBuildStageDefinition.class);
+    builder
+      .withTask("startGoogleCloudBuildTask", StartGoogleCloudBuildTask.class);
+  }
+}

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.tasks;
+
+import com.google.api.services.cloudbuild.v1.model.Operation;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.igor.IgorService;
+import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildStageDefinition;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+
+@Component
+@RequiredArgsConstructor
+public class StartGoogleCloudBuildTask implements Task {
+  private final IgorService igorService;
+
+  @Override
+  @Nonnull public TaskResult execute(@Nonnull Stage stage) {
+    GoogleCloudBuildStageDefinition stageDefinition = stage.mapTo(GoogleCloudBuildStageDefinition.class);
+    Operation result = igorService.createGoogleCloudBuild(stageDefinition.getAccount(), stageDefinition.getBuildDefinition());
+    return new TaskResult(ExecutionStatus.SUCCEEDED);
+  }
+}

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/pipeline/GoogleCloudBuildStageSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/pipeline/GoogleCloudBuildStageSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.pipeline
+
+import com.google.api.services.cloudbuild.v1.model.Build
+import com.netflix.spinnaker.orca.igor.tasks.StartGoogleCloudBuildTask
+import spock.lang.Specification
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class GoogleCloudBuildStageSpec extends Specification {
+  def ACCOUNT = "my-account"
+  def BUILD = new Build()
+
+  def "should start a build"() {
+    given:
+    def googleCloudBuildStage = new GoogleCloudBuildStage()
+
+    def stage = stage {
+      type = "googleCloudBuild"
+      context = [
+        account: ACCOUNT,
+        buildDefinition: BUILD,
+      ]
+    }
+
+    when:
+    def tasks = googleCloudBuildStage.buildTaskGraph(stage)
+
+    then:
+    tasks.findAll {
+      it.implementingClass == StartGoogleCloudBuildTask
+    }.size() == 1
+  }
+}

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.tasks
+
+import com.google.api.services.cloudbuild.v1.model.Build
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.igor.IgorService
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import spock.lang.Specification
+import spock.lang.Subject
+
+class StartGoogleCloudBuildTaskSpec extends Specification {
+  def ACCOUNT = "my-account"
+  def BUILD = new Build()
+
+  Execution execution = Mock(Execution)
+  IgorService igorService = Mock(IgorService)
+
+  @Subject
+  StartGoogleCloudBuildTask task = new StartGoogleCloudBuildTask(igorService)
+
+  def "starts a build"() {
+    given:
+
+    when:
+    def stage = new Stage(execution, "googleCloudBuild", [account: ACCOUNT, buildDefinition: BUILD])
+    TaskResult result = task.execute(stage)
+
+    then:
+    1 * igorService.createGoogleCloudBuild(*_)
+  }
+}


### PR DESCRIPTION
Add a stage that triggers a build using Google Cloud Build. At this point, the stage only accepts a build definition directly in the stage, and does not wait for the build to complete.