### PR TITLE
fix(orca): if build stage fails and prop file exists, try and fetch

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/GetPropertiesStage.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/GetPropertiesStage.java
@@ -1,0 +1,34 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.orca.igor.pipeline;
+
+import com.netflix.spinnaker.orca.igor.tasks.GetBuildPropertiesTask;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+
+@Component
+public class GetPropertiesStage implements StageDefinitionBuilder {
+  @Override
+  public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
+    builder.withTask("getPropertiesFile", GetBuildPropertiesTask.class);
+  }
+}

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildPropertiesTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildPropertiesTask.java
@@ -41,7 +41,12 @@ public class GetBuildPropertiesTask extends RetryableIgorTask {
       return TaskResult.SUCCEEDED;
     }
 
-    Map<String, Object> properties = buildService.getPropertyFile(stageDefinition.getBuildNumber(), stageDefinition.getPropertyFile(), stageDefinition.getMaster(), stageDefinition.getJob());
+    Map<String, Object> properties = buildService.getPropertyFile(
+      stageDefinition.getBuildNumber(),
+      stageDefinition.getPropertyFile(),
+      stageDefinition.getMaster(),
+      stageDefinition.getJob()
+    );
     if (properties.size() == 0) {
       throw new IllegalStateException(String.format("Expected properties file %s but it was either missing, empty or contained invalid syntax", stageDefinition.getPropertyFile()));
     }


### PR DESCRIPTION
This fixes a "regression" that was introduced with the ci stage refactor. Previously we would try and get the properties file if the jenkins job failed. This pr adds a failure stage so that if a property file is defined, and the ci stage fails, we will try and get the property file. This failure stage may fail, but that seems fine because the stage itself already failed.

A user of ours is asking for this behavior. 