### PR TITLE
fix(orchestration): mark tasks failed if the stage is marked ignore failure

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -152,10 +152,11 @@ class RunTaskHandler(
           queue.push(CompleteTask(message, SUCCEEDED))
         } else {
           log.error("Error running ${message.taskType.simpleName} for ${message.executionType}[${message.executionId}]", e)
+          val status = stage.failureStatus(default = TERMINAL)
           stage.context["exception"] = exceptionDetails
           repository.storeStage(stage)
-          queue.push(CompleteTask(message, stage.failureStatus()))
-          trackResult(stage, thisInvocationStartTimeMs, taskModel, stage.failureStatus())
+          queue.push(CompleteTask(message, status, TERMINAL))
+          trackResult(stage, thisInvocationStartTimeMs, taskModel, status)
         }
       }
     }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -649,7 +649,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
         }
 
         it("marks the task as failed but continue") {
-          verify(queue).push(CompleteTask(message, FAILED_CONTINUE))
+          verify(queue).push(CompleteTask(message, FAILED_CONTINUE, TERMINAL))
         }
       }
 


### PR DESCRIPTION
When a task fails due to an exception in the `execute` and the stage is marked
as 'failPipeline=false' the `RunTaskHandler` incorrectly set the task status to
FAIL_CONTINUE.
This causes subsequent tasks in the stage to run even if after a failure. This
also causes the original exception to be hidden by failures in subsequent tasks
This change corrects this behavior and treats task exceptions same as if the task
returned `TERMINAL`

