### PR TITLE
fix(task): FindArtifactFromExecutionTask no longer matches its own artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . workdir/
 
 WORKDIR workdir
 
-RUN GRADLE_USER_HOME=cache ./gradlew -I gradle/init-publish.gradle buildDeb -x test && \
+RUN GRADLE_USER_HOME=cache ./gradlew -PenablePublishing=true buildDeb -x test && \
   dpkg -i ./orca-web/build/distributions/*.deb && \
   cd .. && \
   rm -rf workdir

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
@@ -73,7 +73,7 @@ public class FindArtifactFromExecutionTask implements Task {
     if (match == null) {
       outputs.put(
           "exception",
-          "No artifacts matching " + expectedArtifact + " found among " + priorArtifacts);
+          "No artifact matching " + expectedArtifact + " found among " + priorArtifacts);
       return TaskResult.builder(ExecutionStatus.TERMINAL)
           .context(new HashMap<>())
           .outputs(outputs)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
@@ -53,7 +53,8 @@ public class FindArtifactFromExecutionTask implements Task {
     List<Artifact> priorArtifacts;
     // never resolve artifacts from the same stage in a prior execution
     // we will get the set of the artifacts and remove them from the collection
-    String pipelineConfigId = Optional.ofNullable(stage.getExecution().getPipelineConfigId()).orElse("");
+    String pipelineConfigId =
+        Optional.ofNullable(stage.getExecution().getPipelineConfigId()).orElse("");
     if (pipelineConfigId.equals(pipeline)) {
       priorArtifacts =
           artifactResolver.getArtifactsForPipelineIdWithoutStageRef(

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
@@ -63,7 +63,8 @@ public class FindArtifactFromExecutionTask implements Task {
           artifactResolver.getArtifactsForPipelineIdWithoutStageRef(
               pipeline, stage.getRefId(), executionOptions.toCriteria());
     } else {
-      priorArtifacts = artifactResolver.getArtifactsForPipelineId(pipeline, executionOptions.toCriteria());
+      priorArtifacts =
+          artifactResolver.getArtifactsForPipelineId(pipeline, executionOptions.toCriteria());
     }
 
     Artifact match =

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +53,8 @@ public class FindArtifactFromExecutionTask implements Task {
     List<Artifact> priorArtifacts;
     // never resolve artifacts from the same stage in a prior execution
     // we will get the set of the artifacts and remove them from the collection
-    if (stage.getExecution().getPipelineConfigId().equals(pipeline)) {
+    String pipelineConfigId = Optional.ofNullable(stage.getExecution().getPipelineConfigId()).orElse("");
+    if (pipelineConfigId.equals(pipeline)) {
       priorArtifacts =
           artifactResolver.getArtifactsForPipelineIdWithoutStageRef(
               pipeline, stage.getRefId(), executionOptions.toCriteria());

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
@@ -55,15 +55,15 @@ public class FindArtifactFromExecutionTask implements Task {
     ExecutionOptions executionOptions =
         objectMapper.convertValue(context.get("executionOptions"), ExecutionOptions.class);
 
-    List<Artifact> priorArtifacts =
-        artifactResolver.getArtifactsForPipelineId(pipeline, executionOptions.toCriteria());
-
+    List<Artifact> priorArtifacts;
     // never resolve artifacts from the same stage in a prior execution
     // we will get the set of the artifacts and remove them from the collection
     if (stage.getExecution().getPipelineConfigId().equals(pipeline)) {
       priorArtifacts =
           artifactResolver.getArtifactsForPipelineIdWithoutStageRef(
               pipeline, stage.getRefId(), executionOptions.toCriteria());
+    } else {
+      priorArtifacts = artifactResolver.getArtifactsForPipelineId(pipeline, executionOptions.toCriteria());
     }
 
     Artifact match =

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -101,7 +101,8 @@ public class ArtifactResolver {
     return getAllArtifacts(execution, Optional.empty());
   }
 
-  public @Nonnull List<Artifact> getAllArtifacts(@Nonnull Execution execution, Optional<Predicate<Stage>> stageFilter) {
+  public @Nonnull List<Artifact> getAllArtifacts(
+      @Nonnull Execution execution, Optional<Predicate<Stage>> stageFilter) {
     // Get all artifacts emitted by the execution's stages; we'll sort the stages topologically,
     // then reverse the result so that artifacts from later stages will appear
     // earlier in the results.

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -98,11 +98,11 @@ public class ArtifactResolver {
   }
 
   public @Nonnull List<Artifact> getAllArtifacts(@Nonnull Execution execution) {
-    return getAllArtifacts(execution, Optional.empty());
+    return getAllArtifacts(execution, true, Optional.empty());
   }
 
   public @Nonnull List<Artifact> getAllArtifacts(
-      @Nonnull Execution execution, Optional<Predicate<Stage>> stageFilter) {
+      @Nonnull Execution execution, Boolean includeTrigger, Optional<Predicate<Stage>> stageFilter) {
     // Get all artifacts emitted by the execution's stages; we'll sort the stages topologically,
     // then reverse the result so that artifacts from later stages will appear
     // earlier in the results.
@@ -125,11 +125,13 @@ public class ArtifactResolver {
     // Get all artifacts in the parent pipeline's trigger; these artifacts go at the end of the
     // list,
     // after any that were emitted by the pipeline
-    List<Artifact> triggerArtifacts =
+    if(includeTrigger) {
+      List<Artifact> triggerArtifacts =
         objectMapper.convertValue(
-            execution.getTrigger().getArtifacts(), new TypeReference<List<Artifact>>() {});
+          execution.getTrigger().getArtifacts(), new TypeReference<List<Artifact>>() {});
 
-    emittedArtifacts.addAll(triggerArtifacts);
+      emittedArtifacts.addAll(triggerArtifacts);
+    }
 
     return emittedArtifacts;
   }
@@ -232,7 +234,7 @@ public class ArtifactResolver {
       return Collections.emptyList();
     }
 
-    return getAllArtifacts(execution, Optional.of(it -> stageRef.equals(it.getRefId())));
+    return getAllArtifacts(execution, false, Optional.of(it -> stageRef.equals(it.getRefId())));
   }
 
   public void resolveArtifacts(@Nonnull Map pipeline) {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -102,7 +102,9 @@ public class ArtifactResolver {
   }
 
   public @Nonnull List<Artifact> getAllArtifacts(
-      @Nonnull Execution execution, Boolean includeTrigger, Optional<Predicate<Stage>> stageFilter) {
+      @Nonnull Execution execution,
+      Boolean includeTrigger,
+      Optional<Predicate<Stage>> stageFilter) {
     // Get all artifacts emitted by the execution's stages; we'll sort the stages topologically,
     // then reverse the result so that artifacts from later stages will appear
     // earlier in the results.
@@ -125,10 +127,10 @@ public class ArtifactResolver {
     // Get all artifacts in the parent pipeline's trigger; these artifacts go at the end of the
     // list,
     // after any that were emitted by the pipeline
-    if(includeTrigger) {
+    if (includeTrigger) {
       List<Artifact> triggerArtifacts =
-        objectMapper.convertValue(
-          execution.getTrigger().getArtifacts(), new TypeReference<List<Artifact>>() {});
+          objectMapper.convertValue(
+              execution.getTrigger().getArtifacts(), new TypeReference<List<Artifact>>() {});
 
       emittedArtifacts.addAll(triggerArtifacts);
     }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -217,15 +217,13 @@ public class ArtifactResolver {
 
   public @Nonnull List<Artifact> getArtifactsForPipelineIdWithoutStageRef(
       @Nonnull String pipelineId, @Nonnull String stageRef, @Nonnull ExecutionCriteria criteria) {
-    List<Artifact> artifacts = getArtifactsForPipelineId(pipelineId, criteria);
-    List<Artifact> stageArtifacts =
-        getArtifactsForPipelineIdStageRef(pipelineId, stageRef, criteria);
+    Execution execution = getExecutionForPipelineId(pipelineId, criteria);
 
-    stageArtifacts.forEach(artifact -> artifacts.remove(artifact));
-    if (stageArtifacts.size() > 0) {
-      log.debug("Removed artifacts from " + pipelineId + ": " + stageArtifacts.toString());
+    if (execution == null) {
+      return Collections.emptyList();
     }
-    return artifacts;
+
+    return getAllArtifacts(execution, true, Optional.of(it -> !stageRef.equals(it.getRefId())));
   }
 
   public @Nonnull List<Artifact> getArtifactsForPipelineIdStageRef(

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -135,14 +135,14 @@ public class ArtifactResolver {
   }
 
   /**
-   * Used to fully resolve a bound artifacts on a stage that can either select an expected artifacts
-   * ID for an expected artifacts defined in a prior stage or as a trigger constraint OR define an
-   * inline expression-evaluable default artifacts.
+   * Used to fully resolve a bound artifact on a stage that can either select an expected artifact
+   * ID for an expected artifact defined in a prior stage or as a trigger constraint OR define an
+   * inline expression-evaluable default artifact.
    *
-   * @param stage The stage containing context to evaluate expressions on the bound artifacts.
-   * @param id An expected artifacts id. Either id or artifacts must be specified.
-   * @param artifact An inline default artifacts. Either id or artifacts must be specified.
-   * @return A bound artifacts with expressions evaluated.
+   * @param stage The stage containing context to evaluate expressions on the bound artifact.
+   * @param id An expected artifact id. Either id or artifact must be specified.
+   * @param artifact An inline default artifact. Either id or artifact must be specified.
+   * @return A bound artifact with expressions evaluated.
    */
   public @Nullable Artifact getBoundArtifactForStage(
       Stage stage, @Nullable String id, @Nullable Artifact artifact) {
@@ -355,7 +355,7 @@ public class ArtifactResolver {
       default:
         if (requireUniqueMatches) {
           throw new InvalidRequestException(
-              "Expected artifacts " + expectedArtifact + " matches multiple artifacts " + matches);
+              "Expected artifact " + expectedArtifact + " matches multiple artifacts " + matches);
         }
         result = matches.get(0);
     }
