### PR TITLE
fix(k8s): Deploy manifest now accepts stage-inlined artifacts

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestContext.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestContext.java
@@ -17,7 +17,9 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import lombok.Getter;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,27 +30,49 @@ import java.util.Optional;
 public class DeployManifestContext extends HashMap<String, Object> {
   private final String source;
   private final String manifestArtifactId;
+  private final Artifact manifestArtifact;
   private final String manifestArtifactAccount;
   private final Boolean skipExpressionEvaluation;
   private final TrafficManagement trafficManagement;
   private final List<String> requiredArtifactIds;
+  private final List<BindArtifact> requiredArtifacts;
 
   // There does not seem to be a way to auto-generate a constructor using our current version of Lombok (1.16.20) that
   // Jackson can use to deserialize.
   public DeployManifestContext(
     @JsonProperty("source") String source,
     @JsonProperty("manifestArtifactId") String manifestArtifactId,
+    @JsonProperty("manifestArtifact") Artifact manifestArtifact,
     @JsonProperty("manifestArtifactAccount") String manifestArtifactAccount,
     @JsonProperty("skipExpressionEvaluation") Boolean skipExpressionEvaluation,
     @JsonProperty("trafficManagement") TrafficManagement trafficManagement,
-    @JsonProperty("requiredArtifactIds") List<String> requiredArtifactIds
+    @JsonProperty("requiredArtifactIds") List<String> requiredArtifactIds,
+    @JsonProperty("requiredArtifacts") List<BindArtifact> requiredArtifacts
   ){
     this.source = source;
     this.manifestArtifactId = manifestArtifactId;
+    this.manifestArtifact = manifestArtifact;
     this.manifestArtifactAccount = manifestArtifactAccount;
     this.skipExpressionEvaluation = skipExpressionEvaluation;
     this.trafficManagement = trafficManagement;
     this.requiredArtifactIds = requiredArtifactIds;
+    this.requiredArtifacts = requiredArtifacts;
+  }
+
+  @Getter
+  public static class BindArtifact {
+    @Nullable
+    private final String expectedArtifactId;
+
+    @Nullable
+    private final Artifact artifact;
+
+
+    public BindArtifact(@JsonProperty("expectedArtifactId") @Nullable String expectedArtifactId,
+                        @JsonProperty("artifact") @Nullable Artifact artifact) {
+      this.expectedArtifactId = expectedArtifactId;
+      this.artifact = artifact;
+    }
   }
 
   @Getter

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
@@ -44,6 +44,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static java.util.Collections.emptyList;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -70,25 +72,25 @@ public class DeployManifestTask extends AbstractCloudProviderAwareTask implement
     Map<String, Object> task = new HashMap<>(context);
     String artifactSource = context.getSource();
     if (StringUtils.isNotEmpty(artifactSource) && artifactSource.equals("artifact")) {
-      String manifestArtifactId = context.getManifestArtifactId();
-      if (manifestArtifactId == null) {
+      Artifact manifestArtifact = artifactResolver.getBoundArtifactForStage(stage, context.getManifestArtifactId(),
+        context.getManifestArtifact());
+
+      if (manifestArtifact == null) {
         throw new IllegalArgumentException("No manifest artifact was specified.");
       }
 
-      String manifestArtifactAccount = context.getManifestArtifactAccount();
-      if (manifestArtifactAccount == null) {
-        throw new IllegalArgumentException("No manifest artifact account was specified.");
+      // Once the legacy artifacts feature is removed, all trigger expected artifacts will be required to define
+      // an account up front.
+      if(context.getManifestArtifactId() != null && manifestArtifact.getArtifactAccount() == null) {
+        manifestArtifact.setArtifactAccount(context.getManifestArtifactAccount());
       }
 
-      Artifact manifestArtifact = artifactResolver.getBoundArtifactForId(stage, manifestArtifactId);
-
-      if (manifestArtifact == null) {
-        throw new IllegalArgumentException("No artifact could be bound to '" + manifestArtifactId + "'");
+      if (manifestArtifact.getArtifactAccount() == null) {
+        throw new IllegalArgumentException("No manifest artifact account was specified.");
       }
 
       log.info("Using {} as the manifest to be deployed", manifestArtifact);
 
-      manifestArtifact.setArtifactAccount(manifestArtifactAccount);
       Object parsedManifests = retrySupport.retry(() -> {
         try {
           Response manifestText = oort.fetchArtifact(manifestArtifact);
@@ -132,16 +134,19 @@ public class DeployManifestTask extends AbstractCloudProviderAwareTask implement
       task.put("source", "text");
     }
 
-    List<String> requiredArtifactIds = context.getRequiredArtifactIds();
     List<Artifact> requiredArtifacts = new ArrayList<>();
-    requiredArtifactIds = requiredArtifactIds == null ? new ArrayList<>() : requiredArtifactIds;
-    for (String id : requiredArtifactIds) {
+    for (String id : Optional.ofNullable(context.getRequiredArtifactIds()).orElse(emptyList())) {
       Artifact requiredArtifact = artifactResolver.getBoundArtifactForId(stage, id);
       if (requiredArtifact == null) {
         throw new IllegalStateException("No artifact with id '" + id + "' could be found in the pipeline context.");
       }
 
       requiredArtifacts.add(requiredArtifact);
+    }
+
+    // resolve SpEL expressions in artifacts defined inline in the stage
+    for (DeployManifestContext.BindArtifact artifact : Optional.ofNullable(context.getRequiredArtifacts()).orElse(emptyList())) {
+      requiredArtifacts.add(artifactResolver.getBoundArtifactForStage(stage, artifact.getExpectedArtifactId(), artifact.getArtifact()));
     }
 
     log.info("Deploying {} artifacts within the provided manifest", requiredArtifacts);

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
@@ -81,7 +81,7 @@ public class DeployManifestTask extends AbstractCloudProviderAwareTask implement
 
       // Once the legacy artifacts feature is removed, all trigger expected artifacts will be required to define
       // an account up front.
-      if(context.getManifestArtifactId() != null && manifestArtifact.getArtifactAccount() == null) {
+      if(context.getManifestArtifactAccount() != null) {
         manifestArtifact.setArtifactAccount(context.getManifestArtifactAccount());
       }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
@@ -146,7 +146,13 @@ public class DeployManifestTask extends AbstractCloudProviderAwareTask implement
 
     // resolve SpEL expressions in artifacts defined inline in the stage
     for (DeployManifestContext.BindArtifact artifact : Optional.ofNullable(context.getRequiredArtifacts()).orElse(emptyList())) {
-      requiredArtifacts.add(artifactResolver.getBoundArtifactForStage(stage, artifact.getExpectedArtifactId(), artifact.getArtifact()));
+      Artifact requiredArtifact = artifactResolver.getBoundArtifactForStage(stage, artifact.getExpectedArtifactId(), artifact.getArtifact());
+
+      if (requiredArtifact == null) {
+        throw new IllegalStateException("No artifact with id '" + artifact.getExpectedArtifactId() + "' could be found in the pipeline context.");
+      }
+
+      requiredArtifacts.add(requiredArtifact);
     }
 
     log.info("Deploying {} artifacts within the provided manifest", requiredArtifacts);


### PR DESCRIPTION
In 1.13, the K8S deploy manifest stage displays the new artifacts UI when the feature flag is enabled. The JSON structure it produces for the stage is not digestable by Orca. As a refresher on the structural changes done such that this is backwards compatible:

1. `manifestArtifact` can (optionally) have an `artifactAccount` now. With the new artifacts UI, you _must_ specify an artifact account up front in the expected artifact definition, so any artifacts created with the new UI will have it. `manifestArtifactAccount` is now a backwards compatible fallback for existing pipelines.
2. `requiredArtifacts` contains a list of bind artifacts that contain either an `expectedArtifactId` or a fully-defined `artifact`. The UI presents any artifacts defined in the old model (still present in `requiredArtifactIds`) along with any artifacts defined in the new model side-by-side.

![image](https://user-images.githubusercontent.com/1697736/55930951-3b2fb280-5be9-11e9-8dcd-eecb07fba8e9.png)

Here's an example of what I mean by stage-inlined artifacts in the context of the k8s deploy manifest stage:

![image](https://user-images.githubusercontent.com/1697736/55931147-0ff99300-5bea-11e9-9abd-97939ffee319.png)
