### PR TITLE
refactor(gcb): Use generic maps for GCB objects

### DIFF
--- a/orca-igor/orca-igor.gradle
+++ b/orca-igor/orca-igor.gradle
@@ -22,7 +22,6 @@ dependencies {
   compile project(":orca-front50")
   compile spinnaker.dependency('kork')
   compile spinnaker.dependency('bootAutoConfigure')
-  compile spinnaker.dependency('googleCloudBuild')
   compileOnly spinnaker.dependency("lombok")
   annotationProcessor spinnaker.dependency("lombok")
   testCompile project(":orca-test-groovy")

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -15,8 +15,6 @@
  */
 package com.netflix.spinnaker.orca.igor;
 
-import com.google.api.services.cloudbuild.v1.model.Build;
-import com.google.api.services.cloudbuild.v1.model.Operation;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import retrofit.http.*;
 
@@ -72,7 +70,7 @@ public interface IgorService {
     @Path(value = "job", encode = false) String job);
 
   @POST("/gcb/builds/create/{account}")
-  Operation createGoogleCloudBuild(
+  Map<String, Object> createGoogleCloudBuild(
     @Path("account") String account,
-    @Body Build job);
+    @Body Map<String, Object> job);
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
@@ -17,19 +17,20 @@
 package com.netflix.spinnaker.orca.igor.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.api.services.cloudbuild.v1.model.Build;
 import lombok.Getter;
+
+import java.util.Map;
 
 @Getter
 public class GoogleCloudBuildStageDefinition {
   private final String account;
-  private final Build buildDefinition;
+  private final Map<String, Object> buildDefinition;
 
   // There does not seem to be a way to auto-generate a constructor using our current version of Lombok (1.16.20) that
   // Jackson can use to deserialize.
   public GoogleCloudBuildStageDefinition(
     @JsonProperty("account") String account,
-    @JsonProperty("buildDefinition") Build buildDefinition
+    @JsonProperty("buildDefinition") Map<String, Object> buildDefinition
   ) {
     this.account = account;
     this.buildDefinition = buildDefinition;

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca.igor.tasks;
 
-import com.google.api.services.cloudbuild.v1.model.Operation;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.Task;
 import com.netflix.spinnaker.orca.TaskResult;
@@ -27,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -36,7 +36,7 @@ public class StartGoogleCloudBuildTask implements Task {
   @Override
   @Nonnull public TaskResult execute(@Nonnull Stage stage) {
     GoogleCloudBuildStageDefinition stageDefinition = stage.mapTo(GoogleCloudBuildStageDefinition.class);
-    Operation result = igorService.createGoogleCloudBuild(stageDefinition.getAccount(), stageDefinition.getBuildDefinition());
+    Map<String, Object> result = igorService.createGoogleCloudBuild(stageDefinition.getAccount(), stageDefinition.getBuildDefinition());
     return new TaskResult(ExecutionStatus.SUCCEEDED);
   }
 }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/pipeline/GoogleCloudBuildStageSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/pipeline/GoogleCloudBuildStageSpec.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.orca.igor.pipeline
 
-import com.google.api.services.cloudbuild.v1.model.Build
+
 import com.netflix.spinnaker.orca.igor.tasks.StartGoogleCloudBuildTask
 import spock.lang.Specification
 
@@ -24,7 +24,7 @@ import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
 class GoogleCloudBuildStageSpec extends Specification {
   def ACCOUNT = "my-account"
-  def BUILD = new Build()
+  def BUILD = new HashMap<String, Object>()
 
   def "should start a build"() {
     given:

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.orca.igor.tasks
 
-import com.google.api.services.cloudbuild.v1.model.Build
+
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.igor.IgorService
 import com.netflix.spinnaker.orca.pipeline.model.Execution
@@ -26,7 +26,7 @@ import spock.lang.Subject
 
 class StartGoogleCloudBuildTaskSpec extends Specification {
   def ACCOUNT = "my-account"
-  def BUILD = new Build()
+  def BUILD = new HashMap<String, Object>()
 
   Execution execution = Mock(Execution)
   IgorService igorService = Mock(IgorService)


### PR DESCRIPTION
Orca currently deserializes the build configuration in the stage to a Build object only to send it immediately over to igor (which re-serializes it). As orca doesn't actually need to know any of the details about the Build object it's sending over, just use a generic Map.

This addresses an issue where some fields are not correctly deserializing using the default objectMapper; I'll need to work around this in igor, but this reduces the scope of where that workaround needs to live.  (This also allows us to better encapsulate which microservices actually need to know about GCB objects.)