### PR TITLE
fix(config): fix bakery port in orca-web/config

### DIFF
--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -23,7 +23,7 @@ igor:
   baseUrl: http://localhost:8088
 bakery:
   enabled: true
-  baseUrl: http://localhost:8089
+  baseUrl: http://localhost:8087
   # Rosco exposes more endpoints than Netflix's internal bakery. This disables
   # the use of those endpoints.
   roscoApisEnabled: true


### PR DESCRIPTION
rosco service listens port 8087, 8089 is listened by echo instead
