### PR TITLE
fix(RRB): Correctly determine source ASG

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.moniker.Moniker
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.CreateServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.ResizeServerGroupStage
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.AbstractServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
@@ -159,7 +160,7 @@ class ApplySourceServerGroupCapacityTask extends AbstractServerGroupTask {
       }
       def pipeline = executionRepository.retrieve(PIPELINE, pipelineStage.context.executionId as String)
       deployStage = pipeline.stages.find {
-        it.context.type == "createServerGroup" && it.context.containsKey("deploy.server.groups")
+        it.context.type == CreateServerGroupStage.PIPELINE_CONFIG_TYPE && it.context.containsKey("deploy.server.groups")
       }
     }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
@@ -37,8 +37,6 @@ import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
-import javax.annotation.Nonnull
-
 import static com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.DeployStagePreProcessor.StageDefinition
 import static com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup.Support.locationFromStageData
 import static com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.newStage

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeStrategySupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ResizeStrategySupport.groovy
@@ -26,7 +26,7 @@ import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy.Capacity
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Component
 
 @Component
 @Slf4j
@@ -42,7 +42,7 @@ public class ResizeStrategySupport {
                                          StageData stageData,
                                          Map baseContext) {
     if (StageData.EMPTY_SOURCE.equals(stageData.source)) {
-      return null;
+      return null
     }
 
     if (stageData.source) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleExactResizeStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/ScaleExactResizeStrategy.groovy
@@ -54,18 +54,21 @@ class ScaleExactResizeStrategy implements ResizeStrategy {
   }
 
   static Capacity mergeConfiguredCapacityWithCurrent(Capacity configured, Capacity current) {
-    boolean minConfigured = configured.min != null;
-    boolean desiredConfigured = configured.desired != null;
-    boolean maxConfigured = configured.max != null;
+    boolean minConfigured = configured.min != null
+    boolean desiredConfigured = configured.desired != null
+    boolean maxConfigured = configured.max != null
+
     Capacity result = new Capacity(
       min: minConfigured ? configured.min : current.min,
     )
+
     if (maxConfigured) {
       result.max = configured.max
       result.min = Math.min(result.min, configured.max)
     } else {
       result.max = Math.max(result.min, current.max)
     }
+
     if (desiredConfigured) {
       result.desired = configured.desired
     } else {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -338,21 +338,50 @@ public class Stage implements Serializable {
     return tasks.stream().filter(it -> it.getId().equals(taskId)).findFirst().orElse(null);
   }
 
-  /** Gets all ancestor stages, including the current stage. */
+  /**
+   * Gets all ancestor stages, including the current stage.
+   *
+   * <p>Ancestors include: <br>
+   * - stages this stage depends on (via requisiteStageRefIds) <br>
+   * - parent stages of this stage <br>
+   * - synthetic stages that share a parent with this stage & occur prior to current stage <br>
+   */
   public List<Stage> ancestors() {
     if (execution != null) {
       Set<String> visited = Sets.newHashSetWithExpectedSize(execution.getStages().size());
-      return ImmutableList.<Stage>builder().add(this).addAll(ancestorsOnly(visited)).build();
+      return ImmutableList.<Stage>builder()
+          .add(this)
+          .addAll(getAncestorsImpl(visited, false))
+          .build();
     } else {
       return emptyList();
     }
   }
 
-  private List<Stage> ancestorsOnly(Set<String> visited) {
+  /**
+   * Gets all ancestor stages that are direct parents, including the current stage.
+   *
+   * <p>Ancestors include: <br>
+   * - parent stages of this stage <br>
+   * - synthetic stages that share a parent with this stage & occur prior to current stage
+   */
+  public List<Stage> directAncestors() {
+    if (execution != null) {
+      Set<String> visited = Sets.newHashSetWithExpectedSize(execution.getStages().size());
+      return ImmutableList.<Stage>builder()
+          .add(this)
+          .addAll(getAncestorsImpl(visited, true))
+          .build();
+    } else {
+      return emptyList();
+    }
+  }
+
+  private List<Stage> getAncestorsImpl(Set<String> visited, boolean directParentOnly) {
     visited.add(this.refId);
 
-    if (!requisiteStageRefIds.isEmpty()) {
-      // Get parent stages, but exclude already visited ones.
+    if (!requisiteStageRefIds.isEmpty() && !directParentOnly) {
+      // Get stages this stage depends on via requisiteStageRefIds:
       List<Stage> previousStages =
           execution.getStages().stream()
               .filter(it -> requisiteStageRefIds.contains(it.refId))
@@ -371,10 +400,12 @@ public class Stage implements Serializable {
           .addAll(syntheticStages)
           .addAll(
               previousStages.stream()
-                  .flatMap(it -> it.ancestorsOnly(visited).stream())
+                  .flatMap(it -> it.getAncestorsImpl(visited, directParentOnly).stream())
                   .collect(toList()))
           .build();
     } else if (parentStageId != null && !visited.contains(parentStageId)) {
+      // Get parent stages, but exclude already visited ones:
+
       List<Stage> ancestors = new ArrayList<>();
       if (getSyntheticStageOwner() == SyntheticStageOwner.STAGE_AFTER) {
         ancestors.addAll(
@@ -394,7 +425,7 @@ public class Stage implements Serializable {
                   parent ->
                       ImmutableList.<Stage>builder()
                           .add(parent)
-                          .addAll(parent.ancestorsOnly(visited))
+                          .addAll(parent.getAncestorsImpl(visited, directParentOnly))
                           .build())
               .orElse(emptyList()));
 
@@ -405,9 +436,16 @@ public class Stage implements Serializable {
   }
 
   /**
-   * Computes all ancestor stages, including those of parent pipelines
+   * Find the ancestor stage that satisfies the given predicate (including traversing the parent
+   * execution graphs)
    *
-   * @return list of ancestor stages
+   * <p>Ancestor stages include: <br>
+   * - stages this stage depends on (via requisiteStageRefIds) <br>
+   * - parent stages of this stage <br>
+   * - synthetic stages that share a parent with this stage & occur prior to current stage <br>
+   * - stages in parent execution that satisfy above criteria <br>
+   *
+   * @return the first stage that matches the predicate, or null
    */
   public Stage findAncestor(Predicate<Stage> predicate) {
     return Stage.findAncestor(this, this.execution, predicate);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -377,6 +377,15 @@ public class Stage implements Serializable {
     }
   }
 
+  /**
+   * Worker method to get the list of all ancestors (parents and, optionally, prerequisite stages)
+   * of the current stage.
+   *
+   * @param visited list of visited nodes
+   * @param directParentOnly true to only include direct parents of the stage, false to also include
+   *     stages this stage depends on (via requisiteRefIds)
+   * @return list of ancestor stages
+   */
   private List<Stage> getAncestorsImpl(Set<String> visited, boolean directParentOnly) {
     visited.add(this.refId);
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -297,18 +297,6 @@ class RunTaskHandler(
     } else ZERO
   }
 
-  /**
-   * Keys that should never be added to global context. Eventually this will
-   * disappear along with global context itself.
-   */
-  private val blacklistGlobalKeys = setOf(
-    "propertyIdList",
-    "originalProperties",
-    "propertyAction",
-    "propertyAction",
-    "deploymentDetails"
-  )
-
   private fun Stage.processTaskOutput(result: TaskResult) {
     val filteredOutputs = result.outputs.filterKeys { it != "stageTimeoutMs" }
     if (result.context.isNotEmpty() || filteredOutputs.isNotEmpty()) {


### PR DESCRIPTION
Currently, if there are two ASGs:
(1) Newer one but disabled
(2) Older one but enabled

The RRB strategy will pick ASG (1) as the "source" which is incorrect for the deploy process.
This change takes advantage of the `determineSourceServerGroup` task and uses the ASG from it.