### PR TITLE
fix(jobs): fix race condition in override

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStage.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.job
 
-
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.clouddriver.config.PreconfiguredJobStageProperties
 import com.netflix.spinnaker.orca.clouddriver.exception.PreconfiguredJobNotFoundException
 import com.netflix.spinnaker.orca.clouddriver.service.JobService
@@ -28,9 +28,11 @@ import org.springframework.stereotype.Component
 class PreconfiguredJobStage extends RunJobStage {
 
   private JobService jobService
+  private ObjectMapper objectMapper
 
   public PreconfiguredJobStage(Optional<JobService> optionalJobService) {
     this.jobService = optionalJobService.orElse(null)
+    this.objectMapper = new ObjectMapper()
   }
 
   @Override
@@ -46,9 +48,14 @@ class PreconfiguredJobStage extends RunJobStage {
   }
 
   private Map<String, Object> overrideIfNotSetInContextAndOverrideDefault(Map<String, Object> context, PreconfiguredJobStageProperties preconfiguredJob) {
+    // without converting this object, assignments to `context[it]` will result in
+    // references being assigned instead of values which causes the overrides in context
+    // to override the underlying job. this avoids that problem by giving us a fresh "copy"
+    // to work wit
+    Map<String, Object> preconfiguredMap = objectMapper.convertValue(preconfiguredJob, Map.class)
     preconfiguredJob.getOverridableFields().each {
-      if (context[it] == null || preconfiguredJob[it] != null) {
-        context[it] = preconfiguredJob[it]
+      if (context[it] == null || preconfiguredMap[it] != null) {
+        context[it] = preconfiguredMap[it]
       }
     }
     preconfiguredJob.parameters.each { defaults ->

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStageSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.clouddriver.pipeline.job
 import com.netflix.spinnaker.orca.clouddriver.config.PreconfiguredJobStageParameter
 import com.netflix.spinnaker.orca.clouddriver.service.JobService
 import com.netflix.spinnaker.orca.clouddriver.config.KubernetesPreconfiguredJobProperties
+import io.kubernetes.client.models.V1Job
 import spock.lang.Specification
 
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
@@ -54,5 +55,48 @@ class PreconfiguredJobStageSpec extends Specification {
     "cloudProvider" | "somethingElse" | "testJob" | [account: "test-account", parameters: ["cloudProvider": "somethingElse"]] | new KubernetesPreconfiguredJobProperties(enabled: true, label: "testJob", type: "testJob", parameters: [new PreconfiguredJobStageParameter(mapping: "cloudProvider", defaultValue: "titus", "name": "cloudProvider")], cloudProvider: "kubernetes")
 
 
+  }
+
+  def "should use copy of preconfigured job to populate context"() {
+
+    given:
+    def manifestMetadataName = "defaultName"
+    def overriddenName = "fromParameter"
+    def stage = stage {
+      type = "test"
+      context = [account: "test"]
+    }
+    def property = new KubernetesPreconfiguredJobProperties(
+      enabled: true,
+      label: "test",
+      type: "test",
+      parameters: [
+        new PreconfiguredJobStageParameter(
+          mapping: "manifest.metadata.name",
+          defaultValue: "fromParameter",
+          name: "metadataName"
+        )
+      ],
+      manifest: new V1Job(metadata: [name: "defaultName"])
+    )
+
+    def jobService = Mock(JobService) {
+      2 * getPreconfiguredStages() >> {
+        return [
+          property
+        ]
+      }
+    }
+
+    when:
+    PreconfiguredJobStage preconfiguredJobStage = new PreconfiguredJobStage(Optional.of(jobService))
+    preconfiguredJobStage.buildTaskGraph(stage)
+
+    then:
+    // verify that underlying job configuration hasn't been modified
+    def preconfiguredJob = (KubernetesPreconfiguredJobProperties) jobService.getPreconfiguredStages().get(0)
+    preconfiguredJob.getManifest().getMetadata().getName() == manifestMetadataName
+    // verify that stage manifest has the correctly overridden name
+    stage.getContext().get("manifest").metadata.name == overriddenName
   }
 }


### PR DESCRIPTION
fixes a case where parameter overrides would override the base job
configuration as well as the job in the context. this is because the
previous implementation would assign a reference to context[it]
instead of a copy. when the parameter overriding was done it would not
only modify the fields in context but also the base configuration. this
presented itself when running > 1 job in parallel. by focing a new copy
(via converValue for simplicity) we get a fresh object reference we
can assign.
