### PR TITLE
fix(gcb): Bind artifacts produced from GCB stage

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
@@ -74,6 +74,10 @@ public class ContextParameterProcessor {
       boolean allowUnknownKeys,
       ExpressionEvaluationSummary summary) {
 
+    if (source == null) {
+      return null;
+    }
+
     if (source.isEmpty()) {
       return new HashMap<>();
     }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/GoogleCloudBuildStage.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/pipeline/GoogleCloudBuildStage.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.igor.tasks.StartGoogleCloudBuildTask;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +39,7 @@ public class GoogleCloudBuildStage implements StageDefinitionBuilder {
     builder
         .withTask("startGoogleCloudBuildTask", StartGoogleCloudBuildTask.class)
         .withTask("monitorGoogleCloudBuildTask", MonitorGoogleCloudBuildTask.class)
-        .withTask("getGoogleCloudBuildArtifactsTask", GetGoogleCloudBuildArtifactsTask.class);
+        .withTask("getGoogleCloudBuildArtifactsTask", GetGoogleCloudBuildArtifactsTask.class)
+        .withTask("bindProducedArtifacts", BindProducedArtifactsTask.class);
   }
 }


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4503

* fix(spel): Fix NPE in SpEL evaluation 

  Evaluating SpEL on a null object throws an NPE; if the input object is null, just return null as the evaluated expression.

* fix(gcb): Bind artifacts produced from GCB stage 

  Because we didn't include the BindProducedArtifacts task in the GCB stage, produced artifacts were not matched to expected artifacts, which prevented correctly using them downstream.