@@ -385,7 +385,7 @@ public class ArtifactResolver {
               expectedArtifact, receivedArtifacts, priorArtifacts, requireUniqueMatches);
       if (resolved == null) {
         throw new InvalidRequestException(
-            format("Unmatched expected artifacts %s could not be resolved.", expectedArtifact));
+            format("Unmatched expected artifact %s could not be resolved.", expectedArtifact));
       } else {
         resolvedArtifacts.add(resolved);
       }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -226,17 +226,6 @@ public class ArtifactResolver {
     return getAllArtifacts(execution, true, Optional.of(it -> !stageRef.equals(it.getRefId())));
   }
 
-  public @Nonnull List<Artifact> getArtifactsForPipelineIdStageRef(
-      @Nonnull String pipelineId, @Nonnull String stageRef, @Nonnull ExecutionCriteria criteria) {
-    Execution execution = getExecutionForPipelineId(pipelineId, criteria);
-
-    if (execution == null) {
-      return Collections.emptyList();
-    }
-
-    return getAllArtifacts(execution, false, Optional.of(it -> stageRef.equals(it.getRefId())));
-  }
-
   public void resolveArtifacts(@Nonnull Map pipeline) {
     Map<String, Object> trigger = (Map<String, Object>) pipeline.get("trigger");
     List<ExpectedArtifact> expectedArtifacts =

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverSpec.groovy
@@ -300,7 +300,7 @@ class ArtifactResolverSpec extends Specification {
         outputs.artifacts = [new Artifact(type: "2")]
       }
       stage {
-        // This stage does not emit an artifacts
+        // This stage does not emit an artifact
         requisiteStageRefIds = ["2"]
       }
     }
