### PR TITLE
fix(orca-core): Add CANCELED to list of COMPLETED statuses

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/ExecutionStatus.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/ExecutionStatus.java
@@ -102,7 +102,7 @@ public enum ExecutionStatus {
     return halt;
   }
 
-  public static final Collection<ExecutionStatus> COMPLETED = Collections.unmodifiableList(Arrays.asList(SUCCEEDED, STOPPED, SKIPPED, TERMINAL, FAILED_CONTINUE));
+  public static final Collection<ExecutionStatus> COMPLETED = Collections.unmodifiableList(Arrays.asList(CANCELED, SUCCEEDED, STOPPED, SKIPPED, TERMINAL, FAILED_CONTINUE));
 
   private static final Collection<ExecutionStatus> SUCCESSFUL = Collections.unmodifiableList(Arrays.asList(SUCCEEDED, STOPPED, SKIPPED));
   private static final Collection<ExecutionStatus> FAILURE = Collections.unmodifiableList(Arrays.asList(TERMINAL, STOPPED, FAILED_CONTINUE));


### PR DESCRIPTION
This will enable cleanup of old `CANCELED` tasks
