### PR TITLE
feat(core): Add SpEL Function Helpers for Resolved Trigger Artifacts

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.pipeline.expressions;
 
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.expressions.ExpressionEvaluationSummary;
 import com.netflix.spinnaker.kork.expressions.ExpressionFunctionProvider;
 import com.netflix.spinnaker.kork.expressions.ExpressionTransform;
@@ -44,6 +45,7 @@ public class PipelineExpressionEvaluator {
 
   private static Class[] extraAllowedReturnTypes =
       new Class[] {
+        Artifact.class,
         Execution.class,
         Stage.class,
         Trigger.class,

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/ArtifactExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/ArtifactExpressionFunctionProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.expressions.functions;
+
+import static java.lang.String.format;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
+import com.netflix.spinnaker.kork.expressions.ExpressionFunctionProvider;
+import com.netflix.spinnaker.kork.expressions.SpelHelperFunctionException;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import java.util.function.Predicate;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ArtifactExpressionFunctionProvider implements ExpressionFunctionProvider {
+  @Nullable
+  @Override
+  public String getNamespace() {
+    return null;
+  }
+
+  @NotNull
+  @Override
+  public Functions getFunctions() {
+    return new Functions(
+        new FunctionDefinition(
+            "triggerResolvedArtifact",
+            new FunctionParameter(
+                Execution.class, "execution", "The execution to search for artifacts"),
+            new FunctionParameter(String.class, "name", "The name of the resolved artifact")),
+        new FunctionDefinition(
+            "triggerResolvedArtifactByType",
+            new FunctionParameter(
+                Execution.class, "execution", "The execution to search for artifacts"),
+            new FunctionParameter(String.class, "type", "The type of the resolved artifact")));
+  }
+
+  public static Artifact triggerResolvedArtifact(Execution execution, String name) {
+    return triggerResolvedArtifactBy(execution, name, artifact -> name.equals(artifact.getName()));
+  }
+
+  public static Artifact triggerResolvedArtifactByType(Execution execution, String type) {
+    return triggerResolvedArtifactBy(execution, type, artifact -> type.equals(artifact.getType()));
+  }
+
+  private static Artifact triggerResolvedArtifactBy(
+      Execution execution, String nameOrType, Predicate<Artifact> predicate) {
+    return execution.getTrigger().getResolvedExpectedArtifacts().stream()
+        .filter(
+            expectedArtifact ->
+                expectedArtifact.getBoundArtifact() != null
+                    && predicate.test(expectedArtifact.getBoundArtifact()))
+        .findFirst()
+        .map(ExpectedArtifact::getBoundArtifact)
+        .orElseThrow(
+            () ->
+                new SpelHelperFunctionException(
+                    format(
+                        "Unable to locate resolved artifact %s in trigger execution %s.",
+                        nameOrType, execution.getId())));
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
@@ -28,10 +28,7 @@ import com.netflix.spinnaker.kork.expressions.ExpressionFunctionProvider;
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
 import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator;
-import com.netflix.spinnaker.orca.pipeline.expressions.functions.DeployedServerGroupsExpressionFunctionProvider;
-import com.netflix.spinnaker.orca.pipeline.expressions.functions.ManifestLabelValueExpressionFunctionProvider;
-import com.netflix.spinnaker.orca.pipeline.expressions.functions.StageExpressionFunctionProvider;
-import com.netflix.spinnaker.orca.pipeline.expressions.functions.UrlExpressionFunctionProvider;
+import com.netflix.spinnaker.orca.pipeline.expressions.functions.*;
 import com.netflix.spinnaker.orca.pipeline.model.*;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -55,6 +52,7 @@ public class ContextParameterProcessor {
   public ContextParameterProcessor() {
     this(
         Arrays.asList(
+            new ArtifactExpressionFunctionProvider(),
             new DeployedServerGroupsExpressionFunctionProvider(),
             new ManifestLabelValueExpressionFunctionProvider(),
             new StageExpressionFunctionProvider(),

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/ArtifactExpressionFunctionProviderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/ArtifactExpressionFunctionProviderSpec.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.expressions.functions
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
+import com.netflix.spinnaker.kork.expressions.SpelHelperFunctionException
+import com.netflix.spinnaker.orca.pipeline.model.DefaultTrigger
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static com.netflix.spinnaker.orca.pipeline.expressions.functions.ArtifactExpressionFunctionProvider.triggerResolvedArtifact
+import static com.netflix.spinnaker.orca.pipeline.expressions.functions.ArtifactExpressionFunctionProvider.triggerResolvedArtifactByType
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+
+
+class ArtifactExpressionFunctionProviderSpec extends Specification {
+  @Shared
+  def pipeline1 = pipeline {
+    def matchArtifact1 = new Artifact(type: "docker/image", "name": "artifact1")
+    def boundArtifact = new Artifact(type: "docker/image", "name": "artifact1", "reference": "artifact1")
+
+    trigger = new DefaultTrigger("manual", "artifact1")
+    trigger.resolvedExpectedArtifacts = [
+      new ExpectedArtifact(matchArtifact: matchArtifact1, boundArtifact: boundArtifact),
+    ]
+  }
+
+  def "triggerResolvedArtifact returns resolved trigger artifact by name"() {
+    when:
+    def artifact = triggerResolvedArtifact(pipeline1, "artifact1")
+
+    then:
+    artifact.type == "docker/image"
+    artifact.name == "artifact1"
+  }
+
+  def "triggerResolvedArtifactByType returns resolved trigger artifact by type"() {
+    when:
+    def artifact = triggerResolvedArtifactByType(pipeline1, "docker/image")
+
+    then:
+    artifact.type == "docker/image"
+    artifact.name == "artifact1"
+  }
+
+
+  def "triggerResolvedArtifact throws when artifact is not found"() {
+    when:
+    triggerResolvedArtifact(pipeline1, "somename")
+
+    then:
+    thrown(SpelHelperFunctionException)
+  }
+
+  def "triggerResolvedArtifactByType throws if artifact is not found"() {
+    when:
+    triggerResolvedArtifactByType(pipeline1, "s3/object")
+
+    then:
+    thrown(SpelHelperFunctionException)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/4783
This MR  adds the following helper functions to Spinnaker Pipeline Expressions

`#triggerResolvedArtifact(name)` gets *one* resolved expected artifact that matches the provided `name`. I used `name` instead of `type` here to make it consistent with `#stage(..)`.

`#triggerResolvedArtifactByType(type)` is similar to `#triggerResolvedArtifact` but uses `type` of the artifact.