### PR TITLE
feat(gremlin): Add Halyard config for Gremlin

### DIFF
--- a/halconfig/orca.yml
+++ b/halconfig/orca.yml
@@ -41,3 +41,8 @@ redis:
 tasks:
   executionWindow:
     timezone: ${global.spinnaker.timezone:America/Los_Angeles}
+
+integrations:
+  gremlin:
+    enabled: ${features.gremlin:false}
+    baseUrl: https://api.gremlin.com/v1


### PR DESCRIPTION
Set `integrations.gremlin.enabled` from the Halyard feature named `--gremlin`.
This will work once spinnaker/halyard#1261 is merged.