### PR TITLE
feat(injectArtifact): inject artifacts stage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/artifacts/InjectArtifactStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/artifacts/InjectArtifactStage.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.artifacts;
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.artifacts.InjectArtifactTask;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InjectArtifactStage implements StageDefinitionBuilder {
+
+  @Override
+  public void taskGraph(Stage stage, TaskNode.Builder builder) {
+    builder.withTask(InjectArtifactTask.TASK_NAME, InjectArtifactTask.class);
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/InjectArtifactTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/InjectArtifactTask.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.artifacts;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
+import lombok.NonNull;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Objects;
+
+@Component
+public class InjectArtifactTask implements Task {
+  public static final String TASK_NAME = "injectArtifact";
+
+  private ArtifactResolver artifactResolver;
+  private OortService oort;
+  private RetrySupport retrySupport;
+  private ObjectMapper objectMapper = new ObjectMapper();
+
+  public InjectArtifactTask(ArtifactResolver artifactResolver, OortService oortService, RetrySupport retrySupport) {
+    this.artifactResolver = artifactResolver;
+    this.oort = oortService;
+    this.retrySupport = retrySupport;
+  }
+
+  @Override
+  public TaskResult execute(@NonNull Stage stage) {
+    Map<String, Object> task = stage.getContext();
+    String artifactId = (String) task.get("artifactId");
+
+    Artifact artifact = artifactResolver.getBoundArtifactForId(stage, artifactId);
+    if (artifact == null) {
+      throw new IllegalArgumentException("No artifact could be bound to '" + artifactId + "'");
+    }
+
+    artifact.setArtifactAccount((String) task.get("artifactAccount"));
+
+    InputStream fetchedArtifact = retrySupport.retry(() -> {
+      Response artifactBody = oort.fetchArtifact(artifact);
+      try {
+        return artifactBody.getBody().in();
+      } catch (Exception e) {
+        throw new IllegalStateException("Failed to fetch artifact.");
+      }
+    }, 10, 200, true);
+
+    try {
+      Map<String, Object> parsed = objectMapper.readValue(fetchedArtifact, new TypeReference<Map<String, Object>>(){});
+
+      // null values in the parsed result cause calls to TaskBuilder::context to throw an exception
+      // so we remove them to avoid that.
+      parsed.values().removeIf(Objects::isNull);
+
+      return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(parsed).build();
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to deserialize artifact as JSON: " + e.getMessage());
+    }
+
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/InjectArtifactTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/InjectArtifactTaskSpec.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.tasks.artifacts.InjectArtifactTask
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver
+import retrofit.client.Response
+import retrofit.mime.TypedString
+import spock.lang.Specification
+import spock.lang.Subject
+
+class InjectArtifactTaskSpec extends Specification{
+
+  def oortService = Mock(OortService)
+  def artifactResolver = Stub(ArtifactResolver) {
+    getBoundArtifactForId(*_) >> new Artifact()
+  }
+
+  @Subject
+  InjectArtifactTask task = new InjectArtifactTask(
+    artifactResolver,
+    oortService,
+    new RetrySupport()
+  )
+
+  def "parses JSON artifact into task outputs"() {
+    given:
+    def stage = new Stage(Stub(Execution), "injectArtifact", [
+      artifactId: "12345",
+      artifactAccount: "test",
+    ])
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * oortService.fetchArtifact(*_) >> new Response('http://oort.com', 200, 'Okay', [], new TypedString(response))
+    0 * oortService._
+    result.status == ExecutionStatus.SUCCEEDED
+    result.context == expected
+
+    where:
+    response                           | expected
+    '{"foo": "bar"}'                   | ['foo': 'bar']
+    '{"foo": "bar", "tobenull": null}' | ['foo': 'bar']
+  }
+}


### PR DESCRIPTION
the `InjectArtifactStage` fetches an artifact, parses it and returns it
to the stage context. this can be useful for when jobs produce artifacts
that aren't deployable but may influence the flow of a pipeline or have
data that can be used in other downstream stages.