### PR TITLE
fix(cleanup): remove 2nd check on thresholdDays in old pipeline cleanup

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgent.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgent.java
@@ -28,7 +28,11 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -179,15 +183,9 @@ public class OldPipelineCleanupPollingNotificationAgent extends AbstractPollingN
         .subList(0, (executions.size() - minimumPipelineExecutions))
         .forEach(
             p -> {
-              long startTime = p.startTime == null ? p.buildTime : p.startTime;
-              long days =
-                  ChronoUnit.DAYS.between(
-                      Instant.ofEpochMilli(startTime), Instant.ofEpochMilli(clock.millis()));
-              if (days > thresholdDays) {
-                log.info("Deleting pipeline execution " + p.id + ": " + p.toString());
-                registry.counter(deletedId.withTag("application", p.application)).increment();
-                executionRepository.delete(PIPELINE, p.id);
-              }
+              log.info("Deleting pipeline execution " + p.id + ": " + p.toString());
+              executionRepository.delete(PIPELINE, p.id);
+              registry.counter(deletedId.withTag("application", p.application)).increment();
             });
   }
 


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/4467

OldPipelineCleanupPollingNotificationAgent is checking the age of the
pipeline execution twice before removing it:

1. the `Observable<Execution>` returned from
`executionRepository.retrievePipelinesForApplication(app)` is filtered
to only executions that have a completed status and where startTime (or
buildTime, if startTime is not set) is before `now - thresholdDays days`

2. After converting the `Observable<Execution>` to a `List`, sorting it,
and retaining `minimumPipelineExecutions` elements, each execution is
only deleted if `days between startTime and now > thresholdDays`.

The first check is true for executions as soon as they are a moment
older than `executionDays` days, but the second requires executions to be
older than `executionDays + 1` days (due to using `>`).

Since the second check seems redundant, I've simplify removed it.

My assumption here is that it is a bug that a configuration setting like
`thresholdDays: N` actually only removes executions older than `N+1`
days.