### PR TITLE
feat(admin): admin endpoints to retrieve executions

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
@@ -240,9 +240,10 @@ class DualExecutionRepository(
     updatedAtEnd: Long
   ): List<Execution> {
 
-    return primary.retrieveExecutionsWithStatusInTimeWindow(executionType, status, updatedAtStart, updatedAtStart)
-      .plus(previous.retrieveExecutionsWithStatusInTimeWindow(executionType, status, updatedAtStart, updatedAtStart)
-    )
+    return Observable.merge(
+      Observable.from(primary.retrieveExecutionsWithStatusInTimeWindow(executionType, status, updatedAtStart, updatedAtStart)),
+      Observable.from(previous.retrieveExecutionsWithStatusInTimeWindow(executionType, status, updatedAtStart, updatedAtStart))
+    ).toList().toBlocking().single()
   }
 
   override fun retrieveExecutionsWithSpecificStageTypesInTimeWindow(
@@ -253,9 +254,10 @@ class DualExecutionRepository(
     updatedAtEnd: Long
   ): List<Execution> {
 
-    return primary.retrieveExecutionsWithSpecificStageTypesInTimeWindow(executionType, status, stageType, updatedAtStart, updatedAtStart)
-      .plus(previous.retrieveExecutionsWithSpecificStageTypesInTimeWindow(executionType, status, stageType, updatedAtStart, updatedAtStart)
-      )
+    return Observable.merge(
+      Observable.from(primary.retrieveExecutionsWithSpecificStageTypesInTimeWindow(executionType, status, stageType, updatedAtStart, updatedAtStart)),
+      Observable.from(previous.retrieveExecutionsWithSpecificStageTypesInTimeWindow(executionType, status, stageType, updatedAtStart, updatedAtStart))
+    ).toList().toBlocking().single()
   }
 
   override fun retrieveOrchestrationsForApplication(

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
@@ -233,6 +233,31 @@ class DualExecutionRepository(
     )
   }
 
+  override fun retrieveExecutionsWithStatusInTimeWindow(
+    executionType: Execution.ExecutionType,
+    status: String,
+    updatedAtStart: Long,
+    updatedAtEnd: Long
+  ): List<Execution> {
+
+    return primary.retrieveExecutionsWithStatusInTimeWindow(executionType, status, updatedAtStart, updatedAtStart)
+      .plus(previous.retrieveExecutionsWithStatusInTimeWindow(executionType, status, updatedAtStart, updatedAtStart)
+    )
+  }
+
+  override fun retrieveExecutionsWithSpecificStageTypesInTimeWindow(
+    executionType: Execution.ExecutionType,
+    status: String,
+    stageType: String,
+    updatedAtStart: Long,
+    updatedAtEnd: Long
+  ): List<Execution> {
+
+    return primary.retrieveExecutionsWithSpecificStageTypesInTimeWindow(executionType, status, stageType, updatedAtStart, updatedAtStart)
+      .plus(previous.retrieveExecutionsWithSpecificStageTypesInTimeWindow(executionType, status, stageType, updatedAtStart, updatedAtStart)
+      )
+  }
+
   override fun retrieveOrchestrationsForApplication(
     application: String,
     criteria: ExecutionCriteria,

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -114,6 +114,18 @@ public interface ExecutionRepository {
       @Nonnull String application, @Nonnull ExecutionCriteria criteria);
 
   @Nonnull
+  List<Execution> retrieveExecutionsWithStatusInTimeWindow(
+      ExecutionType executionType, String status, long updatedAtStart, long updatedAtEnd);
+
+  @Nonnull
+  List<Execution> retrieveExecutionsWithSpecificStageTypesInTimeWindow(
+      ExecutionType executionType,
+      String status,
+      String stageType,
+      long updatedAtStart,
+      long updatedAtEnd);
+
+  @Nonnull
   List<Execution> retrieveOrchestrationsForApplication(
       @Nonnull String application,
       @Nonnull ExecutionCriteria criteria,

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -53,6 +53,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.Nullable;
@@ -614,6 +615,27 @@ public class RedisExecutionRepository implements ExecutionRepository {
     }
 
     return currentObservable;
+  }
+
+  @Override
+  public List<Execution> retrieveExecutionsWithStatusInTimeWindow(
+      Execution.ExecutionType executionType,
+      String status,
+      long updatedAtStart,
+      long updatedAtEnd) {
+    throw new NotImplementedException(
+        "retrieveExecutionsWithStatusInTimeWindow Not supported in RedisExecutionRepository");
+  }
+
+  @Override
+  public List<Execution> retrieveExecutionsWithSpecificStageTypesInTimeWindow(
+      Execution.ExecutionType executionType,
+      String status,
+      String stageType,
+      long updatedAtStart,
+      long updatedAtEnd) {
+    throw new NotImplementedException(
+        "retrieveExecutionsWithStatusInTimeWindow Not supported in RedisExecutionRepository");
   }
 
   @Nonnull

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -53,7 +53,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.Nullable;
@@ -623,8 +622,10 @@ public class RedisExecutionRepository implements ExecutionRepository {
       String status,
       long updatedAtStart,
       long updatedAtEnd) {
-    throw new NotImplementedException(
-        "retrieveExecutionsWithStatusInTimeWindow Not supported in RedisExecutionRepository");
+    log.error(
+        "retrieveExecutionsWithStatusInTimeWindow is not supported in RedisExecutionRepository");
+
+    return emptyList();
   }
 
   @Override
@@ -634,8 +635,10 @@ public class RedisExecutionRepository implements ExecutionRepository {
       String stageType,
       long updatedAtStart,
       long updatedAtEnd) {
-    throw new NotImplementedException(
-        "retrieveExecutionsWithStatusInTimeWindow Not supported in RedisExecutionRepository");
+    log.error(
+        "retrieveExecutionsWithSpecificStageTypesInTimeWindow is not supported in RedisExecutionRepository");
+
+    return emptyList();
   }
 
   @Nonnull

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
@@ -170,6 +170,29 @@ class RedisInstrumentedExecutionRepository(
     }
   }
 
+  override fun retrieveExecutionsWithStatusInTimeWindow(
+    executionType: Execution.ExecutionType,
+    status: String,
+    updatedAtStart: Long,
+    updatedAtEnd: Long
+  ): List<Execution> {
+    return withMetrics("retrieveExecutionsWithStatusInTimeWindow") {
+      executionRepository.retrieveExecutionsWithStatusInTimeWindow(executionType, status, updatedAtStart, updatedAtEnd)
+    }
+  }
+
+  override fun retrieveExecutionsWithSpecificStageTypesInTimeWindow(
+    executionType: Execution.ExecutionType,
+    status: String,
+    stageType: String,
+    updatedAtStart: Long,
+    updatedAtEnd: Long
+  ): List<Execution> {
+    return withMetrics("retrieveExecutionsWithSpecificStageTypesInTimeWindow") {
+      executionRepository.retrieveExecutionsWithSpecificStageTypesInTimeWindow(executionType, status, stageType, updatedAtStart, updatedAtEnd)
+    }
+  }
+
   override fun retrieveOrchestrationsForApplication(
     application: String,
     criteria: ExecutionRepository.ExecutionCriteria,

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/SpringLiquibaseProxy.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/SpringLiquibaseProxy.kt
@@ -67,8 +67,8 @@ class SpringLiquibaseProxy(
   private fun createDataSource(): DataSource =
     sqlProperties.migration.run {
       val ds = SingleConnectionDataSource(jdbcUrl, user, password, true)
-      if (driver != null) {
-        ds.setDriverClassName(driver)
+      driver?.let {
+        ds.setDriverClassName(it)
       }
       ds
     }

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlInstrumentedExecutionRepository.kt
@@ -174,6 +174,29 @@ class SqlInstrumentedExecutionRepository(
     }
   }
 
+  override fun retrieveExecutionsWithStatusInTimeWindow(
+    executionType: Execution.ExecutionType,
+    status: String,
+    updatedAtStart: Long,
+    updatedAtEnd: Long
+  ): List<Execution> {
+    return withMetrics("retrieveExecutionsWithStatusInTimeWindow") {
+      executionRepository.retrieveExecutionsWithStatusInTimeWindow(executionType, status, updatedAtStart, updatedAtEnd)
+    }
+  }
+
+  override fun retrieveExecutionsWithSpecificStageTypesInTimeWindow(
+    executionType: Execution.ExecutionType,
+    status: String,
+    stageType: String,
+    updatedAtStart: Long,
+    updatedAtEnd: Long
+  ): List<Execution> {
+    return withMetrics("retrieveExecutionsWithSpecificStageTypesInTimeWindow") {
+      executionRepository.retrieveExecutionsWithSpecificStageTypesInTimeWindow(executionType, status, stageType, updatedAtStart, updatedAtEnd)
+    }
+  }
+
   override fun retrieveOrchestrationsForApplication(
     application: String,
     criteria: ExecutionCriteria,

--- a/orca-sql/src/main/resources/db/changelog-master.yml
+++ b/orca-sql/src/main/resources/db/changelog-master.yml
@@ -35,3 +35,6 @@ databaseChangeLog:
 - include:
     file: changelog/20190530-pipeline-config-index.yml
     relativeToChangelogFile: true
+- include:
+    file: changelog/20190604-stages-updatedat-index.yml
+    relativeToChangelogFile: true

--- a/orca-sql/src/main/resources/db/changelog/20190604-stages-updatedat-index.yml
+++ b/orca-sql/src/main/resources/db/changelog/20190604-stages-updatedat-index.yml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+  - changeSet:
+      id: 20190604-update-stages-indices
+      author: mvulfson
+      changes:
+      - createIndex:
+          indexName: pipeline_stages_updated_at_idx
+          tableName: pipeline_stages
+          columns:
+          - column:
+              name: updated_at
+      - createIndex:
+          indexName: orchestration_stages_updated_at_idx
+          tableName: orchestration_stages
+          columns:
+            - column:
+                name: updated_at
+      rollback:
+      - dropIndex:
+          indexName: pipeline_stages_updated_at_idx
+          tableName: pipeline_stages
+      - dropIndex:
+          indexName: orchestration_stages_updated_at_idx
+          tableName: orchestration_stages

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/AdminController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/AdminController.groovy
@@ -82,8 +82,9 @@ class AdminController {
 
   @RequestMapping(value = "/executions", method = RequestMethod.GET)
   AdminExecutionSearchResult getExecutions(@RequestParam(value = "status", required = true) String status,
-  @RequestParam(value = "startTime", required = true) long startTime,
-  @RequestParam(value = "endTime", required = true) long endTime) {
+                                           @RequestParam(value = "startTime", required = true) long startTime,
+                                           @RequestParam(value = "endTime", required = true) long endTime) {
+
     AdminExecutionSearchResult searchResult = new AdminExecutionSearchResult()
     searchResult.pipelines = repository.retrieveExecutionsWithStatusInTimeWindow(Execution.ExecutionType.PIPELINE, status, startTime, endTime)
     searchResult.orchestrations = repository.retrieveExecutionsWithStatusInTimeWindow(Execution.ExecutionType.ORCHESTRATION, status, startTime, endTime)
@@ -93,9 +94,10 @@ class AdminController {
 
   @RequestMapping(value = "/executionsWithStage", method = RequestMethod.GET)
   AdminExecutionSearchResult getExecutions(@RequestParam(value = "status", required = true) String status,
-                             @RequestParam(value = "stageType", required = true) String stageType,
-                             @RequestParam(value = "startTime", required = true) long startTime,
-                             @RequestParam(value = "endTime", required = true) long endTime) {
+                                           @RequestParam(value = "stageType", required = true) String stageType,
+                                           @RequestParam(value = "startTime", required = true) long startTime,
+                                           @RequestParam(value = "endTime", required = true) long endTime) {
+
     AdminExecutionSearchResult searchResult = new AdminExecutionSearchResult()
     searchResult.pipelines = repository.retrieveExecutionsWithSpecificStageTypesInTimeWindow(Execution.ExecutionType.PIPELINE, status, stageType, startTime, endTime)
     searchResult.orchestrations = repository.retrieveExecutionsWithSpecificStageTypesInTimeWindow(Execution.ExecutionType.ORCHESTRATION, status, stageType, startTime, endTime)

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/model/AdminExecutionSearchResult.java
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/model/AdminExecutionSearchResult.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.model;
+
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import java.util.List;
+
+public class AdminExecutionSearchResult {
+  public List<Execution> pipelines;
+  public List<Execution> orchestrations;
+}


### PR DESCRIPTION
Currently, when there is an outage and the Spinnaker operators needs to
locate pipelines affected by the outage one must go straight to the executions DB.
This adds two endpoint points:
* one to retrieve executions (pipelines & orchestrations) that ran during a given time window with a specific status (e.g. `TERMINAL`)
* one to retrieve executions that had a stage of particular type complete with a specific status (e.g. `TERMINAL`) in a given time window

Admin EPs so not exposed in `gate`
