### PR TITLE
feat(aws/lambda): Lambda stage can handle arbitrary ops

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/LambdaFunctionStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/LambdaFunctionStage.java
@@ -16,7 +16,7 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws;
 
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
-import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.lambdaFunctionTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.LambdaFunctionTask;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
@@ -30,7 +30,7 @@ public class LambdaFunctionStage implements StageDefinitionBuilder {
   @Override
   public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
     builder
-        .withTask(lambdaFunctionTask.TASK_NAME, lambdaFunctionTask.class)
+        .withTask(LambdaFunctionTask.TASK_NAME, LambdaFunctionTask.class)
         .withTask("monitorLambdaFunction", MonitorKatoTask.class);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/LambdaFunctionStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/LambdaFunctionStage.java
@@ -16,7 +16,7 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws;
 
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
-import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.updateLambdaFunctionTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.lambdaFunctionTask;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
@@ -24,13 +24,13 @@ import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
-public class UpdateLambdaFunctionStage implements StageDefinitionBuilder {
-  public static final String PIPELINE_CONFIG_TYPE = "updateLambdaFunction";
+public class LambdaFunctionStage implements StageDefinitionBuilder {
+  public static final String PIPELINE_CONFIG_TYPE = "lambdaFunction";
 
   @Override
   public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
     builder
-        .withTask(updateLambdaFunctionTask.TASK_NAME, updateLambdaFunctionTask.class)
+        .withTask(lambdaFunctionTask.TASK_NAME, lambdaFunctionTask.class)
         .withTask("monitorLambdaFunction", MonitorKatoTask.class);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/LambdaFunctionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/LambdaFunctionTask.java
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Component;
   essentially just passes an arbitrary operation over to Clouddriver.
 */
 @Component
-public class lambdaFunctionTask extends AbstractCloudProviderAwareTask implements Task {
+public class LambdaFunctionTask extends AbstractCloudProviderAwareTask implements Task {
 
   @Autowired KatoService katoService;
 
@@ -52,7 +52,7 @@ public class lambdaFunctionTask extends AbstractCloudProviderAwareTask implement
     Map<String, Object> task = new HashMap<>(stage.getContext());
 
     String operationName = (String) task.get("operation");
-    if (!StringUtils.isNotBlank(operationName)) {
+    if (StringUtils.isBlank(operationName)) {
       throw new IllegalArgumentException(
           "Field 'operation' is missing and must be present in stage context");
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/lambdaFunctionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/lambdaFunctionTask.java
@@ -27,15 +27,22 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+/*
+  lambdaFunctionTask creates a Clouddriver operation using the field labeled
+  'operation'. The context of the task are added to the operation body. Users
+  will have to know what Clouddriver is expecting to use this task. It
+  essentially just passes an arbitrary operation over to Clouddriver.
+*/
 @Component
-public class updateLambdaFunctionTask extends AbstractCloudProviderAwareTask implements Task {
+public class lambdaFunctionTask extends AbstractCloudProviderAwareTask implements Task {
 
   @Autowired KatoService katoService;
 
-  public static final String TASK_NAME = "updateLambdaFunctionConfiguration";
+  public static final String TASK_NAME = "lambdaFunction";
 
   @Nonnull
   @Override
@@ -44,8 +51,14 @@ public class updateLambdaFunctionTask extends AbstractCloudProviderAwareTask imp
 
     Map<String, Object> task = new HashMap<>(stage.getContext());
 
+    String operationName = (String) task.get("operation");
+    if (!StringUtils.isNotBlank(operationName)) {
+      throw new IllegalArgumentException(
+        "Field 'operation' is missing and must be present in stage context");
+    }
+
     Map<String, Map> operation =
-        new ImmutableMap.Builder<String, Map>().put(TASK_NAME, task).build();
+        new ImmutableMap.Builder<String, Map>().put(operationName, task).build();
 
     TaskId taskId =
         katoService

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/lambdaFunctionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/lambdaFunctionTask.java
@@ -54,7 +54,7 @@ public class lambdaFunctionTask extends AbstractCloudProviderAwareTask implement
     String operationName = (String) task.get("operation");
     if (!StringUtils.isNotBlank(operationName)) {
       throw new IllegalArgumentException(
-        "Field 'operation' is missing and must be present in stage context");
+          "Field 'operation' is missing and must be present in stage context");
     }
 
     Map<String, Map> operation =


### PR DESCRIPTION
The `updateLambdaFunction` stage that was added before only supported updating lambda function config. It didn't allow users to update the lambda function code, create or delete a lambda. This modification will allow users to forward arbitrary operations to Clouddriver.

## Usage
The instructions [here](https://github.com/spinnaker/clouddriver/tree/master/clouddriver-lambda) describe how to enable lambda and available operations. Then you can hit Orca with something like:

```curl -X POST \
  http://localhost:8083/orchestrate \
  -H 'Content-Type: application/json' \
  -d '
  {
      "application": "andrewtest",
      "description": "lambda Test",
      "stages": [
        {
            "type": "lambdaFunction",
            "operation": "updateLambdaFunctionCode",
            "region": "us-east-1",
            "functionName": "andrew-lambda-handler",
            "credentials": "aws-dev",
            "s3Bucket": "armory-lambda-dev",
            "s3Key": "handler.zip",
            "publish": "true"
        }
      ] 
  }
'
```
The required fields are `operation` and `type`.