### PR TITLE
fix(zombie-check): make zombie check run regardless of instance status

### DIFF
--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/metrics/AtlasQueueMonitorTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/metrics/AtlasQueueMonitorTest.kt
@@ -99,7 +99,6 @@ object AtlasQueueMonitorTest : SubjectSpek<AtlasQueueMonitor>({
       registry,
       repository,
       clock,
-      listOf(activator),
       conch,
       true,
       Optional.of(Schedulers.immediate()),


### PR DESCRIPTION
Remove check for all activators being up before running a zombie check.
It doesn't really buy us anything other than confusion.
E.g. if there is a dedicated instance that runs zombie checks but has
queue disabled the zombie check will not run.
Even if down instances run a zombie check that should be ok since their
view of the queue should still be accurate
