### PR TITLE
perf(kubernetes): WaitForManifestStableTask - don't check already com…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableContext.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableContext.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Getter;
+
+@Getter
+public class WaitForManifestStableContext extends HashMap<String, Object> {
+
+  private final Optional<List<String>> messages;
+  private final Optional<Exception> exception;
+  private final Optional<List<Map<String, String>>> stableManifests;
+  private final Optional<List<Map<String, String>>> failedManifests;
+  private final Optional<List> warnings;
+
+  // There does not seem to be a way to auto-generate a constructor using our current version of
+  // Lombok (1.16.20) that
+  // Jackson can use to deserialize.
+  public WaitForManifestStableContext(
+      @JsonProperty("messages") Optional<List<String>> messages,
+      @JsonProperty("exception") Optional<Exception> exception,
+      @JsonProperty("stableManifests") Optional<List<Map<String, String>>> stableManifests,
+      @JsonProperty("failedManifests") Optional<List<Map<String, String>>> failedManifests,
+      @JsonProperty("warnings") Optional<List> warnings) {
+    this.messages = messages;
+    this.exception = exception;
+    this.stableManifests = stableManifests;
+    this.failedManifests = failedManifests;
+    this.warnings = warnings;
+  }
+
+  public List<Map<String, String>> getCompletedManifests() {
+    return Stream.concat(
+            stableManifests.orElse(Collections.emptyList()).stream(),
+            failedManifests.orElse(Collections.emptyList()).stream())
+        .collect(Collectors.toList());
+  }
+
+  public Optional<List<String>> getFailureMessages() {
+    return getException()
+        .flatMap((exception) -> exception.getDetails().map(details -> details.get("errors")));
+  }
+
+  @Getter
+  private static class Exception {
+    private final Optional<Map<String, List<String>>> details;
+
+    public Exception(@JsonProperty("details") Optional<Map<String, List<String>>> details) {
+      this.details = details;
+    }
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTask.java
@@ -27,7 +27,6 @@ import com.netflix.spinnaker.orca.clouddriver.model.Manifest;
 import com.netflix.spinnaker.orca.clouddriver.model.Manifest.Status;
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,13 +65,11 @@ public class WaitForManifestStableTask
 
     WaitForManifestStableContext context = stage.mapTo(WaitForManifestStableContext.class);
 
-    List<String> messages = context.getMessages().orElseGet(ArrayList::new);
-    List<String> failureMessages = context.getFailureMessages().orElseGet(ArrayList::new);
-    List<Map<String, String>> stableManifests =
-        context.getStableManifests().orElseGet(ArrayList::new);
-    List<Map<String, String>> failedManifests =
-        context.getFailedManifests().orElseGet(ArrayList::new);
-    List warnings = context.getWarnings().orElseGet(ArrayList::new);
+    List<String> messages = context.getMessages();
+    List<String> failureMessages = context.getFailureMessages();
+    List<Map<String, String>> stableManifests = context.getStableManifests();
+    List<Map<String, String>> failedManifests = context.getFailedManifests();
+    List warnings = context.getWarnings();
 
     boolean allStable = true;
     boolean anyFailed = false;

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskSpec.groovy
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2019 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.model.Manifest
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
+import static com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
+
+class WaitForManifestStableTaskSpec extends Specification {
+
+  def oortService = Mock(OortService)
+
+  @Subject
+  WaitForManifestStableTask task = new WaitForManifestStableTask(
+    oortService,
+    Stub(ObjectMapper)
+  )
+
+  def "task result is SUCCEEDED when a single deployed manifest is stable"() {
+    given:
+    def stage = createStage([
+      "outputs.manifestNamesByNamespace": [
+        "my-namespace": ["my-manifest-1"]
+      ]
+    ])
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * oortService.getManifest("my-k8s-account", "my-namespace", "my-manifest-1", false) >> stableManifest("stable", [[type: "warning", message: "my-manifest-1 warning"]])
+
+    result.status == SUCCEEDED
+    result.context == createContext([
+      stableManifests: [[manifestName: "my-manifest-1", location: "my-namespace"]],
+      warnings       : [[type: "warning", message: "my-manifest-1 warning"]]
+    ])
+  }
+
+  def "task result is TERMINAL when a single deployed manifest is failed"() {
+    given:
+    def stage = createStage([
+      "outputs.manifestNamesByNamespace": [
+        "my-namespace": ["my-manifest-1"]
+      ]
+    ])
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * oortService.getManifest("my-k8s-account", "my-namespace", "my-manifest-1", false) >> failedManifest("failed to stabilize")
+
+    result.status == TERMINAL
+    result.context == createContext([
+      messages       : [
+        "'my-manifest-1' in 'my-namespace' for account my-k8s-account: waiting for manifest to stabilize",
+        "'my-manifest-1' in 'my-namespace' for account my-k8s-account: failed to stabilize"
+      ],
+      failedManifests: [[manifestName: "my-manifest-1", location: "my-namespace"]],
+      exception      : [
+        details: [
+          errors: ["'my-manifest-1' in 'my-namespace' for account my-k8s-account: failed to stabilize"]
+        ]
+      ]
+    ])
+  }
+
+  def "manifests that are known to be failed or stable are not checked again"() {
+    given:
+    def stage = createStage([
+      "outputs.manifestNamesByNamespace": [
+        "my-namespace": ["my-manifest-1", "my-manifest-2", "my-manifest-3", "my-manifest-4"]
+      ],
+      "stableManifests"                 : [[manifestName: "my-manifest-1", location: "my-namespace"]],
+      "failedManifests"                 : [[manifestName: "my-manifest-3", location: "my-namespace"]],
+      messages                          : [
+        "'my-manifest-2' in 'my-namespace' for account my-k8s-account: waiting for manifest to stabilize",
+        "'my-manifest-3' in 'my-namespace' for account my-k8s-account: failed to stabilize"
+      ],
+      exception                         : [
+        details: [
+          errors: ["'my-manifest-3' in 'my-namespace' for account my-k8s-account: failed to stabilize"]
+        ]
+      ],
+      warnings                          : [[type: "warning", message: "my-manifest-1 warning"]]
+    ])
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * oortService.getManifest("my-k8s-account", "my-namespace", "my-manifest-2", false) >> stableManifest()
+    1 * oortService.getManifest("my-k8s-account", "my-namespace", "my-manifest-4", false) >> failedManifest("failed to stabilize", [[type: "warning", message: "my-manifest-4 warning"]])
+    0 * oortService._
+
+    result.status == TERMINAL
+    result.context == createContext([
+      stableManifests: [
+        [manifestName: "my-manifest-1", location: "my-namespace"],
+        [manifestName: "my-manifest-2", location: "my-namespace"]
+      ],
+      failedManifests: [
+        [manifestName: "my-manifest-3", location: "my-namespace"],
+        [manifestName: "my-manifest-4", location: "my-namespace"]
+      ],
+      messages       : [
+        "'my-manifest-2' in 'my-namespace' for account my-k8s-account: waiting for manifest to stabilize",
+        "'my-manifest-3' in 'my-namespace' for account my-k8s-account: failed to stabilize",
+        "'my-manifest-4' in 'my-namespace' for account my-k8s-account: waiting for manifest to stabilize",
+        "'my-manifest-4' in 'my-namespace' for account my-k8s-account: failed to stabilize"
+      ],
+      exception      : [
+        details: [
+          errors: [
+            "'my-manifest-3' in 'my-namespace' for account my-k8s-account: failed to stabilize",
+            "'my-manifest-4' in 'my-namespace' for account my-k8s-account: failed to stabilize"
+          ]
+        ]
+      ],
+      warnings       : [
+        [type: "warning", message: "my-manifest-1 warning"],
+        [type: "warning", message: "my-manifest-4 warning"],
+      ]
+    ])
+  }
+
+  def stableManifest(message = "Stable", warnings = null) {
+    return Stub(Manifest) {
+      getStatus() >> Stub(Manifest.Status) {
+        getStable() >> [state: true, message: message]
+        getFailed() >> [state: false, message: null]
+      }
+
+      if (warnings != null) {
+        getWarnings() >> warnings
+      }
+    }
+  }
+
+  def failedManifest(String message, warnings = null) {
+    return Stub(Manifest) {
+      getStatus() >> Stub(Manifest.Status) {
+        getStable() >> [state: false, message: null]
+        getFailed() >> [state: true, message: message]
+      }
+
+
+      if (warnings != null) {
+        getWarnings() >> warnings
+      }
+    }
+  }
+
+  def createContext(Map extra) {
+    return [
+      messages       : [],
+      stableManifests: [],
+      failedManifests: []
+    ] + extra
+  }
+
+  def createStage(Map extraContext) {
+    return new Stage(Stub(Execution), "waitForManifestToStabilize", [
+      account: "my-k8s-account",
+    ] + extraContext)
+  }
+}


### PR DESCRIPTION
…pleted manifests

This change simply uses the existing persisted information (in the context) about stable manifests and failed manifests to prevent rechecking known stable/failed manifests.

When WaitForManifestStableTask executes, it checks all manifests involved in a deployment, even if those manifests have been checked previously and known to be stable or failed. 

This can have some compounding effects when you have a deployment with a lot of manifests, of which most become stable immediately (e.g. configmaps, networkpolicy, etc), and others take many minutes to become stable (e.g. deployments). 

This leads to unnecessary sustained pressure on the kubernetes API server, especially when many concurrent deployments are occurring. It's exacerbated further by the issue described in https://github.com/spinnaker/orca/pull/2997

