### PR TITLE
perf(artifacts): only load prior artifacts when needed

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
@@ -59,7 +59,7 @@ public class FindArtifactFromExecutionTask implements Task {
         artifactResolver.getArtifactsForPipelineId(pipeline, executionOptions.toCriteria());
 
     Artifact match =
-        artifactResolver.resolveSingleArtifact(expectedArtifact, priorArtifacts, null, false);
+        artifactResolver.resolveSingleArtifact(expectedArtifact, priorArtifacts, false);
 
     if (match == null) {
       outputs.put(

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -35,7 +35,6 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.Execu
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +46,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import lombok.Data;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -393,12 +391,6 @@ public class ArtifactResolver {
     ArtifactResolutionException(String message, Throwable cause) {
       super(message, cause);
     }
-  }
-
-  @Data
-  public static class ResolveResult {
-    Set<Artifact> resolvedArtifacts = new HashSet<>();
-    Set<ExpectedArtifact> unresolvedExpectedArtifacts = new HashSet<>();
   }
 
   private static Func2<Execution, Execution, Integer> startTimeOrId =

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverSpec.groovy
@@ -242,7 +242,7 @@ class ArtifactResolverSpec extends Specification {
   def "should find a matching artifact for #expected"() {
     when:
     def artifactResolver = makeArtifactResolver()
-    def artifact = artifactResolver.resolveSingleArtifact(expected, existing, null, true)
+    def artifact = artifactResolver.resolveSingleArtifact(expected, existing,true)
 
     then:
     artifact == desired
@@ -258,7 +258,7 @@ class ArtifactResolverSpec extends Specification {
   def "should fail find a matching artifact for #expected"() {
     when:
     def artifactResolver = makeArtifactResolver()
-    def artifact = artifactResolver.resolveSingleArtifact(expected, existing, null, true)
+    def artifact = artifactResolver.resolveSingleArtifact(expected, existing, true)
 
     then:
     artifact == null


### PR DESCRIPTION
When a pipeline is triggered via `POST /orchestrate`,
OperationsController will resolve artifacts for the pipeline. The
behavior of `ArtifactResolver.resolveArtifacts(Map)` will load all
previous executions of the pipeline in order to find prior artifacts of
the pipeline (from the most recent execution), even if the
`priorArtifacts` list is never accessed (because the pipeline trigger
contains all expected artifacts).

This change tries to avoid the unnecessary loading of previous
executions / prior artifacts by wrapping the calls to
getArtifactsForPipelineId() etc in a `Supplier` so that the data (which
could be voluminous if old pipeline execution cleanup is not enabled) is
only loaded when truly needed.

To make the change a little bit smaller, I refactored the signature for
the public `resolveSingleArtifact` method to remove the `priorArtifacts`
parameter which was always null in all call sites.

See https://github.com/spinnaker/spinnaker/issues/4367 for more details.
