### PR TITLE
fix(exceptions): don't let `null` strings leak into errors field

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/exceptions/ExceptionHandler.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/exceptions/ExceptionHandler.java
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.orca.exceptions;
 
+import com.google.common.base.Strings;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /** ExceptionHandler. */
 public interface ExceptionHandler {
@@ -90,7 +92,13 @@ public interface ExceptionHandler {
   static Map<String, Object> responseDetails(String error, List<String> errors) {
     Map<String, Object> details = new HashMap<>();
     details.put("error", error);
-    details.put("errors", errors == null ? Collections.emptyList() : errors);
+    if (errors == null) {
+      errors = Collections.emptyList();
+    }
+
+    details.put(
+        "errors",
+        errors.stream().filter(x -> !Strings.isNullOrEmpty(x)).collect(Collectors.toList()));
     return details;
   }
 }


### PR DESCRIPTION
`errors` should be a meaningful message since that's what UI will show.
some parts of the code (`RetrofitExceptionHandler`) already ensure that the
message can't be null, but the default handler does not.
Adding it to the lowest level so callers don't have to worry about it
