### PR TITLE
chore(migrations): ignore empty migrations

### DIFF
--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/SpringLiquibaseProxy.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/SpringLiquibaseProxy.kt
@@ -51,6 +51,7 @@ class SpringLiquibaseProxy(
 
     // Then if anything else has been defined, do that afterwards
     sqlProperties.migration.additionalChangeLogs
+      .filter { !it.isEmpty() }
       .map {
         SpringLiquibase().apply {
           changeLog = "classpath:$it"


### PR DESCRIPTION
Currently, any non-standard migrations are defined in the orca.yml as a list.
Sometimes, it's nice to be able to run without those migrations
(e.g. when developing both in OSS and private land). However, due to an issue in
spring (which, I believe, should be fixed in boot2.0.3) it's impossible to
override a list with an empty list, but you can override a list with a new list.
Hence this change to not run empty entries
