### PR TITLE
fix(Orca):Bake of HelmBakeManifestRequest error converting YAML to JSON: yaml: control characters are not allowed #4570

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
@@ -114,7 +114,7 @@ public class CreateBakeManifestTask implements RetryableTask {
 
     HelmBakeManifestRequest request = new HelmBakeManifestRequest();
     request.setInputArtifacts(inputArtifacts);
-    request.setTemplateRenderer(context.getTemplateRenderer());
+    request.setTemplateRenderer("HELM2");
     request.setOutputName(context.getOutputName());
     request.setOverrides(overrides);
     request.setNamespace(context.getNamespace());


### PR DESCRIPTION
Hi ,
Since UI is not able to load "HELM2" in template renderer, we are facing issue in creation on Bake manifest for Helm. For reference, please find the below link:

https://github.com/spinnaker/spinnaker/issues/4570