### PR TITLE
fix(pipelines): an execution only starts one dep pipeline once

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -86,7 +86,7 @@ class DependentPipelineStarter implements ApplicationContextAware {
       parentPipelineStageId: parentPipelineStageId,
       parameters           : [:],
       strategy             : suppliedParameters.strategy == true,
-      correlationId        : parentPipeline.id
+      correlationId        : parentPipeline.id + "_" + pipelineConfig.id + "_" + parentPipeline.startTime
     ]
 
     if (pipelineConfig.parameterConfig || !suppliedParameters.isEmpty()) {

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -85,7 +85,8 @@ class DependentPipelineStarter implements ApplicationContextAware {
       parentExecution      : parentPipeline,
       parentPipelineStageId: parentPipelineStageId,
       parameters           : [:],
-      strategy             : suppliedParameters.strategy == true
+      strategy             : suppliedParameters.strategy == true,
+      correlationId        : parentPipeline.id
     ]
 
     if (pipelineConfig.parameterConfig || !suppliedParameters.isEmpty()) {


### PR DESCRIPTION
If a pipeline that triggers a downstream pipeline is canceled, and that downstream pipeline doesn't limit concurrent pipelines, you can get two duplicate downstream pipeline executions.

This PR adds the `parent execution id` as a `correlationId` so that the downstream pipeline only run once.