### PR TITLE
 refactor(provider/kubernetes): Add tests and simplify cache refresh

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -300,6 +301,7 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
   }
 
   @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
   static private class StageData {
     Map<String, List<String>> manifestNamesByNamespace = new HashMap<>();
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTaskSpec.groovy
@@ -18,10 +18,12 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.manifest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheStatusService
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import retrofit.client.Response
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -30,21 +32,33 @@ import java.time.Instant
 import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
+import static java.net.HttpURLConnection.HTTP_ACCEPTED
+import static java.net.HttpURLConnection.HTTP_OK
+
 class ManifestForceCacheRefreshTaskSpec extends Specification {
+  static final String ACCOUNT = "k8s"
+  static final String PROVIDER = "kubernetes"
+  static final String REFRESH_TYPE = "manifest"
+
   def now = Instant.now()
+
+  def cacheService = Mock(CloudDriverCacheService)
+  def cacheStatusService = Mock(CloudDriverCacheStatusService)
+  def objectMapper = new ObjectMapper()
 
   def registry = new DefaultRegistry()
   @Subject task = new ManifestForceCacheRefreshTask(
     registry,
-    Mock(CloudDriverCacheService),
-    Mock(CloudDriverCacheStatusService),
-    Mock(ObjectMapper),
+    cacheService,
+    cacheStatusService,
+    objectMapper,
     Clock.fixed(now, ZoneId.of("UTC"))
   )
 
   def "auto Succeed from timeout increments counter"() {
     given:
-    def stage = new Stage(Execution.newPipeline("orca"), "whatever")
+    def stage = mockStage([:])
     stage.setStartTime(now.minusMillis(TimeUnit.MINUTES.toMillis(13)).toEpochMilli())
     def taskResult = task.execute(stage)
 
@@ -52,4 +66,614 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult.getStatus().isSuccessful()
     registry.timer("manifestForceCacheRefreshTask.duration", "success", "true", "outcome", "autoSucceed").count() == 1
   }
+
+  def "returns RUNNING when the refresh request is accepted but not processed"() {
+    given:
+    def namespace = "my-namespace"
+    def manifest = "replicaSet my-replicaset-v014"
+    def context = [
+        account: ACCOUNT,
+        cloudProvider: PROVIDER,
+        "outputs.manifestNamesByNamespace": [
+          (namespace): [
+            manifest
+          ]
+        ],
+    ]
+    def refreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: manifest
+    ]
+    def stage = mockStage(context)
+    stage.setStartTime(now.toEpochMilli())
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+  }
+
+  def "returns SUCCEEDED when the refresh request is immediately processed"() {
+    given:
+    def namespace = "my-namespace"
+    def manifest = "replicaSet my-replicaset-v014"
+    def context = [
+      account: ACCOUNT,
+      cloudProvider: PROVIDER,
+      "outputs.manifestNamesByNamespace": [
+        (namespace): [
+          manifest
+        ]
+      ],
+    ]
+    def refreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: manifest
+    ]
+    def stage = mockStage(context)
+    stage.setStartTime(now.toEpochMilli())
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_OK)
+    taskResult.getStatus() == ExecutionStatus.SUCCEEDED
+  }
+
+  def "waits for a pending refresh"() {
+    given:
+    def namespace = "my-namespace"
+    def manifest = "replicaSet my-replicaset-v014"
+    def context = [
+      account: ACCOUNT,
+      cloudProvider: PROVIDER,
+      "outputs.manifestNamesByNamespace": [
+        (namespace): [
+          manifest
+        ]
+      ],
+    ]
+    def refreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: manifest
+    ]
+    def stage = mockStage(context)
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.SUCCEEDED
+  }
+
+  def "only returns succeeded if a processed refresh exactly matches"() {
+    given:
+    def namespace = "my-namespace"
+    def manifest = "replicaSet my-replicaset-v014"
+    def noMatch = "no-match"
+    def context = [
+      account: ACCOUNT,
+      cloudProvider: PROVIDER,
+      "outputs.manifestNamesByNamespace": [
+        (namespace): [
+          manifest
+        ]
+      ],
+    ]
+    def refreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: manifest
+    ]
+    def stage = mockStage(context)
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      processedRefresh(refreshDetails + [account: noMatch]),
+      processedRefresh(refreshDetails + [location: noMatch]),
+      processedRefresh(refreshDetails + [name: noMatch])
+    ]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+  }
+
+  def "retries when the cache does not know about the refresh request"() {
+    given:
+    def namespace = "my-namespace"
+    def manifest = "replicaSet my-replicaset-v014"
+    def context = [
+      account: ACCOUNT,
+      cloudProvider: PROVIDER,
+      "outputs.manifestNamesByNamespace": [
+        (namespace): [
+          manifest
+        ]
+      ],
+    ]
+    def refreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: manifest
+    ]
+    def stage = mockStage(context)
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> []
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.SUCCEEDED
+  }
+
+  def "waits until all manifests are processed when one is immediately processed"() {
+    given:
+    def namespace = "my-namespace"
+    def replicaSet = "replicaSet my-replicaset-v014"
+    def deployment = "deployment my-deployment"
+    def context = [
+      account: ACCOUNT,
+      cloudProvider: PROVIDER,
+      "outputs.manifestNamesByNamespace": [
+        (namespace): [
+          replicaSet,
+          deployment
+        ]
+      ],
+    ]
+    def replicaSetRefreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: replicaSet
+    ]
+    def deploymentRefreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: deployment
+    ]
+    def stage = mockStage(context)
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_OK)
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(deploymentRefreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(deploymentRefreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(deploymentRefreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.SUCCEEDED
+  }
+
+  def "waits until all manifests are processed when all are accepted for later processing"() {
+    given:
+    def namespace = "my-namespace"
+    def replicaSet = "replicaSet my-replicaset-v014"
+    def deployment = "deployment my-deployment"
+    def context = [
+      account: ACCOUNT,
+      cloudProvider: PROVIDER,
+      "outputs.manifestNamesByNamespace": [
+        (namespace): [
+          replicaSet,
+          deployment
+        ]
+      ],
+    ]
+    def replicaSetRefreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: replicaSet
+    ]
+    def deploymentRefreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: deployment
+    ]
+    def stage = mockStage(context)
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      pendingRefresh(replicaSetRefreshDetails),
+      pendingRefresh(deploymentRefreshDetails)
+    ]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      processedRefresh(replicaSetRefreshDetails),
+      pendingRefresh(deploymentRefreshDetails)
+    ]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      processedRefresh(replicaSetRefreshDetails),
+      processedRefresh(deploymentRefreshDetails)
+    ]
+    taskResult.getStatus() == ExecutionStatus.SUCCEEDED
+  }
+
+  def "returns RUNNING if there is an outstanding request, even if all requests in the current iteration succeeded"() {
+    given:
+    def namespace = "my-namespace"
+    def replicaSet = "replicaSet my-replicaset-v014"
+    def deployment = "deployment my-deployment"
+    def context = [
+      account: ACCOUNT,
+      cloudProvider: PROVIDER,
+      "outputs.manifestNamesByNamespace": [
+        (namespace): [
+          replicaSet,
+          deployment
+        ]
+      ],
+    ]
+    def replicaSetRefreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: replicaSet
+    ]
+    def deploymentRefreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: deployment
+    ]
+    def stage = mockStage(context)
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      pendingRefresh(replicaSetRefreshDetails)
+    ]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_OK)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      pendingRefresh(replicaSetRefreshDetails)
+    ]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      processedRefresh(replicaSetRefreshDetails)
+    ]
+    taskResult.getStatus() == ExecutionStatus.SUCCEEDED
+  }
+
+  def "handles refreshing the cache for manifests in different namespaces"() {
+    given:
+    def replicaSetNamespace = "replicaSet-namespace"
+    def deploymentNamespace = "deployment-namespace"
+    def replicaSet = "replicaSet my-replicaset-v014"
+    def deployment = "deployment my-deployment"
+    def context = [
+      account: ACCOUNT,
+      cloudProvider: PROVIDER,
+      "outputs.manifestNamesByNamespace": [
+        (replicaSetNamespace): [
+          replicaSet
+        ],
+        (deploymentNamespace): [
+          deployment
+        ]
+      ],
+    ]
+    def replicaSetRefreshDetails = [
+      account: ACCOUNT,
+      location: replicaSetNamespace,
+      name: replicaSet
+    ]
+    def deploymentRefreshDetails = [
+      account: ACCOUNT,
+      location: deploymentNamespace,
+      name: deployment
+    ]
+    def stage = mockStage(context)
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      pendingRefresh(replicaSetRefreshDetails),
+      pendingRefresh(deploymentRefreshDetails)
+    ]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      processedRefresh(replicaSetRefreshDetails),
+      pendingRefresh(deploymentRefreshDetails)
+    ]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      processedRefresh(replicaSetRefreshDetails),
+      processedRefresh(deploymentRefreshDetails)
+    ]
+    taskResult.getStatus() == ExecutionStatus.SUCCEEDED
+  }
+
+  def "properly handles a manifest without a namespace"() {
+    given:
+    def namespace = ""
+    def manifest = "namespace new-namespace"
+    def context = [
+      account: ACCOUNT,
+      cloudProvider: PROVIDER,
+      "outputs.manifestNamesByNamespace": [
+        (namespace): [
+          manifest
+        ]
+      ],
+    ]
+    def refreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: manifest
+    ]
+    def stage = mockStage(context)
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshDetails)]
+    taskResult.getStatus() == ExecutionStatus.SUCCEEDED
+  }
+
+  def "properly handles a manifest without a namespace, even if incorrectly assigned a namespace"() {
+    given:
+    def namespace = "my-namespace"
+    def manifest = "namespace new-namespace"
+    def context = [
+      account: ACCOUNT,
+      cloudProvider: PROVIDER,
+      "outputs.manifestNamesByNamespace": [
+        (namespace): [
+          manifest
+        ]
+      ],
+    ]
+    def refreshDetails = [
+      account: ACCOUNT,
+      location: namespace,
+      name: manifest
+    ]
+    def refreshResponseDetails = [
+      account: ACCOUNT,
+      location: "",
+      name: manifest
+    ]
+    def stage = mockStage(context)
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshResponseDetails)]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshResponseDetails)]
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshResponseDetails)]
+    taskResult.getStatus() == ExecutionStatus.SUCCEEDED
+  }
+
+  private Response mockResponse(int status) {
+    return new Response("", status, "", [], null)
+  }
+
+  private Stage mockStage(Map context) {
+    Stage stage = new Stage(new Execution(PIPELINE, "test"), "whatever", context)
+    stage.setStartTime(now.toEpochMilli())
+    return stage
+  }
+
+  private Map pendingRefresh(Map refreshDetails) {
+    return [
+      details: refreshDetails,
+      processedCount: 0,
+      processedTime: -1,
+      cacheTime: now.plusMillis(10).toEpochMilli()
+    ]
+  }
+
+  private Map processedRefresh(Map refreshDetails) {
+    return [
+      details: refreshDetails,
+      processedCount: 1,
+      processedTime: now.plusMillis(5000).toEpochMilli(),
+      cacheTime: now.plusMillis(10).toEpochMilli()
+    ]
+  }
+
+  private Map staleRefresh(Map refreshDetails) {
+    return [
+      details: refreshDetails,
+      processedCount: 1,
+      processedTime: now.plusMillis(5000).toEpochMilli(),
+      cacheTime: now.minusMillis(10).toEpochMilli()
+    ]
+  }
+
 }


