### PR TITLE
fix(sql): optimize reading executions by pipeline id

### DIFF
--- a/orca-sql/src/main/resources/db/changelog-master.yml
+++ b/orca-sql/src/main/resources/db/changelog-master.yml
@@ -32,3 +32,6 @@ databaseChangeLog:
 - include:
     file: changelog/20190516-index-correlated-execution-ids.yml
     relativeToChangelogFile: true
+- include:
+    file: changelog/20190530-pipeline-config-index.yml
+    relativeToChangelogFile: true

--- a/orca-sql/src/main/resources/db/changelog/20190530-pipeline-config-index.yml
+++ b/orca-sql/src/main/resources/db/changelog/20190530-pipeline-config-index.yml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 20190530-update-pipeline-config-indices
+      author: afeldman
+      changes:
+      - createIndex:
+          indexName: pipeline_config_id_idx
+          tableName: pipelines
+          columns:
+          - column:
+              name: config_id
+          - column:
+              name: id
+      - dropIndex:
+          indexName: pipeline_config_idx
+          tableName: pipelines
+      rollback:
+      - createIndex:
+          indexName: pipeline_config_idx
+          tableName: pipelines
+          columns:
+          - column:
+              name: config_id
+      - dropIndex:
+          indexName: pipeline_config_id_idx
+          tableName: pipelines


### PR DESCRIPTION
This PR fixes an issue where calls to `/applications/{application}/pipelines` can result in a full `pipelines` table scan per each of the applications pipeline configuration ids if they have more than N executions, where N is determined by the sql query optimizer at runtime.