### PR TITLE
fix(rollback): capture the source capacity before anything else

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
@@ -92,11 +92,14 @@ class ExplicitRollback implements Rollback {
       ]
     }
 
-    def stages = [enableServerGroupStage]
+    // https://github.com/spinnaker/spinnaker/issues/4895 - capture the source capacity as early as possible
+    def stages = []
     if (!parentStage.getContext().containsKey("sourceServerGroupCapacitySnapshot")) {
       // capacity has been previously captured (likely as part of a failed deploy), no need to do again!
       stages << buildCaptureSourceServerGroupCapacityStage(parentStage, parentStage.mapTo(ResizeStrategy.Source))
     }
+
+    stages << enableServerGroupStage
 
     Map resizeServerGroupContext = new HashMap(parentStage.context) + [
       action                       : ResizeStrategy.ResizeAction.scale_to_server_group.toString(),

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollbackSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollbackSpec.groovy
@@ -83,17 +83,13 @@ class ExplicitRollbackSpec extends Specification {
     then:
     beforeStages.isEmpty()
     afterStages*.type == [
+      "captureSourceServerGroupCapacity",  // spinnaker/issues/4895, capture capacity snapshot first
       "enableServerGroup",
-      "captureSourceServerGroupCapacity",
       "resizeServerGroup",
       "disableServerGroup",
       "applySourceServerGroupCapacity"
     ]
-    afterStages[0].context == stage.context + [
-      serverGroupName: "servergroup-v001",
-      targetHealthyDeployPercentage: 95
-    ]
-    afterStages[1].context == [
+    afterStages[0].context == [
       source           : [
         asgName        : "servergroup-v002",
         serverGroupName: "servergroup-v002",
@@ -102,6 +98,10 @@ class ExplicitRollbackSpec extends Specification {
         cloudProvider  : "aws"
       ],
       useSourceCapacity: true
+    ]
+    afterStages[1].context == stage.context + [
+      serverGroupName: "servergroup-v001",
+      targetHealthyDeployPercentage: 95
     ]
     afterStages[2].context == stage.context + [
       action            : "scale_to_server_group",
@@ -152,8 +152,8 @@ class ExplicitRollbackSpec extends Specification {
 
     where:
     delayBeforeDisableSeconds || expectedAfterStageTypes
-    null                      || ["enableServerGroup", "captureSourceServerGroupCapacity", "resizeServerGroup", "disableServerGroup", "applySourceServerGroupCapacity"]
-    0                         || ["enableServerGroup", "captureSourceServerGroupCapacity", "resizeServerGroup", "disableServerGroup", "applySourceServerGroupCapacity"]
-    1                         || ["enableServerGroup", "captureSourceServerGroupCapacity", "resizeServerGroup", "wait", "disableServerGroup", "applySourceServerGroupCapacity"]
+    null                      || ["captureSourceServerGroupCapacity", "enableServerGroup", "resizeServerGroup", "disableServerGroup", "applySourceServerGroupCapacity"]
+    0                         || ["captureSourceServerGroupCapacity", "enableServerGroup", "resizeServerGroup", "disableServerGroup", "applySourceServerGroupCapacity"]
+    1                         || ["captureSourceServerGroupCapacity", "enableServerGroup", "resizeServerGroup", "wait", "disableServerGroup", "applySourceServerGroupCapacity"]
   }
 }


### PR DESCRIPTION
Does not entirely address this issue but makes it less likely to happen:
https://github.com/spinnaker/spinnaker/issues/4895

The "danger zone" is when a resize of the source server group happens
between the start of the rollback and the moment we take the capacity
snapshot. This change should reduce that "danger zone" from minutes to
seconds.
