### PR TITLE
fix: add default config for security groups

### DIFF
--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -4,6 +4,9 @@ server:
 default:
   bake:
     account: default
+  securityGroups: []
+  vpc:
+    securityGroups: []
 
 front50:
   enabled: true


### PR DESCRIPTION
Currently, we are testing features in debug mode, but aws server
group creation always failed because: "Missing security groups:
nf-datacenter,nf-infrastructure". This caused by default config
file in orca-web/config/orca.yml doesn't have default security
group settings, hence when we create alb in deck, orca always
adds two nonexistent security group name into security groups,
and failure happens because clouddriver cannot find them.

We donnot want others cost valuable time in resolving such issue
when they are fresh or unfamiliar with aws provider code logic.

This patch simply adds these settings in default config.

