### PR TITLE
fix(webhook): Supply additional context when fetching `RestTemplate`

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/DefaultRestTemplateProvider.java
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/DefaultRestTemplateProvider.java
@@ -37,7 +37,7 @@ public class DefaultRestTemplateProvider implements RestTemplateProvider {
   }
 
   @Override
-  public RestTemplate getRestTemplate() {
+  public RestTemplate getRestTemplate(String targetUrl) {
     return restTemplate;
   }
 }

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/RestTemplateProvider.java
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/RestTemplateProvider.java
@@ -35,5 +35,5 @@ public interface RestTemplateProvider {
   }
 
   /** @return a configured {@code RestTemplate} */
-  RestTemplate getRestTemplate();
+  RestTemplate getRestTemplate(String targetUrl);
 }

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookService.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookService.groovy
@@ -57,7 +57,7 @@ class WebhookService {
     )
     HttpHeaders headers = buildHttpHeaders(customHeaders)
     HttpEntity<Object> payloadEntity = new HttpEntity<>(payload, headers)
-    return restTemplateProvider.getRestTemplate().exchange(validatedUri, httpMethod, payloadEntity, Object)
+    return restTemplateProvider.getRestTemplate(url).exchange(validatedUri, httpMethod, payloadEntity, Object)
   }
 
   ResponseEntity<Object> getStatus(String url, Object customHeaders) {


### PR DESCRIPTION
This supports the use-case of needing a specific `RestTemplate`
per url.
