### PR TITLE
feat(kubernetes): pass DeployManifestTask strategy to Clouddriver to enable downstream validation

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestConte
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestForceCacheRefreshTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestStrategyStagesAdder;
-import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestStrategyType;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.PromoteManifestKatoOutputsTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.WaitForManifestStableTask;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
@@ -35,8 +34,6 @@ import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifacts
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
@@ -163,6 +163,7 @@ public class DeployManifestTask extends AbstractCloudProviderAwareTask implement
     if (context.getTrafficManagement() != null && context.getTrafficManagement().isEnabled()) {
       task.put("services", context.getTrafficManagement().getOptions().getServices());
       task.put("enableTraffic", context.getTrafficManagement().getOptions().isEnableTraffic());
+      task.put("strategy", context.getTrafficManagement().getOptions().getStrategy().name());
     } else {
       // For backwards compatibility, traffic is always enabled to new server groups when the new traffic management
       // features are not enabled.


### PR DESCRIPTION
- feat(kubernetes): pass DeployManifestTask strategy to Clouddriver to enable downstream validation
 - fix(kubernetes): remove unused imports from DeployManifestStage