### PR TITLE
 feat(provider/kubernetes): Add traffic options to deploy manifest

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestContext.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestContext.java
@@ -19,8 +19,10 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 public class DeployManifestContext extends HashMap<String, Object> {
@@ -28,6 +30,7 @@ public class DeployManifestContext extends HashMap<String, Object> {
   private final String manifestArtifactId;
   private final String manifestArtifactAccount;
   private final Boolean skipExpressionEvaluation;
+  private final TrafficManagement trafficManagement;
   private final List<String> requiredArtifactIds;
 
   // There does not seem to be a way to auto-generate a constructor using our current version of Lombok (1.16.20) that
@@ -37,12 +40,42 @@ public class DeployManifestContext extends HashMap<String, Object> {
     @JsonProperty("manifestArtifactId") String manifestArtifactId,
     @JsonProperty("manifestArtifactAccount") String manifestArtifactAccount,
     @JsonProperty("skipExpressionEvaluation") Boolean skipExpressionEvaluation,
+    @JsonProperty("trafficManagement") TrafficManagement trafficManagement,
     @JsonProperty("requiredArtifactIds") List<String> requiredArtifactIds
   ){
     this.source = source;
     this.manifestArtifactId = manifestArtifactId;
     this.manifestArtifactAccount = manifestArtifactAccount;
     this.skipExpressionEvaluation = skipExpressionEvaluation;
+    this.trafficManagement = trafficManagement;
     this.requiredArtifactIds = requiredArtifactIds;
+  }
+
+  @Getter
+  static class TrafficManagement {
+    private final boolean enabled;
+    private final Options options;
+
+    public TrafficManagement (
+      @JsonProperty("enabled") Boolean enabled,
+      @JsonProperty("options") Options options
+    ) {
+      this.enabled = Optional.ofNullable(enabled).orElse(false);
+      this.options = options;
+    }
+
+    @Getter
+    static class Options {
+      private final boolean enableTraffic;
+      private final List<String> services;
+
+      public Options(
+        @JsonProperty("enableTraffic") Boolean enableTraffic,
+        @JsonProperty("services") List<String> services
+      ) {
+        this.enableTraffic = Optional.ofNullable(enableTraffic).orElse(false);
+        this.services = Optional.ofNullable(services).orElse(Collections.emptyList());
+      }
+    }
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
@@ -31,45 +31,31 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTa
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import retrofit.client.Response;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class DeployManifestTask extends AbstractCloudProviderAwareTask implements Task {
-  @Autowired
-  KatoService kato;
-
-  @Autowired
-  OortService oort;
-
-  @Autowired
-  ArtifactResolver artifactResolver;
-
-  @Autowired
-  ObjectMapper objectMapper;
+  private final KatoService kato;
+  private final OortService oort;
+  private final ArtifactResolver artifactResolver;
+  private final ObjectMapper objectMapper;
+  private final ContextParameterProcessor contextParameterProcessor;
 
   private static final ThreadLocal<Yaml> yamlParser = ThreadLocal.withInitial(() -> new Yaml(new SafeConstructor()));
-
-  @Autowired
-  ContextParameterProcessor contextParameterProcessor;
-
-  RetrySupport retrySupport = new RetrySupport();
+  private final RetrySupport retrySupport = new RetrySupport();
 
   public static final String TASK_NAME = "deployManifest";
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
@@ -148,6 +148,16 @@ public class DeployManifestTask extends AbstractCloudProviderAwareTask implement
 
     task.put("requiredArtifacts", requiredArtifacts);
     task.put("optionalArtifacts", artifacts);
+
+    if (context.getTrafficManagement() != null && context.getTrafficManagement().isEnabled()) {
+      task.put("services", context.getTrafficManagement().getOptions().getServices());
+      task.put("enableTraffic", context.getTrafficManagement().getOptions().isEnableTraffic());
+    } else {
+      // For backwards compatibility, traffic is always enabled to new server groups when the new traffic management
+      // features are not enabled.
+      task.put("enableTraffic", true);
+    }
+
     Map<String, Map> operation = new ImmutableMap.Builder<String, Map>()
         .put(TASK_NAME, task)
         .build();

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTaskSpec.groovy
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
+import rx.Observable
+import spock.lang.Specification
+import spock.lang.Subject
+
+class DeployManifestTaskSpec extends Specification {
+  def TASK_ID = "12345"
+
+  def katoService = Mock(KatoService)
+  def artifactResolver = Stub(ArtifactResolver) {
+    getArtifacts(*_) >> []
+  }
+
+  @Subject
+  DeployManifestTask task = new DeployManifestTask(
+    katoService,
+    Stub(OortService),
+    artifactResolver,
+    new ObjectMapper(),
+    Stub(ContextParameterProcessor)
+  )
+
+  def "enables traffic when the trafficManagement field is absent"() {
+    given:
+    def stage = createStage([:])
+
+    when:
+    task.execute(stage)
+
+    then:
+    1 * katoService.requestOperations("kubernetes", {
+      Map it -> it.deployManifest.enableTraffic == true && !it.deployManifest.services
+    }) >> Observable.from(new TaskId(TASK_ID))
+    0 * katoService._
+  }
+
+  def "enables traffic when trafficManagement is disabled"() {
+    given:
+    def stage = createStage([
+        trafficManagement: [
+            enabled: false
+        ]
+    ])
+
+    when:
+    task.execute(stage)
+
+    then:
+    1 * katoService.requestOperations("kubernetes", {
+      Map it -> it.deployManifest.enableTraffic == true && !it.deployManifest.services
+    }) >> Observable.from(new TaskId(TASK_ID))
+    0 * katoService._
+  }
+
+  def "enables traffic when trafficManagement is enabled and explicitly enables traffic"() {
+    given:
+    def stage = createStage([
+      trafficManagement: [
+        enabled: true,
+        options: [
+            enableTraffic: true,
+            services: ["service my-service"]
+        ]
+      ]
+    ])
+
+    when:
+    task.execute(stage)
+
+    then:
+    1 * katoService.requestOperations("kubernetes", {
+      Map it -> it.deployManifest.enableTraffic == true && it.deployManifest.services == ["service my-service"]
+    }) >> Observable.from(new TaskId(TASK_ID))
+    0 * katoService._
+  }
+
+  def "does not enable traffic when trafficManagement is enabled and enableTraffic is disabled"() {
+    given:
+    def stage = createStage([
+      trafficManagement: [
+        enabled: true,
+        options: [
+          enableTraffic: false,
+          services: ["service my-service"]
+        ]
+      ]
+    ])
+
+    when:
+    task.execute(stage)
+
+    then:
+    1 * katoService.requestOperations("kubernetes", {
+      Map it -> it.deployManifest.enableTraffic == false && it.deployManifest.services == ["service my-service"]
+    }) >> Observable.from(new TaskId(TASK_ID))
+    0 * katoService._
+  }
+
+
+  def createStage(Map extraParams) {
+    return new Stage(Stub(Execution), "deployManifest", [
+      account: "my-k8s-account",
+      cloudProvider: "kubernetes",
+      source: "text",
+    ] + extraParams)
+  }
+}


### PR DESCRIPTION
* refactor(provider/kubernetes): Use constructor injection 

  Refactor DeployManifestTask to use constructor injection, and change impelentation-specific fields to be private and final.

* feat(provider/kubernetes): Add traffic options to deploy manifest 

  Add functionality to the deploy manifest task to handle the fields in the new trafficManagement section. In particular, pass along any specified service as well as whether to send traffic to new workloads.
