### PR TITLE
fix(clouddriver): Hoist inferredRegions var to parent scope so it is accessible to groovy code down below

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -122,11 +122,11 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
 
     Set<String> imageNames = []
     Map<Location, String> imageIds = [:]
+    Set<String> inferredRegions = new HashSet<>()
 
     if (cloudProvider == 'aws') {
       // Supplement config with regions from subsequent deploy/canary stages:
       def deployRegions = regionCollector.getRegionsFromChildStages(stage)
-      Set<String> inferredRegions = new HashSet<>()
 
       deployRegions.forEach {
         if (!config.regions.contains(it)) {


### PR DESCRIPTION
fixes this exception:

```
No such property: inferredRegions for class: com.netflix.spinnaker.orca.clouddriver.tasks.cluster.FindImageFromClusterTask
```