### PR TITLE
fix(repository): don't generate invalid grammar

### DIFF
--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositorySpec.groovy
@@ -491,4 +491,14 @@ class SqlExecutionRepositorySpec extends ExecutionRepositoryTck<SqlExecutionRepo
     storeLimit = 6
   }
 
+  def "doesn't fail on empty configIds"() {
+    expect:
+    repository
+      .retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
+      [],
+      0L,
+      5L,
+      new ExecutionCriteria().setPageSize(1).setSortType(BUILD_TIME_ASC)
+    ).size() == 0
+  }
 }

--- a/orca-sql/src/test/java/com/netflix/spinnaker/orca/sql/SqlTestUtil.java
+++ b/orca-sql/src/test/java/com/netflix/spinnaker/orca/sql/SqlTestUtil.java
@@ -33,17 +33,17 @@ import java.io.Closeable;
 import java.sql.SQLException;
 import java.util.Arrays;
 
-import static org.jooq.SQLDialect.H2;
+import static org.jooq.SQLDialect.MYSQL;
 import static org.jooq.conf.RenderNameStyle.AS_IS;
 
 public class SqlTestUtil {
 
   public static TestDatabase initDatabase() {
-    return initDatabase("jdbc:h2:mem:orca_test");
+    return initDatabase("jdbc:h2:mem:orca_test;MODE=MYSQL");
   }
 
   public static TestDatabase initPreviousDatabase() {
-    return initDatabase("jdbc:h2:mem:orca_test_previous");
+    return initDatabase("jdbc:h2:mem:orca_test_previous;MODE=MYSQL");
   }
 
   public static TestDatabase initDatabase(String jdbcUrl) {
@@ -54,7 +54,7 @@ public class SqlTestUtil {
 
     DefaultConfiguration config = new DefaultConfiguration();
     config.set(new DataSourceConnectionProvider(dataSource));
-    config.setSQLDialect(H2);
+    config.setSQLDialect(MYSQL);
     config.settings().withRenderNameStyle(AS_IS);
 
     DSLContext context = new DefaultDSLContext(config);


### PR DESCRIPTION
When performing a search with a pipeline name that doesn't exist
sqlrepository will generate a query with an empty IN clause:
```
SELECT * FROM ... WHERE IN ()
```

this change short circuits this evaluation.

Additionally, set H2 into `MODE=MYSQL` so that we can actually catch
this invalid SQL in unit tests
