### PR TITLE
 feat(gcb): Allow the build definition to come from an artifact 

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.igor.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import lombok.Getter;
 
 import java.util.Map;
@@ -27,6 +28,10 @@ public class GoogleCloudBuildStageDefinition implements RetryableStageDefinition
   private final String account;
   private final GoogleCloudBuild buildInfo;
   private final Map<String, Object> buildDefinition;
+  private final String buildDefinitionSource;
+  private final String buildDefinitionArtifactAccount;
+  private final Artifact buildDefinitionArtifact;
+  private final String buildDefinitionArtifactId;
   private final int consecutiveErrors;
 
   // There does not seem to be a way to auto-generate a constructor using our current version of Lombok (1.16.20) that
@@ -35,11 +40,19 @@ public class GoogleCloudBuildStageDefinition implements RetryableStageDefinition
     @JsonProperty("account") String account,
     @JsonProperty("buildInfo") GoogleCloudBuild build,
     @JsonProperty("buildDefinition") Map<String, Object> buildDefinition,
+    @JsonProperty("buildDefinitionSource") String buildDefinitionSource,
+    @JsonProperty("buildDefinitionArtifactAccount") String buildDefinitionArtifactAccount,
+    @JsonProperty("buildDefinitionArtifact") Artifact buildDefinitionArtifact,
+    @JsonProperty("buildDefinitionArtifactId") String buildDefinitionArtifactId,
     @JsonProperty("consecutiveErrors") Integer consecutiveErrors
   ) {
     this.account = account;
     this.buildInfo = build;
     this.buildDefinition = buildDefinition;
+    this.buildDefinitionSource = buildDefinitionSource;
+    this.buildDefinitionArtifactAccount = buildDefinitionArtifactAccount;
+    this.buildDefinitionArtifact = buildDefinitionArtifact;
+    this.buildDefinitionArtifactId = buildDefinitionArtifactId;
     this.consecutiveErrors = Optional.ofNullable(consecutiveErrors).orElse(0);
   }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
@@ -16,30 +16,80 @@
 
 package com.netflix.spinnaker.orca.igor.tasks;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.Task;
 import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.igor.IgorService;
 import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuild;
 import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildStageDefinition;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import retrofit.client.Response;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class StartGoogleCloudBuildTask implements Task {
   private final IgorService igorService;
+  private final OortService oortService;
+  private final ArtifactResolver artifactResolver;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final RetrySupport retrySupport = new RetrySupport();
+  private static final ThreadLocal<Yaml> yamlParser = ThreadLocal.withInitial(() -> new Yaml(new SafeConstructor()));
 
   @Override
   @Nonnull public TaskResult execute(@Nonnull Stage stage) {
     GoogleCloudBuildStageDefinition stageDefinition = stage.mapTo(GoogleCloudBuildStageDefinition.class);
-    GoogleCloudBuild result = igorService.createGoogleCloudBuild(stageDefinition.getAccount(), stageDefinition.getBuildDefinition());
+
+    Map<String, Object> buildDefinition;
+    if (stageDefinition.getBuildDefinitionSource() != null && stageDefinition.getBuildDefinitionSource().equals("artifact")) {
+      buildDefinition = getBuildDefinitionFromArtifact(stage, stageDefinition);
+    } else {
+      buildDefinition = stageDefinition.getBuildDefinition();
+    }
+    GoogleCloudBuild result = igorService.createGoogleCloudBuild(stageDefinition.getAccount(), buildDefinition);
     Map<String, Object> context = stage.getContext();
     context.put("buildInfo", result);
     return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(context).build();
   }
+
+  private Map<String, Object> getBuildDefinitionFromArtifact(@Nonnull Stage stage, GoogleCloudBuildStageDefinition stageDefinition) {
+    Artifact buildDefinitionArtifact = artifactResolver.getBoundArtifactForStage(stage, stageDefinition.getBuildDefinitionArtifactId(),
+      stageDefinition.getBuildDefinitionArtifact());
+
+    if (buildDefinitionArtifact == null) {
+      throw new IllegalArgumentException("No manifest artifact was specified.");
+    }
+
+    if(stageDefinition.getBuildDefinitionArtifactAccount() != null) {
+      buildDefinitionArtifact.setArtifactAccount(stageDefinition.getBuildDefinitionArtifactAccount());
+    }
+
+    if (buildDefinitionArtifact.getArtifactAccount() == null) {
+      throw new IllegalArgumentException("No manifest artifact account was specified.");
+    }
+
+    return retrySupport.retry(() -> {
+      try {
+        Response buildText = oortService.fetchArtifact(buildDefinitionArtifact);
+        Object result = yamlParser.get().load(buildText.getBody().in());
+        return (Map<String, Object>) result;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 10, 200, false);
+  }
 }
+

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
@@ -18,10 +18,12 @@ package com.netflix.spinnaker.orca.igor.tasks
 
 
 import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.igor.IgorService
 import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuild
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -31,9 +33,11 @@ class StartGoogleCloudBuildTaskSpec extends Specification {
 
   Execution execution = Mock(Execution)
   IgorService igorService = Mock(IgorService)
+  OortService oortService = Mock(OortService)
+  ArtifactResolver artifactResolver = Mock(ArtifactResolver)
 
   @Subject
-  StartGoogleCloudBuildTask task = new StartGoogleCloudBuildTask(igorService)
+  StartGoogleCloudBuildTask task = new StartGoogleCloudBuildTask(igorService, oortService, artifactResolver)
 
   def "starts a build"() {
     given:


### PR DESCRIPTION
* feat(gcb): Allow the build definition to come from an artifact 

  As an alternative to having the build definition inline in the stage, allow it to come from an artifact.

* chore(gcb): nest gcb artifact properties under one key 