### PR TITLE
feat(core): Support client-provided execution IDs

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -198,6 +198,7 @@ public class ExecutionLauncher {
     // TODO: can we not just annotate the class properly to avoid all this?
     Map<String, Serializable> config = objectMapper.readValue(configJson, Map.class);
     return new PipelineBuilder(getString(config, "application"))
+        .withId(getString(config, "executionId"))
         .withName(getString(config, "name"))
         .withPipelineConfigId(getString(config, "id"))
         .withTrigger(objectMapper.convertValue(config.get("trigger"), Trigger.class))

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.pipeline.model;
 
+import com.google.common.base.Strings;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -25,6 +26,13 @@ import java.util.Map;
 public class PipelineBuilder {
   public PipelineBuilder(String application) {
     pipeline = Execution.newPipeline(application);
+  }
+
+  public PipelineBuilder withId(String id) {
+    if (!Strings.isNullOrEmpty(id)) {
+      pipeline.setId(id);
+    }
+    return this;
   }
 
   public PipelineBuilder withTrigger(Trigger trigger) {


### PR DESCRIPTION
The V2 trigger pipeline endpoint is currently broken (it doesn't return a valid ref for people to lookup progress). This is one of 3 changes (other two in echo, gate), allowing clients to pass an execution ID (in addition to or in substitution of) a correlation ID. This will allow Gate to generate a pipeline execution ID and return it to the client without blocking on Orca to actually process the request.

echo: https://github.com/spinnaker/echo/pull/563
gate: https://github.com/spinnaker/gate/pull/811