### PR TITLE
feat(kubernetes): Skip loading events for manifest retrieval in WaitF…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -42,6 +42,11 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   }
 
   @Override
+  public Manifest getManifest(String account, String name, boolean includeEvents) {
+    return getService().getManifest(account, name, includeEvents);
+  }
+
+  @Override
   public Manifest getManifest(String account, String location, String name) {
     return StringUtils.isEmpty(location)
         ? getService().getManifest(account, name)
@@ -49,9 +54,29 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   }
 
   @Override
+  public Manifest getManifest(String account, String location, String name, boolean includeEvents) {
+    return StringUtils.isEmpty(location)
+        ? getService().getManifest(account, name, includeEvents)
+        : getService().getManifest(account, location, name, includeEvents);
+  }
+
+  @Override
   public Manifest getDynamicManifest(
       String account, String location, String kind, String app, String cluster, String criteria) {
     return getService().getDynamicManifest(account, location, kind, app, cluster, criteria);
+  }
+
+  @Override
+  public Manifest getDynamicManifest(
+      String account,
+      String location,
+      String kind,
+      String app,
+      String cluster,
+      String criteria,
+      boolean includeEvents) {
+    return getService()
+        .getDynamicManifest(account, location, kind, app, cluster, criteria, includeEvents);
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -37,20 +37,8 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   }
 
   @Override
-  public Manifest getManifest(String account, String name) {
-    return getService().getManifest(account, name);
-  }
-
-  @Override
   public Manifest getManifest(String account, String name, boolean includeEvents) {
     return getService().getManifest(account, name, includeEvents);
-  }
-
-  @Override
-  public Manifest getManifest(String account, String location, String name) {
-    return StringUtils.isEmpty(location)
-        ? getService().getManifest(account, name)
-        : getService().getManifest(account, location, name);
   }
 
   @Override
@@ -64,19 +52,6 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   public Manifest getDynamicManifest(
       String account, String location, String kind, String app, String cluster, String criteria) {
     return getService().getDynamicManifest(account, location, kind, app, cluster, criteria);
-  }
-
-  @Override
-  public Manifest getDynamicManifest(
-      String account,
-      String location,
-      String kind,
-      String app,
-      String cluster,
-      String criteria,
-      boolean includeEvents) {
-    return getService()
-        .getDynamicManifest(account, location, kind, app, cluster, criteria, includeEvents);
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -47,17 +47,8 @@ interface OortService {
 
   @GET("/manifests/{account}/_/{manifest}")
   Manifest getManifest(@Path("account") String account,
-                       @Path("manifest") String manifest)
-
-  @GET("/manifests/{account}/_/{manifest}")
-  Manifest getManifest(@Path("account") String account,
                        @Path("manifest") String manifest,
                        @Query("includeEvents") boolean includeEvents)
-
-  @GET("/manifests/{account}/{location}/{manifest}")
-  Manifest getManifest(@Path("account") String account,
-                       @Path("location") String location,
-                       @Path("manifest") String manifest)
 
   @GET("/manifests/{account}/{location}/{manifest}")
   Manifest getManifest(@Path("account") String account,
@@ -72,15 +63,6 @@ interface OortService {
                               @Path("app") String app,
                               @Path("clusterName") String clusterName,
                               @Path("criteria") String criteria)
-
-  @GET("/manifests/{account}/{location}/{kind}/cluster/{app}/{clusterName}/dynamic/{criteria}")
-  Manifest getDynamicManifest(@Path("account") String account,
-                              @Path("location") String location,
-                              @Path("kind") String kind,
-                              @Path("app") String app,
-                              @Path("clusterName") String clusterName,
-                              @Path("criteria") String criteria,
-                              @Query("includeEvents") boolean includeEvents)
 
   @Deprecated
   @GET("/applications/{app}/serverGroups/{account}/{region}/{serverGroup}")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -49,10 +49,21 @@ interface OortService {
   Manifest getManifest(@Path("account") String account,
                        @Path("manifest") String manifest)
 
+  @GET("/manifests/{account}/_/{manifest}")
+  Manifest getManifest(@Path("account") String account,
+                       @Path("manifest") String manifest,
+                       @Query("includeEvents") boolean includeEvents)
+
   @GET("/manifests/{account}/{location}/{manifest}")
   Manifest getManifest(@Path("account") String account,
                        @Path("location") String location,
                        @Path("manifest") String manifest)
+
+  @GET("/manifests/{account}/{location}/{manifest}")
+  Manifest getManifest(@Path("account") String account,
+                       @Path("location") String location,
+                       @Path("manifest") String manifest,
+                       @Query("includeEvents") boolean includeEvents)
 
   @GET("/manifests/{account}/{location}/{kind}/cluster/{app}/{clusterName}/dynamic/{criteria}")
   Manifest getDynamicManifest(@Path("account") String account,
@@ -61,6 +72,15 @@ interface OortService {
                               @Path("app") String app,
                               @Path("clusterName") String clusterName,
                               @Path("criteria") String criteria)
+
+  @GET("/manifests/{account}/{location}/{kind}/cluster/{app}/{clusterName}/dynamic/{criteria}")
+  Manifest getDynamicManifest(@Path("account") String account,
+                              @Path("location") String location,
+                              @Path("kind") String kind,
+                              @Path("app") String app,
+                              @Path("clusterName") String clusterName,
+                              @Path("criteria") String criteria,
+                              @Query("includeEvents") boolean includeEvents)
 
   @Deprecated
   @GET("/applications/{app}/serverGroups/{account}/{region}/{serverGroup}")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactsFromResourceTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactsFromResourceTask.java
@@ -49,7 +49,8 @@ public class FindArtifactsFromResourceTask extends AbstractCloudProviderAwareTas
 
     Manifest manifest =
         retrySupport.retry(
-            () -> oortService.getManifest(account, stageData.location, stageData.manifestName),
+            () ->
+                oortService.getManifest(account, stageData.location, stageData.manifestName, false),
             5,
             1000,
             true);

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTask.java
@@ -78,7 +78,7 @@ public class WaitForManifestStableTask
         String identifier = readableIdentifier(account, location, name);
         Manifest manifest;
         try {
-          manifest = oortService.getManifest(account, location, name);
+          manifest = oortService.getManifest(account, location, name, false);
         } catch (RetrofitError e) {
           log.warn("Unable to read manifest {}", identifier, e);
           return TaskResult.builder(ExecutionStatus.RUNNING)


### PR DESCRIPTION
This change makes use of the changes in https://github.com/spinnaker/clouddriver/pull/3796 to skip loading events when retrieving manifests in WaitForManifestStableTask.

We ran into this scenario when we had a lot of deployment pipelines running concurrently, and each deployment involved a decent number of manifests (~30). This task iterates through the manifests involved in the deployment and calls the retrieve manifest API for each one, which (when live manifest mode is enabled) causes a lot of full event loads to occur, which tanks (in our case) the kubernetes API server. 

WaitForManifestStableTask does not actually need any event information to do its job, so in this particular case we can skip loading events and prevent the extra load on the kubernetes api server.
