### PR TITLE
fix(queue): Propagate auth context on CancelStageHandler

### DIFF
--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandlerTest.kt
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.q.CancelStage
 import com.netflix.spinnaker.orca.q.singleTaskStage
 import com.netflix.spinnaker.q.Queue
@@ -52,6 +53,7 @@ object CancelStageHandlerTest : SubjectSpek<CancelStageHandler>({
   val repository: ExecutionRepository = mock()
   val executor = MoreExecutors.directExecutor()
   val taskResolver: TaskResolver = TaskResolver(emptyList())
+  val stageNavigator: StageNavigator = mock()
 
   val cancellableStage: CancelableStageDefinitionBuilder = mock()
   val stageResolver = StageResolver(listOf(singleTaskStage, cancellableStage))
@@ -61,6 +63,7 @@ object CancelStageHandlerTest : SubjectSpek<CancelStageHandler>({
       queue,
       repository,
       DefaultStageDefinitionBuilderFactory(stageResolver),
+      stageNavigator,
       executor,
       taskResolver
     )


### PR DESCRIPTION
This fixes https://github.com/spinnaker/spinnaker/issues/4596

Authentication is not propagated in Cancellable stages such as `CIStage`, so cancellation will fail if using Fiat permissions in build masters.

The fix is to propagate authentication context to the cancellation handler.



