### PR TITLE
fix(MPTv1): Fix template expansion

### DIFF
--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -8,10 +8,7 @@ dependencies {
   implementation(project(":orca-front50"))
   implementation(project(":orca-clouddriver"))
 
-  implementation("com.hubspot.jinjava:jinjava:2.2.3") {
-    force = true
-  }
-
+  implementation("com.hubspot.jinjava:jinjava")
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
   implementation("com.jayway.jsonpath:json-path:2.2.0")

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/RenderTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/RenderTransform.java
@@ -186,6 +186,7 @@ public class RenderTransform implements PipelineTemplateVisitor {
               .withCause("Received type " + rendered.getClass().toString())
               .withLocation(context.getLocation()));
     }
+    context.getVariables().putAll((Map<String, Object>) rendered);
     stage.setConfig((Map<String, Object>) rendered);
 
     stage.setName(


### PR DESCRIPTION
With kork-bom, we have picked up a new version of jinjava (despite the force=true
directive to gradle which doesn't work in bom scenarios where first one wins)
Anyway, old jinjava would handle missing variables by evaluating the expression to false;
new jinjava throws.
When a stage has a `{when}` condition that uses a variable that was part of the stage config
that variable doesn't get added to the context until we process the stage the second time!
Add those variables to the context on the first time round to make template expansion happy
