### PR TITLE
fix(expressions): make sure trigger is a map

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTask.java
@@ -36,6 +36,11 @@ public class EvaluateVariablesTask implements Task {
   public EvaluateVariablesTask() {
   }
 
+  /**
+   * Copies previously evaluated expressions to the outputs map for consumption by subsequent stages.
+   * The variables aren't evaluated here because would've been evaluated already by a call to
+   * e.g. ExpressionAware.Stage#withMergedContext
+   */
   @Nonnull
   @Override
   public TaskResult execute(@Nonnull Stage stage) {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTaskSpec.groovy
@@ -26,7 +26,7 @@ class EvaluateVariablesTaskSpec extends Specification {
   @Subject
   task = new EvaluateVariablesTask()
 
-  void "Should correctly evaulate variables"() {
+  void "Should correctly copy evaluated variables"() {
     setup:
     def stage = stage {
       refId = "1"

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
@@ -16,7 +16,10 @@
 
 package com.netflix.spinnaker.orca.q.handler
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.expressions.ExpressionEvaluationSummary
 import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator
 import com.netflix.spinnaker.orca.pipeline.model.Execution
@@ -35,6 +38,9 @@ interface ExpressionAware {
   val contextParameterProcessor: ContextParameterProcessor
   val log: Logger
     get() = LoggerFactory.getLogger(javaClass)
+  private val mapper: ObjectMapper
+    get() = OrcaObjectMapper.newInstance()
+
 
   fun Stage.withMergedContext(): Stage {
     val evalSummary = ExpressionEvaluationSummary()
@@ -130,7 +136,9 @@ interface ExpressionAware {
 
   private fun StageContext.augmentContext(execution: Execution): StageContext =
     if (execution.type == PIPELINE) {
-      this + mapOf("trigger" to execution.trigger, "execution" to execution)
+      this + mapOf(
+        "trigger" to mapper.convertValue<Map<String, Any>>(execution.trigger),
+        "execution" to execution)
     } else {
       this
     }


### PR DESCRIPTION
Some places uses `ContextParameterProcessor.buildExecutionContext` which (correctly) converts the
`trigger` in the pipeline to an object (instead of keeping it as `Trigger` class).
However, when tasks run, they use `.withMergedContext` which opts to build it's own SpEL
executionContext (in `.augmentContext`). This is needed so that fancy look up in ancestor stages works.
Fix `.augmentContext` to convert the trigger to an object/map.

This addresses issues evaluating expressions like
`${trigger.buildNumber ?: #stage('s1').context.buildNumber}`` when no `buildNumber` is present on the `trigger`
