### PR TITLE
fix(provider/cf): Bind clone manifest artifacts

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.orca.clouddriver.FeaturesService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForUpInstancesTask
-import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CloneServerGroupTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.clone.CloneServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.AddServerGroupEntityTagsTask
 import com.netflix.spinnaker.orca.pipeline.TaskNode

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
@@ -16,27 +16,18 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.cf;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCreator;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nullable;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -85,22 +76,7 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
   }
 
   private Artifact manifestArtifact(Stage stage, Object input) {
-    Manifest manifest = mapper.convertValue(input, Manifest.class);
-    if (manifest.getDirect() != null) {
-      return Artifact.builder()
-        .name("manifest")
-        .type("embedded/base64")
-        .artifactAccount("embedded-artifact")
-        .reference(Base64.getEncoder().encodeToString(manifest.getDirect().toManifestYml().getBytes()))
-        .build();
-    }
-
-    Artifact artifact = artifactResolver.getBoundArtifactForStage(stage, manifest.getArtifactId(), manifest.getArtifact());
-    if(artifact == null) {
-      throw new IllegalArgumentException("Unable to bind the manifest artifact");
-    }
-
-    return artifact;
+    return mapper.convertValue(input, Manifest.class).toArtifact(artifactResolver, stage);
   }
 
   @Override
@@ -125,90 +101,5 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
 
     @Nullable
     private Artifact artifact;
