### PR TITLE
refactor(ci): Generify RetryableIgorTask

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/CIStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/CIStageDefinition.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Getter
-public class CIStageDefinition {
+public class CIStageDefinition implements RetryableStageDefinition {
   private final String master;
   private final String job;
   private final String propertyFile;

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/RetryableStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/RetryableStageDefinition.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.model;
+
+public interface RetryableStageDefinition {
+  int getConsecutiveErrors();
+}

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTask.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.igor.BuildService;
 import com.netflix.spinnaker.orca.igor.model.CIStageDefinition;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -34,7 +35,7 @@ import java.util.Map;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class GetBuildArtifactsTask extends RetryableIgorTask {
+public class GetBuildArtifactsTask extends RetryableIgorTask<CIStageDefinition> {
   private final BuildService buildService;
 
   @Override
@@ -47,5 +48,10 @@ public class GetBuildArtifactsTask extends RetryableIgorTask {
     );
     Map<String, List<Artifact>> outputs = Collections.singletonMap("artifacts", artifacts);
     return new TaskResult(ExecutionStatus.SUCCEEDED, Collections.emptyMap(), outputs);
+  }
+
+  @Override
+  protected @Nonnull CIStageDefinition mapStage(@Nonnull Stage stage) {
+    return stage.mapTo(CIStageDefinition.class);
   }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildPropertiesTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildPropertiesTask.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.igor.BuildService;
 import com.netflix.spinnaker.orca.igor.model.CIStageDefinition;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -32,7 +33,7 @@ import java.util.Map;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class GetBuildPropertiesTask extends RetryableIgorTask {
+public class GetBuildPropertiesTask extends RetryableIgorTask<CIStageDefinition> {
   private final BuildService buildService;
 
   @Override
@@ -53,5 +54,10 @@ public class GetBuildPropertiesTask extends RetryableIgorTask {
     HashMap<String, Object> outputs = new HashMap<>(properties);
     outputs.put("propertyFileContents", properties);
     return new TaskResult(ExecutionStatus.SUCCEEDED, outputs, outputs);
+  }
+
+  @Override
+  protected @Nonnull CIStageDefinition mapStage(@Nonnull Stage stage) {
+    return stage.mapTo(CIStageDefinition.class);
   }
 }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/RetryableIgorTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/RetryableIgorTaskSpec.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.orca.igor.tasks
 
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.TaskResult
-import com.netflix.spinnaker.orca.igor.model.CIStageDefinition
+import com.netflix.spinnaker.orca.igor.model.RetryableStageDefinition
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import retrofit.RetrofitError
 import retrofit.client.Response
@@ -26,13 +26,13 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 class RetryableIgorTaskSpec extends Specification {
-  CIStageDefinition jobRequest = Stub(CIStageDefinition)
-  Stage stage = Mock(Stage) {
-    mapTo(CIStageDefinition.class) >> jobRequest
-  }
+  RetryableStageDefinition jobRequest = Stub(RetryableStageDefinition)
+  Stage stage = Mock(Stage)
 
   @Subject
-  RetryableIgorTask task = Spy(RetryableIgorTask)
+  RetryableIgorTask task = Spy(RetryableIgorTask) {
+    mapStage(stage) >> jobRequest
+  }
 
   def "should delegate to subclass"() {
     given:


### PR DESCRIPTION
* refactor(ci): Generify RetryableIgorTask 

  I'd like to re-use the logic in RetryableIgorTask for some GCB tasks, but it requires that the stage map to a CIStageDefinition. Make the stage definition a parameter to the class so it can be re-used.

  At some point it might make sense to make this even more general than just for igor tasks, but at least this makes it a bit more general than it is now.