@@ -451,7 +451,7 @@ class ArtifactResolverSpec extends Specification {
     given:
     def matchArtifact = Artifact.builder().type("docker/.*").build()
     def expectedArtifact = ExpectedArtifact.builder().matchArtifact(matchArtifact).build()
-    def receivedArtifact = Artifact.builder().name("my-artifacts").type("docker/image").build()
+    def receivedArtifact = Artifact.builder().name("my-artifact").type("docker/image").build()
     def pipeline = [
       id: "abc",
       trigger: [:],
@@ -470,11 +470,11 @@ class ArtifactResolverSpec extends Specification {
 
   def "resolveArtifacts adds received artifacts to the trigger, skipping duplicates"() {
     given:
-    def matchArtifact = Artifact.builder().name("my-pipeline-artifacts").type("docker/.*").build()
+    def matchArtifact = Artifact.builder().name("my-pipeline-artifact").type("docker/.*").build()
     def expectedArtifact = ExpectedArtifact.builder().matchArtifact(matchArtifact).build()
-    def receivedArtifact = Artifact.builder().name("my-pipeline-artifacts").type("docker/image").build()
-    def triggerArtifact = Artifact.builder().name("my-trigger-artifacts").type("docker/image").build()
-    def bothArtifact = Artifact.builder().name("my-both-artifacts").type("docker/image").build()
+    def receivedArtifact = Artifact.builder().name("my-pipeline-artifact").type("docker/image").build()
+    def triggerArtifact = Artifact.builder().name("my-trigger-artifact").type("docker/image").build()
+    def bothArtifact = Artifact.builder().name("my-both-artifact").type("docker/image").build()
     def pipeline = [
       id: "abc",
       trigger: [
@@ -496,11 +496,11 @@ class ArtifactResolverSpec extends Specification {
 
   def "resolveArtifacts is idempotent"() {
     given:
-    def matchArtifact = Artifact.builder().name("my-pipeline-artifacts").type("docker/.*").build()
+    def matchArtifact = Artifact.builder().name("my-pipeline-artifact").type("docker/.*").build()
     def expectedArtifact = ExpectedArtifact.builder().matchArtifact(matchArtifact).build()
-    def receivedArtifact = Artifact.builder().name("my-pipeline-artifacts").type("docker/image").build()
-    def triggerArtifact = Artifact.builder().name("my-trigger-artifacts").type("docker/image").build()
-    def bothArtifact = Artifact.builder().name("my-both-artifacts").type("docker/image").build()
+    def receivedArtifact = Artifact.builder().name("my-pipeline-artifact").type("docker/image").build()
+    def triggerArtifact = Artifact.builder().name("my-trigger-artifact").type("docker/image").build()
+    def bothArtifact = Artifact.builder().name("my-both-artifact").type("docker/image").build()
     def pipeline = [
       id: "abc",
       trigger: [

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverSpec.groovy
@@ -360,41 +360,6 @@ class ArtifactResolverSpec extends Specification {
     emptyArtifacts == []
   }
 
-  def "should find artifacts from a specific stage ref"() {
-    when:
-    def execution = pipeline {
-      id: pipelineId
-      stage {
-        refId = "1"
-        outputs.artifacts = [new Artifact(type: "1")]
-      }
-      stage {
-        refId = "2"
-        requisiteStageRefIds = ["1"]
-        outputs.artifacts = [new Artifact(type: "2")]
-      }
-      stage {
-        // This stage does not emit an artifacts
-        requisiteStageRefIds = ["2"]
-      }
-    }
-    execution.trigger = new DefaultTrigger("webhook", null, "user", [:], [new Artifact(type: "trigger")])
-
-    def executionRepositoryStub = Stub(ExecutionRepository) {
-      // only a call to retrievePipelinesForPipelineConfigId() with these argument values is expected
-      retrievePipelinesForPipelineConfigId(pipelineId, expectedExecutionCriteria) >> Observable.just(execution)
-      // any other interaction is unexpected
-      0 * _
-    }
-
-    def artifactResolver = makeArtifactResolverWithStub(executionRepositoryStub)
-
-    then:
-    def artifacts = artifactResolver.getArtifactsForPipelineIdStageRef(pipelineId, "2", expectedExecutionCriteria)
-    artifacts.size == 1
-    artifacts*.type == ["2"]
-  }
-
   def "should find artifacts without a specific stage ref"() {
     when:
     def execution = pipeline {


### PR DESCRIPTION
Background
Currently the FindArtifactFromExecution stage resolves all artifacts for a pipeline and searches back to front for a matching artifact. This is undesirable when resolving from the same pipeline as the resolver will always resolve the same artifact produced from the previous FindArtifactFromExecution stage.

Change
Add new method getArtifactsForPipelineIdStageRef, which resolves artifacts for a given stage ref. This method is used to remove matched artifacts from the pipeline artifact resolver. By removing the artifacts found from the previous stage execution the task will not match artifacts produced by this stage.

Test
Added unit test for ArtifactResolver. Ran test suite. Writing UT for the task proved difficult with all the dependencies, since it currently has no UT i left it like that.