### PR TITLE
fix(bake): Lookup artifact details from all upstream stages

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/ecs/EcsServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/ecs/EcsServerGroupCreator.groovy
@@ -49,7 +49,7 @@ class EcsServerGroupCreator implements ServerGroupCreator, DeploymentDetailsAwar
       if (imageDescription.fromContext) {
         if (stage.execution.type == ExecutionType.ORCHESTRATION) {
           // Use image from specific "find image from tags" stage
-          def imageStage = getAncestors(stage, stage.execution).find {
+          def imageStage = stage.ancestorsWithParentPipelines().find {
             it.refId == imageDescription.stageId && it.context.containsKey("amiDetails")
           }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
@@ -62,7 +62,7 @@ trait DeploymentDetailsAware {
       return null
     }
 
-    return getAncestors(stage, stage.execution).find {
+    return stage.ancestorsWithParentPipelines().find {
       def regions = (it.context.region ? [it.context.region] : it.context.regions) as Set<String>
       def cloudProviderFromContext = it.context.cloudProvider ?: it.context.cloudProviderType
       boolean hasTargetCloudProvider = !cloudProviderFromContext || targetCloudProvider == cloudProviderFromContext
@@ -86,53 +86,6 @@ trait DeploymentDetailsAware {
       return previousStage.context.cloudProvider == stage.context.cloudProvider
     }
     return true
-  }
-
-  List<Stage> getAncestors(Stage stage, Execution execution) {
-    if (stage?.requisiteStageRefIds) {
-      def previousStages = execution.stages.findAll {
-        it.refId in stage.requisiteStageRefIds
-
-      }
-      def syntheticStages = execution.stages.findAll {
-        it.parentStageId in previousStages*.id
-      }
-      return (previousStages + syntheticStages) + previousStages.collect { getAncestors(it, execution ) }.flatten()
-    } else if (stage?.parentStageId) {
-      def parent = execution.stages.find { it.id == stage.parentStageId }
-      return ([parent] + getAncestors(parent, execution)).flatten()
-    } else if (execution.type == PIPELINE) {
-      def parentPipelineExecution = getParentPipelineExecution(execution)
-
-      if (parentPipelineExecution) {
-        String parentPipelineStageId = (execution.trigger as PipelineTrigger).parentPipelineStageId
-        Stage parentPipelineStage = parentPipelineExecution.stages?.find {
-          it.type == "pipeline" && it.id == parentPipelineStageId
-        }
-
-        if (parentPipelineStage) {
-          return getAncestors(parentPipelineStage, parentPipelineExecution)
-        } else {
-          List<Stage> parentPipelineStages = parentPipelineExecution.stages?.collect()?.sort {
-            a, b -> b.endTime <=> a.endTime
-          }
-
-          if (parentPipelineStages) {
-            // The list is sorted in reverse order by endTime.
-            Stage firstStage = parentPipelineStages.last()
-
-            return parentPipelineStages + getAncestors(firstStage, parentPipelineExecution)
-          } else {
-            // Parent pipeline has no stages.
-            return getAncestors(null, parentPipelineExecution)
-          }
-        }
-      }
-
-      return []
-    } else {
-      return []
-    }
   }
 
   private Execution getParentPipelineExecution(Execution execution) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DeploymentDetailsAware.groovy
@@ -62,7 +62,7 @@ trait DeploymentDetailsAware {
       return null
     }
 
-    return stage.ancestorsWithParentPipelines().find {
+    Stage ancestorWithImage = stage.findAncestor({
       def regions = (it.context.region ? [it.context.region] : it.context.regions) as Set<String>
       def cloudProviderFromContext = it.context.cloudProvider ?: it.context.cloudProviderType
       boolean hasTargetCloudProvider = !cloudProviderFromContext || targetCloudProvider == cloudProviderFromContext
@@ -70,7 +70,9 @@ trait DeploymentDetailsAware {
       boolean hasImage = it.context.containsKey("ami") || it.context.containsKey("amiDetails")
 
       return hasImage && hasTargetRegion && hasTargetCloudProvider
-    }
+    })
+
+    return ancestorWithImage
   }
 
   List<Execution> getPipelineExecutions(Execution execution) {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.java
@@ -31,9 +31,9 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 /**
- * This class inspects the context of a stage, preceding stages, the trigger, and possibly the
- * parent pipeline in order to see if an artifact matching the name(s) specified in the bake stage
- * was produced. If so, that version will be used in the bake request. If nothing is found after all
+ * This class inspects the context of a stage, preceding stages, the trigger, and the parent
+ * pipeline in order to see if an artifact matching the name(s) specified in the bake stage was
+ * produced. If so, that version will be used in the bake request. If nothing is found after all
  * this searching it is up to the bakery to pull the latest package version.
  *
  * <p>Artifact information comes from Jenkins on the pipeline trigger in the field
@@ -386,7 +386,7 @@ public class PackageInfo {
   private static Map<String, Object> findBuildInfoInUpstreamStage(
       Stage currentStage, List<Pattern> packageFilePatterns) {
     Stage upstreamStage =
-        currentStage.ancestors().stream()
+        currentStage.ancestorsWithParentPipelines().stream()
             .filter(
                 it -> {
                   Map<String, Object> buildInfo =

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.java
@@ -385,19 +385,17 @@ public class PackageInfo {
 
   private static Map<String, Object> findBuildInfoInUpstreamStage(
       Stage currentStage, List<Pattern> packageFilePatterns) {
+
     Stage upstreamStage =
-        currentStage.ancestorsWithParentPipelines().stream()
-            .filter(
-                it -> {
-                  Map<String, Object> buildInfo =
-                      (Map<String, Object>) it.getOutputs().get("buildInfo");
-                  return buildInfo != null
-                      && artifactMatch(
-                          (List<Map<String, String>>) buildInfo.get("artifacts"),
-                          packageFilePatterns);
-                })
-            .findFirst()
-            .orElse(null);
+        currentStage.findAncestor(
+            it -> {
+              Map<String, Object> buildInfo =
+                  (Map<String, Object>) it.getOutputs().get("buildInfo");
+              return buildInfo != null
+                  && artifactMatch(
+                      (List<Map<String, String>>) buildInfo.get("artifacts"), packageFilePatterns);
+            });
+
     return upstreamStage != null
         ? (Map<String, Object>) upstreamStage.getOutputs().get("buildInfo")
         : emptyMap();
@@ -405,6 +403,7 @@ public class PackageInfo {
 
   private static boolean artifactMatch(
       List<Map<String, String>> artifacts, List<Pattern> patterns) {
+
     return artifacts != null
         && artifacts.stream()
             .anyMatch(

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
@@ -779,25 +779,59 @@ class PackageInfoSpec extends Specification {
     [["fileName": "test-package-1539516142-1.x86_64.rpm"]]   | [["fileName": "test-package-1539516142-1.x86_64.rpm"]]     | "test-package"     | "test-package-1539516142-1.x86_64"
   }
 
-  def "parent pipeline jenkins job has artifact, but there are other jenkins stages"() {
+  def "locates correct artifact from prior Jenkins stages (including parent executions)"() {
     given:
-    def parentPipeline = pipeline {
+    def grandParentPipeline = pipeline {
       stage {
-        refId = "1"
+        refId = "1-gp"
+        type = "jenkins"
+        outputs["buildInfo"] = [
+          url      : "http://jenkins",
+          master   : "master",
+          name     : "grandParentStage",
+          number   : 1,
+          artifacts: [[fileName: "artifact1_1.1.1-h01.grandParent.deb", relativePath: "."],
+                      [fileName: "artifact2_1.1.1-h01.grandParent.deb", relativePath: "."]],
+          scm      : []
+        ]
+      }
+      stage {
+        refId = "2-gp"
+        type = "pipeline"
+        requisiteStageRefIds = ["1-gp"]
+      }
+    }
+
+    def parentPipeline = pipeline {
+      trigger = new PipelineTrigger(
+        "pipeline",
+        null,
+        "example@example.com",
+        [:],
+        [],
+        [],
+        false,
+        false,
+        false,
+        grandParentPipeline,
+        grandParentPipeline.stageByRef("2-gp").id
+      )
+      stage {
+        refId = "1-p"
         type = "jenkins"
         outputs["buildInfo"] = [
           url      : "http://jenkins",
           master   : "master",
           name     : "parentStage",
           number   : 1,
-          artifacts: [[fileName: "api_1.1.1-h01.sha123_all.deb", relativePath: "."]],
+          artifacts: [[fileName: "artifact1_1.1.2-h02-parent.deb", relativePath: "."]],
           scm      : []
         ]
       }
       stage {
-        refId = "2"
+        refId = "2-p"
         type = "pipeline"
-        requisiteStageRefIds = ["1"]
+        requisiteStageRefIds = ["1-p"]
       }
     }
     def pipeline = pipeline {
@@ -812,7 +846,7 @@ class PackageInfoSpec extends Specification {
         false,
         false,
         parentPipeline,
-        parentPipeline.stageByRef("2").id
+        parentPipeline.stageByRef("2-p").id
       )
       stage {
         refId = "1-child"
@@ -820,31 +854,63 @@ class PackageInfoSpec extends Specification {
         outputs["buildInfo"] = [
           url      : "http://jenkins",
           master   : "master",
-          name     : "job",
+          name     : "childStage",
           number   : 1,
-          artifacts: [[fileName: "blah_1.1.1-h01.sha123_all.deb", relativePath: "."]],
+          artifacts: [[fileName: "blah_1.1.1-h01.child.deb", relativePath: "."]],
           scm      : []
         ]
       }
       stage {
-        type = "bake"
-        refId = "2-child"
+        type = "bake-child"
+        refId = "child-bake-bakes-blah"
         requisiteStageRefIds = ["1-child"]
-        context["package"] = "api"
+        context["package"] = "blah"
+      }
+      stage {
+        type = "bake-parent"
+        refId = "child-bake-bakes-artifact1"
+        requisiteStageRefIds = ["1-child"]
+        context["package"] = "artifact1"
+      }
+      stage {
+        type = "bake-grandparent"
+        refId = "child-bake-bakes-artifact2"
+        requisiteStageRefIds = ["1-child"]
+        context["package"] = "artifact2"
       }
     }
 
-    def bakeStage = pipeline.stageByRef("2-child")
     PackageType packageType = DEB
     ObjectMapper objectMapper = new ObjectMapper()
-    PackageInfo packageInfo = new PackageInfo(bakeStage, [], packageType.packageType, packageType.versionDelimiter, true, true, objectMapper)
 
     when:
-    def buildInfo = packageInfo.findTargetPackage(false)
+    PackageInfo packageInfo1 = new PackageInfo(
+      pipeline.stageByRef("child-bake-bakes-blah"), [], packageType.packageType, packageType.versionDelimiter, true, true, objectMapper)
+    def buildInfo1 = packageInfo1.findTargetPackage(false)
 
     then:
     noExceptionThrown()
-    buildInfo == [packageVersion:"1.1.1-h01.sha123", package:"api_1.1.1-h01.sha123_all",
+    buildInfo1 == [packageVersion:"1.1.1-h01.child", package:"blah_1.1.1-h01.child",
+                  buildInfoUrl:"http://jenkins", job:"childStage", buildNumber:1]
+
+    when:
+    PackageInfo packageInfo2 = new PackageInfo(
+      pipeline.stageByRef("child-bake-bakes-artifact1"), [], packageType.packageType, packageType.versionDelimiter, true, true, objectMapper)
+    def buildInfo2 = packageInfo2.findTargetPackage(false)
+
+    then:
+    noExceptionThrown()
+    buildInfo2 == [packageVersion:"1.1.2-h02-parent", package:"artifact1_1.1.2-h02-parent",
                   buildInfoUrl:"http://jenkins", job:"parentStage", buildNumber:1]
+
+    when:
+    PackageInfo packageInfo3 = new PackageInfo(
+      pipeline.stageByRef("child-bake-bakes-artifact2"), [], packageType.packageType, packageType.versionDelimiter, true, true, objectMapper)
+    def buildInfo3 = packageInfo3.findTargetPackage(false)
+
+    then:
+    noExceptionThrown()
+    buildInfo3 == [packageVersion:"1.1.1-h01.grandParent", package:"artifact2_1.1.1-h01.grandParent",
+                   buildInfoUrl:"http://jenkins", job:"grandParentStage", buildNumber:1]
   }
 }


### PR DESCRIPTION
Imagine following setup:
```
Pipeline A
 -> Jenkins job (produces foo.*.deb)
 -> Run Pipeline B
    -> Jenkins job (produces bar.*.deb)
    -> Bake package foo
```

In this case, the package lookup for bake stage will fail to lookup artifact
details for `foo.deb` to pass to the bakery. Thus the bakery is free to pick the
latest artifact matching the name which can be the wrong artifact.

This change allows package look up to traverse up parent pipeline stages, similar
to `FindImage` tasks