### PR TITLE
feat(core): Delegate task/stage lookup to `TaskResolver` and `StageResolver` respectively

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/StageResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/StageResolver.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca;
+
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+/**
+ * {@code StageResolver} allows for {@code StageDefinitionBuilder} retrieval via bean name or alias.
+ * <p>
+ * Aliases represent the previous bean names that a {@code StageDefinitionBuilder} registered as.
+ */
+public class StageResolver {
+  private final Map<String, StageDefinitionBuilder> stageDefinitionBuilderByAlias = new HashMap<>();
+
+  public StageResolver(Collection<StageDefinitionBuilder> stageDefinitionBuilders) {
+    for (StageDefinitionBuilder stageDefinitionBuilder : stageDefinitionBuilders) {
+      stageDefinitionBuilderByAlias.put(stageDefinitionBuilder.getType(), stageDefinitionBuilder);
+      for (String alias : stageDefinitionBuilder.aliases()) {
+        if (stageDefinitionBuilderByAlias.containsKey(alias)) {
+          throw new DuplicateStageAliasException(
+              format(
+                  "Duplicate stage alias detected (alias: %s, previous: %s, current: %s)",
+                  alias,
+                  stageDefinitionBuilderByAlias.get(alias).getClass().getCanonicalName(),
+                  stageDefinitionBuilder.getClass().getCanonicalName()
+              )
+          );
+        }
+
+        stageDefinitionBuilderByAlias.put(alias, stageDefinitionBuilder);
+      }
+    }
+  }
+
+  /**
+   * Fetch a {@code StageDefinitionBuilder} by {@param type} or {@param typeAlias}.
+   *
+   * @param type      StageDefinitionBuilder type
+   * @param typeAlias StageDefinitionBuilder alias (optional)
+   * @return the StageDefinitionBuilder matching {@param type} or {@param typeAlias}
+   * @throws NoSuchStageDefinitionBuilderException if StageDefinitionBuilder does not exist
+   */
+  @Nonnull
+  public StageDefinitionBuilder getStageDefinitionBuilder(@Nonnull String type, String typeAlias) {
+    StageDefinitionBuilder stageDefinitionBuilder = stageDefinitionBuilderByAlias.getOrDefault(
+        type, stageDefinitionBuilderByAlias.get(typeAlias)
+    );
+
+    if (stageDefinitionBuilder == null) {
+      throw new NoSuchStageDefinitionBuilderException(type, stageDefinitionBuilderByAlias.keySet());
+    }
+
+    return stageDefinitionBuilder;
+  }
+
+  class DuplicateStageAliasException extends IllegalStateException {
+    DuplicateStageAliasException(String message) {
+      super(message);
+    }
+  }
+
+  class NoSuchStageDefinitionBuilderException extends IllegalArgumentException {
+    NoSuchStageDefinitionBuilderException(String type, Collection<String> knownTypes) {
+      super(
+          format(
+              "No StageDefinitionBuilder implementation for %s found (knownTypes: %s)",
+              type,
+              String.join(",", knownTypes)
+          )
+      );
+    }
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/Task.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/Task.java
@@ -18,6 +18,13 @@ package com.netflix.spinnaker.orca;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 
 import javax.annotation.Nonnull;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 
 public interface Task {
   @Nonnull TaskResult execute(@Nonnull Stage stage);
@@ -25,4 +32,18 @@ public interface Task {
   default void onTimeout(@Nonnull Stage stage) {}
 
   default void onCancel(@Nonnull Stage stage) {}
+
+  default Collection<String> aliases() {
+    if (getClass().isAnnotationPresent(Aliases.class)) {
+      return Arrays.asList(getClass().getAnnotation(Aliases.class).value());
+    }
+
+    return Collections.emptyList();
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.TYPE)
+  @interface Aliases {
+    String[] value() default {};
+  }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskResolver.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+/**
+ * {@code TaskResolver} allows for {@code Task} retrieval via class name or alias.
+ * <p>
+ * Aliases represent the previous class names of a {@code Task}.
+ */
+public class TaskResolver {
+  private final Map<String, Task> taskByAlias = new HashMap<>();
+
+  private final boolean allowFallback;
+
+  @VisibleForTesting
+  public TaskResolver(Collection<Task> tasks) {
+    this(tasks, true);
+  }
+
+  /**
+   * @param tasks         Task implementations
+   * @param allowFallback Fallback to {@code Class.forName()} if a task cannot be located by name or alias
+   */
+  public TaskResolver(Collection<Task> tasks, boolean allowFallback) {
+    for (Task task : tasks) {
+      taskByAlias.put(task.getClass().getCanonicalName(), task);
+      for (String alias : task.aliases()) {
+        if (taskByAlias.containsKey(alias)) {
+          throw new DuplicateTaskAliasException(
+              String.format(
+                  "Duplicate task alias detected (alias: %s, previous: %s, current: %s)",
+                  alias,
+                  taskByAlias.get(alias).getClass().getCanonicalName(),
+                  task.getClass().getCanonicalName()
+              )
+          );
+        }
+
+        taskByAlias.put(alias, task);
+      }
+    }
+
+    this.allowFallback = allowFallback;
+  }
+
+  /**
+   * Fetch a {@code Task} by {@param taskTypeIdentifier}.
+   *
+   * @param taskTypeIdentifier Task identifier (class name or alias)
+   * @return the Task matching {@param taskTypeIdentifier}
+   * @throws NoSuchTaskException if Task does not exist
+   */
+  @Nonnull
+  public Task getTask(@Nonnull String taskTypeIdentifier) {
+    Task task = taskByAlias.get(taskTypeIdentifier);
+
+    if (task == null) {
+      throw new NoSuchTaskException(taskTypeIdentifier);
+    }
+
+    return task;
+  }
+
+  /**
+   * @param taskTypeIdentifier Task identifier (class name or alias)
+   * @return Task Class
+   * @throws NoSuchTaskException if task does not exist
+   */
+  @Nonnull
+  public Class<? extends Task> getTaskClass(@Nonnull String taskTypeIdentifier) {
+    try {
+      return getTask(taskTypeIdentifier).getClass();
+    } catch (IllegalArgumentException e) {
+      if (!allowFallback) {
+        throw e;
+      }
+
+      try {
+        return (Class<? extends Task>) Class.forName(taskTypeIdentifier);
+      } catch (ClassNotFoundException ex) {
+        throw e;
+      }
+    }
+  }
+
+  class DuplicateTaskAliasException extends IllegalStateException {
+    DuplicateTaskAliasException(String message) {
+      super(message);
+    }
+  }
+
+  class NoSuchTaskException extends IllegalArgumentException {
+    NoSuchTaskException(String taskTypeIdentifier) {
+      super("No task found for '" + taskTypeIdentifier + "'");
+    }
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -18,6 +18,9 @@ package com.netflix.spinnaker.orca.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.orca.StageResolver;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResolver;
 import com.netflix.spinnaker.orca.commands.ForceExecutionCancellationCommand;
 import com.netflix.spinnaker.orca.events.ExecutionEvent;
 import com.netflix.spinnaker.orca.events.ExecutionListenerAdapter;
@@ -145,8 +148,8 @@ public class OrcaConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(StageDefinitionBuilderFactory.class)
-  public StageDefinitionBuilderFactory stageDefinitionBuilderFactory(Collection<StageDefinitionBuilder> stageDefinitionBuilders) {
-    return new DefaultStageDefinitionBuilderFactory(stageDefinitionBuilders);
+  public StageDefinitionBuilderFactory stageDefinitionBuilderFactory(StageResolver stageResolver) {
+    return new DefaultStageDefinitionBuilderFactory(stageResolver);
   }
 
   @Bean
@@ -179,6 +182,16 @@ public class OrcaConfiguration {
     scheduler.setThreadNamePrefix("scheduler-");
     scheduler.setPoolSize(10);
     return scheduler;
+  }
+
+  @Bean
+  public TaskResolver taskResolver(Collection<Task> tasks) {
+    return new TaskResolver(tasks, true);
+  }
+
+  @Bean
+  public StageResolver stageResolver(Collection<StageDefinitionBuilder> stageDefinitionBuilders) {
+    return new StageResolver(stageDefinitionBuilders);
   }
 
   @Bean(name = EVENT_LISTENER_FACTORY_BEAN_NAME)

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/DefaultStageDefinitionBuilderFactory.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/DefaultStageDefinitionBuilderFactory.java
@@ -16,36 +16,20 @@
 
 package com.netflix.spinnaker.orca.pipeline;
 
-import static java.util.stream.Collectors.toList;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 import javax.annotation.Nonnull;
-import com.netflix.spinnaker.orca.pipeline.ExecutionRunner.NoSuchStageDefinitionBuilder;
+
+import com.netflix.spinnaker.orca.StageResolver;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 
 public class DefaultStageDefinitionBuilderFactory implements StageDefinitionBuilderFactory {
-  private final Collection<StageDefinitionBuilder> stageDefinitionBuilders;
+  private final StageResolver stageResolver;
 
-  public DefaultStageDefinitionBuilderFactory(Collection<StageDefinitionBuilder> stageDefinitionBuilders) {
-    this.stageDefinitionBuilders = stageDefinitionBuilders;
-  }
-
-  public DefaultStageDefinitionBuilderFactory(StageDefinitionBuilder... stageDefinitionBuilders) {
-    this(Arrays.asList(stageDefinitionBuilders));
+  public DefaultStageDefinitionBuilderFactory(StageResolver stageResolver) {
+    this.stageResolver = stageResolver;
   }
 
   @Override
-  public @Nonnull StageDefinitionBuilder builderFor(
-    @Nonnull Stage stage) throws NoSuchStageDefinitionBuilder {
-    return stageDefinitionBuilders
-      .stream()
-      .filter((it) -> it.getType().equals(stage.getType()) || it.getType().equals(stage.getContext().get("alias")))
-      .findFirst()
-      .orElseThrow(() -> {
-        List<String> knownTypes = stageDefinitionBuilders.stream().map(it -> it.getType()).sorted().collect(toList());
-        return new NoSuchStageDefinitionBuilder(stage.getType(), knownTypes);
-      });
+  public @Nonnull StageDefinitionBuilder builderFor(@Nonnull Stage stage) {
+    return stageResolver.getStageDefinitionBuilder(stage.getType(), (String) stage.getContext().get("alias"));
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionRunner.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionRunner.java
@@ -47,11 +47,4 @@ public interface ExecutionRunner {
     @Nonnull String user, @Nullable String reason) throws Exception {
     throw new UnsupportedOperationException();
   }
-
-  class NoSuchStageDefinitionBuilder extends RuntimeException {
-    public NoSuchStageDefinitionBuilder(String type, Collection<String> knownTypes) {
-      super(format("No StageDefinitionBuilder implementation for %s found. %s", type,
-        knownTypes == null || knownTypes.size() == 0 ? "There are no known stage types." : format(" Known stage types: %s", String.join(",", knownTypes))));
-    }
-  }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.pipeline;
 
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.orca.Task;
 import com.netflix.spinnaker.orca.pipeline.TaskNode.TaskGraph;
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
@@ -25,6 +26,13 @@ import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -185,5 +193,19 @@ public interface StageDefinitionBuilder {
     } catch (Exception e) {
       return true;
     }
+  }
+
+  default Collection<String> aliases() {
+    if (getClass().isAnnotationPresent(Aliases.class)) {
+      return Arrays.asList(getClass().getAnnotation(Aliases.class).value());
+    }
+
+    return Collections.emptyList();
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.TYPE)
+  @interface Aliases {
+    String[] value() default {};
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilderFactory.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilderFactory.java
@@ -17,13 +17,9 @@
 package com.netflix.spinnaker.orca.pipeline;
 
 import javax.annotation.Nonnull;
-import com.netflix.spinnaker.orca.pipeline.ExecutionRunner.NoSuchStageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 
 @FunctionalInterface
 public interface StageDefinitionBuilderFactory {
-
-  @Nonnull StageDefinitionBuilder builderFor(
-    @Nonnull Stage stage) throws NoSuchStageDefinitionBuilder;
-
+  @Nonnull StageDefinitionBuilder builderFor(@Nonnull Stage stage);
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/StageResolverSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/StageResolverSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca
+
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.pipeline.WaitStage
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import javax.annotation.Nonnull;
+
+class StageResolverSpec extends Specification {
+  @Subject
+  def stageResolver = new StageResolver([
+      new WaitStage(),
+      new AliasedStageDefinitionBuilder()
+  ])
+
+  @Unroll
+  def "should lookup stage by name or alias"() {
+    expect:
+    stageResolver.getStageDefinitionBuilder(stageTypeIdentifier, null).getType() == expectedStageType
+
+    where:
+    stageTypeIdentifier || expectedStageType
+    "wait"              || "wait"
+    "aliased"           || "aliased"
+    "notAliased"        || "aliased"
+  }
+
+  def "should raise exception on duplicate alias"() {
+    when:
+    new StageResolver([
+        new AliasedStageDefinitionBuilder(),
+        new AliasedStageDefinitionBuilder()
+    ])
+
+    then:
+    thrown(StageResolver.DuplicateStageAliasException)
+  }
+
+  def "should raise exception when stage not found"() {
+    when:
+    stageResolver.getStageDefinitionBuilder("DoesNotExist", null)
+
+    then:
+    thrown(StageResolver.NoSuchStageDefinitionBuilderException)
+  }
+
+  @StageDefinitionBuilder.Aliases("notAliased")
+  class AliasedStageDefinitionBuilder implements StageDefinitionBuilder {
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/TaskResolverSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/TaskResolverSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca
+
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import javax.annotation.Nonnull;
+
+class TaskResolverSpec extends Specification {
+  @Subject
+  def taskResolver = new TaskResolver([
+      new WaitTask(),
+      new AliasedTask()
+  ], false)
+
+  @Unroll
+  def "should lookup task by name or alias"() {
+    expect:
+    taskResolver.getTaskClass(taskTypeIdentifier) == expectedTaskClass
+
+    where:
+    taskTypeIdentifier                                        || expectedTaskClass
+    "com.netflix.spinnaker.orca.pipeline.tasks.WaitTask"      || WaitTask.class
+    "com.netflix.spinnaker.orca.TaskResolverSpec.AliasedTask" || AliasedTask.class
+    "com.netflix.spinnaker.orca.NotAliasedTask"               || AliasedTask.class
+  }
+
+  def "should raise exception on duplicate alias"() {
+    when:
+    new TaskResolver([
+        new AliasedTask(),
+        new AliasedTask()
+    ], false)
+
+    then:
+    thrown(TaskResolver.DuplicateTaskAliasException)
+  }
+
+  def "should raise exception when task not found"() {
+    when:
+    taskResolver.getTaskClass("DoesNotExist")
+
+    then:
+    thrown(TaskResolver.NoSuchTaskException)
+  }
+
+  @Task.Aliases("com.netflix.spinnaker.orca.NotAliasedTask")
+  class AliasedTask implements Task {
+    @Override
+    TaskResult execute(@Nonnull Stage stage) {
+      return TaskResult.SUCCEEDED
+    }
+  }
+}

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/config/DryRunConfiguration.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/config/DryRunConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.config
 
+import com.netflix.spinnaker.orca.StageResolver
 import com.netflix.spinnaker.orca.dryrun.DryRunStageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
@@ -33,10 +34,10 @@ import org.springframework.context.annotation.Configuration
 class DryRunConfiguration {
   @Bean
   fun dryRunStageDefinitionBuilderFactory(
-    stageDefinitionBuilders: Collection<StageDefinitionBuilder>
+    stageResolver: StageResolver
   ): StageDefinitionBuilderFactory {
     log.info("Dry run trigger support enabled")
-    return DryRunStageDefinitionBuilderFactory(stageDefinitionBuilders)
+    return DryRunStageDefinitionBuilderFactory(stageResolver)
   }
 
   private val log = LoggerFactory.getLogger(javaClass)

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunStageDefinitionBuilderFactory.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunStageDefinitionBuilderFactory.kt
@@ -16,14 +16,15 @@
 
 package com.netflix.spinnaker.orca.dryrun
 
+import com.netflix.spinnaker.orca.StageResolver
 import com.netflix.spinnaker.orca.pipeline.CheckPreconditionsStage
 import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 
 class DryRunStageDefinitionBuilderFactory(
-  stageDefinitionBuilders: Collection<StageDefinitionBuilder>
-) : DefaultStageDefinitionBuilderFactory(stageDefinitionBuilders) {
+  stageResolver: StageResolver
+) : DefaultStageDefinitionBuilderFactory(stageResolver) {
 
   override fun builderFor(stage: Stage): StageDefinitionBuilder =
     stage.execution.let { execution ->

--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisOrcaQueueConfiguration.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisOrcaQueueConfiguration.kt
@@ -19,9 +19,12 @@ import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PRO
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType
 import com.netflix.spinnaker.orca.q.redis.migration.ExecutionTypeDeserializer
 import com.netflix.spinnaker.orca.q.redis.migration.OrcaToKeikoSerializationMigrator
+import com.netflix.spinnaker.orca.q.redis.migration.TaskTypeDeserializer
 import com.netflix.spinnaker.orca.q.redis.pending.RedisPendingExecutionService
 import com.netflix.spinnaker.q.metrics.EventPublisher
 import com.netflix.spinnaker.q.migration.SerializationMigrator
@@ -41,13 +44,16 @@ import java.util.*
 @EnableConfigurationProperties(ObjectMapperSubtypeProperties::class)
 class RedisOrcaQueueConfiguration : RedisQueueConfiguration() {
 
-  @Autowired fun redisQueueObjectMapper(mapper: ObjectMapper,
-                                             objectMapperSubtypeProperties: ObjectMapperSubtypeProperties) {
+  @Autowired
+  fun redisQueueObjectMapper(mapper: ObjectMapper,
+                             objectMapperSubtypeProperties: ObjectMapperSubtypeProperties,
+                             taskResolver: TaskResolver) {
     mapper.apply {
       registerModule(KotlinModule())
       registerModule(
         SimpleModule()
           .addDeserializer(ExecutionType::class.java, ExecutionTypeDeserializer())
+          .addDeserializer(Class::class.java, TaskTypeDeserializer(taskResolver))
       )
       disable(FAIL_ON_UNKNOWN_PROPERTIES)
 

--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/migration/TaskTypeDeserializer.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/migration/TaskTypeDeserializer.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.q.redis.migration
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.netflix.spinnaker.orca.TaskResolver
+
+class TaskTypeDeserializer(
+  private val taskResolver: TaskResolver
+) : JsonDeserializer<Class<*>>() {
+  override fun deserialize(
+    p: JsonParser,
+    ctxt: DeserializationContext
+  ) = if (p.parsingContext.currentName == "taskType") {
+    taskResolver.getTaskClass(p.valueAsString)
+  } else {
+    Class.forName(p.valueAsString)
+  }
+}

--- a/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/migration/TaskTypeDeserializerTest.kt
+++ b/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/migration/TaskTypeDeserializerTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.q.redis.migration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResolver
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import org.assertj.core.api.Assertions
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+
+object TaskTypeDeserializerTest : Spek({
+  val taskResolver = TaskResolver(listOf(DummyTask()), false)
+
+  val objectMapper = ObjectMapper().apply {
+    registerModule(KotlinModule())
+    registerModule(
+      SimpleModule()
+        .addDeserializer(Class::class.java, TaskTypeDeserializer(taskResolver))
+    )
+  }
+
+  describe("when 'taskType' is deserialized") {
+    val canonicalJson = """{ "taskType" : "${DummyTask::class.java.canonicalName}" }"""
+    Assertions.assertThat(
+      objectMapper.readValue(canonicalJson, Target::class.java).taskType
+    ).isEqualTo(DummyTask::class.java)
+
+    val aliasedJson = """{ "taskType" : "anotherTaskAlias" }"""
+    Assertions.assertThat(
+      objectMapper.readValue(aliasedJson, Target::class.java).taskType
+    ).isEqualTo(DummyTask::class.java)
+
+    val notTaskTypeJson = """{ "notTaskType" : "java.lang.String" }"""
+    Assertions.assertThat(
+      objectMapper.readValue(notTaskTypeJson, Target::class.java).notTaskType
+    ).isEqualTo(String::class.java)
+  }
+})
+
+class Target(val taskType: Class<*>?, val notTaskType: Class<*>?)
+
+@Task.Aliases("anotherTaskAlias")
+class DummyTask : Task {
+  override fun execute(stage: Stage): TaskResult {
+    return TaskResult.SUCCEEDED
+  }
+}

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/admin/HydrateQueueCommand.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/admin/HydrateQueueCommand.kt
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED
 import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
 import com.netflix.spinnaker.orca.RetryableTask
+import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.ext.afterStages
 import com.netflix.spinnaker.orca.ext.allAfterStagesSuccessful
 import com.netflix.spinnaker.orca.ext.allBeforeStagesSuccessful
@@ -55,7 +56,8 @@ import kotlin.reflect.full.memberProperties
 @Component
 class HydrateQueueCommand(
   private val queue: Queue,
-  private val executionRepository: ExecutionRepository
+  private val executionRepository: ExecutionRepository,
+  private val taskResolver: TaskResolver
 ) : (HydrateQueueInput) -> HydrateQueueOutput {
 
   private val log = LoggerFactory.getLogger(javaClass)
@@ -258,7 +260,7 @@ class HydrateQueueCommand(
 
   @Suppress("UNCHECKED_CAST")
   private val com.netflix.spinnaker.orca.pipeline.model.Task.type
-    get() = Class.forName(implementingClass) as Class<out com.netflix.spinnaker.orca.Task>
+    get() = taskResolver.getTaskClass(implementingClass)
 
   private fun Task.isRetryable(): Boolean =
     RetryableTask::class.java.isAssignableFrom(type)

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandler.kt
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.CancellableStage
 import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
-import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.*
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
@@ -35,7 +35,9 @@ class CancelStageHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   override val stageDefinitionBuilderFactory: StageDefinitionBuilderFactory,
-  @Qualifier("messageHandlerPool") private val executor: Executor
+
+  @Qualifier("messageHandlerPool") private val executor: Executor,
+  private val taskResolver: TaskResolver
 ) : OrcaMessageHandler<CancelStage>, StageBuilderAware {
 
   override val messageType = CancelStage::class.java
@@ -101,5 +103,5 @@ class CancelStageHandler(
 
   @Suppress("UNCHECKED_CAST")
   private val com.netflix.spinnaker.orca.pipeline.model.Task.type
-    get() = Class.forName(implementingClass) as Class<out Task>
+    get() = taskResolver.getTaskClass(implementingClass)
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RescheduleExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RescheduleExecutionHandler.kt
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.ExecutionStatus
-import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.RescheduleExecution
 import com.netflix.spinnaker.orca.q.RunTask
@@ -27,7 +27,8 @@ import org.springframework.stereotype.Component
 @Component
 class RescheduleExecutionHandler(
   override val queue: Queue,
-  override val repository: ExecutionRepository
+  override val repository: ExecutionRepository,
+  private val taskResolver: TaskResolver
 ) : OrcaMessageHandler<RescheduleExecution> {
 
   override val messageType = RescheduleExecution::class.java
@@ -45,7 +46,7 @@ class RescheduleExecutionHandler(
               queue.reschedule(RunTask(message,
                 stage.id,
                 it.id,
-                Class.forName(it.implementingClass) as Class<out Task>
+                taskResolver.getTaskClass(it.implementingClass)
               ))
             }
         }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeTaskHandler.kt
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.ExecutionStatus.PAUSED
 import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
-import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.ResumeTask
 import com.netflix.spinnaker.orca.q.RunTask
@@ -28,7 +28,8 @@ import org.springframework.stereotype.Component
 @Component
 class ResumeTaskHandler(
   override val queue: Queue,
-  override val repository: ExecutionRepository
+  override val repository: ExecutionRepository,
+  private val taskResolver: TaskResolver
 ) : OrcaMessageHandler<ResumeTask> {
 
   override val messageType = ResumeTask::class.java
@@ -48,5 +49,5 @@ class ResumeTaskHandler(
 
   @Suppress("UNCHECKED_CAST")
   private val com.netflix.spinnaker.orca.pipeline.model.Task.type
-    get() = Class.forName(implementingClass) as Class<out Task>
+    get() = taskResolver.getTaskClass(implementingClass)
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandler.kt
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
-import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.events.TaskStarted
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
@@ -35,6 +35,7 @@ class StartTaskHandler(
   override val repository: ExecutionRepository,
   override val contextParameterProcessor: ContextParameterProcessor,
   @Qualifier("queueEventPublisher") private val publisher: ApplicationEventPublisher,
+  private val taskResolver: TaskResolver,
   private val clock: Clock
 ) : OrcaMessageHandler<StartTask>, ExpressionAware {
 
@@ -55,5 +56,5 @@ class StartTaskHandler(
 
   @Suppress("UNCHECKED_CAST")
   private val com.netflix.spinnaker.orca.pipeline.model.Task.type
-    get() = Class.forName(implementingClass) as Class<out Task>
+    get() = taskResolver.getTaskClass(implementingClass)
 }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/admin/HydrateQueueCommandTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/admin/HydrateQueueCommandTest.kt
@@ -19,6 +19,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.ExecutionStatus.NOT_STARTED
 import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
 import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
+import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.ext.beforeStages
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
@@ -65,9 +66,10 @@ object HydrateQueueCommandTest : SubjectSpek<HydrateQueueCommand>({
 
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
+  val taskResolver = TaskResolver(emptyList())
 
   subject(CachingMode.GROUP) {
-    HydrateQueueCommand(queue, repository)
+    HydrateQueueCommand(queue, repository, taskResolver)
   }
 
   fun resetMocks() = reset(queue, repository)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandlerTest.kt
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.orca.q.handler
 import com.google.common.util.concurrent.MoreExecutors
 import com.netflix.spinnaker.orca.CancellableStage
 import com.netflix.spinnaker.orca.ExecutionStatus.*
+import com.netflix.spinnaker.orca.StageResolver
+import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
 import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
@@ -39,14 +41,18 @@ object CancelStageHandlerTest : SubjectSpek<CancelStageHandler>({
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
   val executor = MoreExecutors.directExecutor()
+  val taskResolver: TaskResolver = TaskResolver(emptyList())
+
   val cancellableStage: CancelableStageDefinitionBuilder = mock()
+  val stageResolver = StageResolver(listOf(singleTaskStage, cancellableStage))
 
   subject(GROUP) {
     CancelStageHandler(
       queue,
       repository,
-      DefaultStageDefinitionBuilderFactory(singleTaskStage, cancellableStage),
-      executor
+      DefaultStageDefinitionBuilderFactory(stageResolver),
+      executor,
+      taskResolver
     )
   }
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.orca.ExecutionStatus.*
+import com.netflix.spinnaker.orca.StageResolver
 import com.netflix.spinnaker.orca.events.StageComplete
 import com.netflix.spinnaker.orca.exceptions.DefaultExceptionHandler
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
@@ -114,17 +115,21 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
       contextParameterProcessor,
       registry,
       DefaultStageDefinitionBuilderFactory(
-        singleTaskStage,
-        multiTaskStage,
-        stageWithSyntheticBefore,
-        stageWithSyntheticAfter,
-        stageWithParallelBranches,
-        stageWithTaskAndAfterStages,
-        stageThatBlowsUpPlanningAfterStages,
-        stageWithSyntheticOnFailure,
-        stageWithNothingButAfterStages,
-        stageWithSyntheticOnFailure,
-        emptyStage
+        StageResolver(
+          listOf(
+            singleTaskStage,
+            multiTaskStage,
+            stageWithSyntheticBefore,
+            stageWithSyntheticAfter,
+            stageWithParallelBranches,
+            stageWithTaskAndAfterStages,
+            stageThatBlowsUpPlanningAfterStages,
+            stageWithSyntheticOnFailure,
+            stageWithNothingButAfterStages,
+            stageWithSyntheticOnFailure,
+            emptyStage
+          )
+        )
       )
     )
   }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RescheduleExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RescheduleExecutionHandlerTest.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
 import com.netflix.spinnaker.orca.fixture.task
@@ -35,9 +36,10 @@ object RescheduleExecutionHandlerTest : SubjectSpek<RescheduleExecutionHandler>(
 
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
+  val taskResolver = TaskResolver(emptyList())
 
   subject(CachingMode.GROUP) {
-    RescheduleExecutionHandler(queue, repository)
+    RescheduleExecutionHandler(queue, repository, taskResolver)
   }
 
   fun resetMocks() = reset(queue, repository)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.ExecutionStatus.*
+import com.netflix.spinnaker.orca.StageResolver
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
 import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
@@ -49,9 +50,13 @@ object RestartStageHandlerTest : SubjectSpek<RestartStageHandler>({
       queue,
       repository,
       DefaultStageDefinitionBuilderFactory(
-        singleTaskStage,
-        stageWithSyntheticBefore,
-        stageWithNestedSynthetics
+        StageResolver(
+          listOf(
+            singleTaskStage,
+            stageWithSyntheticBefore,
+            stageWithNestedSynthetics
+          )
+        )
       ),
       pendingExecutionService,
       clock

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeTaskHandlerTest.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.ExecutionStatus.PAUSED
 import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
+import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
 import com.netflix.spinnaker.orca.fixture.task
@@ -38,9 +39,10 @@ object ResumeTaskHandlerTest : SubjectSpek<ResumeTaskHandler>({
 
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
+  val taskResolver = TaskResolver(emptyList())
 
   subject(GROUP) {
-    ResumeTaskHandler(queue, repository)
+    ResumeTaskHandler(queue, repository, taskResolver)
   }
 
   fun resetMocks() = reset(queue, repository)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.assertj.assertSoftly
 import com.netflix.spinnaker.orca.ExecutionStatus.*
+import com.netflix.spinnaker.orca.StageResolver
 import com.netflix.spinnaker.orca.events.StageStarted
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.fixture.pipeline
@@ -65,16 +66,20 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       repository,
       stageNavigator,
       DefaultStageDefinitionBuilderFactory(
-        singleTaskStage,
-        multiTaskStage,
-        stageWithSyntheticBefore,
-        stageWithSyntheticAfter,
-        stageWithParallelBranches,
-        rollingPushStage,
-        zeroTaskStage,
-        stageWithSyntheticAfterAndNoTasks,
-        webhookStage,
-        failPlanningStage
+        StageResolver(
+          listOf(
+            singleTaskStage,
+            multiTaskStage,
+            stageWithSyntheticBefore,
+            stageWithSyntheticAfter,
+            stageWithParallelBranches,
+            rollingPushStage,
+            zeroTaskStage,
+            stageWithSyntheticAfterAndNoTasks,
+            webhookStage,
+            failPlanningStage
+          )
+        )
       ),
       ContextParameterProcessor(),
       publisher,

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandlerTest.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
+import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.events.TaskStarted
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
@@ -40,10 +41,11 @@ object StartTaskHandlerTest : SubjectSpek<StartTaskHandler>({
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
   val publisher: ApplicationEventPublisher = mock()
+  val taskResolver = TaskResolver(emptyList())
   val clock = fixedClock()
 
   subject(GROUP) {
-    StartTaskHandler(queue, repository, ContextParameterProcessor(), publisher, clock)
+    StartTaskHandler(queue, repository, ContextParameterProcessor(), publisher, taskResolver, clock)
   }
 
   fun resetMocks() = reset(queue, repository, publisher)


### PR DESCRIPTION
The `*Resolver` implementations will be able to look at both raw
implementation classes _as well as_ any specified aliases.

This supports (currently unsupported!) use cases that would be made
easier if a `Task` or `StageDefinitionBuilder` could be renamed.
