### PR TITLE
fix(core) Handle circular reference in Stage class

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -24,7 +24,9 @@ import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -46,6 +48,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class Stage implements Serializable {
 
   private static final ULID ID_GENERATOR = new ULID();


### PR DESCRIPTION
This attempts to fix https://github.com/spinnaker/spinnaker/issues/4762

Due to `ContextParameterProcessor` ultimately accepting `Stage` as return value, it is possible for a `Stage` whose `context` has been replaced with the one with all expressions evaluated (using `Stage.withMergedContext` extension in `ExpressionAware`) to contain cyclic reference to itself. 

This can be reproduced by having the `${#currentStage()}` inside the stage context. We found the bug above from a mistake when writing customised stage notification message (engineer write `${#currentStage()}` instead of `${#currentStage()['name'])}`.

The circular reference causes Orca to throw StackOverflowException in `StartStageHandler` during the `repository.storeStage(stage)` step. As a result, the stage will never be persisted and executed.

The fix proposed in this PR is to add `@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")` which will truncate the recursive reference to Stage inside the context to its ID, I feel that this behaviour should be good enough as it should not stop Orca from failing `StartStageHandler` anymore.

Before coming up with this solution, I was thinking how to implement the fix around `ContextParameterProcessor` by somehow sanitising the resulting context from circular reference of itself, but I was unable to figure out how. Let me know if you can think of a cleaner solution.

Note: The test case added is just to illustrate the failure, I will replace it with a proper test case once the overall strategy has been agreed.
