### PR TITLE
feat(pipeline): add stage status precondition task

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/StageStatusPreconditionTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/StageStatusPreconditionTask.java
@@ -16,11 +16,9 @@
 
 package com.netflix.spinnaker.orca.pipeline.tasks;
 
-import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import lombok.Getter;
 import org.springframework.stereotype.Component;
@@ -61,17 +59,10 @@ public class StageStatusPreconditionTask implements PreconditionTask {
                             stageName)));
     String actualStatus = foundStage.getStatus().toString();
     if (!actualStatus.equals(assertedStatus)) {
-      Map<String, Object> outputs =
-          ImmutableMap.of(
-              "exception",
-              ImmutableMap.of(
-                  "details",
-                  ImmutableMap.of(
-                      "error",
-                      String.format(
-                          "The status of stage %s was asserted to be %s, but was actually %s",
-                          stageName, assertedStatus, actualStatus))));
-      return TaskResult.builder(ExecutionStatus.TERMINAL).context(outputs).build();
+      throw new RuntimeException(
+          String.format(
+              "The status of stage %s was asserted to be %s, but was actually %s",
+              stageName, assertedStatus, actualStatus));
     }
     return TaskResult.builder(ExecutionStatus.SUCCEEDED).build();
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/StageStatusPreconditionTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/StageStatusPreconditionTask.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.tasks;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StageStatusPreconditionTask implements PreconditionTask {
+
+  @Override
+  public String getPreconditionType() {
+    return "stageStatus";
+  }
+
+  @Override
+  public @Nonnull TaskResult execute(@Nonnull Stage stage) {
+    StageStatusPreconditionContext context =
+        stage.mapTo("/context", StageStatusPreconditionContext.class);
+    String stageName = context.getStageName();
+    String assertedStatus = context.getStageStatus();
+    if (stageName == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Stage name is required for preconditions of type %s.", getPreconditionType()));
+    }
+    if (assertedStatus == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Stage status is required for preconditions of type %s.", getPreconditionType()));
+    }
+    Stage foundStage =
+        stage.getExecution().getStages().stream()
+            .filter(s -> s.getName().equals(stageName))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        String.format(
+                            "Failed to find stage %s in execution. Please specify a valid stage name",
+                            stageName)));
+    String actualStatus = foundStage.getStatus().toString();
+    if (!actualStatus.equals(assertedStatus)) {
+      Map<String, Object> outputs =
+          ImmutableMap.of(
+              "exception",
+              ImmutableMap.of(
+                  "details",
+                  ImmutableMap.of(
+                      "error",
+                      String.format(
+                          "The status of stage %s was asserted to be %s, but was actually %s",
+                          stageName, assertedStatus, actualStatus))));
+      return TaskResult.builder(ExecutionStatus.TERMINAL).context(outputs).build();
+    }
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).build();
+  }
+
+  @Getter
+  private static class StageStatusPreconditionContext {
+    public String stageName;
+    public String stageStatus;
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/StageStatusPreconditionTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/StageStatusPreconditionTaskSpec.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.tasks
+
+import spock.lang.Specification
+import spock.lang.Unroll
+import static com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
+import static com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class StageStatusPreconditionTaskSpec extends Specification {
+  @Unroll
+  def "should evaluate stage status precondition against stage context at execution time"() {
+    given:
+    def task = new StageStatusPreconditionTask()
+    def stage = stage {
+      name = "Check Stage Status"
+      context.context = [
+        stageName: stageName,
+        stageStatus: stageStatus
+      ]
+      execution = pipeline {
+        stage {
+          name = "Stage A"
+          status = SUCCEEDED
+        }
+        stage {
+          name = "Stage B"
+          status = TERMINAL
+        }
+      }
+    }
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    taskResult.status == taskResultStatus
+
+    where:
+    stageName | stageStatus || taskResultStatus
+    "Stage A" | "SUCCEEDED" || SUCCEEDED
+    "Stage A" | "TERMINAL"  || TERMINAL
+    "Stage B" | "SUCCEEDED" || TERMINAL
+    "Stage B" | "TERMINAL"  || SUCCEEDED
+  }
+
+  def "should throw error when input is invalid"() {
+    given:
+    def task = new StageStatusPreconditionTask()
+    def stage = stage {
+      name = "Check Stage Status"
+      context.context = [
+        stageName: stageName,
+        stageStatus: stageStatus
+      ]
+      execution = pipeline {
+        stage {
+          name = "Stage A"
+          status = SUCCEEDED
+        }
+      }
+    }
+
+    when:
+    task.execute(stage)
+
+    then:
+    thrown(IllegalArgumentException)
+
+    where:
+    stageName | stageStatus
+    "Invalid" | "SUCCEEDED"
+    null      | "SUCCEEDED"
+    "Stage A" |  null
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/StageStatusPreconditionTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/StageStatusPreconditionTaskSpec.groovy
@@ -55,8 +55,6 @@ class StageStatusPreconditionTaskSpec extends Specification {
     where:
     stageName | stageStatus || taskResultStatus
     "Stage A" | "SUCCEEDED" || SUCCEEDED
-    "Stage A" | "TERMINAL"  || TERMINAL
-    "Stage B" | "SUCCEEDED" || TERMINAL
     "Stage B" | "TERMINAL"  || SUCCEEDED
   }
 
@@ -88,5 +86,38 @@ class StageStatusPreconditionTaskSpec extends Specification {
     "Invalid" | "SUCCEEDED"
     null      | "SUCCEEDED"
     "Stage A" |  null
+  }
+
+  def "should throw error when status assertion is false"() {
+    given:
+    def task = new StageStatusPreconditionTask()
+    def stage = stage {
+      name = "Check Stage Status"
+      context.context = [
+        stageName: stageName,
+        stageStatus: stageStatus
+      ]
+      execution = pipeline {
+        stage {
+          name = "Stage A"
+          status = SUCCEEDED
+        }
+        stage {
+          name = "Stage B"
+          status = TERMINAL
+        }
+      }
+    }
+
+    when:
+    task.execute(stage)
+
+    then:
+    thrown(RuntimeException)
+
+    where:
+    stageName | stageStatus
+    "Stage A" | "TERMINAL"
+    "Stage B" | "SUCCEEDED"
   }
 }


### PR DESCRIPTION
Closes: https://github.com/spinnaker/spinnaker/issues/4768
Corresponding Deck PR: https://github.com/spinnaker/deck/pull/7348

Thoughts on surfacing useful error messages in Deck:
- Based on Deck's [expectations](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/orchestratedItem/orchestratedItem.transformer.ts#L171), non-thrown error messages should be set on a task's outputs `exception.details.error` or `exception.details.errors` to be surfaced in the `StageFailureMessage` component. I haven't encountered a standard way to do this in Orca but if you get this message and you know The Right Way please help me out :love_letter: 
- I'm also unsure of any conventions around when to throw an error vs. attach an error to the task context. I went with 1) throw an error when inputs are invalid, such that the task cannot be performed 2) attach an error message to the task context when the task completed but failed (in this case, because the precondition assertion was incorrect).

(Edit: should throw an error in both cases so it gets picked up by RunTaskHandler)

@robfletcher I feel like you might be an expert on error conventions -- any wisdom is appreciated :pray: :pray: 