### PR TITLE
fix(gremlin): Remove Gremlin config template and let Halyard do it from scratch

### DIFF
--- a/halconfig/orca.yml
+++ b/halconfig/orca.yml
@@ -41,8 +41,3 @@ redis:
 tasks:
   executionWindow:
     timezone: ${global.spinnaker.timezone:America/Los_Angeles}
-
-integrations:
-  gremlin:
-    enabled: ${features.gremlin:false}
-    baseUrl: https://api.gremlin.com/v1


### PR DESCRIPTION
Related Halyard PR: https://github.com/spinnaker/halyard/pull/1293

I previously had the wrong idea about how Halyard was propagating config. This should put all of the burden onto Halyard to do it programatically.