### PR TITLE
fix(webhook-task): replace deprecated method for json parsing

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.PathNotFoundException
-import com.jayway.jsonpath.internal.JsonContext
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.TaskResult
@@ -157,7 +156,7 @@ class CreateWebhookTask implements RetryableTask {
       }
       if (stage.context.containsKey("expectedArtifacts") && !((List) stage.context.get("expectedArtifacts")).isEmpty()) {
         try {
-          def artifacts = new JsonContext().parse(response.body).read("artifacts")
+          def artifacts = JsonPath.parse(response.body).read("artifacts")
           outputs << [artifacts: artifacts]
         } catch (Exception e) {
           outputs.webhook << [error: "Expected artifacts in webhook response none were found"]


### PR DESCRIPTION
After cadence 1.14, kork introduce json-path 2.4.0 as dependency and the JsonContext().parse method is deprecated.
As a result, webhook stage fails to bind expected artifacts. 
Issue: https://github.com/spinnaker/spinnaker/issues/4599

This PR is for replacing the method with a static parse method which works for both json-path 2.4.0 and 2.2.0

reference:
https://static.javadoc.io/com.jayway.jsonpath/json-path/2.4.0/com/jayway/jsonpath/internal/JsonContext.html
https://static.javadoc.io/com.jayway.jsonpath/json-path/2.2.0/com/jayway/jsonpath/internal/JsonContext.html