### PR TITLE
New endpoint to list correlated executions

### DIFF
--- a/gradle/groovy.gradle
+++ b/gradle/groovy.gradle
@@ -26,4 +26,5 @@ dependencies {
   testImplementation("cglib:cglib-nodep")
   testImplementation("org.objenesis:objenesis")
   testImplementation("org.codehaus.groovy:groovy-all")
+  testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -76,9 +76,16 @@ dependencies {
   testImplementation("org.spockframework:spock-core")
   testImplementation("org.spockframework:spock-spring")
   testImplementation("org.springframework:spring-test")
+  testImplementation("org.springframework.security:spring-security-test")
   testImplementation("cglib:cglib-nodep")
   testImplementation("org.objenesis:objenesis")
-  testImplementation("junit:junit")
+  testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.hamcrest:hamcrest-core:1.3")
   testImplementation("com.netflix.spinnaker.keiko:keiko-mem:$keikoVersion")
+}
+
+test {
+  useJUnitPlatform {
+    includeEngines("junit-jupiter", "junit-vintage")
+  }
 }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/CorrelatedTasksController.java
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/CorrelatedTasksController.java
@@ -1,0 +1,51 @@
+package com.netflix.spinnaker.orca.controllers;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION;
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE;
+import static java.util.stream.Collectors.toList;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+public class CorrelatedTasksController {
+
+  private final ExecutionRepository executionRepository;
+
+  @Autowired
+  public CorrelatedTasksController(ExecutionRepository executionRepository) {
+    this.executionRepository = executionRepository;
+  }
+
+  @GetMapping(
+    path = "/executions/correlated/{correlationId}",
+    produces = APPLICATION_JSON_VALUE
+  )
+  public List<String> getCorrelatedExecutions(@PathVariable String correlationId) {
+    return Stream
+      .<Execution>builder()
+      .add(getCorrelated(PIPELINE, correlationId))
+      .add(getCorrelated(ORCHESTRATION, correlationId))
+      .build()
+      .filter(Objects::nonNull)
+      .map(Execution::getId)
+      .collect(toList());
+  }
+
+  private Execution getCorrelated(ExecutionType executionType, String correlationId) {
+    try {
+      return executionRepository.retrieveByCorrelationId(executionType, correlationId);
+    } catch (ExecutionNotFoundException ignored) {
+      return null;
+    }
+  }
+}

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/CorrelatedTasksControllerTest.java
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/CorrelatedTasksControllerTest.java
@@ -1,0 +1,89 @@
+package com.netflix.spinnaker.orca.controllers;
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
+import com.netflix.spinnaker.orca.test.model.ExecutionBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHESTRATION;
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE;
+import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+  classes = {CorrelatedTasksController.class},
+  webEnvironment = MOCK
+)
+@AutoConfigureMockMvc
+@EnableWebMvc
+@WithMockUser("Bea O'Problem")
+class CorrelatedTasksControllerTest {
+
+  @MockBean ExecutionRepository executionRepository;
+
+  @Autowired
+  MockMvc mvc;
+
+  final String correlationId = randomUUID().toString();
+  final MockHttpServletRequestBuilder request = get(
+    "/executions/correlated/{correlationId}",
+    correlationId
+  );
+
+  @Test
+  void returnsEmptyResponseIfNoCorrelatedExecutionsExist() throws Exception {
+    when(executionRepository.retrieveByCorrelationId(any(), eq(correlationId)))
+      .thenThrow(ExecutionNotFoundException.class);
+
+    mvc
+      .perform(request)
+      .andExpect(status().is2xxSuccessful())
+      .andExpect(content().json("[]"));
+  }
+
+  @Test
+  void returnsIdsOfAnyCorrelatedPipelines() throws Exception {
+    Execution pipeline = ExecutionBuilder.pipeline();
+    when(executionRepository.retrieveByCorrelationId(PIPELINE, correlationId))
+      .thenReturn(pipeline);
+    when(executionRepository.retrieveByCorrelationId(ORCHESTRATION, correlationId))
+      .thenThrow(ExecutionNotFoundException.class);
+
+    mvc
+      .perform(request)
+      .andExpect(status().is2xxSuccessful())
+      .andExpect(content().json(format("[\"%s\"]", pipeline.getId())));
+  }
+
+  @Test
+  void returnsIdsOfAnyCorrelatedOrchestrations() throws Exception {
+    Execution orchestration = ExecutionBuilder.orchestration();
+    when(executionRepository.retrieveByCorrelationId(PIPELINE, correlationId))
+      .thenThrow(ExecutionNotFoundException.class);
+    when(executionRepository.retrieveByCorrelationId(ORCHESTRATION, correlationId))
+      .thenReturn(orchestration);
+
+    mvc
+      .perform(request)
+      .andExpect(status().is2xxSuccessful())
+      .andExpect(content().json(format("[\"%s\"]", orchestration.getId())));
+  }
+}


### PR DESCRIPTION
I want to avoid writing redundant resource history in Keel so rather than blindly submitting tasks and relying on Orca to de-dupe using the correlation id I'd like to first see if there are any in-flight tasks and if so do nothing in Keel.