### PR TITLE
feat(pipelines): Add validation errors to failure message

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
@@ -96,7 +96,7 @@ class PipelineTemplatePreprocessor
       }
     }
 
-    recordRequest(context, context.getErrors().hasErrors(false))
+    recordRequest(context, !context.getErrors().hasErrors(false))
 
     log.debug("Handler chain complete")
     return context.getProcessedOutput()


### PR DESCRIPTION
If a pipeline fails to start due to a validation error (thrown by the MPT parsers), add the error information to the reason message displayed in Deck. Depends on https://github.com/spinnaker/echo/pull/546 to work.

Examples:
![image](https://user-images.githubusercontent.com/155558/57559682-5bd35f80-7383-11e9-9e5d-00e688cec09d.png)

![image](https://user-images.githubusercontent.com/155558/57559688-61c94080-7383-11e9-90e6-0224a11a0df9.png)