### PR TITLE
feat(mptv1): Support templated stage IDs in looped stages

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/RenderTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/transform/RenderTransform.java
@@ -131,10 +131,19 @@ public class RenderTransform implements PipelineTemplateVisitor {
       int index = 0;
       for (Object value : (Collection) loopValue) {
         StageDefinition expandedStage = wrapClone(stage);
-        expandedStage.setId(stage.getId() + index);
 
         expandedStage.getLoopContext().put("value", value);
         expandedStage.setLoopWith(null);
+
+        // If the stage ID is templated, allow access to the templateLoop context for rendering.
+        if (stage.getId().contains("{{") && stage.getId().contains("}}")) {
+          RenderContext loopedContext = context.copy();
+          loopedContext.getVariables().put("templateLoop", expandedStage.getLoopContext());
+          expandedStage.setId(renderer.render(stage.getId(), loopedContext));
+        } else {
+          expandedStage.setId(stage.getId() + index);
+        }
+
         stage.getLoopedStages().add(expandedStage);
 
         index++;

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-expected.json
@@ -38,7 +38,7 @@
       "requisiteStageRefIds": ["joinWait"],
       "name": "Wait 5 seconds",
       "id": null,
-      "refId": "stageLoop0",
+      "refId": "stageLoop-5",
       "type": "wait",
       "waitTime": 5
     },
@@ -46,7 +46,7 @@
       "requisiteStageRefIds": ["joinWait"],
       "name": "Wait 10 seconds",
       "id": null,
-      "refId": "stageLoop1",
+      "refId": "stageLoop-10",
       "type": "wait",
       "waitTime": 10
     }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-template.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-template.yml
@@ -20,7 +20,7 @@ stages:
     waitTime: 3
   dependsOn:
   - loopedPartial
-- id: stageLoop
+- id: "stageLoop-{{ templateLoop.value }}"
   type: wait
   name: "Wait {{ templateLoop.value }} seconds"
   config:


### PR DESCRIPTION
Small enhancement for v1 MPT from an internal team.

They want to be able to be able to have like a `regions` (or in their case, `stacks`) var that they can iterate over to generate multiple deploy stages and be able to reference them by name later on.