### PR TITLE
feat(webhooks): add support for cancellation to webhooks

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStage.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStage.groovy
@@ -32,14 +32,19 @@ import org.springframework.stereotype.Component
 @Component
 class PreconfiguredWebhookStage extends WebhookStage {
 
-  @Autowired
-  private WebhookService webhookService
-
-  @Value('${services.fiat.enabled:false}')
-  boolean fiatEnabled;
-
-  @Autowired(required = false)
+  boolean fiatEnabled
   FiatService fiatService
+
+  @Autowired
+  PreconfiguredWebhookStage(
+    WebhookService webhookService,
+    @Value('${services.fiat.enabled:false}') boolean fiatEnabled,
+    FiatService fiatService) {
+    super(webhookService)
+
+    this.fiatEnabled = fiatEnabled
+    this.fiatService = fiatService
+  }
 
   def fields = PreconfiguredWebhook.declaredFields.findAll {
     !it.synthetic && !['props', 'enabled', 'label', 'description', 'type', 'parameters'].contains(it.name)

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
@@ -24,12 +24,14 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.webhook.pipeline.WebhookStage
 import com.netflix.spinnaker.orca.webhook.service.WebhookService
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import org.springframework.web.client.HttpStatusCodeException
 
+import javax.annotation.Nonnull
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
@@ -40,6 +42,7 @@ class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
   long backoffPeriod = TimeUnit.SECONDS.toMillis(1)
   long timeout = TimeUnit.HOURS.toMillis(1)
   private static final String JSON_PATH_NOT_FOUND_ERR_FMT = "Unable to parse %s: JSON property '%s' not found in response body"
+  WebhookService webhookService
 
   @Override
   long getDynamicBackoffPeriod(Stage stage, Duration taskDuration) {
@@ -52,16 +55,23 @@ class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
   }
 
   @Autowired
-  WebhookService webhookService
+  MonitorWebhookTask(WebhookService webhookService) {
+    this.webhookService = webhookService
+  }
 
   @Override
   TaskResult execute(Stage stage) {
-    StageData stageData = stage.mapTo(StageData)
+    WebhookStage.StageData stageData = stage.mapTo(WebhookStage.StageData)
 
     if (Strings.isNullOrEmpty(stageData.statusEndpoint) || Strings.isNullOrEmpty(stageData.statusJsonPath)) {
       throw new IllegalStateException(
         "Missing required parameter(s): statusEndpoint = ${stageData.statusEndpoint}, statusJsonPath = ${stageData.statusJsonPath}")
     }
+
+    // Preserve the responses we got from createWebhookTask, but reset the monitor subkey as we will overwrite it new data
+    def originalResponse = stage.context.getOrDefault("webhook", [:])
+    originalResponse["monitor"] = [:]
+    originalResponse = [webhook: originalResponse]
 
     def response
     try {
@@ -81,7 +91,7 @@ class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
 
       String errorMessage = "an exception occurred in webhook monitor to ${stageData.statusEndpoint}: ${e}"
       log.error(errorMessage, e)
-      Map<String, ?> outputs = [webhook: [monitor: [:]]]
+      Map<String, ?> outputs = originalResponse
       outputs.webhook.monitor << [error: errorMessage]
       return TaskResult.builder(ExecutionStatus.TERMINAL).context(outputs).build()
     } catch (HttpStatusCodeException  e) {
@@ -93,30 +103,25 @@ class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
                             ((stageData.retryStatusCodes != null) && (stageData.retryStatusCodes.contains(statusValue)))
 
       if (shouldRetry) {
-        log.warn("Failed to get webhook status from ${stageData.statusEndpoint} with statusCode=${statusCode.value()}, will retry", e)
+        log.warn("Failed to get webhook status from ${stageData.statusEndpoint} with statusCode=${statusValue}, will retry", e)
         return TaskResult.ofStatus(ExecutionStatus.RUNNING)
       }
 
       String errorMessage = "an exception occurred in webhook monitor to ${stageData.statusEndpoint}: ${e}"
       log.error(errorMessage, e)
-      Map<String, ?> outputs = [webhook: [monitor: [:]]]
+      Map<String, ?> outputs = originalResponse
       outputs.webhook.monitor << [error: errorMessage]
       return TaskResult.builder(ExecutionStatus.TERMINAL).context(outputs).build()
     }
 
     def result
-    def responsePayload = [
-      webhook: [
-        monitor: [
+    def responsePayload = originalResponse
+    responsePayload.webhook.monitor =  [
           body: response.body,
           statusCode: response.statusCode,
           statusCodeValue: response.statusCode.value()
         ]
-      ],
-      buildInfo: response.body, // TODO: deprecated
-      deprecationWarning: "All webhook information will be moved beneath the key 'webhook', " +
-        "and the keys 'statusCode', 'buildInfo', 'statusEndpoint' and 'error' will be removed. Please migrate today."
-    ]
+
     try {
       result = JsonPath.read(response.body, stageData.statusJsonPath)
     } catch (PathNotFoundException e) {
@@ -141,7 +146,6 @@ class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
         return TaskResult.builder(ExecutionStatus.TERMINAL).context(responsePayload).build()
       }
       if (progress) {
-        responsePayload << [progressMessage: progress] // TODO: deprecated
         responsePayload.webhook.monitor << [progressMessage: progress]
       }
     }
@@ -150,14 +154,39 @@ class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
 
     if (result instanceof Number) {
       def status = result == 100 ? ExecutionStatus.SUCCEEDED : ExecutionStatus.RUNNING
-      responsePayload << [percentComplete: result] // TODO: deprecated
       responsePayload.webhook.monitor << [percentComplete: result]
       return TaskResult.builder(status).context(responsePayload).build()
     } else if (statusMap.containsKey(result.toString().toUpperCase())) {
       return TaskResult.builder(statusMap[result.toString().toUpperCase()]).context(responsePayload).build()
     }
 
-    return TaskResult.builder(ExecutionStatus.RUNNING).context(response ? responsePayload : [:]).build()
+    stage.context
+    return TaskResult.builder(ExecutionStatus.RUNNING).context(response ? responsePayload : originalResponse).build()
+  }
+
+  @Override void onCancel(@Nonnull Stage stage) {
+    WebhookStage.StageData stageData = stage.mapTo(WebhookStage.StageData)
+
+    // Only do cancellation if we made the initial webhook request
+    if (!Strings.isNullOrEmpty(stageData.webhook.statusCode)) {
+      try {
+        log.info("Sending best effort webhook cancellation to ${stageData.cancelEndpoint}")
+        def response = webhookService.exchange(stageData.cancelMethod, stageData.cancelEndpoint, stageData.cancelPayload, stageData.customHeaders)
+        log.debug(
+          "Received status code {} from cancel endpoint {} in execution {} in stage {}",
+          response.statusCode,
+          stageData.cancelEndpoint,
+          stage.execution.id,
+          stage.id
+        )
+      } catch (HttpStatusCodeException e) {
+        log.warn("Failed to cancel webhook ${stageData.cancelEndpoint} with statusCode=${e.getStatusCode().value()}", e)
+      } catch (Exception e) {
+        log.warn("Failed to cancel webhook ${stageData.cancelEndpoint}", e)
+      }
+    } else {
+      log.info("Not sending webhook cancellation because it hasn't started yet")
+    }
   }
 
   private static Map<String, ExecutionStatus> createStatusMap(String successStatuses, String canceledStatuses, String terminalStatuses) {
@@ -174,16 +203,5 @@ class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
 
   private static Map<String, ExecutionStatus> mapStatuses(String statuses, ExecutionStatus status) {
     statuses.split(",").collectEntries { [(it.trim().toUpperCase()): status] }
-  }
-
-  private static class StageData {
-    public String statusEndpoint
-    public String statusJsonPath
-    public String progressJsonPath
-    public String successStatuses
-    public String canceledStatuses
-    public String terminalStatuses
-    public Object customHeaders
-    public List<Integer> retryStatusCodes
   }
 }

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
@@ -33,7 +33,7 @@ class PreconfiguredWebhookStageSpec extends Specification {
   def builder = new TaskNode.Builder()
 
   @Subject
-  preconfiguredWebhookStage = new PreconfiguredWebhookStage(webhookService: webhookService)
+  preconfiguredWebhookStage = new PreconfiguredWebhookStage(webhookService, false, null)
 
   def "Context should be taken from PreconfiguredWebhookProperties"() {
     given:

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTaskSpec.groovy
@@ -61,8 +61,6 @@ class CreateWebhookTaskSpec extends Specification {
     then:
     result.status == ExecutionStatus.SUCCEEDED
     result.context as Map == [
-      deprecationWarning: "All webhook information will be moved beneath the key 'webhook', and the keys 'statusCode', 'buildInfo', 'statusEndpoint' and 'error' will be removed. Please migrate today.",
-      statusCode: HttpStatus.OK,
       webhook: [
         statusCode: HttpStatus.OK,
         statusCodeValue: HttpStatus.OK.value()
@@ -141,9 +139,6 @@ class CreateWebhookTaskSpec extends Specification {
     then:
     result.status == ExecutionStatus.TERMINAL
     result.context as Map == [
-      deprecationWarning: "All webhook information will be moved beneath the key 'webhook', and the keys 'statusCode', 'buildInfo', 'statusEndpoint' and 'error' will be removed. Please migrate today.",
-      statusCode: HttpStatus.BAD_REQUEST,
-      buildInfo: [error: bodyString],
       webhook: [
         statusCode: HttpStatus.BAD_REQUEST,
         statusCodeValue: HttpStatus.BAD_REQUEST.value(),
@@ -357,9 +352,6 @@ class CreateWebhookTaskSpec extends Specification {
     then:
     result.status == ExecutionStatus.SUCCEEDED
     result.context as Map == [
-      deprecationWarning: "All webhook information will be moved beneath the key 'webhook', and the keys 'statusCode', 'buildInfo', 'statusEndpoint' and 'error' will be removed. Please migrate today.",
-      statusCode: HttpStatus.CREATED,
-      buildInfo: [success: true],
       webhook: [
         statusCode: HttpStatus.CREATED,
         statusCodeValue: HttpStatus.CREATED.value(),
@@ -390,9 +382,6 @@ class CreateWebhookTaskSpec extends Specification {
     then:
     result.status == ExecutionStatus.SUCCEEDED
     result.context as Map == [
-      deprecationWarning: "All webhook information will be moved beneath the key 'webhook', and the keys 'statusCode', 'buildInfo', 'statusEndpoint' and 'error' will be removed. Please migrate today.",
-      statusCode: HttpStatus.CREATED,
-      buildInfo: [success: true],
       webhook: [
         statusCode: HttpStatus.CREATED,
         statusCodeValue: HttpStatus.CREATED.value(),
@@ -424,9 +413,6 @@ class CreateWebhookTaskSpec extends Specification {
     then:
     result.status == ExecutionStatus.SUCCEEDED
     result.context as Map == [
-      deprecationWarning: "All webhook information will be moved beneath the key 'webhook', and the keys 'statusCode', 'buildInfo', 'statusEndpoint' and 'error' will be removed. Please migrate today.",
-      statusCode: HttpStatus.CREATED,
-      buildInfo: body,
       webhook: [
         statusCode: HttpStatus.CREATED,
         statusCodeValue: HttpStatus.CREATED.value(),
@@ -527,46 +513,10 @@ class CreateWebhookTaskSpec extends Specification {
     then:
     result.status == ExecutionStatus.SUCCEEDED
     result.context as Map == [
-      deprecationWarning: "All webhook information will be moved beneath the key 'webhook', and the keys 'statusCode', 'buildInfo', 'statusEndpoint' and 'error' will be removed. Please migrate today.",
-      statusCode: HttpStatus.OK,
-      buildInfo: "<html></html>",
       webhook: [
         statusCode: HttpStatus.OK,
         statusCodeValue: HttpStatus.OK.value(),
         body: "<html></html>"
-      ]
-    ]
-  }
-
-// TODO: Remove test when removing the deprecated fields
-  def "should add deprecation warning to the outputs"() {
-    setup:
-    def stage = new Stage(pipeline, "webhook", "My webhook", [
-      url: "https://my-service.io/api/",
-      method: "post",
-      payload: [payload1: "Hello Spinnaker!"]
-    ])
-
-    createWebhookTask.webhookService = Stub(WebhookService) {
-      exchange(
-        HttpMethod.POST,
-        "https://my-service.io/api/",
-        [payload1: "Hello Spinnaker!"],
-        null
-      ) >> new ResponseEntity<Map>([:], HttpStatus.OK)
-    }
-
-    when:
-    def result = createWebhookTask.execute(stage)
-
-    then:
-    result.status == ExecutionStatus.SUCCEEDED
-    result.context as Map == [
-      deprecationWarning: "All webhook information will be moved beneath the key 'webhook', and the keys 'statusCode', 'buildInfo', 'statusEndpoint' and 'error' will be removed. Please migrate today.",
-      statusCode: HttpStatus.OK,
-      webhook: [
-        statusCode: HttpStatus.OK,
-        statusCodeValue: HttpStatus.OK.value(),
       ]
     ]
   }
@@ -599,9 +549,6 @@ class CreateWebhookTaskSpec extends Specification {
     then:
     result.status == ExecutionStatus.SUCCEEDED
     result.context as Map == [
-      deprecationWarning: "All webhook information will be moved beneath the key 'webhook', and the keys 'statusCode', 'buildInfo', 'statusEndpoint' and 'error' will be removed. Please migrate today.",
-      statusCode: HttpStatus.OK,
-      buildInfo: [ artifacts: [[ name: "overrides", type: "github/file", artifactAccount: "github", reference: "https://api.github.com/file", version: "master" ]]],
       webhook: [
         statusCode: HttpStatus.OK,
         statusCodeValue: HttpStatus.OK.value(),


### PR DESCRIPTION
for webhooks that have `waitForCompletion=true` (i.e. monitored webhook) it is
desirable to have an indication of cancellation (either user cancels execution
or the execution is terminated due to some failure)

NOTE: this also deleted fields marked deprecated from webhook response. These have been marked deprecated 1yr ago so it's time to let them go