### PR TITLE
fix(google): fix scale down cluster task in gce red/black

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ScaleDownClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ScaleDownClusterTask.groovy
@@ -44,9 +44,9 @@ class ScaleDownClusterTask extends AbstractClusterWideClouddriverTask {
     ClusterSelection clusterSelection = stage.mapTo(ClusterSelection)
     Map resizeOp = [capacity: [min: 0, max: 0, desired: 0]]
     if (clusterSelection.cloudProvider == 'gce' && serverGroup.getAutoscalingPolicy()) {
-      resizeOp.autoscalingMode = 'OFF'
+      resizeOp.autoscalingMode = 'ON'
 
-      // Avoid overriding persisted autoscaling policy metadata to 0/0/0 and mode = OFF.
+      // Avoid overriding persisted autoscaling policy metadata to 0/0/0 and mode = ON.
       // This ensures the server group will be scaled properly with the previously persisted
       // autoscaling policy if re-enabled.
       resizeOp.writeMetadata = false


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4810

In response to the deprecation of GCE autoscaler's `ONLY_DOWN` mode, we set the mode to `OFF` in the `ScaleDownClusterTask` in this [PR](https://github.com/spinnaker/orca/pull/3087/files). However, when we scale down a server group with an autoscaler, we are actually enacting the scale-down by updating the capacity of the autoscaler, so if we set its mode to OFF, the scale-down will hang until the task times out. Since we are setting `min`, `max`, and `desired` capacity to 0, I don't think it will matter whether the mode is ONLY_DOWN or ON, since it will have to scale down in order to actuate the new capacity.

<details><summary>Before</summary>
<p>

![6thykQUyAbX](https://user-images.githubusercontent.com/15936279/65187140-32b19280-da39-11e9-9b7c-486c0d26d15b.png)

</p>
</details>

<details><summary>After</summary>
<p>

![NiUbZwBTMyh](https://user-images.githubusercontent.com/15936279/65187221-61c80400-da39-11e9-81f3-1e906cb6eb50.png)


</p>
</details>


