### PR TITLE
fix(logging context header): add pipeline description details to MDC

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -311,7 +311,9 @@ class RunTaskHandler(
     try {
       MDC.put("stageType", type)
       MDC.put("taskType", taskModel.implementingClass)
-      MDC.put(AuthenticatedRequest.Header.makeCustomHeader("pipeline-description"), execution.description)
+      if (execution.name != null) {
+        MDC.put(AuthenticatedRequest.Header.makeCustomHeader("pipeline-name"), execution.name)
+      }
       if (taskModel.startTime != null) {
         MDC.put("taskStartTime", taskModel.startTime.toString())
       }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -54,6 +54,7 @@ import com.netflix.spinnaker.orca.time.toDuration
 import com.netflix.spinnaker.orca.time.toInstant
 import com.netflix.spinnaker.q.Message
 import com.netflix.spinnaker.q.Queue
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import org.apache.commons.lang3.time.DurationFormatUtils
 import org.slf4j.MDC
 import org.springframework.stereotype.Component
@@ -310,7 +311,7 @@ class RunTaskHandler(
     try {
       MDC.put("stageType", type)
       MDC.put("taskType", taskModel.implementingClass)
-
+      MDC.put(AuthenticatedRequest.Header.makeCustomHeader("pipeline-description"), execution.description)
       if (taskModel.startTime != null) {
         MDC.put("taskStartTime", taskModel.startTime.toString())
       }


### PR DESCRIPTION
- Adding the pipeline description to `PIPELINE-DESCRIPTION` header , this will be consumed and set in `clouddriver` Eg  `X-Titus-CallReason` while making calls to titus.
