### PR TITLE
fix(provider/kubernetes): Don't poll immediately after cache refresh

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
@@ -108,9 +108,9 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
     StageData stageData = fromStage(stage);
     stageData.deployedManifests = getDeployedManifests(stage);
 
-    refreshManifests(cloudProvider, stageData);
-
     checkPendingRefreshes(cloudProvider, stageData, startTime);
+
+    refreshManifests(cloudProvider, stageData);
 
     if (allManifestsProcessed(stageData)) {
       registry.timer(durationTimerId.withTags("success", "true", "outcome", "complete"))

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
@@ -108,66 +108,68 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
     StageData stageData = fromStage(stage);
     stageData.deployedManifests = getDeployedManifests(stage);
 
-    if (refreshManifests(cloudProvider, stageData)) {
+    refreshManifests(cloudProvider, stageData);
+
+    checkPendingRefreshes(cloudProvider, stageData, startTime);
+
+    if (allManifestsProcessed(stageData)) {
       registry.timer(durationTimerId.withTags("success", "true", "outcome", "complete"))
         .record(duration, TimeUnit.MILLISECONDS);
       return new TaskResult(SUCCEEDED, toContext(stageData));
-    } else {
-      TaskResult taskResult = checkPendingRefreshes(cloudProvider, stageData, startTime);
-
-      // ignoring any non-success, non-failure statuses
-      if (taskResult.getStatus().isSuccessful()) {
-        registry.timer(durationTimerId.withTags("success", "true", "outcome", "complete"))
-          .record(duration, TimeUnit.MILLISECONDS);
-      } else if (taskResult.getStatus().isFailure()) {
-        registry.timer(durationTimerId.withTags("success", "false", "outcome", "failure"))
-          .record(duration, TimeUnit.MILLISECONDS);
-      }
-      return taskResult;
     }
+
+    return new TaskResult(RUNNING, toContext(stageData));
   }
 
-  private TaskResult checkPendingRefreshes(String provider, StageData stageData, long startTime) {
-    Collection<PendingRefresh> pendingRefreshes = objectMapper.convertValue(
-        cacheStatusService.pendingForceCacheUpdates(provider, REFRESH_TYPE),
-        new TypeReference<Collection<PendingRefresh>>() { }
-    );
+  /**
+   * Checks whether all manifests deployed in the stage have been processed by the cache
+   * @return true if all manifests have been processed
+   */
+  private boolean allManifestsProcessed(StageData stageData) {
+    return stageData.getProcessedManifests().containsAll(stageData.getDeployedManifests());
+  }
 
-    List<ScopedManifest> deployedManifests = stageData.getDeployedManifests();
+  /**
+   * Checks on the status of any pending on-demand cache refreshes. If a pending refresh has been processed, adds the
+   * corresponding manifest to processedManifests; if a pending refresh is not found in clouddriver or is invalid,
+   * removes the corresponding manifest from refreshedManifests
+   */
+  private void checkPendingRefreshes(String provider, StageData stageData, long startTime) {
     Set<ScopedManifest> refreshedManifests = stageData.getRefreshedManifests();
     Set<ScopedManifest> processedManifests = stageData.getProcessedManifests();
-    boolean allProcessed = true;
 
-    for (ScopedManifest manifest : deployedManifests) {
-      if (processedManifests.contains(manifest)) {
-        continue;
-      }
+    List<ScopedManifest> manifestsToCheck = refreshedManifests.stream()
+      .filter(m -> !processedManifests.contains(m))
+      .collect(Collectors.toList());
 
-      Optional<RefreshStatus> refreshStatus = pendingRefreshes.stream()
+    if (manifestsToCheck.isEmpty()) {
+      return;
+    }
+
+    Collection<PendingRefresh> pendingRefreshes = objectMapper.convertValue(
+      cacheStatusService.pendingForceCacheUpdates(provider, REFRESH_TYPE),
+      new TypeReference<Collection<PendingRefresh>>() { }
+    );
+
+    for (ScopedManifest manifest : manifestsToCheck) {
+      RefreshStatus refreshStatus = pendingRefreshes.stream()
         .filter(pr -> pr.getScopedManifest() != null)
         .filter(pr -> refreshMatches(pr.getScopedManifest(), manifest))
         .map(pr -> getRefreshStatus(pr, startTime))
-        .filter(status -> status != RefreshStatus.INVALID)
         .sorted()
-        .findFirst();
+        .findFirst()
+        .orElse(RefreshStatus.INVALID);
 
-      if (refreshStatus.isPresent()) {
-        RefreshStatus status = refreshStatus.get();
-        if (status == RefreshStatus.PROCESSED) {
-          log.debug("Pending manifest refresh of {} completed", manifest);
-          processedManifests.add(manifest);
-        } else if (status == RefreshStatus.PENDING) {
-          log.debug("Pending manifest refresh of {} still pending", manifest);
-          allProcessed = false;
-        }
+      if (refreshStatus == RefreshStatus.PROCESSED) {
+        log.debug("Pending manifest refresh of {} completed", manifest);
+        processedManifests.add(manifest);
+      } else if (refreshStatus == RefreshStatus.PENDING) {
+        log.debug("Pending manifest refresh of {} still pending", manifest);
       } else {
         log.warn("No valid pending refresh of {}", manifest);
-        allProcessed = false;
         refreshedManifests.remove(manifest);
       }
     }
-
-    return new TaskResult(allProcessed ? SUCCEEDED : RUNNING, toContext(stageData));
   }
 
   private boolean refreshMatches(ScopedManifest refresh, ScopedManifest manifest) {
@@ -212,10 +214,14 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
       .collect(Collectors.toList());
   }
 
-  private boolean refreshManifests(String provider, StageData stageData) {
+  /**
+   * Requests and on-demand cache refresh for any manifest without an refresh requests that is either pending or
+   * processed. Adds each manifest to refreshedManifests; if the request to clouddriver was immediately processed,
+   * also adds the manifest to processedManifests.
+   */
+  private void refreshManifests(String provider, StageData stageData) {
     List<ScopedManifest> manifests = manifestsNeedingRefresh(stageData);
 
-    boolean allRefreshesSucceeded = true;
     for (ScopedManifest manifest : manifests) {
       Map<String, String> request = objectMapper.convertValue(manifest, new TypeReference<Map<String, String>>() {});
       try {
@@ -223,27 +229,14 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
         if (response.getStatus() == HTTP_OK) {
           log.info("Refresh of {} succeeded immediately", manifest);
           stageData.getProcessedManifests().add(manifest);
-        } else {
-          allRefreshesSucceeded = false;
         }
 
         stageData.getRefreshedManifests().add(manifest);
       } catch (Exception e) {
         log.warn("Failed to refresh {}: ", manifest, e);
-        allRefreshesSucceeded = false;
         stageData.errors.add(e.getMessage());
       }
     }
-
-    boolean allRefreshesProcessed = stageData.getRefreshedManifests().equals(stageData.getProcessedManifests());
-
-    // This can happen when the prior execution of this task returned RUNNING because one or more manifests
-    // were not processed. In this case, all manifests may have been refreshed successfully without finishing processing.
-    if (allRefreshesSucceeded && !allRefreshesProcessed) {
-      log.warn("All refreshes succeeded, but not all have been processed yet...");
-    }
-
-    return allRefreshesSucceeded && allRefreshesProcessed;
   }
 
   private StageData fromStage(Stage stage) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
@@ -215,7 +215,7 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
   }
 
   /**
-   * Requests and on-demand cache refresh for any manifest without an refresh requests that is either pending or
+   * Requests an on-demand cache refresh for any manifest without a refresh requests that is either pending or
    * processed. Adds each manifest to refreshedManifests; if the request to clouddriver was immediately processed,
    * also adds the manifest to processedManifests.
    */

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTaskSpec.groovy
@@ -92,9 +92,9 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
-    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
   }
 
@@ -123,8 +123,8 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_OK)
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
 
@@ -152,9 +152,9 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -163,8 +163,8 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -173,8 +173,8 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
 
@@ -203,9 +203,9 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
-    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -214,12 +214,12 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
       processedRefresh(refreshDetails + [account: noMatch]),
       processedRefresh(refreshDetails + [location: noMatch]),
       processedRefresh(refreshDetails + [name: noMatch])
     ]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
   }
 
