### PR TITLE
fix(runJob): inject manifest fcr for k8s runjob

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStageSpec.groovy
@@ -69,6 +69,7 @@ class PreconfiguredJobStageSpec extends Specification {
       enabled: true,
       label: "test",
       type: "test",
+      cloudProvider: "kubernetes",
       parameters: [
         new PreconfiguredJobStageParameter(
           mapping: "manifest.metadata.name",


### PR DESCRIPTION
if the job is for kubernetes v2 (denoted by either `source` or
`manifest` keys), inject a couple of manifest refresh stages to prevent
cache misses when `WaitForJobCompletion` runs. this isn't the most ideal
way to implement this, however. we should eventually abstract this out
into the provider specific job runner classes.