### PR TITLE
fix(test): Bumping execution latch to 10s

### DIFF
--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/ExecutionLatch.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/ExecutionLatch.kt
@@ -43,7 +43,7 @@ class ExecutionLatch(private val predicate: Predicate<ExecutionComplete>) :
     }
   }
 
-  fun await() = latch.await(5, TimeUnit.SECONDS)
+  fun await() = latch.await(10, TimeUnit.SECONDS)
 }
 
 fun ConfigurableApplicationContext.runToCompletion(execution: Execution, launcher: (Execution) -> Unit, repository: ExecutionRepository) {


### PR DESCRIPTION
- fixing test failures because wait time seems low
- Seeing the following failure occasionally in travis and locally:

``
com.netflix.spinnaker.orca.q.sql.SqlQueueIntegrationTest > can run a fork join pipeline FAILED
    java.lang.AssertionError: Pipeline did not complete
``

