### PR TITLE
fix(Orca):Wrong order for the pipeline status history #3830

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -169,6 +169,11 @@ public class Execution implements Serializable {
    */
   @JsonIgnoreProperties(value = "execution")
   public @Nonnull List<Stage> getStages() {
+    if (stages.size() == 0) {
+      setStartTime(new Date().getTime());
+      setEndTime(new Date().getTime());
+    }
+
     return stages;
   }
 


### PR DESCRIPTION
Set the end time for the failure case of pipielines. For reference please find the below link :: 

https://github.com/spinnaker/spinnaker/issues/3830