### PR TITLE
fix(executionprocessor): add @Order to execution processors

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/preprocessors/DefaultApplicationExecutionPreprocessor.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/preprocessors/DefaultApplicationExecutionPreprocessor.kt
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.orca.preprocessors
 
 import com.netflix.spinnaker.orca.config.DefaultApplicationConfigurationProperties
 import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
+import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 import javax.annotation.Nonnull
 
@@ -24,6 +25,7 @@ import javax.annotation.Nonnull
  * Populates an Execution config payload with a default application value if one is not provided.
  */
 @Component
+@Order(1)
 class DefaultApplicationExecutionPreprocessor(
   private val properties: DefaultApplicationConfigurationProperties
 ) : ExecutionPreprocessor {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
@@ -27,11 +27,13 @@ import com.netflix.spinnaker.orca.pipelinetemplate.handler.SchemaVersionHandler
 import com.netflix.spinnaker.orca.pipelinetemplate.v2schema.model.V2PipelineTemplate
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 import javax.annotation.Nonnull
 import javax.annotation.PostConstruct
 
 @Component("pipelineTemplatePreprocessor")
+@Order(1)
 class PipelineTemplatePreprocessor
 @Autowired constructor(
   private val pipelineTemplateObjectMapper: ObjectMapper,

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
@@ -33,7 +33,7 @@ import javax.annotation.Nonnull
 import javax.annotation.PostConstruct
 
 @Component("pipelineTemplatePreprocessor")
-@Order(1)
+@Order(2)
 class PipelineTemplatePreprocessor
 @Autowired constructor(
   private val pipelineTemplateObjectMapper: ObjectMapper,

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -78,10 +78,10 @@ class OperationsController {
   ContextParameterProcessor contextParameterProcessor
 
   @Autowired(required = false)
-  List<ExecutionPreprocessor> executionPreprocessors = new ArrayList<>();
+  List<ExecutionPreprocessor> executionPreprocessors = new ArrayList<>()
 
   @Autowired(required = false)
-  private List<PipelineModelMutator> pipelineModelMutators = new ArrayList<>();
+  private List<PipelineModelMutator> pipelineModelMutators = new ArrayList<>()
 
   @Autowired(required = false)
   WebhookService webhookService
@@ -103,24 +103,24 @@ class OperationsController {
 
   @RequestMapping(value = "/orchestrate", method = RequestMethod.POST)
   Map<String, Object> orchestrate(@RequestBody Map pipeline, HttpServletResponse response) {
-    planOrOrchestratePipeline(pipeline)
+    return planOrOrchestratePipeline(pipeline)
   }
 
   @RequestMapping(value = "/orchestrate/{pipelineConfigId}", method = RequestMethod.POST)
   Map<String, Object> orchestratePipelineConfig(@PathVariable String pipelineConfigId, @RequestBody Map trigger) {
     Map pipelineConfig = buildPipelineConfig(pipelineConfigId, trigger)
-    planOrOrchestratePipeline(pipelineConfig)
+    return planOrOrchestratePipeline(pipelineConfig)
   }
 
   @RequestMapping(value = "/plan", method = RequestMethod.POST)
   Map<String, Object> plan(@RequestBody Map pipeline, @Query("resolveArtifacts") boolean resolveArtifacts, HttpServletResponse response) {
-    planPipeline(pipeline, resolveArtifacts)
+    return planPipeline(pipeline, resolveArtifacts)
   }
 
   @RequestMapping(value = "/plan/{pipelineConfigId}", method = RequestMethod.POST)
   Map<String, Object> planPipelineConfig(@PathVariable String pipelineConfigId, @Query("resolveArtifacts") boolean resolveArtifacts, @RequestBody Map trigger) {
     Map pipelineConfig = buildPipelineConfig(pipelineConfigId, trigger)
-    planPipeline(pipelineConfig, resolveArtifacts)
+    return planPipeline(pipelineConfig, resolveArtifacts)
   }
 
   private Map buildPipelineConfig(String pipelineConfigId, Map trigger) {
@@ -139,9 +139,9 @@ class OperationsController {
 
   private Map planOrOrchestratePipeline(Map pipeline) {
     if (pipeline.plan) {
-      planPipeline(pipeline, false)
+      return planPipeline(pipeline, false)
     } else {
-      orchestratePipeline(pipeline)
+      return orchestratePipeline(pipeline)
     }
   }
 


### PR DESCRIPTION
This allows an execution processor to specify order of invocation.
This is useful (/ needed) when an preprocessor needs to operate on a
fully instantiated pipeline. If the pipeline is templated it won't be
fully instantiated till the templatepreprocessor runs.
