### PR TITLE
chore(cf): allow deployment strategies to work across different regions

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroup.groovy
@@ -169,7 +169,8 @@ class TargetServerGroup {
     static Location locationFromStageData(StageData stageData) {
       try {
         List zones = stageData.availabilityZones?.values()?.flatten()?.toArray()
-        return resolveLocation(stageData.namespace, stageData.region, zones?.getAt(0))
+        String region = stageData.destination?.region?:stageData.region
+        return resolveLocation(stageData.namespace, region, zones?.getAt(0))
       } catch (e) {
         throw new IllegalArgumentException("Incorrect location specified for ${stageData}: ${e.message}")
       }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/clone/CloudFoundryManifestArtifactDecorator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/clone/CloudFoundryManifestArtifactDecorator.java
@@ -50,7 +50,7 @@ public class CloudFoundryManifestArtifactDecorator implements CloneDescriptionDe
       .name(op.getSource().getAsgName())
       .build());
     operation.put("manifest", op.getManifest().toArtifact(artifactResolver, stage));
-    operation.put("credentials", op.getDestination().getAccount());
+    operation.put("credentials", op.getAccount());
     operation.put("region", op.getDestination().getRegion());
 
     operation.remove("source");
@@ -59,6 +59,7 @@ public class CloudFoundryManifestArtifactDecorator implements CloneDescriptionDe
 
   @Data
   private static class CloudFoundryCloneServerGroupOperation {
+    private String account;
     private Manifest manifest;
     private Source source;
     private Destination destination;
@@ -72,7 +73,6 @@ public class CloudFoundryManifestArtifactDecorator implements CloneDescriptionDe
 
     @Data
     static class Destination {
-      String account;
       String region;
     }
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageData.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageData.groovy
@@ -44,6 +44,7 @@ class StageData {
   Boolean useSourceCapacity
   Boolean preferSourceCapacity
   Source source
+  Destination destination
 
   @Deprecated
   long delayBeforeDisableSec
@@ -65,9 +66,6 @@ class StageData {
   }
 
   String getAccount() {
-    if (account && credentials && account != credentials) {
-      throw new IllegalStateException("Cannot specify different values for 'account' and 'credentials' (${application})")
-    }
     return account ?: credentials
   }
 
@@ -113,6 +111,12 @@ class StageData {
     String serverGroupName
     Boolean useSourceCapacity
     Boolean preferSourceCapacity
+  }
+
+  @EqualsAndHashCode
+  @ToString
+  static class Destination {
+    String region
   }
 
   static class PipelineBeforeCleanup {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageDataSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/StageDataSpec.groovy
@@ -72,7 +72,6 @@ class StageDataSpec extends Specification {
 
     where:
       account | credentials || expectedAccount
-      "test"  | "prod"      || "IllegalStateException"
       "test"  | null        || "test"
       null    | "test"      || "test"
   }


### PR DESCRIPTION
* allow deployment strategies to work across different regions
* relax constraints so that account does not have to be the same credentials.

spinnaker/spinnaker#4258