### PR TITLE
fix(mysql): Delete old db and users on fresh setup

### DIFF
--- a/orca-sql-mysql/mysql-setup.sql
+++ b/orca-sql-mysql/mysql-setup.sql
@@ -1,5 +1,9 @@
 SET tx_isolation = 'READ-COMMITTED';
 
+DROP DATABASE IF EXISTS orca;
+DROP USER IF EXISTS orca_migrate;
+DROP USER IF EXISTS orca_service;
+
 CREATE DATABASE orca;
 CREATE USER orca_migrate;
 CREATE USER orca_service;


### PR DESCRIPTION
When setting up spinnaker via the spinnaker-oss-setup script, the original script runs into an error if the database and users already exist (which happens if you run it twice for whatever reason).

This change checks whether the database and users exist and drops them if they do before continuing with the rest of the setup.

An alternative option is to check if the database and users exist during their creation using the `IF NOT EXISTS` conditional, but that runs the risk of leaving stale state in that database, where (I think) the expectation is to have a clean slate install at the end of this process.

Context: I ran into this issue when testing https://github.com/robzienert/spinnaker-oss-setup/pull/9