### PR TITLE
feat(plugins): Added ability to create plugin stages

### DIFF
--- a/orca-api/orca-api.gradle
+++ b/orca-api/orca-api.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply from: "$rootDir/gradle/kotlin.gradle"
+apply from: "$rootDir/gradle/spock.gradle"
+
+test {
+  useJUnitPlatform {
+    includeEngines "junit-vintage", "junit-jupiter"
+  }
+}
+
+dependencies {
+  implementation("com.google.guava:guava")
+}

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStage.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStage.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.api;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public interface SimpleStage<T> {
+  <T> SimpleStageOutput execute(SimpleStageInput<T> simpleStageInput);
+
+  String getName();
+}

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStageInput.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStageInput.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.api;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public class SimpleStageInput<T> {
+  private T value;
+
+  public SimpleStageInput(T value) {
+    this.value = value;
+  }
+
+  public void setValue(T value) {
+    this.value = value;
+  }
+
+  public T getValue() {
+    return this.value;
+  }
+}

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStageOutput.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStageOutput.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.api;
+
+import com.google.common.annotations.Beta;
+import java.util.Map;
+
+@Beta
+public class SimpleStageOutput {
+  private SimpleStageStatus status;
+
+  public void setStatus(SimpleStageStatus status) {
+    this.status = status;
+  }
+
+  public SimpleStageStatus getStatus() {
+    return this.status;
+  }
+
+  private Map outputs;
+
+  public void setOutputs(Map outputs) {
+    this.outputs = outputs;
+  }
+
+  public Map getOutputs() {
+    return this.outputs;
+  }
+}

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStageStatus.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStageStatus.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.api;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public enum SimpleStageStatus {
+  TERMINAL,
+  RUNNING,
+  COMPLETED,
+  NOT_STARTED
+}

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/Stage.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/Stage.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.api;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public interface Stage<T> {
+  <T> StageOutput execute(StageInput<T> stageInput);
+
+  String getName();
+}

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/StageInput.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/StageInput.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.api;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public class StageInput<T> {
+  private T value;
+
+  public StageInput(T value) {
+    this.value = value;
+  }
+
+  public void setValue(T value) {
+    this.value = value;
+  }
+
+  public T getValue() {
+    return this.value;
+  }
+}

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/StageOutput.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/StageOutput.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.api;
+
+import com.google.common.annotations.Beta;
+import java.util.Map;
+
+@Beta
+public class StageOutput {
+  private StageStatus status;
+
+  public void setStatus(StageStatus status) {
+    this.status = status;
+  }
+
+  public StageStatus getStatus() {
+    return this.status;
+  }
+
+  private Map outputs;
+
+  public void setOutputs(Map outputs) {
+    this.outputs = outputs;
+  }
+
+  public Map getOutputs() {
+    return this.outputs;
+  }
+}

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/StageStatus.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/StageStatus.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.api;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public enum StageStatus {
+  TERMINAL,
+  RUNNING,
+  COMPLETED,
+  NOT_STARTED
+}

