### PR TITLE
feat(core): Support deserializing `Execution.initialConfig`

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -206,6 +206,7 @@ public class ExecutionLauncher {
         .withLimitConcurrent(getBoolean(config, "limitConcurrent"))
         .withKeepWaitingPipelines(getBoolean(config, "keepWaitingPipelines"))
         .withNotifications((List<Map<String, Object>>) config.get("notifications"))
+        .withInitialConfig((Map<String, Object>) config.get("initialConfig"))
         .withOrigin(getString(config, "origin"))
         .withStartTimeExpiry(getString(config, "startTimeExpiry"))
         .withSource(

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -292,9 +292,9 @@ public class Execution implements Serializable {
     return notifications;
   }
 
-  private final Map<String, Serializable> initialConfig = new HashMap<>();
+  private final Map<String, Object> initialConfig = new HashMap<>();
 
-  public @Nonnull Map<String, Serializable> getInitialConfig() {
+  public @Nonnull Map<String, Object> getInitialConfig() {
     return initialConfig;
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
@@ -50,6 +50,15 @@ public class PipelineBuilder {
     return this;
   }
 
+  public PipelineBuilder withInitialConfig(Map<String, Object> initialConfig) {
+    pipeline.getInitialConfig().clear();
+    if (initialConfig != null) {
+      pipeline.getInitialConfig().putAll(initialConfig);
+    }
+
+    return this;
+  }
+
   public PipelineBuilder withPipelineConfigId(String id) {
     pipeline.setPipelineConfigId(id);
     return this;

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/EnabledPipelineValidator.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/EnabledPipelineValidator.java
@@ -50,6 +50,12 @@ public class EnabledPipelineValidator implements PipelineValidator {
           "Front50 not enabled, no way to validate pipeline. Fix this by setting front50.enabled: true");
     }
 
+    Boolean isExplicitlyEnabled =
+        (Boolean) pipeline.getInitialConfig().getOrDefault("enabled", false);
+    if (isExplicitlyEnabled) {
+      return;
+    }
+
     if (!isStrategy(pipeline)) {
       try {
         // attempt an optimized lookup via pipeline history vs fetching all pipelines for the


### PR DESCRIPTION
Also adds support for using `initialConfig.enabled` as a short circuit
of the `EnabledPipelineValidator` check.

This seems reasonable as a user can already submit pipeline json against
an arbitrary pipeline config id (that may or may not exist).

Providing an ability to explicitly override the enabled check seems
harmless.
