### PR TITLE
fix issue 4469: orca-core skipping most tests in build

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -58,7 +58,6 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.assertj:assertj-core")
 
-  testRuntimeOnly("org.slf4j:slf4j-simple")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
   testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/locks/LockContextSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/locks/LockContextSpec.groovy
@@ -10,14 +10,14 @@ class LockContextSpec extends Specification {
 
   def "builder uses explicitly provided id in when present"() {
     given:
-    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, type, explicitId, stage)
+    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, lockType, explicitId, stage)
 
     expect:
     builder.build() == expected
 
     where:
     application = 'app'
-    type = 'pipeline'
+    lockType = 'pipeline'
     explicitId = 'bacon'
 
     stage = ExecutionBuilder.stage {
@@ -25,19 +25,19 @@ class LockContextSpec extends Specification {
     }
 
     expectedId = explicitId
-    expected = new LockManager.LockValue(application, type, expectedId)
+    expected = new LockManager.LockValue(application, lockType, expectedId)
   }
 
   def "builder uses execution id in simple execution"() {
     given:
-    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, type, explicitId, stage)
+    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, lockType, explicitId, stage)
 
     expect:
     builder.build() == expected
 
     where:
     application = 'app'
-    type = 'pipeline'
+    lockType = 'pipeline'
     explicitId = null
 
     stage = ExecutionBuilder.stage {
@@ -45,19 +45,19 @@ class LockContextSpec extends Specification {
     }
 
     expectedId = stage.execution.id
-    expected = new LockManager.LockValue(application, type, expectedId)
+    expected = new LockManager.LockValue(application, lockType, expectedId)
   }
 
   def "builder traverses up the hierarchy when execution is triggered by a PipelineTrigger"() {
     given:
-    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, type, explicitId, stage)
+    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, lockType, explicitId, stage)
 
     expect:
     builder.build() == expected
 
     where:
     application = 'app'
-    type = 'pipeline'
+    lockType = 'pipeline'
     explicitId = null
 
     parentStage = ExecutionBuilder.stage {
@@ -75,20 +75,20 @@ class LockContextSpec extends Specification {
     stage = exec.stages[0]
 
     expectedId = parentStage.execution.id
-    expected = new LockManager.LockValue(application, type, expectedId)
+    expected = new LockManager.LockValue(application, lockType, expectedId)
 
   }
 
   def "builder traverses up the hierarchy multiple levels when execution is triggered by a PipelineTrigger"() {
     given:
-    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, type, explicitId, stage)
+    def builder = new LockContext.LockContextBuilder.LockValueBuilder(application, lockType, explicitId, stage)
 
     expect:
     builder.build() == expected
 
     where:
     application = 'app'
-    type = 'pipeline'
+    lockType = 'pipeline'
     explicitId = null
 
 
@@ -103,7 +103,7 @@ class LockContextSpec extends Specification {
     stage = exec.stages[0]
 
     expectedId = grandParentStage.execution.id
-    expected = new LockManager.LockValue(application, type, expectedId)
+    expected = new LockManager.LockValue(application, lockType, expectedId)
 
   }
 

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/ExecutionSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/ExecutionSpec.groovy
@@ -18,11 +18,19 @@ package com.netflix.spinnaker.orca.pipeline.model
 
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import org.slf4j.MDC
+import org.slf4j.helpers.NOPMDCAdapter
 import spock.lang.Specification
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
 class ExecutionSpec extends Specification {
+  void setupSpec() {
+    if (MDC.getMDCAdapter() instanceof NOPMDCAdapter) {
+      throw new IllegalStateException("ExecutionSpec.AuthenticationDetails tests cannot function " +
+              "without a real MDC implementation loaded by slf4j")
+    }
+  }
+
   def "should return Optional.empty if no authenticated details available"() {
     given:
     MDC.clear()


### PR DESCRIPTION
Two problems were introduced by a1de32d0345446e240885b6a792a60b4ff13c2eb:

1. LockContextSpec throws a java.lang.VerifyError when the class is loaded by junit-vintage's TestEngine, which leads it to incorrectly think that there are no tests to run (of the type that it supports)
2. ExecutionSpec was broken in the change from using `org.apache.log4j.MDC` to `org.slf4j.MDC` because orca-core has `slf4j-simple` at `testRuntime` scope, which loads a no-op version of the MDC class which silently discards all values passed to `MDC.put(key, value)`.

Closes https://github.com/spinnaker/spinnaker/issues/4469

The fix for 1 above comes from something @ezimanyi mentioned on Slack - that the use of `type` seems to be confusing the Groovy compiler.