### PR TITLE
fix(expressions): populate context for evaluateExpression endpoint

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -508,9 +508,14 @@ class TaskController {
                                      @RequestParam("expression")
                                        String expression) {
     def execution = executionRepository.retrieve(PIPELINE, id)
+    def context = [
+      execution: execution,
+      trigger: mapper.convertValue(execution.trigger, Map.class)
+    ]
+
     def evaluated = contextParameterProcessor.process(
       [expression: expression],
-      [execution: execution],
+      context,
       true
     )
     return [result: evaluated?.expression, detail: evaluated?.expressionEvaluationSummary]

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.ExecutionRunner
 import com.netflix.spinnaker.orca.pipeline.model.*
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import groovy.json.JsonSlurper
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletResponse
@@ -69,7 +70,8 @@ class TaskControllerSpec extends Specification {
         numberOfOldPipelineExecutionsToInclude: numberOfOldPipelineExecutionsToInclude,
         clock: clock,
         mapper: mapper,
-        registry: registry
+        registry: registry,
+        contextParameterProcessor: new ContextParameterProcessor()
       )
     ).build()
   }
@@ -213,6 +215,33 @@ class TaskControllerSpec extends Specification {
 
     then:
     results.id == ['not-started', 'also-not-started', 'older2', 'older1', 'newer']
+  }
+
+  void '/applications/{application}/evaluateExpressions precomputes values'() {
+    given:
+    executionRepository.retrieve(Execution.ExecutionType.PIPELINE, "1") >> {
+      pipeline {
+        id = "1"
+        application = "doesn't matter"
+        startTime = 1
+        pipelineConfigId = "1"
+        trigger = new DefaultTrigger("manual", "id", "user", [param1: "param1Value"])
+      }
+    }
+
+    when:
+    def response = mockMvc.perform(
+      get("/pipelines/1/evaluateExpression")
+        .param("id", "1")
+        .param("expression", '${parameters.param1}'))
+      .andReturn().response
+    Map results = new ObjectMapper().readValue(response.contentAsString, Map)
+
+    then:
+    results == [
+      result: "param1Value",
+      detail: null
+    ]
   }
 
   void '/pipelines should only return the latest pipelines for the provided config ids, newest first'() {


### PR DESCRIPTION
When calling `pipelines/{id}/evaluateExpression`
we don't populate the eval context in the same way as we do for regular pipeline execution.
This means expressions that work during regular execution don't work when using this EP.
Most notably, nothing in `triggers` (or, more importantly, `trigger.parameters`) is accessible via
`${parameters["myParam"]}` instead one must modify the expression to be
`${execution.trigger.parameters["myParam"]}`
