### PR TITLE
fix(expressions): add missed allowed classes back in

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
@@ -21,12 +21,7 @@ import com.netflix.spinnaker.kork.expressions.ExpressionFunctionProvider;
 import com.netflix.spinnaker.kork.expressions.ExpressionTransform;
 import com.netflix.spinnaker.kork.expressions.ExpressionsSupport;
 import com.netflix.spinnaker.orca.ExecutionStatus;
-import com.netflix.spinnaker.orca.pipeline.model.BuildInfo;
-import com.netflix.spinnaker.orca.pipeline.model.Execution;
-import com.netflix.spinnaker.orca.pipeline.model.JenkinsArtifact;
-import com.netflix.spinnaker.orca.pipeline.model.SourceControl;
-import com.netflix.spinnaker.orca.pipeline.model.Stage;
-import com.netflix.spinnaker.orca.pipeline.model.Trigger;
+import com.netflix.spinnaker.orca.pipeline.model.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -54,6 +49,8 @@ public class PipelineExpressionEvaluator {
         Trigger.class,
         BuildInfo.class,
         JenkinsArtifact.class,
+        JenkinsBuildInfo.class,
+        ConcourseBuildInfo.class,
         SourceControl.class,
         ExecutionStatus.class,
         Execution.AuthenticationDetails.class,


### PR DESCRIPTION
Several classes were missed during the kork-expression migration
https://github.com/spinnaker/orca/pull/3071/files#diff-32563145a925ce8860f9464194446db8L60
this caused expressions such as ${execution.trigger.buildinfo} to fail for jenkins triggers
