### PR TITLE
fix(webhook): Support verification of redirected urls

### DIFF
--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -51,6 +51,8 @@ public class WebhookProperties {
   private List<PreconfiguredWebhook> preconfigured = new ArrayList<>();
   private TrustSettings trust;
 
+  private boolean verifyRedirects = true;
+
   @Data
   @NoArgsConstructor
   public static class TrustSettings {

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
@@ -49,13 +49,16 @@ class WebhookServiceSpec extends Specification {
   def webhookConfiguration = new WebhookConfiguration(webhookProperties)
 
   @Shared
-  def requestFactory = webhookConfiguration.webhookRequestFactory(okHttpClientConfigurationProperties)
+  def userConfiguredUrlRestrictions = new UserConfiguredUrlRestrictions.Builder().withRejectLocalhost(false).build()
+
+  @Shared
+  def requestFactory = webhookConfiguration.webhookRequestFactory(
+    okHttpClientConfigurationProperties,
+    userConfiguredUrlRestrictions
+  )
 
   @Shared
   def restTemplateProvider = new DefaultRestTemplateProvider(webhookConfiguration.restTemplate(requestFactory))
-
-  @Shared
-  def userConfiguredUrlRestrictions = new UserConfiguredUrlRestrictions.Builder().withRejectLocalhost(false).build()
 
   def preconfiguredWebhookProperties = new WebhookProperties()
 


### PR DESCRIPTION
```
public boolean isRedirect() {
    switch (code) {
      case HTTP_PERM_REDIRECT:
      case HTTP_TEMP_REDIRECT:
      case HTTP_MULT_CHOICE:
      case HTTP_MOVED_PERM:
      case HTTP_MOVED_TEMP:
      case HTTP_SEE_OTHER:
        return true;
      default:
        return false;
    }
  }
```

In the event that a redirect is detected, the value of the `Location`
header will be checked against `UserConfiguredUrlRestrictions`.

Can be disabled by setting `webhook.verifyRedirects: false`
