### PR TITLE
 feat(gcb): Monitor GCB build status after starting a build

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -74,4 +74,9 @@ public interface IgorService {
   GoogleCloudBuild createGoogleCloudBuild(
     @Path("account") String account,
     @Body Map<String, Object> job);
+
+  @GET("/gcb/builds/{account}/{buildId}")
+  GoogleCloudBuild getGoogleCloudBuild(
+    @Path("account") String account,
+    @Path("buildId") String buildId);
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.orca.igor;
 
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuild;
 import retrofit.http.*;
 
 import java.util.List;
@@ -70,7 +71,7 @@ public interface IgorService {
     @Path(value = "job", encode = false) String job);
 
   @POST("/gcb/builds/create/{account}")
-  Map<String, Object> createGoogleCloudBuild(
+  GoogleCloudBuild createGoogleCloudBuild(
     @Path("account") String account,
     @Body Map<String, Object> job);
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuild.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuild.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@Getter
+@RequiredArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleCloudBuild {
+  private final String id;
+  private final Status status;
+  private final String logUrl;
+
+  @JsonCreator
+  public GoogleCloudBuild(
+    @JsonProperty("id") String id,
+    @JsonProperty("status") String status,
+    @JsonProperty("logUrl") String logUrl
+  ) {
+    this.id = id;
+    this.status = Status.fromString(status);
+    this.logUrl = logUrl;
+  }
+
+  public enum Status {
+    STATUS_UNKNOWN(ExecutionStatus.RUNNING),
+    QUEUED(ExecutionStatus.RUNNING),
+    WORKING(ExecutionStatus.RUNNING),
+    SUCCESS(ExecutionStatus.SUCCEEDED),
+    FAILURE(ExecutionStatus.TERMINAL),
+    INTERNAL_ERROR(ExecutionStatus.TERMINAL),
+    TIMEOUT(ExecutionStatus.TERMINAL),
+    CANCELLED(ExecutionStatus.TERMINAL);
+
+    @Getter
+    private ExecutionStatus executionStatus;
+
+    Status(ExecutionStatus executionStatus) {
+      this.executionStatus = executionStatus;
+    }
+
+    public static Status fromString(String status) {
+      try {
+        return valueOf(status);
+      } catch (NullPointerException | IllegalArgumentException e) {
+        return STATUS_UNKNOWN;
+      }
+    }
+  }
+}

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
@@ -24,15 +24,18 @@ import java.util.Map;
 @Getter
 public class GoogleCloudBuildStageDefinition {
   private final String account;
+  private final GoogleCloudBuild buildInfo;
   private final Map<String, Object> buildDefinition;
 
   // There does not seem to be a way to auto-generate a constructor using our current version of Lombok (1.16.20) that
   // Jackson can use to deserialize.
   public GoogleCloudBuildStageDefinition(
     @JsonProperty("account") String account,
+    @JsonProperty("buildInfo") GoogleCloudBuild build,
     @JsonProperty("buildDefinition") Map<String, Object> buildDefinition
   ) {
     this.account = account;
+    this.buildInfo = build;
     this.buildDefinition = buildDefinition;
   }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.Task;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.igor.IgorService;
+import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuild;
 import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildStageDefinition;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,9 @@ public class StartGoogleCloudBuildTask implements Task {
   @Override
   @Nonnull public TaskResult execute(@Nonnull Stage stage) {
     GoogleCloudBuildStageDefinition stageDefinition = stage.mapTo(GoogleCloudBuildStageDefinition.class);
-    Map<String, Object> result = igorService.createGoogleCloudBuild(stageDefinition.getAccount(), stageDefinition.getBuildDefinition());
-    return new TaskResult(ExecutionStatus.SUCCEEDED);
+    GoogleCloudBuild result = igorService.createGoogleCloudBuild(stageDefinition.getAccount(), stageDefinition.getBuildDefinition());
+    Map<String, Object> context = stage.getContext();
+    context.put("buildInfo", result);
+    return new TaskResult(ExecutionStatus.SUCCEEDED, context);
   }
 }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTaskSpec.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.tasks
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.igor.IgorService
+import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuild
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import retrofit.RetrofitError
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class MonitorGoogleCloudBuildTaskSpec extends Specification {
+  def ACCOUNT = "my-account"
+  def BUILD_ID = "0cc67a01-714f-49c7-aaf3-d09b5ec1a18a"
+
+  Execution execution = Mock(Execution)
+  IgorService igorService = Mock(IgorService)
+
+  @Subject
+  MonitorGoogleCloudBuildTask task = new MonitorGoogleCloudBuildTask(igorService)
+
+  @Unroll
+  def "task returns #executionStatus when build returns #buildStatus"() {
+    given:
+    def stage = new Stage(execution, "googleCloudBuild", [
+      account: ACCOUNT,
+      buildInfo: [
+        id: BUILD_ID
+      ],
+    ])
+
+    when:
+    TaskResult result = task.execute(stage)
+
+    then:
+    1 * igorService.getGoogleCloudBuild(ACCOUNT, BUILD_ID) >> GoogleCloudBuild.builder()
+      .id(BUILD_ID)
+      .status(GoogleCloudBuild.Status.valueOf(buildStatus))
+      .build()
+    0 * igorService._
+    result.getStatus() == executionStatus
+
+    where:
+    buildStatus      | executionStatus
+    "STATUS_UNKNOWN" | ExecutionStatus.RUNNING
+    "QUEUED"         | ExecutionStatus.RUNNING
+    "WORKING"        | ExecutionStatus.RUNNING
+    "SUCCESS"        | ExecutionStatus.SUCCEEDED
+    "FAILURE"        | ExecutionStatus.TERMINAL
+    "INTERNAL_ERROR" | ExecutionStatus.TERMINAL
+    "TIMEOUT"        | ExecutionStatus.TERMINAL
+    "CANCELLED"      | ExecutionStatus.TERMINAL
+  }
+
+  def "task returns RUNNING when communcation with igor fails"() {
+    given:
+    def stage = new Stage(execution, "googleCloudBuild", [
+      account: ACCOUNT,
+      buildInfo: [
+        id: BUILD_ID
+      ],
+    ])
+
+    when:
+    TaskResult result = task.execute(stage)
+
+    then:
+    1 * igorService.getGoogleCloudBuild(ACCOUNT, BUILD_ID) >> { throw Mock(RetrofitError) }
+    0 * igorService._
+    result.getStatus() == ExecutionStatus.RUNNING
+  }
+}

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.igor.tasks
 
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.igor.IgorService
+import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuild
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import spock.lang.Specification
@@ -42,6 +43,8 @@ class StartGoogleCloudBuildTaskSpec extends Specification {
     TaskResult result = task.execute(stage)
 
     then:
-    1 * igorService.createGoogleCloudBuild(*_)
+    1 * igorService.createGoogleCloudBuild(ACCOUNT, BUILD) >> GoogleCloudBuild.builder()
+      .id("98edf783-162c-4047-9721-beca8bd2c275")
+      .build();
   }
 }


### PR DESCRIPTION
* refactor(gcb): Use a GoogleCloudBuild type as return from igor 

  To make the task logic simpler, create a class GoogleCloudBuild that has the build fields that Orca cares about and have retrofit deserialize the result from igor. Also, add the resulting field to the stage context so it can be used by downstream tasks.

* feat(gcb): Monitor GCB build status after starting a build 

  Instead of immediatly returning success once the new GCB build is accepted, wait until the build completes and set the status of the stage based on the result of the build.
