### PR TITLE
fix(gcb): Properly set buildInfo in the context

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTask.java
@@ -28,6 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -48,7 +50,9 @@ public class MonitorGoogleCloudBuildTask extends RetryableIgorTask<GoogleCloudBu
       stageDefinition.getAccount(),
       stageDefinition.getBuildInfo().getId()
     );
-    return TaskResult.ofStatus(build.getStatus().getExecutionStatus());
+    Map<String, Object> context = new HashMap<>();
+    context.put("buildInfo", build);
+    return TaskResult.builder(build.getStatus().getExecutionStatus()).context(context).build();
   }
 
   @Override

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
@@ -40,6 +40,6 @@ public class StartGoogleCloudBuildTask implements Task {
     GoogleCloudBuild result = igorService.createGoogleCloudBuild(stageDefinition.getAccount(), stageDefinition.getBuildDefinition());
     Map<String, Object> context = stage.getContext();
     context.put("buildInfo", result);
-    return TaskResult.SUCCEEDED;
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(context).build();
   }
 }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTaskSpec.groovy
@@ -40,6 +40,10 @@ class MonitorGoogleCloudBuildTaskSpec extends Specification {
   @Unroll
   def "task returns #executionStatus when build returns #buildStatus"() {
     given:
+    def igorResponse = GoogleCloudBuild.builder()
+      .id(BUILD_ID)
+      .status(GoogleCloudBuild.Status.valueOf(buildStatus))
+      .build()
     def stage = new Stage(execution, "googleCloudBuild", [
       account: ACCOUNT,
       buildInfo: [
@@ -51,12 +55,10 @@ class MonitorGoogleCloudBuildTaskSpec extends Specification {
     TaskResult result = task.execute(stage)
 
     then:
-    1 * igorService.getGoogleCloudBuild(ACCOUNT, BUILD_ID) >> GoogleCloudBuild.builder()
-      .id(BUILD_ID)
-      .status(GoogleCloudBuild.Status.valueOf(buildStatus))
-      .build()
+    1 * igorService.getGoogleCloudBuild(ACCOUNT, BUILD_ID) >>igorResponse
     0 * igorService._
     result.getStatus() == executionStatus
+    result.getContext().buildInfo == igorResponse
 
     where:
     buildStatus      | executionStatus

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
@@ -37,14 +37,16 @@ class StartGoogleCloudBuildTaskSpec extends Specification {
 
   def "starts a build"() {
     given:
+    def igorResponse = GoogleCloudBuild.builder()
+      .id("98edf783-162c-4047-9721-beca8bd2c275")
+      .build()
 
     when:
     def stage = new Stage(execution, "googleCloudBuild", [account: ACCOUNT, buildDefinition: BUILD])
     TaskResult result = task.execute(stage)
 
     then:
-    1 * igorService.createGoogleCloudBuild(ACCOUNT, BUILD) >> GoogleCloudBuild.builder()
-      .id("98edf783-162c-4047-9721-beca8bd2c275")
-      .build();
+    1 * igorService.createGoogleCloudBuild(ACCOUNT, BUILD) >> igorResponse
+    result.context.buildInfo == igorResponse
   }
 }


### PR DESCRIPTION
The refactor of TaskResult dropped setting the context in StartGoogleCloudBuildTask; restore it. We also should update the context each time we run MonitorGoogleCloudBuildTask so the context has an up-to-date status; add this.