### PR TITLE
fix(Orca): pipelines/templates : Pipleline template issue - Not able …

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -169,6 +169,11 @@ public class Execution implements Serializable {
    */
   @JsonIgnoreProperties(value = "execution")
   public @Nonnull List<Stage> getStages() {
+    if (stages.size() == 0) {
+      setStartTime(new Date().getTime());
+      setEndTime(new Date().getTime());
+    }
+
     return stages;
   }
 


### PR DESCRIPTION
Hi ,
From UI , the  parameter "tag"is not able to load as "latest" in template renderer, which is default for every Pipeline template. For reference, please find the below link: https://github.com/spinnaker/spinnaker/issues/4670