### PR TITLE
perf(orca): reuse ObjectMapper instances

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
@@ -33,7 +33,7 @@ import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.
  */
 trait DeploymentDetailsAware {
 
-  private ObjectMapper pipelineObjectMapper = OrcaObjectMapper.newInstance()
+  private ObjectMapper pipelineObjectMapper = OrcaObjectMapper.getInstance()
 
   void withImageFromPrecedingStage(
     Stage stage,

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -97,7 +97,7 @@ public class OrcaConfiguration {
 
   @Bean
   public ObjectMapper mapper() {
-    return OrcaObjectMapper.newInstance();
+    return OrcaObjectMapper.getInstance();
   }
 
   @Bean

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/jackson/OrcaObjectMapper.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/jackson/OrcaObjectMapper.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule;
 public class OrcaObjectMapper {
   private OrcaObjectMapper() {}
 
+  private static final ObjectMapper INSTANCE = newInstance();
+
   public static ObjectMapper newInstance() {
     ObjectMapper instance = new ObjectMapper();
     instance.registerModule(new Jdk8Module());
@@ -40,5 +42,16 @@ public class OrcaObjectMapper {
     instance.disable(FAIL_ON_UNKNOWN_PROPERTIES);
     instance.setSerializationInclusion(NON_NULL);
     return instance;
+  }
+
+  /**
+   * Return an ObjectMapper instance that can be reused. Do not change the configuration of this
+   * instance as it will be shared across the entire application, use {@link #newInstance()}
+   * instead.
+   *
+   * @return Reusable ObjectMapper instance
+   */
+  public static ObjectMapper getInstance() {
+    return INSTANCE;
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -436,7 +436,7 @@ public class Stage implements Serializable {
     return mapTo(null, type);
   }
 
-  @JsonIgnore private final transient ObjectMapper objectMapper = OrcaObjectMapper.newInstance();
+  @JsonIgnore private final transient ObjectMapper objectMapper = OrcaObjectMapper.getInstance();
 
   /**
    * Maps the stage's context to a typed object at a provided pointer. Uses <a

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/BuildDetailExtractor.java
@@ -31,7 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 public class BuildDetailExtractor {
 
   private final List<DetailExtractor> detailExtractors;
-  private final ObjectMapper mapper = OrcaObjectMapper.newInstance();
+  private final ObjectMapper mapper = OrcaObjectMapper.getInstance();
 
   public BuildDetailExtractor() {
     this.detailExtractors =

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
@@ -43,7 +43,7 @@ public class ContextParameterProcessor {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  private static final ObjectMapper mapper = OrcaObjectMapper.newInstance();
+  private static final ObjectMapper mapper = OrcaObjectMapper.getInstance();
 
   private ExpressionEvaluator expressionEvaluator;
 

--- a/orca-integrations-cloudfoundry/src/main/java/com/netflix/spinnaker/orca/cf/pipeline/expressions/functions/ServiceKeyExpressionFunctionProvider.java
+++ b/orca-integrations-cloudfoundry/src/main/java/com/netflix/spinnaker/orca/cf/pipeline/expressions/functions/ServiceKeyExpressionFunctionProvider.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ServiceKeyExpressionFunctionProvider implements ExpressionFunctionProvider {
   private static final String CREATE_SERVICE_KEY_STAGE_NAME = "createServiceKey";
-  private static final ObjectMapper objectMapper = OrcaObjectMapper.newInstance();
+  private static final ObjectMapper objectMapper = OrcaObjectMapper.getInstance();
 
   @Nullable
   @Override

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
@@ -45,7 +45,7 @@ public class PipelineTemplateService {
 
   private final Renderer renderer;
 
-  private final ObjectMapper mapper = OrcaObjectMapper.newInstance();
+  private final ObjectMapper mapper = OrcaObjectMapper.getInstance();
 
   @Autowired
   public PipelineTemplateService(

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
@@ -38,7 +38,7 @@ interface ExpressionAware {
   val contextParameterProcessor: ContextParameterProcessor
 
   companion object {
-    val mapper: ObjectMapper = OrcaObjectMapper.newInstance()
+    val mapper: ObjectMapper = OrcaObjectMapper.getInstance()
   }
 
   val log: Logger

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -79,7 +79,7 @@ public class RedisExecutionRepository implements ExecutionRepository {
 
   private final RedisClientDelegate redisClientDelegate;
   private final Optional<RedisClientDelegate> previousRedisClientDelegate;
-  private final ObjectMapper mapper = OrcaObjectMapper.newInstance();
+  private final ObjectMapper mapper = OrcaObjectMapper.getInstance();
   private final int chunkSize;
   private final Scheduler queryAllScheduler;
   private final Scheduler queryByAppScheduler;

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/web/config/WebConfiguration.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/web/config/WebConfiguration.groovy
@@ -53,7 +53,7 @@ class WebConfiguration extends WebMvcConfigurerAdapter {
   }
 
   @Bean(name = "objectMapper", autowire = Autowire.BY_TYPE) ObjectMapper orcaObjectMapper() {
-    OrcaObjectMapper.newInstance()
+    OrcaObjectMapper.getInstance()
   }
 
   @Bean


### PR DESCRIPTION
creating a new ObjectMapper instance for each Stage or other per-request
contexts can be wasteful; ObjectMapper is safe to reuse across threads
(after it is configured). See https://github.com/spinnaker/spinnaker/issues/4367 for more details.