@@ -247,20 +247,9 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
-    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> []
-    taskResult.getStatus() == ExecutionStatus.RUNNING
-
-    when:
-    context << taskResult.context
-    stage = mockStage(context)
-    taskResult = task.execute(stage)
-
-    then:
-    0 * cacheService._
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -269,8 +258,19 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
 
@@ -305,10 +305,10 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(deploymentRefreshDetails)]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_OK)
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(deploymentRefreshDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -317,8 +317,8 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(deploymentRefreshDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -327,8 +327,8 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(deploymentRefreshDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
 
@@ -363,13 +363,13 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
-    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
-    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
       pendingRefresh(replicaSetRefreshDetails),
       pendingRefresh(deploymentRefreshDetails)
     ]
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -378,11 +378,11 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
       processedRefresh(replicaSetRefreshDetails),
       pendingRefresh(deploymentRefreshDetails)
     ]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -391,11 +391,11 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
       processedRefresh(replicaSetRefreshDetails),
       processedRefresh(deploymentRefreshDetails)
     ]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
 
@@ -430,12 +430,12 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      pendingRefresh(replicaSetRefreshDetails)
+    ]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
-      pendingRefresh(replicaSetRefreshDetails)
-    ]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -444,11 +444,11 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+      pendingRefresh(replicaSetRefreshDetails)
+    ]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_OK)
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
-      pendingRefresh(replicaSetRefreshDetails)
-    ]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -457,10 +457,10 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
       processedRefresh(replicaSetRefreshDetails)
     ]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
 
