### PR TITLE
fix(core): update validaton to exclude hyphenated variable names

### DIFF
--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v2schema/model/V2PipelineTemplate.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v2schema/model/V2PipelineTemplate.java
@@ -60,7 +60,7 @@ public class V2PipelineTemplate implements VersionedSchema {
   @NoArgsConstructor
   @AllArgsConstructor
   public static class Variable implements NamedContent<Variable>, Cloneable {
-    public static final String TEMPLATE_VALID_VARIABLE_NAME_REGEX = "^[a-zA-Z0-9-_]+$";
+    public static final String TEMPLATE_VALID_VARIABLE_NAME_REGEX = "^[a-zA-Z0-9_]+$";
     private String name;
     private String description;
     private String type;


### PR DESCRIPTION
hyphenated variable names are invalid, update validation used by the the save pipeline template task.

https://github.com/spinnaker/spinnaker/issues/4694

