### PR TITLE
fix(findImage) : Fix child deploy to use correct find image when clou…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
@@ -84,7 +84,10 @@ trait DeploymentDetailsAware {
   List<Stage> getAncestors(Stage stage, Execution execution) {
     if (stage?.requisiteStageRefIds) {
       def previousStages = execution.stages.findAll {
-        it.refId in stage.requisiteStageRefIds
+        // Include cloudProvider check to avoid confusion with multi-provider,
+        // in some cases ancestors can be one of any multi-provider
+        // Eg parent->aws and child->titus
+        it.refId in stage.requisiteStageRefIds && it.context.cloudProvider == stage.context.cloudProvider
       }
       def syntheticStages = execution.stages.findAll {
         it.parentStageId in previousStages*.id

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
@@ -81,7 +81,7 @@ trait DeploymentDetailsAware {
     }
   }
 
-  boolean checkCloudprovider(Stage stage, Stage execution){
+  boolean isCloudProviderEqual(Stage stage, Stage execution){
     if(execution.context.cloudProvider!=null) {
       return execution.context.cloudProvider == stage.context.cloudProvider
     }
@@ -94,7 +94,7 @@ trait DeploymentDetailsAware {
         // Include cloudProvider check to avoid confusion with multi-provider,
         // in some cases ancestors can be one of any multi-provider
         // Eg parent->aws and child->titus
-        it.refId in stage.requisiteStageRefIds && checkCloudprovider(stage,it)
+        it.refId in stage.requisiteStageRefIds && isCloudProviderEqual(stage,it)
 
       }
       def syntheticStages = execution.stages.findAll {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
@@ -81,13 +81,21 @@ trait DeploymentDetailsAware {
     }
   }
 
+  boolean checkCloudprovider(Stage stage, Stage execution){
+    if(execution.context.cloudProvider!=null) {
+      return execution.context.cloudProvider == stage.context.cloudProvider
+    }
+    return true
+  }
+
   List<Stage> getAncestors(Stage stage, Execution execution) {
     if (stage?.requisiteStageRefIds) {
       def previousStages = execution.stages.findAll {
         // Include cloudProvider check to avoid confusion with multi-provider,
         // in some cases ancestors can be one of any multi-provider
         // Eg parent->aws and child->titus
-        it.refId in stage.requisiteStageRefIds && it.context.cloudProvider == stage.context.cloudProvider
+        it.refId in stage.requisiteStageRefIds && checkCloudprovider(stage,it)
+
       }
       def syntheticStages = execution.stages.findAll {
         it.parentStageId in previousStages*.id


### PR DESCRIPTION
Given the following pipelines:
- Parent
  -  Find Image
  - Run Child Pipeline
- Child
   - Find Image
  -  Deploy

You would probably expect the child deploy to deploy the image found by the child.
This is the case when parent and child both find AMIs, but when the child pipeline is finding a container image and deploying to Titus, the deploy ends up using the AMI found by the parent

Fix : Adding a check to make sure the cloud-providers match while getting ancestors

I have tested the following cases and it looks good
Case 1 
- Parent
  -  Find Image (aws) 
  - Run Child Pipeline
- Child
   - Find Image (aws)
  -  Deploy (aws)

Case 2
- Parent
  -  Find Image (aws)
  - Run Child Pipeline
- Child
   - Find Image (titus)
  -  Deploy (titus)