### PR TITLE
fix(findImageFromTags): don't fail on missing tags

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
@@ -47,6 +47,7 @@ public class FindImageFromTagsTask extends AbstractCloudProviderAwareTask implem
   @Override
   public TaskResult execute(Stage stage) {
     String cloudProvider = getCloudProvider(stage);
+
     ImageFinder imageFinder =
         imageFinders.stream()
             .filter(it -> it.getCloudProvider().equals(cloudProvider))
@@ -57,6 +58,11 @@ public class FindImageFromTagsTask extends AbstractCloudProviderAwareTask implem
                         "ImageFinder not found for cloudProvider " + cloudProvider));
 
     StageData stageData = (StageData) stage.mapTo(StageData.class);
+
+    if (stageData.tags == null) {
+      stageData.tags = Collections.emptyMap();
+    }
+
     Collection<ImageFinder.ImageDetails> imageDetails =
         imageFinder.byTags(stage, stageData.packageName, stageData.tags);
 


### PR DESCRIPTION
When `tags` aren't provided by the user, treat it as if the user set them to an empty map
instead of failing with `NullPointerException`
