### PR TITLE
feat(gcb): Fetch artifacts produced by a GCB build

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -79,4 +79,9 @@ public interface IgorService {
   GoogleCloudBuild getGoogleCloudBuild(
     @Path("account") String account,
     @Path("buildId") String buildId);
+
+  @GET("/gcb/builds/{account}/{buildId}/artifacts")
+  List<Artifact> getGoogleCloudBuildArtifacts(
+    @Path("account") String account,
+    @Path("buildId") String buildId);
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
@@ -20,22 +20,26 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 import java.util.Map;
+import java.util.Optional;
 
 @Getter
-public class GoogleCloudBuildStageDefinition {
+public class GoogleCloudBuildStageDefinition implements RetryableStageDefinition {
   private final String account;
   private final GoogleCloudBuild buildInfo;
   private final Map<String, Object> buildDefinition;
+  private final int consecutiveErrors;
 
   // There does not seem to be a way to auto-generate a constructor using our current version of Lombok (1.16.20) that
   // Jackson can use to deserialize.
   public GoogleCloudBuildStageDefinition(
     @JsonProperty("account") String account,
     @JsonProperty("buildInfo") GoogleCloudBuild build,
-    @JsonProperty("buildDefinition") Map<String, Object> buildDefinition
+    @JsonProperty("buildDefinition") Map<String, Object> buildDefinition,
+    @JsonProperty("consecutiveErrors") Integer consecutiveErrors
   ) {
     this.account = account;
     this.buildInfo = build;
     this.buildDefinition = buildDefinition;
+    this.consecutiveErrors = Optional.ofNullable(consecutiveErrors).orElse(0);
   }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/GoogleCloudBuildStage.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/GoogleCloudBuildStage.java
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.orca.igor.pipeline;
 
 import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildStageDefinition;
+import com.netflix.spinnaker.orca.igor.tasks.GetGoogleCloudBuildArtifactsTask;
 import com.netflix.spinnaker.orca.igor.tasks.MonitorGoogleCloudBuildTask;
 import com.netflix.spinnaker.orca.igor.tasks.StartGoogleCloudBuildTask;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
@@ -36,6 +37,8 @@ public class GoogleCloudBuildStage implements StageDefinitionBuilder {
     GoogleCloudBuildStageDefinition stageDefinition = stage.mapTo(GoogleCloudBuildStageDefinition.class);
     builder
       .withTask("startGoogleCloudBuildTask", StartGoogleCloudBuildTask.class)
-      .withTask("monitorGoogleCloudBuildTask", MonitorGoogleCloudBuildTask.class);
+      .withTask("monitorGoogleCloudBuildTask", MonitorGoogleCloudBuildTask.class)
+      .withTask("getGoogleCloudBuildArtifactsTask", GetGoogleCloudBuildArtifactsTask.class)
+    ;
   }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetGoogleCloudBuildArtifactsTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetGoogleCloudBuildArtifactsTask.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.tasks;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.igor.IgorService;
+import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildStageDefinition;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GetGoogleCloudBuildArtifactsTask extends RetryableIgorTask<GoogleCloudBuildStageDefinition> {
+  private final IgorService igorService;
+
+  @Override
+  public @Nonnull TaskResult tryExecute(@Nonnull GoogleCloudBuildStageDefinition stageDefinition) {
+    List<Artifact> artifacts = igorService.getGoogleCloudBuildArtifacts(
+      stageDefinition.getAccount(),
+      stageDefinition.getBuildInfo().getId()
+    );
+    Map<String, List<Artifact>> outputs = Collections.singletonMap("artifacts", artifacts);
+    return new TaskResult(ExecutionStatus.SUCCEEDED, Collections.emptyMap(), outputs);
+  }
+
+  @Override
+  public @Nonnull GoogleCloudBuildStageDefinition mapStage(@Nonnull Stage stage) {
+    return stage.mapTo(GoogleCloudBuildStageDefinition.class);
+  }
+}

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTask.java
@@ -16,21 +16,29 @@
 
 package com.netflix.spinnaker.orca.igor.tasks;
 
+import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.igor.IgorService;
 import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuild;
 import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildStageDefinition;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class MonitorGoogleCloudBuildTask extends RetryableIgorTask<GoogleCloudBuildStageDefinition> {
+public class MonitorGoogleCloudBuildTask extends RetryableIgorTask<GoogleCloudBuildStageDefinition> implements OverridableTimeoutRetryableTask {
+  @Getter
+  protected long backoffPeriod = 10000;
+  @Getter
+  protected long timeout = TimeUnit.HOURS.toMillis(2);
+
   private final IgorService igorService;
 
   @Override

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetGoogleCloudBuildArtifactsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetGoogleCloudBuildArtifactsTaskSpec.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.tasks
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.igor.IgorService
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import retrofit.RetrofitError
+import spock.lang.Specification
+import spock.lang.Subject
+
+class GetGoogleCloudBuildArtifactsTaskSpec extends Specification {
+  def ACCOUNT = "my-account"
+  def BUILD_ID = "f2526c98-0c20-48ff-9f1f-736503937084"
+
+  Execution execution = Mock(Execution)
+  IgorService igorService = Mock(IgorService)
+
+  @Subject
+  GetGoogleCloudBuildArtifactsTask task = new GetGoogleCloudBuildArtifactsTask(igorService)
+
+  def "fetches artifacts from igor and returns success"() {
+    given:
+    def artifacts = [
+      Artifact.builder().reference("abc").build(),
+      Artifact.builder().reference("def").build()
+    ]
+    def stage = new Stage(execution, "googleCloudBuild", [
+      account: ACCOUNT,
+      buildInfo: [
+        id: BUILD_ID
+      ],
+    ])
+
+    when:
+    TaskResult result = task.execute(stage)
+
+    then:
+    1 * igorService.getGoogleCloudBuildArtifacts(ACCOUNT, BUILD_ID) >> artifacts
+    0 * igorService._
+    result.getStatus() == ExecutionStatus.SUCCEEDED
+    result.getOutputs().get("artifacts") == artifacts
+  }
+
+  def "task returns RUNNING when communcation with igor fails"() {
+    given:
+    def stage = new Stage(execution, "googleCloudBuild", [
+      account: ACCOUNT,
+      buildInfo: [
+        id: BUILD_ID
+      ],
+    ])
+
+    when:
+    TaskResult result = task.execute(stage)
+
+    then:
+    1 * igorService.getGoogleCloudBuildArtifacts(ACCOUNT, BUILD_ID) >> { throw stubRetrofitError() }
+    0 * igorService._
+    result.getStatus() == ExecutionStatus.RUNNING
+  }
+
+  def stubRetrofitError() {
+    return Stub(RetrofitError) {
+      getKind() >> RetrofitError.Kind.NETWORK
+    }
+  }
+}

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTaskSpec.groovy
@@ -83,8 +83,14 @@ class MonitorGoogleCloudBuildTaskSpec extends Specification {
     TaskResult result = task.execute(stage)
 
     then:
-    1 * igorService.getGoogleCloudBuild(ACCOUNT, BUILD_ID) >> { throw Mock(RetrofitError) }
+    1 * igorService.getGoogleCloudBuild(ACCOUNT, BUILD_ID) >> { throw stubRetrofitError() }
     0 * igorService._
     result.getStatus() == ExecutionStatus.RUNNING
+  }
+
+  def stubRetrofitError() {
+    return Stub(RetrofitError) {
+      getKind() >> RetrofitError.Kind.NETWORK
+    }
   }
 }


### PR DESCRIPTION
* refactor(gcb): Refactor monitor task to use generic retry logic

  Now that RetryableIgorTask is generic, MonitorGoogleCloudBuildTask can extend it instead of having its own retry logic.                  

* feat(gcb): Fetch artifacts produced by a GCB build

* fix(gcb): Add longer timeout to GCB polling stage

  We're currently using the default timeout of 1 minute, which will likely be too short.  As a starting point, use the timeout and backoff period we use for other CI jobs, though we can change these in the future if needed.