### PR TITLE
fix(google): fix deploying with red/black into an empty cluster

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/GceDeployStagePreProcessor.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/GceDeployStagePreProcessor.java
@@ -24,14 +24,15 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.CaptureSour
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.ResizeServerGroupStage;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.DeployStagePreProcessor;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver;
 import com.netflix.spinnaker.orca.kato.pipeline.strategy.Strategy;
 import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy;
 import com.netflix.spinnaker.orca.kato.pipeline.support.StageData;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -66,7 +67,13 @@ public class GceDeployStagePreProcessor implements DeployStagePreProcessor {
       return ImmutableList.of();
     }
 
-    Map<String, Object> resizeContext = getResizeContext(stageData);
+    Optional<Map<String, Object>> optionalResizeContext = getResizeContext(stageData);
+    if (!optionalResizeContext.isPresent()) {
+      // no source server group, no need to resize
+      return ImmutableList.of();
+    }
+
+    Map<String, Object> resizeContext = optionalResizeContext.get();
     resizeContext.put("pinMinimumCapacity", true);
 
     return ImmutableList.of(
@@ -107,26 +114,25 @@ public class GceDeployStagePreProcessor implements DeployStagePreProcessor {
     return Strategy.fromStrategyKey(strategy) == Strategy.RED_BLACK;
   }
 
-  private Map<String, Object> getResizeContext(StageData stageData) {
-    AbstractDeployStrategyStage.CleanupConfig cleanupConfig =
-        AbstractDeployStrategyStage.CleanupConfig.fromStage(stageData);
-    Map<String, Object> resizeContext = new HashMap<>();
+  private Optional<Map<String, Object>> getResizeContext(StageData stageData) {
+    Map<String, Object> resizeContext =
+        AbstractDeployStrategyStage.CleanupConfig.toContext(stageData);
 
-    resizeContext.put(
-        cleanupConfig.getLocation().singularType(), cleanupConfig.getLocation().getValue());
-    resizeContext.put("cluster", cleanupConfig.getCluster());
-    resizeContext.put("moniker", cleanupConfig.getMoniker());
-    resizeContext.put("credentials", cleanupConfig.getAccount());
-    resizeContext.put("cloudProvider", cleanupConfig.getCloudProvider());
+    try {
+      ResizeStrategy.Source source = getSource(targetServerGroupResolver, stageData, resizeContext);
+      if (source == null) {
+        return Optional.empty();
+      }
 
-    ResizeStrategy.Source source = getSource(targetServerGroupResolver, stageData, resizeContext);
-    resizeContext.put("serverGroupName", source.getServerGroupName());
-    resizeContext.put("action", ResizeStrategy.ResizeAction.scale_to_server_group);
-    resizeContext.put("source", source);
-    resizeContext.put(
-        "useNameAsLabel", true); // hint to deck that it should _not_ override the name
-
-    return resizeContext;
+      resizeContext.put("serverGroupName", source.getServerGroupName());
+      resizeContext.put("action", ResizeStrategy.ResizeAction.scale_to_server_group);
+      resizeContext.put("source", source);
+      resizeContext.put(
+          "useNameAsLabel", true); // hint to deck that it should _not_ override the name
+      return Optional.of(resizeContext);
+    } catch (TargetServerGroup.NotFoundException e) {
+      return Optional.empty();
+    }
   }
 
   @Nullable
@@ -140,7 +146,13 @@ public class GceDeployStagePreProcessor implements DeployStagePreProcessor {
       return null;
     }
 
-    Map<String, Object> resizeContext = getResizeContext(stageData);
+    Optional<Map<String, Object>> optionalResizeContext = getResizeContext(stageData);
+    if (!optionalResizeContext.isPresent()) {
+      // no source server group, no need to unpin
+      return null;
+    }
+
+    Map<String, Object> resizeContext = optionalResizeContext.get();
     resizeContext.put("unpinMinimumCapacity", true);
 
     return new StageDefinition(

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStage.groovy
@@ -200,5 +200,16 @@ abstract class AbstractDeployStrategyStage extends AbstractCloudProviderAwareSta
         location: loc
       )
     }
+
+    static Map<String, Object> toContext(StageData stageData) {
+      CleanupConfig cleanupConfig = fromStage(stageData)
+      Map<String, Object> context = new HashMap<>()
+      context.put(cleanupConfig.getLocation().singularType(), cleanupConfig.getLocation().getValue())
+      context.put("cloudProvider", cleanupConfig.getCloudProvider())
+      context.put("cluster", cleanupConfig.getCluster())
+      context.put("credentials", cleanupConfig.getAccount())
+      context.put("moniker", cleanupConfig.getMoniker())
+      return context
+    }
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RedBlackStrategy.groovy
@@ -16,9 +16,11 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies
 
+import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.DisableClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.ScaleDownClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.ShrinkClusterStage
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.CreateServerGroupStage
 import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
 import com.netflix.spinnaker.orca.pipeline.WaitStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
@@ -50,17 +52,32 @@ class RedBlackStrategy implements Strategy, ApplicationContextAware {
 
   @Override
   List<Stage> composeFlow(Stage stage) {
-    def stages = []
-    def stageData = stage.mapTo(StageData)
-    def cleanupConfig = AbstractDeployStrategyStage.CleanupConfig.fromStage(stage)
+    List<Stage> stages = []
+    StageData stageData = stage.mapTo(StageData)
+    Map<String, Object> baseContext = AbstractDeployStrategyStage.CleanupConfig.toContext(stageData)
 
-    Map baseContext = [
-      (cleanupConfig.location.singularType()): cleanupConfig.location.value,
-      cluster                                : cleanupConfig.cluster,
-      credentials                            : cleanupConfig.account,
-      moniker                                : cleanupConfig.moniker,
-      cloudProvider                          : cleanupConfig.cloudProvider,
-    ]
+    try {
+      Stage parentCreateServerGroupStage = stage.directAncestors().find() { it.type == CreateServerGroupStage.PIPELINE_CONFIG_TYPE }
+
+      if (parentCreateServerGroupStage.status == ExecutionStatus.NOT_STARTED) {
+        // No point in composing the flow if we are called to plan "beforeStages" since we don't have any STAGE_BEFOREs.
+        // Also, we rely on the the source server group task to have run already.
+        // In the near future we will move composeFlow into beforeStages and afterStages instead of the
+        // deprecated aroundStages
+        return []
+      }
+
+      StageData parentStageData = parentCreateServerGroupStage.mapTo(StageData)
+      StageData.Source sourceServerGroup = parentStageData.source
+
+      // Short-circuit if there is no source server group
+      if (sourceServerGroup == null || sourceServerGroup.serverGroupName == null) {
+        return []
+      }
+    } catch (Exception e) {
+      // This probably means there was no parent CreateServerGroup stage - which should never happen
+      throw new IllegalStateException("Failed to determine source server group from parent stage while planning red/black flow", e)
+    }
 
     // We don't want the key propagated if interestingHealthProviderNames isn't defined, since this prevents
     // health providers from the stage's 'determineHealthProviders' task to be added to the context.


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4270

As a Spinnaker user deploying my first server group into a new cluster, I expect it to succeed if I have selected the red/black strategy.

Since Netflix has already added support for this user story in the AWS rolling red/black strategy, this PR takes the same approach: the GCE deploy stage pre-processor now short-circuits when attempting to add stages to pin and unpin the source server group's capacity if there is no source server group ([AWS code](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/AwsDeployStagePreProcessor.groovy#L173), for reference), and the red/black strategy `composeFlow` method now also short-circuits instead of adding stage to disable and shrink the non-existent source server group ([rolling red/black code](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy#L113) and [tests](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategySpec.groovy), for reference).



<details><summary>Before</summary>
<p>

![3dtGMbet5xO](https://user-images.githubusercontent.com/15936279/65170179-18b28880-da16-11e9-8b6f-2b4e1f4554da.png)

</p>
</details>

<details><summary>After</summary>
<p>

![Yuy39tK63h7](https://user-images.githubusercontent.com/15936279/65170230-37b11a80-da16-11e9-89c1-d96f54e7b439.png)


</p>
</details>