### PR TITLE
fix(boot2): camel to kebab for fast properties

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/conditions/ConditionConfigurationProperties.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/conditions/ConditionConfigurationProperties.java
@@ -39,7 +39,7 @@ public class ConditionConfigurationProperties {
   }
 
   public boolean isEnabled() {
-    return configService.getConfig(Boolean.class, "tasks.evaluateCondition", enabled);
+    return configService.getConfig(Boolean.class, "tasks.evaluate-condition", enabled);
   }
 
   public void setEnabled(boolean enabled) {
@@ -48,7 +48,7 @@ public class ConditionConfigurationProperties {
 
   public Long getBackoffWaitMs() {
     return configService.getConfig(
-        Long.class, "tasks.evaluateCondition.backoffWaitMs", backoffWaitMs);
+        Long.class, "tasks.evaluate-condition.backoff-wait-ms", backoffWaitMs);
   }
 
   public void setBackoffWaitMs(Long backoffWaitMs) {
@@ -57,7 +57,7 @@ public class ConditionConfigurationProperties {
 
   public long getWaitTimeoutMs() {
     return configService.getConfig(
-        Long.class, "tasks.evaluateCondition.waitTimeoutMs", waitTimeoutMs);
+        Long.class, "tasks.evaluate-condition.wait-timeout-ms", waitTimeoutMs);
   }
 
   public void setWaitTimeoutMs(long waitTimeoutMs) {
@@ -65,12 +65,12 @@ public class ConditionConfigurationProperties {
   }
 
   public List<String> getClusters() {
-    return configService.getConfig(List.class, "tasks.evaluateCondition.clusters", clusters);
+    return configService.getConfig(List.class, "tasks.evaluate-condition.clusters", clusters);
   }
 
   public List<String> getActiveConditions() {
     return configService.getConfig(
-        List.class, "tasks.evaluateCondition.activeConditions", activeConditions);
+        List.class, "tasks.evaluate-condition.active-conditions", activeConditions);
   }
 
   public void setClusters(List<String> clusters) {
@@ -82,6 +82,6 @@ public class ConditionConfigurationProperties {
   }
 
   public boolean isSkipWait() {
-    return configService.getConfig(Boolean.class, "tasks.evaluateCondition.skipWait", false);
+    return configService.getConfig(Boolean.class, "tasks.evaluate-condition.skip-wait", false);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.cluster
 
-import java.util.function.Function
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuard.java
@@ -39,7 +39,7 @@ import retrofit.RetrofitError;
 
 @Component
 public class TrafficGuard {
-  private static final String MIN_CAPACITY_RATIO = "trafficGuards.minCapacityRatio";
+  private static final String MIN_CAPACITY_RATIO = "traffic-guards.min-capacity-ratio";
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final OortHelper oortHelper;

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockingConfigurationProperties.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/locks/LockingConfigurationProperties.java
@@ -35,7 +35,7 @@ public class LockingConfigurationProperties {
   }
 
   public boolean isLearningMode() {
-    return dynamicConfigService.getConfig(Boolean.class, "locking.learningMode", learningMode);
+    return dynamicConfigService.getConfig(Boolean.class, "locking.learning-mode", learningMode);
   }
 
   public void setLearningMode(boolean learningMode) {
@@ -51,7 +51,7 @@ public class LockingConfigurationProperties {
   }
 
   public int getTtlSeconds() {
-    return dynamicConfigService.getConfig(Integer.class, "locking.ttlSeconds", ttlSeconds);
+    return dynamicConfigService.getConfig(Integer.class, "locking.ttl-seconds", ttlSeconds);
   }
 
   public void setTtlSeconds(int ttlSeconds) {
@@ -60,7 +60,7 @@ public class LockingConfigurationProperties {
 
   public int getBackoffBufferSeconds() {
     return dynamicConfigService.getConfig(
-        Integer.class, "locking.backoffBufferSeconds", backoffBufferSeconds);
+        Integer.class, "locking.backoff-buffer-seconds", backoffBufferSeconds);
   }
 
   public void setBackoffBufferSeconds(int backoffBufferSeconds) {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
@@ -23,6 +23,7 @@ import static com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner.STAG
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
+import com.google.common.base.CaseFormat;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.orca.pipeline.TaskNode.TaskGraph;
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
@@ -165,8 +166,10 @@ public interface StageDefinitionBuilder {
     try {
       return dynamicConfigService.isEnabled(
           String.format(
-              "stages.%s.forceCacheRefresh",
-              Character.toLowerCase(className.charAt(0)) + className.substring(1)),
+              "stages.%s.force-cache-refresh",
+              CaseFormat.LOWER_CAMEL.to(
+                  CaseFormat.LOWER_HYPHEN,
+                  Character.toLowerCase(className.charAt(0)) + className.substring(1))),
           true);
     } catch (Exception e) {
       return true;

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilderSpec.groovy
@@ -33,7 +33,7 @@ class StageDefinitionBuilderSpec extends Specification {
     def isForceCacheRefreshEnabled = stageDefinitionBuilder.isForceCacheRefreshEnabled(dynamicConfigService)
 
     then:
-    1 * dynamicConfigService.isEnabled("stages.myStageDefinitionBuilder.forceCacheRefresh", true) >> {
+    1 * dynamicConfigService.isEnabled("stages.my-stage-definition-builder.force-cache-refresh", true) >> {
       return response()
     }
     0 * _

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionBufferActuator.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionBufferActuator.kt
@@ -67,7 +67,7 @@ class ExecutionBufferActuator(
       withActionDecision(execution) {
         when (it.action) {
           BUFFER -> {
-            if (configService.isEnabled("qos.learningMode", true)) {
+            if (configService.isEnabled("qos.learning-mode", true)) {
               log.debug("Learning mode: Would have buffered execution {} (using $supplierName), reason: ${it.reason}", value("executionId", execution.id))
               registry.counter(bufferedId.withTag("learning", "true")).increment()
             } else {

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferpolicy/NaiveBufferPolicy.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferpolicy/NaiveBufferPolicy.kt
@@ -29,7 +29,7 @@ class NaiveBufferPolicy(
 ) : BufferPolicy {
 
   override fun apply(execution: Execution): BufferResult {
-    if (!configService.isEnabled("qos.bufferPolicy.naive", true)) {
+    if (!configService.isEnabled("qos.buffer-policy.naive", true)) {
       return BufferResult(ENQUEUE, false, "Naive policy is disabled")
     }
     return BufferResult(

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferstate/ActiveExecutionsBufferStateSupplier.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferstate/ActiveExecutionsBufferStateSupplier.kt
@@ -72,8 +72,8 @@ class ActiveExecutionsBufferStateSupplier(
   override fun get() = state
 
   override fun enabled() =
-    configService.getConfig(String::class.java, "qos.bufferingState.supplier", "") == "activeExecutions"
+    configService.getConfig(String::class.java, "qos.buffering-state.supplier", "") == "activeExecutions"
 
   private fun getThreshold() =
-    configService.getConfig(Int::class.java, "qos.bufferingState.activeExecutions.threshold", 100)
+    configService.getConfig(Int::class.java, "qos.buffering-state.active-executions.threshold", 100)
 }

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferstate/KillSwitchBufferStateSupplier.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/bufferstate/KillSwitchBufferStateSupplier.kt
@@ -28,10 +28,10 @@ class KillSwitchBufferStateSupplier(
 ) : BufferStateSupplier {
 
   override fun enabled() =
-    configService.getConfig(String::class.java, "qos.bufferingState.supplier", "") == "killSwitch"
+    configService.getConfig(String::class.java, "qos.buffering-state.supplier", "") == "killSwitch"
 
   override fun get() =
-    when (configService.isEnabled("qos.bufferingState.killSwitch", false)) {
+    when (configService.isEnabled("qos.buffering-state.kill-switch", false)) {
       true -> ACTIVE
       false -> INACTIVE
     }

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/promotionpolicy/NaivePromotionPolicy.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/promotionpolicy/NaivePromotionPolicy.kt
@@ -27,11 +27,11 @@ class NaivePromotionPolicy(
 ) : PromotionPolicy {
 
   override fun apply(candidates: List<Execution>): PromotionResult {
-    if (!configService.isEnabled("qos.promotionPolicy.naive", true)) {
+    if (!configService.isEnabled("qos.promotion-policy.naive", true)) {
       return PromotionResult(candidates, false, "Naive policy is disabled")
     }
 
-    val maxPromoteSize = configService.getConfig(Int::class.java, "qos.promotionPolicy.naive.size", 1)
+    val maxPromoteSize = configService.getConfig(Int::class.java, "qos.promotion-policy.naive.size", 1)
     val promoteSize = if (maxPromoteSize > candidates.size) candidates.size else maxPromoteSize
 
     return PromotionResult(

--- a/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/ExecutionBufferActuatorTest.kt
+++ b/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/ExecutionBufferActuatorTest.kt
@@ -61,7 +61,7 @@ class ExecutionBufferActuatorTest : SubjectSpek<ExecutionBufferActuator>({
   describe("buffering executions") {
     beforeGroup {
       whenever(configService.isEnabled(eq("qos"), any())) doReturn true
-      whenever(configService.isEnabled(eq("qos.learningMode"), any())) doReturn false
+      whenever(configService.isEnabled(eq("qos.learning-mode"), any())) doReturn false
     }
     afterGroup(::resetMocks)
 


### PR DESCRIPTION
Looks like boot2 is not happy with the dynamic spring properties being camel case. Switching to kebab.