--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -32,6 +32,7 @@ dependencies {
   api("io.reactivex:rxjava")
 
   implementation(project(":orca-extensionpoint"))
+  implementation(project(":orca-api"))
   implementation("com.github.ben-manes.caffeine:guava")
   implementation("org.slf4j:slf4j-api")
   implementation("com.fasterxml.jackson.core:jackson-annotations")

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/StageResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/StageResolver.java
@@ -18,10 +18,13 @@ package com.netflix.spinnaker.orca;
 
 import static java.lang.String.format;
 
+import com.netflix.spinnaker.orca.api.SimpleStage;
+import com.netflix.spinnaker.orca.pipeline.SimpleStageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /**
@@ -32,7 +35,9 @@ import javax.annotation.Nonnull;
 public class StageResolver {
   private final Map<String, StageDefinitionBuilder> stageDefinitionBuilderByAlias = new HashMap<>();
 
-  public StageResolver(Collection<StageDefinitionBuilder> stageDefinitionBuilders) {
+  public StageResolver(
+      Collection<StageDefinitionBuilder> stageDefinitionBuilders,
+      Collection<SimpleStage> apiStages) {
     for (StageDefinitionBuilder stageDefinitionBuilder : stageDefinitionBuilders) {
       stageDefinitionBuilderByAlias.put(stageDefinitionBuilder.getType(), stageDefinitionBuilder);
       for (String alias : stageDefinitionBuilder.aliases()) {
@@ -46,6 +51,13 @@ public class StageResolver {
         }
 
         stageDefinitionBuilderByAlias.put(alias, stageDefinitionBuilder);
+      }
+    }
+
+    if (!Objects.equals(apiStages, null)) {
+      for (SimpleStage stage : apiStages) {
+        SimpleStageDefinitionBuilder builder = new SimpleStageDefinitionBuilder(stage);
+        stageDefinitionBuilderByAlias.put(stage.getName(), builder);
       }
     }
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.kork.expressions.ExpressionFunctionProvider;
 import com.netflix.spinnaker.orca.StageResolver;
 import com.netflix.spinnaker.orca.Task;
 import com.netflix.spinnaker.orca.TaskResolver;
+import com.netflix.spinnaker.orca.api.SimpleStage;
 import com.netflix.spinnaker.orca.commands.ForceExecutionCancellationCommand;
 import com.netflix.spinnaker.orca.events.ExecutionEvent;
 import com.netflix.spinnaker.orca.events.ExecutionListenerAdapter;
@@ -40,8 +41,7 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
 import java.time.Clock;
 import java.time.Duration;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -187,8 +187,12 @@ public class OrcaConfiguration {
   }
 
   @Bean
-  public StageResolver stageResolver(Collection<StageDefinitionBuilder> stageDefinitionBuilders) {
-    return new StageResolver(stageDefinitionBuilders);
+  public StageResolver stageResolver(
+      Collection<StageDefinitionBuilder> stageDefinitionBuilders,
+      Optional<Collection<SimpleStage>> simpleStages) {
+    Collection<SimpleStage> stages =
+        simpleStages.isPresent() ? simpleStages.get() : new ArrayList<SimpleStage>();
+    return new StageResolver(stageDefinitionBuilders, stages);
   }
 
   @Bean(name = EVENT_LISTENER_FACTORY_BEAN_NAME)

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleStageDefinitionBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleStageDefinitionBuilder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline;
+
+import com.netflix.spinnaker.orca.api.SimpleStage;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import javax.annotation.Nonnull;
+
+public class SimpleStageDefinitionBuilder implements StageDefinitionBuilder {
+  private SimpleStage simpleStage;
+
+  public SimpleStageDefinitionBuilder(SimpleStage simpleStage) {
+    this.simpleStage = simpleStage;
+  }
+
+  public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
+    SimpleTask task = new SimpleTask(simpleStage);
+    builder.withTask(simpleStage.getName(), task.getClass());
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleTask.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.api.SimpleStage;
+import com.netflix.spinnaker.orca.api.SimpleStageInput;
+import com.netflix.spinnaker.orca.api.SimpleStageOutput;
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.GenericTypeResolver;
+import org.springframework.core.ResolvableType;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SimpleTask implements Task {
+  private SimpleStage simpleStage;
+
+  SimpleTask(@Nullable SimpleStage simpleStage) {
+    this.simpleStage = simpleStage;
+  }
+
+  @Nonnull
+  public TaskResult execute(@Nonnull Stage stage) {
+    ObjectMapper objectMapper = OrcaObjectMapper.newInstance();
+
+    ExecutionStatus status;
+    SimpleStageOutput outputs = new SimpleStageOutput();
+
+    try {
+      List<Class<?>> cArg = Arrays.asList(SimpleStageInput.class);
+      Method method = simpleStage.getClass().getMethod("execute", cArg.toArray(new Class[0]));
+      Type inputType = ResolvableType.forMethodParameter(method, 0).getGeneric().getType();
+      Map<TypeVariable, Type> typeVariableMap =
+          GenericTypeResolver.getTypeVariableMap(simpleStage.getClass());
+
+      SimpleStageInput simpleStageInput =
+          new SimpleStageInput(
+              objectMapper.convertValue(
+                  stage.getContext(), GenericTypeResolver.resolveType(inputType, typeVariableMap)));
+      outputs = simpleStage.execute(simpleStageInput);
+      switch (outputs.getStatus()) {
+        case TERMINAL:
+          status = ExecutionStatus.TERMINAL;
+          break;
+        case RUNNING:
+          status = ExecutionStatus.RUNNING;
+          break;
+        case COMPLETED:
+          status = ExecutionStatus.SUCCEEDED;
+          break;
+        case NOT_STARTED:
+          status = ExecutionStatus.NOT_STARTED;
+          break;
+        default:
+          status = ExecutionStatus.FAILED_CONTINUE;
+          break;
+      }
+    } catch (Exception e) {
+      log.error("Cannot execute stage " + simpleStage.getName());
+      log.error(e.getMessage());
+      status = ExecutionStatus.TERMINAL;
+    }
+
+    return TaskResult.builder(status)
+        .context(outputs.getOutputs())
+        .outputs(outputs.getOutputs())
+        .build();
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/StageResolverSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/StageResolverSpec.groovy
@@ -16,22 +16,24 @@
 
 package com.netflix.spinnaker.orca
 
+import com.netflix.spinnaker.orca.api.SimpleStage
+import com.netflix.spinnaker.orca.api.SimpleStageInput
+import com.netflix.spinnaker.orca.api.SimpleStageOutput
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.WaitStage
-import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
-import javax.annotation.Nonnull;
-
 class StageResolverSpec extends Specification {
   @Subject
   def stageResolver = new StageResolver([
-      new WaitStage(),
-      new AliasedStageDefinitionBuilder()
-  ])
+    new WaitStage(),
+    new AliasedStageDefinitionBuilder()
+  ],
+    [
+      new SimpleStage()
+    ])
 
   @Unroll
   def "should lookup stage by name or alias"() {
@@ -48,9 +50,12 @@ class StageResolverSpec extends Specification {
   def "should raise exception on duplicate alias"() {
     when:
     new StageResolver([
-        new AliasedStageDefinitionBuilder(),
-        new AliasedStageDefinitionBuilder()
-    ])
+      new AliasedStageDefinitionBuilder(),
+      new AliasedStageDefinitionBuilder()
+    ],
+      [
+        new SimpleStage()
+      ])
 
     then:
     thrown(StageResolver.DuplicateStageAliasException)
@@ -66,5 +71,17 @@ class StageResolverSpec extends Specification {
 
   @StageDefinitionBuilder.Aliases("notAliased")
   class AliasedStageDefinitionBuilder implements StageDefinitionBuilder {
+  }
+
+  class SimpleStage implements SimpleStage {
+    @Override
+    public SimpleStageOutput execute(SimpleStageInput input) {
+      return new SimpleStageOutput();
+    }
+
+    @Override
+    public String getName() {
+      return "simpleApiStage";
+    }
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/SimpleTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/SimpleTaskSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.api.SimpleStage
+import com.netflix.spinnaker.orca.api.SimpleStageInput
+import com.netflix.spinnaker.orca.api.SimpleStageOutput
+import com.netflix.spinnaker.orca.api.SimpleStageStatus
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class SimpleTaskSpec extends Specification {
+  private static class MyStage implements SimpleStage<Object> {
+    @Override
+    String getName() {
+      return "myStage"
+    }
+
+    @Override
+    <Object> SimpleStageOutput execute(SimpleStageInput<Object> input) {
+      SimpleStageOutput output = new SimpleStageOutput()
+
+      Map<String, String> stageOutput = new HashMap<>()
+      stageOutput.put("hello", "world")
+
+      output.setStatus(SimpleStageStatus.COMPLETED)
+      output.setOutputs(stageOutput)
+      return output
+    }
+  }
+
+  @Subject
+  def myStage = new MyStage()
+
+  @Unroll
+  def "should check dynamic config property"() {
+    when:
+    def task = new SimpleTask(myStage)
+    def results = task.execute(new com.netflix.spinnaker.orca.pipeline.model.Stage())
+
+    then:
+    results.getStatus() == ExecutionStatus.SUCCEEDED
+    results.context.hello == "world"
+  }
+}

--- a/orca-queue/orca-queue.gradle
+++ b/orca-queue/orca-queue.gradle
@@ -19,6 +19,7 @@ apply from: "$rootDir/gradle/spek.gradle"
 
 dependencies {
   api(project(":orca-core"))
+  api(project(":orca-api"))
   implementation(project(":orca-kotlin"))
   implementation("org.jetbrains.kotlin:kotlin-reflect")
   implementation("com.netflix.spinnaker.keiko:keiko-spring:$keikoVersion")

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandlerTest.kt
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
 import com.netflix.spinnaker.orca.StageResolver
 import com.netflix.spinnaker.orca.TaskResolver
+import com.netflix.spinnaker.orca.api.SimpleStage
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
 import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
@@ -56,7 +57,7 @@ object CancelStageHandlerTest : SubjectSpek<CancelStageHandler>({
   val stageNavigator: StageNavigator = mock()
 
   val cancellableStage: CancelableStageDefinitionBuilder = mock()
-  val stageResolver = StageResolver(listOf(singleTaskStage, cancellableStage))
+  val stageResolver = StageResolver(listOf(singleTaskStage, cancellableStage), emptyList<SimpleStage<Object>>())
 
   subject(GROUP) {
     CancelStageHandler(

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
@@ -26,6 +26,10 @@ import com.netflix.spinnaker.orca.ExecutionStatus.STOPPED
 import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
 import com.netflix.spinnaker.orca.StageResolver
+import com.netflix.spinnaker.orca.api.SimpleStage
+import com.netflix.spinnaker.orca.api.SimpleStageInput
+import com.netflix.spinnaker.orca.api.SimpleStageOutput
+import com.netflix.spinnaker.orca.api.SimpleStageStatus
 import com.netflix.spinnaker.orca.events.StageComplete
 import com.netflix.spinnaker.orca.exceptions.DefaultExceptionHandler
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
@@ -143,6 +147,24 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
     }
   }
 
+  val emptyApiStage = object : SimpleStage<Any> {
+    override fun getName() = "emptyApiStage"
+
+    override fun <Any> execute(simpleStageInput: SimpleStageInput<Any>): SimpleStageOutput {
+      return SimpleStageOutput()
+    }
+  }
+
+  val successfulApiStage = object : SimpleStage<Any> {
+    override fun getName() = "successfulApiStage"
+
+    override fun <Any> execute(simpleStageInput: SimpleStageInput<Any>): SimpleStageOutput {
+      val output = SimpleStageOutput()
+      output.status = SimpleStageStatus.COMPLETED
+      return output
+    }
+  }
+
   subject(GROUP) {
     CompleteStageHandler(
       queue,
@@ -167,6 +189,10 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
             stageWithNothingButAfterStages,
             stageWithSyntheticOnFailure,
             emptyStage
+          ),
+          listOf(
+            emptyApiStage,
+            successfulApiStage
           )
         )
       )
@@ -1465,6 +1491,24 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
           assertThat(pipeline.stageById(message.stageId).status).isEqualTo(TERMINAL)
         }
       }
+    }
+  }
+
+  given("api stage completed successfully") {
+    val pipeline = pipeline {
+      stage {
+        refId = "1"
+        type = successfulApiStage.name
+      }
+    }
+
+    val message = CompleteStage(pipeline.stageByRef("1"))
+    pipeline.stageById(message.stageId).apply {
+      status = SUCCEEDED
+    }
+
+    it("stage was successfully ran") {
+      assertThat(pipeline.stageById(message.stageId).status).isEqualTo(SUCCEEDED)
     }
   }
 })

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
@@ -22,6 +22,9 @@ import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
 import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
 import com.netflix.spinnaker.orca.StageResolver
+import com.netflix.spinnaker.orca.api.SimpleStage
+import com.netflix.spinnaker.orca.api.SimpleStageInput
+import com.netflix.spinnaker.orca.api.SimpleStageOutput
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
 import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
@@ -77,6 +80,14 @@ object RestartStageHandlerTest : SubjectSpek<RestartStageHandler>({
   val pendingExecutionService: PendingExecutionService = mock()
   val clock = fixedClock()
 
+  val emptyApiStage = object : SimpleStage<Object> {
+    override fun getName() = "emptyApiStage"
+
+    override fun <Object> execute(simpleStageInput: SimpleStageInput<Object>): SimpleStageOutput {
+      return SimpleStageOutput()
+    }
+  }
+
   subject(GROUP) {
     RestartStageHandler(
       queue,
@@ -87,6 +98,9 @@ object RestartStageHandlerTest : SubjectSpek<RestartStageHandler>({
             singleTaskStage,
             stageWithSyntheticBefore,
             stageWithNestedSynthetics
+          ),
+          listOf(
+            emptyApiStage
           )
         )
       ),

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
@@ -24,6 +24,10 @@ import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
 import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
 import com.netflix.spinnaker.orca.StageResolver
+import com.netflix.spinnaker.orca.api.SimpleStage
+import com.netflix.spinnaker.orca.api.SimpleStageInput
+import com.netflix.spinnaker.orca.api.SimpleStageOutput
+import com.netflix.spinnaker.orca.api.SimpleStageStatus
 import com.netflix.spinnaker.orca.events.StageStarted
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.fixture.pipeline
@@ -100,6 +104,16 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
   val registry = NoopRegistry()
   val retryDelay = Duration.ofSeconds(5)
 
+  val runningApiStage = object : SimpleStage<Any> {
+    override fun getName() = "runningApiStage"
+
+    override fun <Any> execute(simpleStageInput: SimpleStageInput<Any>): SimpleStageOutput {
+      val output = SimpleStageOutput()
+      output.status = SimpleStageStatus.RUNNING
+      return output
+    }
+  }
+
   subject(GROUP) {
     StartStageHandler(
       queue,
@@ -118,6 +132,9 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
             stageWithSyntheticAfterAndNoTasks,
             webhookStage,
             failPlanningStage
+          ),
+          listOf(
+            runningApiStage
           )
         )
       ),
@@ -134,6 +151,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
   fun resetMocks() = reset(queue, repository, publisher, exceptionHandler)
 
   describe("starting a stage") {
+
     given("there is a single initial task") {
       val pipeline = pipeline {
         application = "foo"
@@ -1130,6 +1148,26 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
 
       it("emits an error event") {
         verify(queue).push(isA<InvalidStageId>())
+      }
+    }
+
+    given("api stage") {
+      val pipeline = pipeline {
+        stage {
+          refId = "1"
+          type = runningApiStage.name
+        }
+      }
+
+      val message = StartStage(pipeline.stageByRef("1"))
+      pipeline.stageById(message.stageId).apply {
+        status = RUNNING
+      }
+
+      afterGroup(::resetMocks)
+
+      it("stage was successfully started") {
+        assertThat(pipeline.stageById(message.stageId).status).isEqualTo(RUNNING)
       }
     }
   }

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -33,6 +33,7 @@ dependencies {
   implementation("net.logstash.logback:logstash-logback-encoder")
 
   implementation(project(":orca-core"))
+  implementation(project(":orca-api"))
   implementation(project(":orca-redis"))
   implementation(project(":orca-bakery"))
   implementation(project(":orca-clouddriver"))

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@
 
 include "orca-extensionpoint",
   "orca-core",
+  "orca-api",
   "orca-core-tck",
   "orca-redis",
   "orca-test-redis",


### PR DESCRIPTION
 ## Motivation

This adds the ability to add very simple Stages as plugins. These Stages are very limited in scope. This allows people to create custom Spinnaker stages without having to dig into and understand all of the Orca codebase. This also means that stages can be added without needing to create a custom version or wait till pull requests are merged.

 ## How to use

To build a plugin stage, one needs to implement the `Stage` interface. The `getName` method is used to determine the Stage's name. The `execute` method takes in a `StageInput<YourClassHere>`. `YourClassHere` is a class you create that has the definition of everything your `Stage` needs to run. At runtime, every `Stage` will be registered with the `StageResolver` after being turned into an `ApiStageDefinitionBuilder`.

The `ApiStageDefinitionBuilder` will build a `taskGraph` with a single `ApiTask` which introspects the type required by the `execute` method. The pipeline context will be converted to your `YourClassHere` and then will call the `execute` method, passing in the correct information.

A quick example on how to implement the Orca plugin stage API:
MyStageContext.java
```
    public class MyStageContext {
        public String artifactName;
        public String artifactLocation;
    }
```

MyStage.java
```
    @Component
    public class MyStage implements Stage<MyStageContext> {
        public String getName() { return "myStage"; }

        public <MyStageContext> StageOutput execute(StageInput<MyStageContext> stageInput) {
            StageOutput stageOutput = new StageOutput();
            // TODO add your stage execution stuff here!
            return stageOutput;
        }
    }
```

To see a more complete example check out: https://github.com/armory/stage-plugin

 ## Future

This is the start of the work needed to support plugin stages. As we get more feedback from users of plugins and plugin creators, we will make adjustments to what these stages can do. For example, a future enhancement maybe to add the ability to support `RetryableTask`s.