### PR TITLE
fix(clouddriver): Enable the parameter of allowDeleteActive

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategy.groovy
@@ -71,7 +71,7 @@ class RedBlackStrategy implements Strategy, ApplicationContextAware {
     if (stageData?.maxRemainingAsgs && (stageData?.maxRemainingAsgs > 0)) {
       Map shrinkContext = baseContext + [
         shrinkToSize         : stageData.maxRemainingAsgs,
-        allowDeleteActive    : false,
+        allowDeleteActive    : stageData.allowDeleteActive ?: false,
         retainLargerOverNewer: false
       ]
       stages << newStage(
@@ -123,7 +123,7 @@ class RedBlackStrategy implements Strategy, ApplicationContextAware {
       }
 
       def scaleDown = baseContext + [
-        allowScaleDownActive         : false,
+        allowScaleDownActive         : stageData.allowScaleDownActive ?: false,
         remainingFullSizeServerGroups: 1,
         preferLargerOverNewer        : false
       ]

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageData.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageData.groovy
@@ -38,6 +38,8 @@ class StageData {
   boolean scaleDown
   Map<String, List<String>> availabilityZones
   int maxRemainingAsgs
+  Boolean allowDeleteActive
+  Boolean allowScaleDownActive
   int maxInitialAsgs = 1
   Boolean useSourceCapacity
   Boolean preferSourceCapacity


### PR DESCRIPTION
There is the logic of “allowDeleteActive” in orca but seems it’s hardcoded to false. Azure has this specific scenario of deleting active instances in the ShrinkClusterTask in the Red/Black strategy, so enable this parameter. Assume other cloud providers that have been worked without interacting with this parameter won’t be impacted since this change makes its value as “false” as what it is used to be if this parameter is not set explicitly anywhere else.
