### PR TITLE
feat(clouddriver): favor configured capacity for certain operations

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTask.groovy
@@ -49,8 +49,17 @@ class WaitForCapacityMatchTask extends AbstractInstancesCheckTask {
         return false
       }
 
-      splainer.add("checking if capacity matches (capacity.desired=${serverGroup.capacity.desired}, instances.size()=${instances.size()}) ")
-      if (serverGroup.capacity.desired != instances.size()) {
+      Integer desired
+
+      if (WaitForUpInstancesTask.useConfiguredCapacity(stage, serverGroup.capacity as Map<String, Integer>)) {
+        desired = ((Map<String, Integer>) stage.context.capacity).desired
+        splainer.add("using desired from stage.context.capacity ($desired)")
+      } else {
+        desired = ((Map<String, Integer>)serverGroup.capacity).desired
+      }
+
+      splainer.add("checking if capacity matches (desired=${desired}, instances.size()=${instances.size()}) ")
+      if (desired != instances.size()) {
         splainer.add("short-circuiting out of WaitForCapacityMatchTask because expected and current capacity don't match}")
         return false
       }


### PR DESCRIPTION
- We generally calculate targetDesired for resize operations by trusting
that clouddriver's cache accurately reflects the new desired size when
waiting for a capacity match. This is often provided via an onDemand
cache object (force cache refresh). When the new configured capacity
doesn't allow for autoscaling, we can derive targetDesired directly from
the stage context. This assists the TitusStreamingUpdateAgent which
doesn't currently implement onDemand caching.