### PR TITLE
feat(core): Allow `ExecutionPreprocessor` to discriminate on type

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/V2Util.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/V2Util.java
@@ -38,7 +38,7 @@ public class V2Util {
     Map<String, Object> finalPipeline = pipeline;
     List<ExecutionPreprocessor> preprocessors = pipelinePreprocessors
       .stream()
-      .filter(p -> p.supports(finalPipeline))
+      .filter(p -> p.supports(finalPipeline, ExecutionPreprocessor.Type.PIPELINE))
       .collect(Collectors.toList());
     for (ExecutionPreprocessor pp : preprocessors) {
       pipeline = pp.process(pipeline);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/preprocessors/DefaultApplicationExecutionPreprocessor.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/preprocessors/DefaultApplicationExecutionPreprocessor.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.preprocessors
 import com.netflix.spinnaker.orca.config.DefaultApplicationConfigurationProperties
 import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
 import org.springframework.stereotype.Component
+import javax.annotation.Nonnull
 
 /**
  * Populates an Execution config payload with a default application value if one is not provided.
@@ -27,7 +28,8 @@ class DefaultApplicationExecutionPreprocessor(
   private val properties: DefaultApplicationConfigurationProperties
 ) : ExecutionPreprocessor {
 
-  override fun supports(execution: MutableMap<String, Any>) = true
+  override fun supports(@Nonnull execution: MutableMap<String, Any>,
+                        @Nonnull type: ExecutionPreprocessor.Type): Boolean = true
 
   override fun process(execution: MutableMap<String, Any>): MutableMap<String, Any> {
     if (!execution.containsKey("application")) {

--- a/orca-extensionpoint/src/main/java/com/netflix/spinnaker/orca/extensionpoint/pipeline/ExecutionPreprocessor.java
+++ b/orca-extensionpoint/src/main/java/com/netflix/spinnaker/orca/extensionpoint/pipeline/ExecutionPreprocessor.java
@@ -26,10 +26,15 @@ public interface ExecutionPreprocessor {
   /**
    * Returns whether or not the preprocess can handle the inbound execution.
    */
-  boolean supports(@Nonnull Map<String, Object> execution);
+  boolean supports(@Nonnull Map<String, Object> execution, @Nonnull Type type);
 
   /**
    * Allows modification of an execution configuration.
    */
   @Nonnull Map<String, Object> process(@Nonnull Map<String, Object> execution);
+
+  enum Type {
+    PIPELINE,
+    ORCHESTRATION
+  }
 }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -101,7 +101,9 @@ class DependentPipelineStarter implements ApplicationContextAware {
     //keep the trigger as the preprocessor removes it.
     def expectedArtifacts = pipelineConfig.expectedArtifacts
 
-    for (ExecutionPreprocessor preprocessor : executionPreprocessors.findAll { it.supports(pipelineConfig) }) {
+    for (ExecutionPreprocessor preprocessor : executionPreprocessors.findAll {
+      it.supports(pipelineConfig, ExecutionPreprocessor.Type.PIPELINE)
+    }) {
       pipelineConfig = preprocessor.process(pipelineConfig)
     }
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v2schema.model.V2PipelineTemp
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import javax.annotation.Nonnull
 import javax.annotation.PostConstruct
 
 @Component("pipelineTemplatePreprocessor")
@@ -44,7 +45,8 @@ class PipelineTemplatePreprocessor
 
   @PostConstruct fun confirmUsage() = log.info("Using ${javaClass.simpleName}")
 
-  override fun supports(execution: MutableMap<String, Any>) = true
+  override fun supports(@Nonnull execution: MutableMap<String, Any>,
+                        @Nonnull type: ExecutionPreprocessor.Type): Boolean = true
 
   override fun process(pipeline: MutableMap<String, Any>): MutableMap<String, Any> {
     // TODO(jacobkiefer): We push the 'toplevel' v2 config into a 'config' field to play nice


### PR DESCRIPTION
This supports existing use cases around pipeline-centric preprocessors.
