### PR TITLE
chore(bakery): config to enable multi-bakery selection without stage context magic

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #Mon Aug 12 20:28:38 UTC 2019
 fiatVersion=1.1.0
 enablePublishing=false
-korkVersion=5.11.1
+korkVersion=5.11.2
 spinnakerGradleVersion=7.0.1
 org.gradle.parallel=true
 keikoVersion=2.12.0

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/BakerySelector.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/BakerySelector.java
@@ -34,6 +34,7 @@ public class BakerySelector {
   private SelectableService<BakeryService> selectableService;
   private final BakeryService defaultService;
   private final Map<String, Object> defaultConfig;
+  private final boolean selectBakery;
 
   public BakerySelector(
       BakeryService defaultBakeryService,
@@ -43,6 +44,7 @@ public class BakerySelector {
     this.defaultConfig = getDefaultConfig(bakeryConfigurationProperties);
     this.selectableService =
         getSelectableService(bakeryConfigurationProperties.getBaseUrls(), getBakeryServiceByUrlFx);
+    this.selectBakery = bakeryConfigurationProperties.isSelectorEnabled();
   }
 
   /**
@@ -52,9 +54,7 @@ public class BakerySelector {
    * @return a bakery service with associated configuration
    */
   public SelectableService.SelectedService<BakeryService> select(Stage stage) {
-    if (selectableService == null
-        || stage.getContext().get(SELECT_BAKERY) == null
-        || !(Boolean) stage.getContext().get(SELECT_BAKERY)) {
+    if (!shouldSelect(stage)) {
       return new SelectableService.SelectedService<>(defaultService, defaultConfig, null);
     }
 
@@ -107,6 +107,18 @@ public class BakerySelector {
 
     return new SelectableService<>(
         baseUrls, defaultService, defaultConfig, getBakeryServiceByUrlFx);
+  }
+
+  private boolean shouldSelect(Stage stage) {
+    if (selectableService == null || selectableService.getServices().size() < 2) {
+      return false;
+    }
+
+    if (selectBakery) {
+      return true;
+    }
+
+    return (Boolean) stage.getContext().getOrDefault(SELECT_BAKERY, false);
   }
 
   interface SelectableFields {

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfigurationProperties.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfigurationProperties.java
@@ -30,6 +30,11 @@ public class BakeryConfigurationProperties {
   private boolean allowMissingPackageInstallation = false;
   private List<SelectableService.BaseUrl> baseUrls;
 
+  // Temporary config that, if true, overrides the need for setting BakerySelector.SELECT_BAKERY in
+  // stage.context
+  // to enable bakery service selection.
+  private boolean selectorEnabled = false;
+
   public String getBaseUrl() {
     return baseUrl;
   }
@@ -68,5 +73,13 @@ public class BakeryConfigurationProperties {
 
   public void setAllowMissingPackageInstallation(boolean allowMissingPackageInstallation) {
     this.allowMissingPackageInstallation = allowMissingPackageInstallation;
+  }
+
+  public boolean isSelectorEnabled() {
+    return selectorEnabled;
+  }
+
+  public void setSelectorEnabled(boolean selectorEnabled) {
+    this.selectorEnabled = selectorEnabled;
   }
 }


### PR DESCRIPTION
Prior to this PR, bakery selection had to be enabled on a per-pipeline basis via setting `"selectBakery": true` in a bake stage's context. This does not enable bakery service selection by default, but allows it to be enabled universally for a running orca instance via setting `bakery.selectorEnabled` to true. Both of these configuration methods are temporary, while bakery selection is in development.