@@ -498,13 +498,13 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
-    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
-    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
       pendingRefresh(replicaSetRefreshDetails),
       pendingRefresh(deploymentRefreshDetails)
     ]
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -513,11 +513,11 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
       processedRefresh(replicaSetRefreshDetails),
       pendingRefresh(deploymentRefreshDetails)
     ]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -526,11 +526,11 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
       processedRefresh(replicaSetRefreshDetails),
       processedRefresh(deploymentRefreshDetails)
     ]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
 
@@ -558,9 +558,9 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -569,8 +569,8 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -579,8 +579,8 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
 
@@ -613,9 +613,9 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshResponseDetails)]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshResponseDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -624,8 +624,8 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshResponseDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
     when:
@@ -634,8 +634,8 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    0 * cacheService._
     1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshResponseDetails)]
+    0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTaskSpec.groovy
@@ -92,7 +92,6 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
@@ -152,7 +151,6 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
@@ -203,7 +201,6 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
@@ -219,6 +216,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
       processedRefresh(refreshDetails + [location: noMatch]),
       processedRefresh(refreshDetails + [name: noMatch])
     ]
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
   }
@@ -247,7 +245,6 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> []
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
@@ -258,7 +255,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> []
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
@@ -305,7 +302,6 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(deploymentRefreshDetails)]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_OK)
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
@@ -363,10 +359,6 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
-      pendingRefresh(replicaSetRefreshDetails),
-      pendingRefresh(deploymentRefreshDetails)
-    ]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
@@ -430,9 +422,6 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
-      pendingRefresh(replicaSetRefreshDetails)
-    ]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
@@ -498,10 +487,6 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
-      pendingRefresh(replicaSetRefreshDetails),
-      pendingRefresh(deploymentRefreshDetails)
-    ]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, replicaSetRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
@@ -558,7 +543,6 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
@@ -613,7 +597,6 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     def taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshResponseDetails)]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING


### PR DESCRIPTION
* test(provider/kubernetes): Re-order statements in tests 

  This commit has no functional effect, it is just going to make the tests much easier to read in the next commit, where I change the order between checking on pending cache refresh requests and sending new ones.

* refactor(provider/kubernetes): Change control flow in refresh 

  Instead of having refreshManifests and checkPendingRefreshes contain logic for determinig if the task is done, have them focus on mutating refreshedManifests and deployedManifests as they take actions.

  Then add allManifestsProcessed to check whether we're done; which is just checking if all deployed manifests have been processed. This removes the need to track the state of all manifests in the mutating functions and allows us to consolidate the return value of the task to one place.

* fix(provider/kubernetes): Don't poll immediately after cache refresh 

  We currently poll clouddriver to get the status of a cache refresh immediately after requesting the cache refresh, and schedule a re-refresh is we don't see the request we just requested.

  For users with a read-only clouddriver pointed at a replica of redis, there will be some replication lag before the pending refresh appears in the cache, which will cause us to keep re-scheduling the same cache refresh.

  To address this, wait one polling cycle before checking on the status of a pending refresh. Do this by changing the order of operations so that we first check on any pending requests from the last cycle, then schedule and needed new requests.