### PR TITLE
fix(MPTv2): Fix for #2803

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
@@ -73,7 +73,7 @@ class DependentPipelineExecutionListener implements ExecutionListener {
     if (pipelinePreprocessors) {
       // Resolve templated pipelines if enabled.
       allPipelines = allPipelines.collect { pipeline ->
-       if (pipeline.type == 'templatedPipeline' && pipeline?.schema != "1") {
+       if (pipeline.type == 'templatedPipeline' && pipeline?.schema != null && pipeline?.schema != "1") {
          return V2Util.planPipeline(contextParameterProcessor, pipelinePreprocessors, pipeline)
        } else {
          return pipeline


### PR DESCRIPTION
Many templatedPipelines don't have a `.schema` set and the code treats them as `v2` but they should
stay as `v1` and not be processed.
We saw a bunch of pipelines going through to `V2Util.planPipeline` increasing traffic to `front50`
about 200x and many calls would fail (presumably due to `v1` being treated as `v2`?)
