### PR TITLE
fix(kubernetes): force cache refresh after deploy stage artifact cleanup

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
@@ -51,6 +51,9 @@ public class DeployManifestStage implements StageDefinitionBuilder {
         .withTask(ManifestForceCacheRefreshTask.TASK_NAME, ManifestForceCacheRefreshTask.class)
         .withTask(WaitForManifestStableTask.TASK_NAME, WaitForManifestStableTask.class)
         .withTask(CleanupArtifactsTask.TASK_NAME, CleanupArtifactsTask.class)
+        .withTask("monitorCleanup", MonitorKatoTask.class)
+        .withTask(PromoteManifestKatoOutputsTask.TASK_NAME, PromoteManifestKatoOutputsTask.class)
+        .withTask(ManifestForceCacheRefreshTask.TASK_NAME, ManifestForceCacheRefreshTask.class)
         .withTask(BindProducedArtifactsTask.TASK_NAME, BindProducedArtifactsTask.class);
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestAware.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestAware.java
@@ -27,7 +27,12 @@ import java.util.logging.Logger;
 public interface ManifestAware {
   default Map<String, List<String>> manifestNamesByNamespace(Stage stage) {
     Map<String, List<String>> result =
-        (Map<String, List<String>>) stage.getContext().get("outputs.manifestNamesByNamespace");
+        (Map<String, List<String>>)
+            stage
+                .getContext()
+                .get(
+                    PromoteManifestKatoOutputsTask.outputKey(
+                        PromoteManifestKatoOutputsTask.MANIFESTS_BY_NAMESPACE_KEY));
     if (result != null) {
       return result;
     }
@@ -43,5 +48,23 @@ public interface ManifestAware {
     }
 
     return result;
+  }
+
+  default Map<String, List<String>> manifestsToRefresh(Stage stage) {
+    Map<String, List<String>> result =
+        (Map<String, List<String>>)
+            stage
+                .getContext()
+                .get(PromoteManifestKatoOutputsTask.MANIFESTS_BY_NAMESPACE_TO_REFRESH_KEY);
+    if (result != null
+        && (boolean)
+            stage
+                .getContext()
+                .get(
+                    PromoteManifestKatoOutputsTask
+                        .SHOULD_REFRESH_MANIFESTS_BY_NAMESPACE_TO_REFRESH_KEY)) {
+      return result;
+    }
+    return manifestNamesByNamespace(stage);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
@@ -112,6 +112,9 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
     StageData stageData = fromStage(stage);
     stageData.deployedManifests = getDeployedManifests(stage);
 
+    // Clear manifests to be refreshed
+    stageData.shouldRefreshManifestNamesByNamespaceToRefresh = false;
+
     checkPendingRefreshes(cloudProvider, stageData, startTime);
 
     refreshManifests(cloudProvider, stageData);
@@ -220,7 +223,7 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
 
   private List<ScopedManifest> getDeployedManifests(Stage stage) {
     String account = getCredentials(stage);
-    Map<String, List<String>> deployedManifests = manifestNamesByNamespace(stage);
+    Map<String, List<String>> deployedManifests = manifestsToRefresh(stage);
     return deployedManifests.entrySet().stream()
         .flatMap(e -> e.getValue().stream().map(v -> new ScopedManifest(account, e.getKey(), v)))
         .collect(Collectors.toList());
@@ -288,6 +291,8 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
     Set<ScopedManifest> processedManifests = new HashSet<>();
 
     Set<String> errors = new HashSet<>();
+
+    boolean shouldRefreshManifestNamesByNamespaceToRefresh;
   }
 
   @Value

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PromoteManifestKatoOutputsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PromoteManifestKatoOutputsTask.java
@@ -45,10 +45,13 @@ public class PromoteManifestKatoOutputsTask implements Task {
   private static final TypeReference<List<Artifact>> artifactListType =
       new TypeReference<List<Artifact>>() {};
   private static final String MANIFESTS_KEY = "manifests";
-  private static final String MANIFESTS_BY_NAMESPACE_KEY = "manifestNamesByNamespace";
+  static final String MANIFESTS_BY_NAMESPACE_KEY = "manifestNamesByNamespace";
   private static final String BOUND_ARTIFACTS_KEY = "boundArtifacts";
   private static final String CREATED_ARTIFACTS_KEY = "createdArtifacts";
   private static final String ARTIFACTS_KEY = "artifacts";
+  static final String MANIFESTS_BY_NAMESPACE_TO_REFRESH_KEY = "manifestNamesByNamespaceToRefresh";
+  static final String SHOULD_REFRESH_MANIFESTS_BY_NAMESPACE_TO_REFRESH_KEY =
+      "shouldRefreshManifestNamesByNamespaceToRefresh";
 
   @Autowired ObjectMapper objectMapper;
 
@@ -77,6 +80,14 @@ public class PromoteManifestKatoOutputsTask implements Task {
     addToOutputs(outputs, allResults, CREATED_ARTIFACTS_KEY, ARTIFACTS_KEY);
     convertKey(outputs, ARTIFACTS_KEY, artifactListType);
 
+    // Surface the most recently operated-on manifests for subsequent ManifestForceCacheRefreshTasks
+    addMostRecentValueToOutputs(
+        outputs, allResults, MANIFESTS_BY_NAMESPACE_KEY, MANIFESTS_BY_NAMESPACE_TO_REFRESH_KEY);
+
+    outputs.put(
+        SHOULD_REFRESH_MANIFESTS_BY_NAMESPACE_TO_REFRESH_KEY,
+        outputs.get(MANIFESTS_BY_NAMESPACE_TO_REFRESH_KEY) != null);
+
     return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).outputs(outputs).build();
   }
 
@@ -84,7 +95,7 @@ public class PromoteManifestKatoOutputsTask implements Task {
     outputs.computeIfPresent(key, (k, v) -> objectMapper.convertValue(v, tr));
   }
 
-  private String outputKey(String input) {
+  static String outputKey(String input) {
     return "outputs." + input;
   }
 
@@ -95,6 +106,17 @@ public class PromoteManifestKatoOutputsTask implements Task {
   private void addToOutputs(
       Map<String, Object> outputs, List<Map> allResults, String key, String targetKey) {
     Optional value = allResults.stream().map(m -> m.get(key)).filter(Objects::nonNull).findFirst();
+
+    value.ifPresent(m -> outputs.put(targetKey, m));
+  }
+
+  private void addMostRecentValueToOutputs(
+      Map<String, Object> outputs, List<Map> allResults, String key, String targetKey) {
+    Optional value =
+        allResults.stream()
+            .map(m -> m.get(key))
+            .filter(Objects::nonNull)
+            .reduce((first, second) -> second);
 
     value.ifPresent(m -> outputs.put(targetKey, m));
   }


### PR DESCRIPTION
Addresses: https://github.com/spinnaker/spinnaker/issues/4422
Related PR: https://github.com/spinnaker/clouddriver/pull/3711

When using Kubernetes V2 Rollout Strategies with the `max-version-history` annotation, Clouddriver sometimes tries to disable a previously-deleted ReplicaSet because we are not refreshing the cache after the Deploy Manifest stage's `CleanupArtifactsTask`. Adds `MonitorKatoTask`, `PromoteManifestKatoOutputsTask`, and `ManifestForceCacheRefreshTask` in order to prevent this.

Previously, each stage had at most one `PromoteManifestKatoOutputsTask`, which composes the outputs of each kato task's outputs by taking the *first* non-null output value at each relevant key. In this case, our cleanup task's `outputs.manifestNamesByNamespace` was never being surfaced because this task would only surface the first kato task's (the Deploy task's) `outputs.manifestNamesByNamespace`. This adds a `manifestNamesByNamespaceToRefresh` key, which will be populated by the most recent task's `manifestNamesByNamespace` and cleared at every run of `ManifestForceCacheRefreshTask`. Continues to also check `manifestNamesByNamespace` when finding manifests to refresh because not all `ManifestForceCacheRefreshTask`s are preceded by `PromoteManifestKatoOutputsTask`s.