### PR DESCRIPTION
* test(provider/kubernetes): Add tests to ManifestForceCacheRefresh 

  Most of the functionality in ManifestForceCacheRefreshTask is not tested. Add significant test coverage to this class to prepare for a bug fix/refactor.

* refactor(provider/kubernetes): Replace nested maps with an object 

  The ManifestForceCacheRefreshTask currently keeps track of its manifests as a Map<String, List<String>> which leads to a lot of complex iteration over this structure. Create a new class ScopedManifest and flatten this structure into a List<ScopedManifest> so that it's much easier to follow the processing that the class is doing.

* refactor(provider/kubernetes): Add account to ScopedManifest 

  Rather than thread account through multiple calls in this class, add it to the ScopedManifest class and set the account on each manifest when we create the initial list.

  This also makes the helper class Details identical to ScopedManifest, so replace instances of Details with ScopedManifest.

  Finally, replace pendingRefreshProcessed which both returns a status and mutates the stage context with getRefreshStatus, which only returns a status. Leave mutation of the context to the caller, checkPendingRefreshes. This allows us to avoid needing to mutate a ScopedManifest and keep the class immutable.

* refactor(provider/kubernetes): Track ScopedManifests directly 

  Now that we have a simple data class to represent a manifest to refresh that implements equals and hashCode, we don't need to manually serialize it with toManifestIdentifier. Just directly add these manifests to the collections we're using to track them.
