### PR TITLE
chore(intellij): fixing first time builds in intellij

### DIFF
--- a/orca-sql/orca-sql.gradle
+++ b/orca-sql/orca-sql.gradle
@@ -16,6 +16,7 @@
 
 apply from: "$rootDir/gradle/kotlin.gradle"
 apply from: "$rootDir/gradle/spock.gradle"
+apply plugin: "java"
 
 dependencies {
   implementation(project(":orca-core"))


### PR DESCRIPTION
for some reason, the latest intellij doesn't copy the sql migration (changelog-master) file.
this change fixes that so we don't have to `gradlew build` to copy the file over

