### PR TITLE
feat(webhook): support yaml parsing

### DIFF
--- a/orca-webhook/orca-webhook.gradle
+++ b/orca-webhook/orca-webhook.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation("com.jayway.jsonpath:json-path:2.2.0")
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
+  implementation("org.yaml:snakeyaml")
 //  testImplementation project(':orca-test')
   testImplementation("org.springframework:spring-test")
 


### PR DESCRIPTION
The Webhook stage supports parsing of the response body when it's a json
string, so it can be embedded as Objects into the context. This patch
adds support for parsing YAML strings as well.
