### PR TITLE
fix(runJob): use explicit artifact source

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.java
@@ -45,7 +45,7 @@ public class RunJobStage implements StageDefinitionBuilder {
       builder.withTask(BindProducedArtifactsTask.TASK_NAME, BindProducedArtifactsTask.class);
     }
 
-    if (stage.getContext().containsKey("consumeArtifactId")) {
+    if (stage.getContext().getOrDefault("consumeArtifactSource", "").toString().equalsIgnoreCase("artifact")) {
       builder.withTask(ConsumeArtifactTask.TASK_NAME, ConsumeArtifactTask.class);
     }
   }


### PR DESCRIPTION
using an explicit artifact source makes it easier to define the stage
such that we don't have to guess what the source type is.