### PR TITLE
fix(artifacts): Use client error code for multiple matching artifacts

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -32,7 +32,15 @@ import com.netflix.spinnaker.orca.pipeline.model.StageContext;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository.ExecutionCriteria;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -310,7 +318,7 @@ public class ArtifactResolver {
         break;
       default:
         if (requireUniqueMatches) {
-          throw new IllegalArgumentException(
+          throw new InvalidRequestException(
               "Expected artifact " + expectedArtifact + " matches multiple artifacts " + matches);
         }
         result = matches.get(0);


### PR DESCRIPTION
Same fix as #2524, but for the case where multiple artifacts matches. Without this, Echo will try to trigger the pipeline five times and it will appear five times in the execution list.

PTAL @ezimanyi 