### PR TITLE
fix(kayenta): plumb through siteLocal for kayenta email support

### DIFF
--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/KayentaService.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/KayentaService.kt
@@ -58,7 +58,9 @@ interface KayentaService {
 
 data class CanaryExecutionRequest(
   val scopes: Map<String, CanaryScopes> = emptyMap(),
-  val thresholds: Thresholds
+  val thresholds: Thresholds,
+  // TODO: Remove all remnants of siteLocal when addressing https://github.com/spinnaker/kayenta/issues/600
+  val siteLocal: Map<String, Any> = emptyMap()
 )
 
 data class CanaryScopes(

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/model/KayentaCanaryContext.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/model/KayentaCanaryContext.kt
@@ -29,8 +29,9 @@ data class KayentaCanaryContext(
   val canaryConfigId: String,
   val scopes: List<CanaryConfigScope> = emptyList(),
   val scoreThresholds: Thresholds = Thresholds(pass = 75, marginal = 50),
-  @Deprecated("Kept to support pipelines that haven't been updated to use lifetimeDuration")
+  val siteLocal: Map<String, Any> = emptyMap(),
 
+  @Deprecated("Kept to support pipelines that haven't been updated to use lifetimeDuration")
   @JsonProperty(access = JsonProperty.Access.READ_WRITE)
   private val lifetimeHours: Int? = null,
 

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/model/RunCanaryContext.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/model/RunCanaryContext.kt
@@ -26,5 +26,6 @@ internal data class RunCanaryContext(
   val storageAccountName: String?,
   val canaryConfigId: String,
   val scopes: Map<String, CanaryScopes> = emptyMap(),
-  val scoreThresholds: Thresholds
+  val scoreThresholds: Thresholds,
+  val siteLocal: Map<String, Any> = emptyMap()
 )

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/RunCanaryIntervalsStage.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/RunCanaryIntervalsStage.kt
@@ -103,7 +103,8 @@ class RunCanaryIntervalsStage(private val clock: Clock) : StageDefinitionBuilder
         canaryConfig.storageAccountName,
         canaryConfig.canaryConfigId,
         buildRequestScopes(canaryConfig, getDeployDetails(parent), i, canaryAnalysisInterval),
-        canaryConfig.scoreThresholds
+        canaryConfig.scoreThresholds,
+        canaryConfig.siteLocal
       )
 
       graph.append {

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/RunKayentaCanaryTask.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/RunKayentaCanaryTask.kt
@@ -44,7 +44,7 @@ class RunKayentaCanaryTask(
       context.metricsAccountName,
       context.configurationAccountName,
       context.storageAccountName,
-      CanaryExecutionRequest(context.scopes, context.scoreThresholds)
+      CanaryExecutionRequest(context.scopes, context.scoreThresholds, context.siteLocal)
     )["canaryExecutionId"] as String
 
     return TaskResult.builder(SUCCEEDED).context("canaryPipelineExecutionId", canaryPipelineExecutionId).build()


### PR DESCRIPTION
This a temporary "hack" until https://github.com/spinnaker/kayenta/issues/600 is addressed.
This changes passes through the `siteLocal` stage context to the kayenta so that it can send
report emails. The `siteLocal` params are currently used at Netflix only but they exist in
OSS `deck`. Medium term, we will remove this from deck and orca