-  }
-
-  @Data
-  static class Manifest {
-    @Nullable
-    private DirectManifest direct;
-
-    @Nullable
-    private String artifactId;
-
-    @Nullable
-    private Artifact artifact;
-  }
-
-  static class DirectManifest {
-    private static ObjectMapper manifestMapper = new ObjectMapper(new YAMLFactory()
-      .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
-      .enable(YAMLGenerator.Feature.INDENT_ARRAYS))
-      .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
-
-    @Getter
-    private final String name = "app"; // doesn't matter, has no effect on the CF app name.
-
-    @Getter
-    @Setter
-    private List<String> buildpacks;
-
-    @Getter
-    @Setter
-    @JsonProperty("disk_quota")
-    @JsonAlias("diskQuota")
-    private String diskQuota;
-
-    @Getter
-    @Setter
-    private String healthCheckType;
-
-    @Getter
-    @Setter
-    private String healthCheckHttpEndpoint;
-
-    @Getter
-    private Map<String, String> env;
-
-    public void setEnvironment(List<EnvironmentVariable> environment) {
-      this.env = environment.stream().collect(Collectors.toMap(EnvironmentVariable::getKey, EnvironmentVariable::getValue));
-    }
-
-    @Setter
-    private List<String> routes;
-
-    public List<Map<String, String>> getRoutes() {
-      return routes.stream()
-        .map(r -> ImmutableMap.<String, String>builder().put("route", r).build())
-        .collect(Collectors.toList());
-    }
-
-    @Getter
-    @Setter
-    private List<String> services;
-
-    @Getter
-    @Setter
-    private Integer instances;
-
-    @Getter
-    @Setter
-    private String memory;
-
-    String toManifestYml() {
-      try {
-        Map<String, List<DirectManifest>> apps = ImmutableMap.<String, List<DirectManifest>>builder()
-          .put("applications", Collections.singletonList(this))
-          .build();
-        return manifestMapper.writeValueAsString(apps);
-      } catch (JsonProcessingException e) {
-        throw new IllegalArgumentException("Unable to generate Cloud Foundry Manifest", e);
-      }
-    }
-  }
-
-  @Data
-  static class EnvironmentVariable {
-    String key;
-    String value;
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/Manifest.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/Manifest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.cf;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.annotation.Nullable;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Setter
+public class Manifest {
+  @Nullable
+  private Direct direct;
+
+  @Nullable
+  private String artifactId;
+
+  @Nullable
+  private Artifact artifact;
+
+  public Artifact toArtifact(ArtifactResolver artifactResolver, Stage stage) {
+    if (direct != null) {
+      return Artifact.builder()
+        .name("manifest")
+        .type("embedded/base64")
+        .artifactAccount("embedded-artifact")
+        .reference(Base64.getEncoder().encodeToString(direct.toManifestYml().getBytes()))
+        .build();
+    }
+
+    Artifact boundArtifact = artifactResolver.getBoundArtifactForStage(stage, artifactId, this.artifact);
+    if(boundArtifact == null) {
+      throw new IllegalArgumentException("Unable to bind the manifest artifact");
+    }
+    return boundArtifact;
+  }
+
+  public static class Direct {
+    private static ObjectMapper manifestMapper = new ObjectMapper(new YAMLFactory()
+      .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+      .enable(YAMLGenerator.Feature.INDENT_ARRAYS))
+      .setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+
+    @Getter
+    private final String name = "app"; // doesn't matter, has no effect on the CF app name.
+
+    @Getter
+    @Setter
+    private List<String> buildpacks;
+
+    @Getter
+    @Setter
+    @JsonProperty("disk_quota")
+    @JsonAlias("diskQuota")
+    private String diskQuota;
+
+    @Getter
+    @Setter
+    private String healthCheckType;
+
+    @Getter
+    @Setter
+    private String healthCheckHttpEndpoint;
+
+    @Getter
+    private Map<String, String> env;
+
+    public void setEnvironment(List<EnvironmentVariable> environment) {
+      this.env = environment.stream().collect(Collectors.toMap(EnvironmentVariable::getKey, EnvironmentVariable::getValue));
+    }
+
+    @Setter
+    private List<String> routes;
+
+    public List<Map<String, String>> getRoutes() {
+      return routes.stream()
+        .map(r -> ImmutableMap.<String, String>builder().put("route", r).build())
+        .collect(Collectors.toList());
+    }
+
+    @Getter
+    @Setter
+    private List<String> services;
+
+    @Getter
+    @Setter
+    private Integer instances;
+
+    @Getter
+    @Setter
+    private String memory;
+
+    String toManifestYml() {
+      try {
+        Map<String, List<Direct>> apps = ImmutableMap.<String, List<Direct>>builder()
+          .put("applications", Collections.singletonList(this))
+          .build();
+        return manifestMapper.writeValueAsString(apps);
+      } catch (JsonProcessingException e) {
+        throw new IllegalArgumentException("Unable to generate Cloud Foundry Manifest", e);
+      }
+    }
+  }
+
+  @Data
+  public static class EnvironmentVariable {
+    private String key;
+    private String value;
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/clone/BakeryImageAccessDescriptionDecorator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/clone/BakeryImageAccessDescriptionDecorator.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.clone
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * Netflix bakes images in their test account. This rigmarole is to allow the
+ * prod account access to that image.
+ */
+@Slf4j
+@Component
+class BakeryImageAccessDescriptionDecorator implements CloneDescriptionDecorator {
+  @Value('${default.bake.account:default}')
+  String defaultBakeAccount
+
+  @Override
+  boolean shouldDecorate(Map operation) {
+    Collection<String> targetRegions = targetRegions(operation)
+
+    return getCloudProvider(operation) == "aws" && // the operation is a clone of stage.context.
+      operation.credentials != defaultBakeAccount &&
+      targetRegions &&
+      operation.amiName
+  }
+
+  @Override
+  void decorate(Map<String, Object> operation, List<Map<String, Object>> descriptions, Stage stage) {
+    def allowLaunchDescriptions = targetRegions(operation).collect { String region ->
+      [
+        allowLaunchDescription: [
+          account    : operation.credentials,
+          credentials: defaultBakeAccount,
+          region     : region,
+          amiName    : operation.amiName
+        ]
+      ]
+    }
+    descriptions.addAll(allowLaunchDescriptions)
+
+    log.info("Generated `allowLaunchDescriptions` (allowLaunchDescriptions: ${allowLaunchDescriptions})")
+  }
+
+  private static Collection<String> targetRegions(Map operation) {
+    return operation.region ? [operation.region] :
+      operation.availabilityZones ? operation.availabilityZones.keySet() : []
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/clone/CloneDescriptionDecorator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/clone/CloneDescriptionDecorator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.clone;
+
+import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+
+import java.util.List;
+import java.util.Map;
+
+public interface CloneDescriptionDecorator extends CloudProviderAware {
+  boolean shouldDecorate(Map<String, Object> operation);
+
+  void decorate(Map<String, Object> operation, List<Map<String, Object>> descriptions, Stage stage);
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/clone/CloudFoundryManifestArtifactDecorator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/clone/CloudFoundryManifestArtifactDecorator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.clone;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.cf.Manifest;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class CloudFoundryManifestArtifactDecorator implements CloneDescriptionDecorator {
+  private final ObjectMapper mapper;
+  private final ArtifactResolver artifactResolver;
+
+  @Override
+  public boolean shouldDecorate(Map<String, Object> operation) {
+    return "cloudfoundry".equals(getCloudProvider(operation));
+  }
+
+  @Override
+  public void decorate(Map<String, Object> operation, List<Map<String, Object>> descriptions, Stage stage) {
+    CloudFoundryCloneServerGroupOperation op = mapper.convertValue(operation, CloudFoundryCloneServerGroupOperation.class);
+
+    operation.put("applicationArtifact", Artifact.builder()
+      .type("cloudfoundry/app")
+      .artifactAccount(op.getSource().getAccount())
+      .location(op.getSource().getRegion())
+      .name(op.getSource().getAsgName())
+      .build());
+    operation.put("manifest", op.getManifest().toArtifact(artifactResolver, stage));
+    operation.put("credentials", op.getDestination().getAccount());
+    operation.put("region", op.getDestination().getRegion());
+
+    operation.remove("source");
+    operation.remove("destination");
+  }
+
+  @Data
+  private static class CloudFoundryCloneServerGroupOperation {
+    private Manifest manifest;
+    private Source source;
+    private Destination destination;
+
+    @Data
+    static class Source {
+      String account;
+      String region;
+      String asgName;
+    }
+
+    @Data
+    static class Destination {
+      String account;
+      String region;
+    }
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CloneServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CloneServerGroupTaskSpec.groovy
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 import com.fasterxml.jackson.datatype.guava.GuavaModule
 import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.clone.BakeryImageAccessDescriptionDecorator
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.clone.CloneServerGroupTask
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.test.model.ExecutionBuilder
@@ -47,6 +49,7 @@ class CloneServerGroupTaskSpec extends Specification {
     mapper.registerModule(new GuavaModule())
 
     task.mapper = mapper
+    task.cloneDescriptionDecorators = [new BakeryImageAccessDescriptionDecorator()]
 
     stage.execution.stages.add(stage)
     stage.context = cloneServerGroupConfig
@@ -67,10 +70,10 @@ class CloneServerGroupTaskSpec extends Specification {
 
     then:
     operations.size() == 3
-    operations[2].cloneServerGroup.amiName == "hodor-image"
-    operations[2].cloneServerGroup.application == "hodor"
-    operations[2].cloneServerGroup.availabilityZones == ["us-east-1": ["a", "d"], "us-west-1": ["a", "b"]]
-    operations[2].cloneServerGroup.credentials == "fzlem"
+    operations[0].cloneServerGroup.amiName == "hodor-image"
+    operations[0].cloneServerGroup.application == "hodor"
+    operations[0].cloneServerGroup.availabilityZones == ["us-east-1": ["a", "d"], "us-west-1": ["a", "b"]]
+    operations[0].cloneServerGroup.credentials == "fzlem"
   }
 
   def "can include optional parameters"() {
@@ -91,7 +94,7 @@ class CloneServerGroupTaskSpec extends Specification {
 
     then:
     operations.size() == 3
-    with(operations[2].cloneServerGroup) {
+    with(operations[0].cloneServerGroup) {
       amiName == "hodor-image"
       application == "hodor"
       availabilityZones == ["us-east-1": ["a", "d"], "us-west-1": ["a", "b"]]
@@ -120,7 +123,7 @@ class CloneServerGroupTaskSpec extends Specification {
 
     then:
     operations.size() == 3
-    with(operations[2].cloneServerGroup) {
+    with(operations[0].cloneServerGroup) {
       amiName == contextAmi
       application == "hodor"
       availabilityZones == ["us-east-1": ["a", "d"], "us-west-1": ["a", "b"]]
@@ -156,7 +159,7 @@ class CloneServerGroupTaskSpec extends Specification {
 
     then:
     operations.size() == 3
-    with(operations[2].cloneServerGroup) {
+    with(operations[0].cloneServerGroup) {
       amiName == bakeAmi
       application == "hodor"
       availabilityZones == ["us-east-1": ["a", "d"], "us-west-1": ["a", "b"]]
@@ -219,11 +222,11 @@ class CloneServerGroupTaskSpec extends Specification {
 
     then:
     operations.size() == 3
-    operations[0].allowLaunchDescription.amiName == contextAmi
-    operations[0].allowLaunchDescription.region == "us-east-1"
+    operations[0].cloneServerGroup.amiName == contextAmi
     operations[1].allowLaunchDescription.amiName == contextAmi
-    operations[1].allowLaunchDescription.region == "us-west-1"
-    operations[2].cloneServerGroup.amiName == contextAmi
+    operations[1].allowLaunchDescription.region == "us-east-1"
+    operations[2].allowLaunchDescription.amiName == contextAmi
+    operations[2].allowLaunchDescription.region == "us-west-1"
 
     where:
     contextAmi = "ami-ctx"
@@ -247,7 +250,6 @@ class CloneServerGroupTaskSpec extends Specification {
 
     then:
     operations.size() == 2
-    operations[0].allowLaunchDescription.region == "eu-west-1"
-
+    operations[1].allowLaunchDescription.region == "eu-west-1"
   }
 }

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreatorTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreatorTest.java
@@ -17,11 +17,16 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.cf;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class CloudFoundryServerGroupCreatorTest {
   @Test
@@ -47,11 +52,13 @@ class CloudFoundryServerGroupCreatorTest {
 
     ObjectMapper mapper = new ObjectMapper();
 
-    CloudFoundryServerGroupCreator.DirectManifest direct = mapper.readValue(manifestPipelineJson,
-      CloudFoundryServerGroupCreator.Manifest.class).getDirect();
+    ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
+    Stage stage = mock(Stage.class);
 
-    assertThat(direct).isNotNull();
-    assertThat(direct.toManifestYml()).isEqualTo(
+    Artifact artifact = mapper.readValue(manifestPipelineJson, Manifest.class).toArtifact(artifactResolver, stage);
+
+    assertThat(artifact.getType()).isEqualTo("embedded/base64");
+    assertThat(new String(Base64.getDecoder().decode(artifact.getReference()))).isEqualTo(
       "---\n" +
         "applications:\n" +
         " -\n" +


### PR DESCRIPTION
There was some AWS-specific logic in `CloneServerGroupTask` that adds launch descriptions to the task list for a clone. Separately, there was a need for us to bind an expected artifact for a manifest that is an input to the CF clone operation. I took this opportunity to extract the cloud provider specific modifications to this task to a `CloneDescriptionDecorator`.

![image](https://user-images.githubusercontent.com/1697736/55582726-d4406400-56e5-11e9-84e6-0817b4d52e13.png)
