### PR TITLE
feat(monitored deploy): add endpoint to get a list of deployment monitors

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/CapabilitiesController.java
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/CapabilitiesController.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.controllers;
+
+import com.netflix.spinnaker.config.MonitoredDeployConfigurationProperties;
+import com.netflix.spinnaker.orca.model.DeploymentMonitorDefinition;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller intended for querying various capabilities of orca */
+@RestController
+public class CapabilitiesController {
+  private MonitoredDeployConfigurationProperties monitoredDeployConfigurationProperties;
+
+  public CapabilitiesController(
+      Optional<MonitoredDeployConfigurationProperties> monitoredDeployConfigurationProperties) {
+    this.monitoredDeployConfigurationProperties =
+        monitoredDeployConfigurationProperties.orElse(null);
+  }
+
+  @GetMapping("/capabilities/deploymentMonitors")
+  public List<DeploymentMonitorDefinition> getDeploymentMonitors() {
+    if (monitoredDeployConfigurationProperties == null) {
+      return Collections.emptyList();
+    }
+
+    return monitoredDeployConfigurationProperties.getDeploymentMonitors().stream()
+        .map(DeploymentMonitorDefinition::new)
+        .collect(Collectors.toList());
+  }
+}

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/model/DeploymentMonitorDefinition.java
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/model/DeploymentMonitorDefinition.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.model;
+
+import lombok.Data;
+
+@Data
+public class DeploymentMonitorDefinition {
+  private String id;
+  private String name;
+
+  public DeploymentMonitorDefinition() {}
+
+  public DeploymentMonitorDefinition(
+      com.netflix.spinnaker.config.DeploymentMonitorDefinition definition) {
+    id = definition.getId();
+    name = definition.getName();
+  }
+}

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/CapabilitiesControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/CapabilitiesControllerSpec.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.controllers
+
+import com.netflix.spinnaker.config.DeploymentMonitorDefinition
+import com.netflix.spinnaker.config.MonitoredDeployConfigurationProperties
+import spock.lang.Specification
+
+class CapabilitiesControllerSpec extends Specification {
+  void '/capabilities/deploymentMonitors returns a empty list when no monitors registered or disabled'() {
+    given:
+    CapabilitiesController controller = new CapabilitiesController(Optional.empty())
+
+    expect:
+    controller.getDeploymentMonitors() == []
+  }
+
+  void '/capabilities/deploymentMonitors returns valid data'() {
+    given:
+    MonitoredDeployConfigurationProperties configProperties = new MonitoredDeployConfigurationProperties()
+    configProperties.deploymentMonitors = new ArrayList<>()
+    (0..2).forEach({
+      def dmdef = new DeploymentMonitorDefinition()
+      dmdef.setName("name${it}")
+      dmdef.setId("id${it}")
+      configProperties.deploymentMonitors.add(dmdef)
+    })
+
+    CapabilitiesController controller = new CapabilitiesController(Optional.of(configProperties))
+
+    when:
+    def result = controller.getDeploymentMonitors()
+
+    then:
+    result.size() == 3
+    result[0].id == "id0"
+    result[0].name == "name0"
+    result[1].id == "id1"
+    result[1].name == "name1"
+  }
+}


### PR DESCRIPTION
Returns the names and ids of registered deployment monitors.
This will be used in `deck` to let the user pick a monitor (also need to plumb through `gate`)
