### PR TITLE
feat(orcestration): add support for dynamic task timeout

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/MonitorJobTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/MonitorJobTask.java
@@ -18,16 +18,17 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.job;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
-import groovy.transform.CompileStatic;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-@CompileStatic
 public class MonitorJobTask extends MonitorKatoTask {
-  final JobUtils jobUtils;
+  private final JobUtils jobUtils;
 
   @Autowired
   public MonitorJobTask(Registry registry, JobUtils jobUtils) {
@@ -41,12 +42,14 @@ public class MonitorJobTask extends MonitorKatoTask {
   }
 
   @Override
-  public void onTimeout(Stage stage) {
+  public @Nullable TaskResult onTimeout(@Nonnull Stage stage) {
     jobUtils.cancelWait(stage);
+
+    return null;
   }
 
   @Override
-  public void onCancel(Stage stage) {
+  public void onCancel(@Nonnull Stage stage) {
     jobUtils.cancelWait(stage);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/RunJobTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/RunJobTask.groovy
@@ -26,6 +26,9 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import javax.annotation.Nonnull
+import javax.annotation.Nullable
+
 @Slf4j
 @Component
 class RunJobTask extends AbstractCloudProviderAwareTask implements RetryableTask {
@@ -43,12 +46,15 @@ class RunJobTask extends AbstractCloudProviderAwareTask implements RetryableTask
   long timeout = 60000
 
   @Override
-  void onTimeout(Stage stage) {
+  @Nullable
+  TaskResult onTimeout(@Nonnull Stage stage) {
     jobUtils.cancelWait(stage)
+
+    return null;
   }
 
   @Override
-  void onCancel(Stage stage) {
+  void onCancel(@Nonnull Stage stage) {
     jobUtils.cancelWait(stage)
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -29,6 +29,8 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import javax.annotation.Nonnull
+import javax.annotation.Nullable
 import java.util.concurrent.TimeUnit
 
 @Component
@@ -50,13 +52,15 @@ public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implemen
 
   static final String REFRESH_TYPE = "Job"
 
-  @Override
-  void onTimeout(Stage stage) {
+  @Override @Nullable
+  TaskResult onTimeout(@Nonnull Stage stage) {
     jobUtils.cancelWait(stage)
+
+    return null
   }
 
   @Override
-  void onCancel(Stage stage) {
+  void onCancel(@Nonnull Stage stage) {
     jobUtils.cancelWait(stage)
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/RetryableTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/RetryableTask.java
@@ -27,6 +27,10 @@ public interface RetryableTask extends Task {
 
   long getTimeout();
 
+  default long getDynamicTimeout(Stage stage) {
+    return getTimeout();
+  }
+
   default long getDynamicBackoffPeriod(Duration taskDuration) {
     return getBackoffPeriod();
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/Task.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/Task.java
@@ -24,12 +24,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public interface Task {
   @Nonnull
   TaskResult execute(@Nonnull Stage stage);
 
-  default void onTimeout(@Nonnull Stage stage) {}
+  default @Nullable TaskResult onTimeout(@Nonnull Stage stage) {
+    return null;
+  }
 
   default void onCancel(@Nonnull Stage stage) {}
 

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -139,7 +139,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -159,7 +159,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult.RUNNING doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -194,7 +194,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -234,7 +234,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -327,7 +327,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(argThat { refId == "2a1" })) doReturn TaskResult.ofStatus(TERMINAL)
     whenever(dummyTask.execute(argThat { refId != "2a1" })) doReturn TaskResult.SUCCEEDED
 
@@ -375,7 +375,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(argThat { refId == "2a1" })) doReturn TaskResult.ofStatus(TERMINAL)
     whenever(dummyTask.execute(argThat { refId != "2a1" })) doReturn TaskResult.SUCCEEDED
 
@@ -430,7 +430,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(argThat { refId == "2a1" })) doReturn TaskResult.ofStatus(TERMINAL)
     whenever(dummyTask.execute(argThat { refId != "2a1" })) doReturn TaskResult.SUCCEEDED
 
@@ -566,7 +566,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -603,7 +603,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -641,7 +641,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult.builder(SUCCEEDED).context(mapOf("output" to "foo")).build()
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -690,7 +690,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED // second run succeeds
 
     context.restartAndRunToCompletion(pipeline.stageByRef("1"), runner::restart, repository)
@@ -731,7 +731,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(any())) doAnswer {
       val stage = it.arguments.first() as Stage
       if (stage.refId == "1") {
@@ -788,7 +788,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(any())) doAnswer {
       val stage = it.arguments.first() as Stage
       if (stage.refId == "1") {
@@ -825,7 +825,7 @@ abstract class QueueIntegrationTest {
     }
     repository.store(pipeline)
 
-    whenever(dummyTask.timeout) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
     whenever(dummyTask.execute(any())) doAnswer {
       val stage = it.arguments.first() as Stage
       if (stage.refId == "1") {
@@ -868,7 +868,7 @@ class TestConfig {
 
   @Bean
   fun dummyTask(): DummyTask = mock {
-    on { timeout } doReturn Duration.ofMinutes(2).toMillis()
+    on { getDynamicTimeout(any()) } doReturn Duration.ofMinutes(2).toMillis()
   }
 
   @Bean

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -84,6 +84,7 @@ class RunTaskHandler(
 
       val thisInvocationStartTimeMs = clock.millis()
       val execution = stage.execution
+      var taskResult: TaskResult? = null
 
       try {
         taskExecutionInterceptors.forEach { t -> stage = t.beforeTaskExecution(task, stage) }
@@ -104,15 +105,22 @@ class RunTaskHandler(
             registry
               .timeoutCounter(stage.execution.type, stage.execution.application, stage.type, taskModel.name)
               .increment()
-            task.onTimeout(stage)
-            throw e
+            taskResult = task.onTimeout(stage)
+
+            if (!setOf(TERMINAL, FAILED_CONTINUE).contains(taskResult?.status)) {
+              log.error("Task ${task.javaClass.name} returned invalid status (${taskResult?.status} for onTimeout")
+              throw e
+            }
           }
 
           stage.withAuth {
             stage.withLoggingContext(taskModel) {
-              var taskResult = task.execute(stage.withMergedContext())
-              taskExecutionInterceptors.forEach { t -> taskResult = t.afterTaskExecution(task, stage, taskResult) }
-              taskResult.let { result: TaskResult ->
+              if (taskResult == null) {
+                taskResult = task.execute(stage.withMergedContext())
+                taskExecutionInterceptors.forEach { t -> taskResult = t.afterTaskExecution(task, stage, taskResult) }
+              }
+
+              taskResult!!.let { result: TaskResult ->
                 // TODO: rather send this data with CompleteTask message
                 stage.processTaskOutput(result)
                 when (result.status) {
@@ -230,7 +238,7 @@ class RunTaskHandler(
           if (this is OverridableTimeoutRetryableTask && stage.parentWithTimeout.isPresent)
             stage.parentWithTimeout.get().timeout.get().toDuration()
           else
-            timeout.toDuration()
+            getDynamicTimeout(stage).toDuration()
           )
         if (elapsedTime.minus(pausedDuration) > actualTimeout) {
           val durationString = formatTimeout(elapsedTime.toMillis())


### PR DESCRIPTION
Currently, task timeouts can't take anything about the execution environment into account (they are essentially a static method).
This change adds the ability for tasks to consider the current `stage` (`execution`) when evaluating timeout.

Additionally, the `onTimeout` method on the task can now return a `TaskResult`.
This allows the tasks to decide if they should be `TERMINAL` or `FAILED_CONTINUE` on timeout and return data to be added to the stage in a standard way

Both are needed for monitored deploy - as the timeout and what action to take depend on the monitor configuration.
This will also become useful for `clouddriver` tasks that are retryable (e.g. backed by sagas)
