### PR TITLE
fix(runjob): add account to destroy task context

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.java
@@ -94,6 +94,7 @@ public class RunJobStage implements StageDefinitionBuilder, CancellableStage {
       destroyContext.put("cloudProvider", context.getCloudProvider());
       destroyContext.put("region", context.getJobStatus().getRegion());
       destroyContext.put("credentials", context.getCredentials());
+      destroyContext.put("account", context.getAccount());
 
       stage.setContext(destroyContext);
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStageContext.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStageContext.java
@@ -30,6 +30,7 @@ public class RunJobStageContext {
   private String cloudProviderType;
   private String application;
   private String credentials;
+  private String account;
 
   @JsonIgnore private Map<String, Object> other = new HashMap<>();
 
@@ -81,5 +82,13 @@ public class RunJobStageContext {
 
   public void setCredentials(String credentials) {
     this.credentials = credentials;
+  }
+
+  public String getAccount() {
+    return account;
+  }
+
+  public void setAccount(String account) {
+    this.account = account;
   }
 }


### PR DESCRIPTION
the kubernetes v2 provider requires the account to determine which
provider version to use for the task converter.