### PR TITLE
feat(kubernetes): support redblack and highlander strategies

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
@@ -19,22 +19,34 @@ package com.netflix.spinnaker.orca.clouddriver.pipeline.manifest;
 
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.artifacts.CleanupArtifactsTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestContext;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestContext.TrafficManagement;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestForceCacheRefreshTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestStrategyStagesAdder;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestStrategyType;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.PromoteManifestKatoOutputsTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.WaitForManifestStableTask;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
+@RequiredArgsConstructor
 public class DeployManifestStage implements StageDefinitionBuilder {
   public static final String PIPELINE_CONFIG_TYPE = "deployManifest";
 
+  private final ManifestStrategyStagesAdder manifestStrategyStagesAdder;
+
   @Override
-  public void taskGraph(Stage stage, TaskNode.Builder builder) {
+  public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
     builder.withTask(DeployManifestTask.TASK_NAME, DeployManifestTask.class)
         .withTask("monitorDeploy", MonitorKatoTask.class)
         .withTask(PromoteManifestKatoOutputsTask.TASK_NAME, PromoteManifestKatoOutputsTask.class)
@@ -42,5 +54,13 @@ public class DeployManifestStage implements StageDefinitionBuilder {
         .withTask(WaitForManifestStableTask.TASK_NAME, WaitForManifestStableTask.class)
         .withTask(CleanupArtifactsTask.TASK_NAME, CleanupArtifactsTask.class)
         .withTask(BindProducedArtifactsTask.TASK_NAME, BindProducedArtifactsTask.class);
+  }
+
+  public void afterStages(@Nonnull Stage stage, @Nonnull StageGraphBuilder graph) {
+    DeployManifestContext context = stage.mapTo(DeployManifestContext.class);
+    TrafficManagement trafficManagement = context.getTrafficManagement();
+    if (trafficManagement.isEnabled()) {
+      manifestStrategyStagesAdder.addAfterStages(trafficManagement.getOptions().getStrategy(), graph, context);
+    }
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestContext.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestContext.java
@@ -54,7 +54,7 @@ public class DeployManifestContext extends HashMap<String, Object> {
     this.manifestArtifact = manifestArtifact;
     this.manifestArtifactAccount = manifestArtifactAccount;
     this.skipExpressionEvaluation = skipExpressionEvaluation;
-    this.trafficManagement = trafficManagement;
+    this.trafficManagement = Optional.ofNullable(trafficManagement).orElse(new TrafficManagement(false, null));
     this.requiredArtifactIds = requiredArtifactIds;
     this.requiredArtifacts = requiredArtifacts;
   }
@@ -76,7 +76,7 @@ public class DeployManifestContext extends HashMap<String, Object> {
   }
 
   @Getter
-  static class TrafficManagement {
+  public static class TrafficManagement {
     private final boolean enabled;
     private final Options options;
 
@@ -85,20 +85,23 @@ public class DeployManifestContext extends HashMap<String, Object> {
       @JsonProperty("options") Options options
     ) {
       this.enabled = Optional.ofNullable(enabled).orElse(false);
-      this.options = options;
+      this.options = Optional.ofNullable(options).orElse(new Options(false, Collections.emptyList(), null));
     }
 
     @Getter
-    static class Options {
+    public static class Options {
       private final boolean enableTraffic;
       private final List<String> services;
+      private final ManifestStrategyType strategy;
 
       public Options(
         @JsonProperty("enableTraffic") Boolean enableTraffic,
-        @JsonProperty("services") List<String> services
+        @JsonProperty("services") List<String> services,
+        @JsonProperty("strategy") String strategy
       ) {
         this.enableTraffic = Optional.ofNullable(enableTraffic).orElse(false);
         this.services = Optional.ofNullable(services).orElse(Collections.emptyList());
+        this.strategy = ManifestStrategyType.fromKey(strategy);
       }
     }
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestHighlanderStrategy.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestHighlanderStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ManifestHighlanderStrategy implements ManifestStrategy {
+  private final ManifestStrategyHandler strategyHandler;
+
+  @Autowired
+  public ManifestHighlanderStrategy(ManifestStrategyHandler strategyHandler) {
+    this.strategyHandler = strategyHandler;
+  }
+
+  public void composeFlow(DeployManifestContext parentContext, StageGraphBuilder graph) {
+    strategyHandler.disableOldManifests(parentContext, graph);
+    strategyHandler.deleteOldManifests(parentContext, graph);
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestNoneStrategy.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestNoneStrategy.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ManifestNoneStrategy implements ManifestStrategy {
+  public void composeFlow(DeployManifestContext parentContext, StageGraphBuilder graph) {}
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestRedBlackStrategy.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestRedBlackStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ManifestRedBlackStrategy implements ManifestStrategy {
+  private final ManifestStrategyHandler strategyHandler;
+
+  @Autowired
+  public ManifestRedBlackStrategy(ManifestStrategyHandler strategyHandler) {
+    this.strategyHandler = strategyHandler;
+  }
+
+  public void composeFlow(DeployManifestContext parentContext, StageGraphBuilder graph) {
+    strategyHandler.disableOldManifests(parentContext, graph);
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestStrategy.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
+
+public interface ManifestStrategy {
+  void composeFlow(DeployManifestContext parentContext, StageGraphBuilder graph);
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestStrategyHandler.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestStrategyHandler.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.netflix.spinnaker.orca.clouddriver.pipeline.manifest.DeleteManifestStage;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.manifest.DisableManifestStage;
+import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper;
+import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ManifestStrategyHandler {
+  private final OortHelper oortHelper;
+
+  void disableOldManifests(DeployManifestContext parentContext, StageGraphBuilder graph) {
+    addStagesForOldManifests(parentContext, graph, DisableManifestStage.PIPELINE_CONFIG_TYPE);
+  }
+
+  void deleteOldManifests(DeployManifestContext parentContext, StageGraphBuilder graph) {
+    addStagesForOldManifests(parentContext, graph, DeleteManifestStage.PIPELINE_CONFIG_TYPE);
+  }
+
+  private Map getNewManifest(DeployManifestContext parentContext) {
+    List<Map<String, ?>> manifests = (List<Map<String, ?>>) parentContext.get("outputs.manifests");
+    return manifests.get(0);
+  }
+
+  private List<String> getOldManifestNames(String application, String account, String clusterName, String namespace, String newManifestName) {
+    Map cluster = oortHelper.getCluster(application, account, clusterName, "kubernetes")
+      .orElseThrow(() -> new IllegalArgumentException(String.format("Error fetching cluster %s in account %s and namespace %s", clusterName, account, namespace)));
+
+    List<Map> serverGroups = Optional.ofNullable((List<Map>) cluster.get("serverGroups"))
+      .orElse(null);
+
+    if (serverGroups == null) {
+      return new ArrayList<>();
+    }
+
+    return serverGroups.stream()
+      .filter(s -> s.get("region").equals(namespace))
+      .filter(s -> !s.get("name").equals(newManifestName))
+      .map(s -> (String) s.get("name"))
+      .collect(Collectors.toList());
+  }
+
+  private void addStagesForOldManifests(DeployManifestContext parentContext, StageGraphBuilder graph, String stageType) {
+    Map deployedManifest = getNewManifest(parentContext);
+    String account = (String) parentContext.get("account");
+    Map manifestMoniker = (Map) parentContext.get("moniker");
+    String application = (String) manifestMoniker.get("app");
+
+    Map manifestMetadata = (Map) deployedManifest.get("metadata");
+    String manifestName = String.format("replicaSet %s", (String) manifestMetadata.get("name"));
+    String namespace = (String) manifestMetadata.get("namespace");
+    Map annotations = (Map) manifestMetadata.get("annotations");
+    String clusterName = (String) annotations.get("moniker.spinnaker.io/cluster");
+    String cloudProvider = "kubernetes";
+
+    List<String> previousManifestNames = getOldManifestNames(application, account, clusterName, namespace, manifestName);
+    previousManifestNames.forEach(name -> {
+      graph.append((stage) -> {
+        stage.setType(stageType);
+        Map<String, Object> context = stage.getContext();
+        context.put("account", account);
+        context.put("app", application);
+        context.put("cloudProvider", cloudProvider);
+        context.put("manifestName", name);
+        context.put("location", namespace);
+      });
+    });
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestStrategyStagesAdder.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestStrategyStagesAdder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ManifestStrategyStagesAdder {
+  private final ManifestHighlanderStrategy highlanderStrategy;
+
+  private final ManifestRedBlackStrategy redBlackStrategy;
+
+  private final ManifestNoneStrategy noneStrategy;
+
+  public void addAfterStages(ManifestStrategyType strategy, StageGraphBuilder graph, DeployManifestContext parentContext) {
+    switch (strategy) {
+      case RED_BLACK:
+        redBlackStrategy.composeFlow(parentContext, graph);
+        break;
+      case HIGHLANDER:
+        highlanderStrategy.composeFlow(parentContext, graph);
+        break;
+      default:
+        noneStrategy.composeFlow(parentContext, graph);
+    }
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestStrategyType.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestStrategyType.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+public enum ManifestStrategyType {
+  RED_BLACK("redblack"),
+  HIGHLANDER("highlander"),
+  NONE("none");
+
+  String key;
+
+  ManifestStrategyType(String key) {
+    this.key = key;
+  }
+
+  public static ManifestStrategyType fromKey(String key) {
+    if (key == null) {
+      return NONE;
+    }
+    for (ManifestStrategyType strategy : values()) {
+      if (key.equals(strategy.key)) {
+        return strategy;
+      }
+    }
+    return NONE;
+  }
+}


### PR DESCRIPTION
Adds support for red/black and highlander rollout strategies to the Kubernetes V2 provider:
- Adds synthetic stages to Deploy Manifest `afterStages` by delegating to strategy-specific `composeFlow` methods, which append a series of Disable and Delete stages for each previous version of the ReplicaSet.
- Adds a Kubernetes-specific `ManifestStrategy` interface (existing VM interface is coupled to deprecated `aroundStages` method, with `composeFlow` returning a list of stages rather than directly mutating to the stage graph).