### PR TITLE
Revert "fix(provider/azure): Failed to disable azure server group when rollback"

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
@@ -45,8 +45,8 @@ class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
       .withTask("determineHealthProviders", DetermineHealthProvidersTask)
       .withTask("resizeServerGroup", ResizeServerGroupTask)
       .withTask("monitorServerGroup", MonitorKatoTask)
-      .withTask("waitForCapacityMatch", WaitForCapacityMatchTask)
       .withTask("forceCacheRefresh", ServerGroupCacheForceRefreshTask)
+      .withTask("waitForCapacityMatch", WaitForCapacityMatchTask)
   }
 
   @Override


### PR DESCRIPTION
Reverts spinnaker/orca#2848

The description provided in the PR doesn't indicate that this is the appropriate fix.