### PR TITLE
fix(pipelines): Fix pipeline triggers for some templated pipelines

### DIFF
--- a/orca-front50/orca-front50.gradle
+++ b/orca-front50/orca-front50.gradle
@@ -30,5 +30,6 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok")
 
   testImplementation(project(":orca-test-groovy"))
+  testImplementation(project(":orca-pipelinetemplate"))
   testImplementation("com.github.ben-manes.caffeine:guava")
 }


### PR DESCRIPTION
Pipeline triggers and pipeline stages were broken for templated pipelines that use a dynamic source that references an artifact. Resolved by resolving the artifacts a bit earlier (before the preprocessors).