### PR TITLE
fix(source resolver): prefer older servergroup when copying capacity

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolver.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolver.groovy
@@ -110,8 +110,13 @@ class SourceResolver {
       regionalAsgs = onlyEnabled
     }
 
+    def instanceSize = { Map asg -> (asg.instances as Collection)?.size() ?: 0 }
+    def created = { Map asg -> asg.createdTime as Long ?: 0 }
+    if (stageData.useSourceCapacity) {
+      regionalAsgs = regionalAsgs.sort { a1, a2 -> instanceSize(a1) <=> instanceSize(a2) ?: created(a2) <=> created(a1) }
+    }
     //with useSourceCapacity prefer the largest ASG over the newest ASG
-    def latestAsg = stageData.useSourceCapacity ? regionalAsgs.sort { (it.instances as Collection)?.size() ?: 0 }.last() : regionalAsgs.last()
+    def latestAsg = regionalAsgs.last()
     return new StageData.Source(
       account: stageData.account, region: latestAsg["region"] as String, asgName: latestAsg["name"] as String, serverGroupName: latestAsg["name"] as String
     )


### PR DESCRIPTION
If there are multiple possible server groups to choose as the source,
and all are of the same size, prefer the older server group.

This supports a use case where multiple simultaneous clone operations
are performed against a single source (the intention is to have
multiple active server groups in the region). Because a server group
can have its capacity manipulated during the deploy lifecycle, we
don't want the second deploy to choose the first deploy as its source
and result in snapshotting a capacity that may have had the min
size pinned high