### PR TITLE
chore(conditions): Adding a flag to skip wait

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/conditions/ConditionConfigurationProperties.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/conditions/ConditionConfigurationProperties.java
@@ -78,4 +78,8 @@ public class ConditionConfigurationProperties {
   public void setActiveConditions(List<String> activeConditions) {
     this.activeConditions = activeConditions;
   }
+
+  public boolean isSkipWait() {
+    return configService.getConfig(Boolean.class, "tasks.evaluateCondition.skipWait", false);
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/conditions/EvaluateConditionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/conditions/EvaluateConditionTask.java
@@ -81,6 +81,12 @@ public class EvaluateConditionTask implements RetryableTask {
   @Override
   public TaskResult execute(@Nonnull Stage stage) {
     final WaitForConditionContext ctx = stage.mapTo(WaitForConditionContext.class);
+    if (conditionsConfigurationProperties.isSkipWait()) {
+      log.debug("Un-pausing deployment to {} (execution: {}) based on configuration",
+        ctx.getCluster(), stage.getExecution());
+      ctx.setStatus(Status.SKIPPED);
+    }
+
     if (ctx.getStatus() == Status.SKIPPED) {
       return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(Collections.singletonMap("status", Status.SKIPPED)).build();
     }


### PR DESCRIPTION
- added config property tasks.evaluateCondition.skipWait
- when skipWait=true, all paused deployments will proceed