### PR TITLE
fix(pipelines): expectedArtifacts inheritance from dynamic parent templates

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequest.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequest.java
@@ -16,7 +16,6 @@
 package com.netflix.spinnaker.orca.pipelinetemplate;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.NamedHashMap;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,7 +26,7 @@ public class TemplatedPipelineRequest {
   String id;
   String schema;
   String type;
-  List<ExpectedArtifact> expectedArtifacts;
+  List<Map<String, Object>> expectedArtifacts;
   Map<String, Object> trigger = new HashMap<>();
   Map<String, Object> config;
   Map<String, Object> template;
@@ -130,11 +129,11 @@ public class TemplatedPipelineRequest {
     return keepWaitingPipelines;
   }
 
-  public void setExpectedArtifacts(List<ExpectedArtifact> expectedArtifacts) {
+  public void setExpectedArtifacts(List<Map<String, Object>> expectedArtifacts) {
     this.expectedArtifacts = expectedArtifacts;
   }
 
-  public List<ExpectedArtifact> getExpectedArtifacts() {
+  public List<Map<String, Object>> getExpectedArtifacts() {
     return this.expectedArtifacts;
   }
 }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -177,7 +177,8 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
         job: "job",
         buildNumber: 1111
       ],
-      triggers: []
+      triggers: [],
+      expectedArtifacts: []
     ]
     assertReflectionEquals(expected, result, ReflectionComparatorMode.IGNORE_DEFAULTS)
   }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.*
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
@@ -47,7 +48,7 @@ import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEqua
 
 class V1SchemaIntegrationSpec extends Specification {
 
-  ObjectMapper objectMapper = new ObjectMapper()
+  ObjectMapper objectMapper = OrcaObjectMapper.newInstance()
   def oortService = Mock(OortService)
 
   TemplateLoader templateLoader = new TemplateLoader([new ResourceSchemeLoader("/integration/v1schema", objectMapper)])
@@ -97,7 +98,7 @@ class V1SchemaIntegrationSpec extends Specification {
   private static class IntegrationTestDataProvider {
 
     Yaml yaml = new Yaml(new SafeConstructor())
-    ObjectMapper objectMapper = new ObjectMapper()
+    ObjectMapper objectMapper = OrcaObjectMapper.newInstance()
 
     List<IntegrationTest> provide() {
       Resource[] resources = new PathMatchingResourcePatternResolver().getResources("/integration/v1schema/**")

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/conditionalStage-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/conditionalStage-expected.json
@@ -7,5 +7,6 @@
   "stages": [],
   "notifications": [],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-expected.json
@@ -52,5 +52,6 @@
   "notifications": [],
   "parameterConfig": [],
   "id": "unknown",
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-expected.json
@@ -52,5 +52,6 @@
     }
   ],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-expected.json
@@ -52,5 +52,6 @@
     }
   ],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/expectedArtifactsInheritance-config.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/expectedArtifactsInheritance-config.yml
@@ -1,0 +1,8 @@
+---
+schema: "1"
+pipeline:
+  application: orca
+configuration:
+  inherit:
+  - expectedArtifacts
+stages: []

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/expectedArtifactsInheritance-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/expectedArtifactsInheritance-expected.json
@@ -1,0 +1,27 @@
+{
+  "id": "unknown",
+  "keepWaitingPipelines": false,
+  "limitConcurrent": true,
+  "application": "orca",
+  "name": "Unnamed Execution",
+  "stages": [],
+  "notifications": [],
+  "parameterConfig": [],
+  "triggers": [],
+  "expectedArtifacts": [
+    {
+      "id": "an-artifact",
+      "displayName": "an-artifact",
+      "defaultArtifact": {
+        "customKind": true
+      },
+      "matchArtifact": {
+        "customKind": true,
+        "type": "http/file",
+        "name": "an-artifact"
+      },
+      "useDefaultArtifact": false,
+      "usePriorArtifact": false
+    }
+  ]
+}

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/expectedArtifactsInheritance-template.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/expectedArtifactsInheritance-template.yml
@@ -1,0 +1,19 @@
+---
+schema: "1"
+id: triggerInheritance
+metadata:
+  name: Trigger Inheritance
+  description: Inheriting triggers from a template
+configuration:
+  expectedArtifacts:
+    - id: an-artifact
+      displayName: an-artifact
+      defaultArtifact:
+        customKind: true
+      matchArtifact:
+        customKind: true
+        type: http/file
+        name: an-artifact
+      useDefaultArtifact: false
+      usePriorArtifact: false
+stages: []

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/inheritance-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/inheritance-expected.json
@@ -36,5 +36,6 @@
   "id": "unknown",
   "notifications": [],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-expected.json
@@ -53,5 +53,6 @@
   ],
   "notifications": [],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/modularStageConfig-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/modularStageConfig-expected.json
@@ -16,5 +16,6 @@
   ],
   "notifications": [],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/modules-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/modules-expected.json
@@ -37,5 +37,6 @@
   ],
   "notifications": [],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/nestedConditionalStage-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/nestedConditionalStage-expected.json
@@ -17,5 +17,6 @@
   ],
   "notifications": [],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/parameterInheritance-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/parameterInheritance-expected.json
@@ -13,5 +13,6 @@
       "default": 9000
     }
   ],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/partials-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/partials-expected.json
@@ -42,5 +42,6 @@
   ],
   "notifications": [],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/partialsAndModules-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/partialsAndModules-expected.json
@@ -33,5 +33,6 @@
   ],
   "notifications": [],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/simple-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/simple-expected.json
@@ -7,5 +7,6 @@
   "stages": [],
   "notifications": [],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/stageInjection-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/stageInjection-expected.json
@@ -64,5 +64,6 @@
   "id": "unknown",
   "notifications": [],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/stageReplacement-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/stageReplacement-expected.json
@@ -133,5 +133,6 @@
     }
   ],
   "parameterConfig": [],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/triggerInheritance-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/triggerInheritance-expected.json
@@ -14,5 +14,6 @@
       "master": "mymaster",
       "job": "myjob"
     }
-  ]
+  ],
+  "expectedArtifacts": []
 }

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/variableParameters-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/variableParameters-expected.json
@@ -13,5 +13,6 @@
       "default": 3
     }
   ],
-  "triggers": []
+  "triggers": [],
+  "expectedArtifacts": []
 }


### PR DESCRIPTION
When expected artifacts are defined in a template that is sourced dynamically,
expected artifacts are not added to the execution.

Expected artifacts can be defined in `TemplatedPipelineRequest`,
`TemplateConfiguration` and `PipelineTemplate` objects, so a merge strategy
is required. Given expected artifacts have a unique `id`, artifacts with
same `id` in these object will be overridden. The artifacts with higher
priority are the ones in `TemplatedPipelineRequest`, then `TemplateConfiguration`
and finally `PipelineTemplate`.

