### PR TITLE
fix(google): do not pin source server group capacity in red/black

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/GceDeployStagePreProcessor.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/GceDeployStagePreProcessor.java
@@ -16,21 +16,14 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.gce;
 
-import static com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategySupport.getSource;
-
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ApplySourceServerGroupCapacityStage;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.CaptureSourceServerGroupCapacityTask;
-import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.DeployStagePreProcessor;
-import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver;
-import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy;
 import com.netflix.spinnaker.orca.kato.pipeline.support.StageData;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -67,26 +60,5 @@ public class GceDeployStagePreProcessor implements DeployStagePreProcessor {
   public boolean supports(Stage stage) {
     StageData stageData = stage.mapTo(StageData.class);
     return stageData.getCloudProvider().equals("gce");
-  }
-
-  private Optional<Map<String, Object>> getResizeContext(StageData stageData) {
-    Map<String, Object> resizeContext =
-        AbstractDeployStrategyStage.CleanupConfig.toContext(stageData);
-
-    try {
-      ResizeStrategy.Source source = getSource(targetServerGroupResolver, stageData, resizeContext);
-      if (source == null) {
-        return Optional.empty();
-      }
-
-      resizeContext.put("serverGroupName", source.getServerGroupName());
-      resizeContext.put("action", ResizeStrategy.ResizeAction.scale_to_server_group);
-      resizeContext.put("source", source);
-      resizeContext.put(
-          "useNameAsLabel", true); // hint to deck that it should _not_ override the name
-      return Optional.of(resizeContext);
-    } catch (TargetServerGroup.NotFoundException e) {
-      return Optional.empty();
-    }
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/GceDeployStagePreProcessor.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/GceDeployStagePreProcessor.java
@@ -21,35 +21,29 @@ import static com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategySup
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ApplySourceServerGroupCapacityStage;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.CaptureSourceServerGroupCapacityTask;
-import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.ResizeServerGroupStage;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.DeployStagePreProcessor;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver;
-import com.netflix.spinnaker.orca.kato.pipeline.strategy.Strategy;
 import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy;
 import com.netflix.spinnaker.orca.kato.pipeline.support.StageData;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GceDeployStagePreProcessor implements DeployStagePreProcessor {
   private final ApplySourceServerGroupCapacityStage applySourceServerGroupSnapshotStage;
-  private final ResizeServerGroupStage resizeServerGroupStage;
   private final TargetServerGroupResolver targetServerGroupResolver;
 
   @Autowired
   public GceDeployStagePreProcessor(
       ApplySourceServerGroupCapacityStage applySourceServerGroupCapacityStage,
-      ResizeServerGroupStage resizeServerGroupStage,
       TargetServerGroupResolver targetServerGroupResolver) {
     this.applySourceServerGroupSnapshotStage = applySourceServerGroupCapacityStage;
-    this.resizeServerGroupStage = resizeServerGroupStage;
     this.targetServerGroupResolver = targetServerGroupResolver;
   }
 
@@ -58,29 +52,6 @@ public class GceDeployStagePreProcessor implements DeployStagePreProcessor {
     return ImmutableList.of(
         new StepDefinition(
             "snapshotSourceServerGroup", CaptureSourceServerGroupCapacityTask.class));
-  }
-
-  @Override
-  public ImmutableList<StageDefinition> beforeStageDefinitions(Stage stage) {
-    StageData stageData = stage.mapTo(StageData.class);
-    if (!shouldPinSourceServerGroup(stageData.getStrategy())) {
-      return ImmutableList.of();
-    }
-
-    Optional<Map<String, Object>> optionalResizeContext = getResizeContext(stageData);
-    if (!optionalResizeContext.isPresent()) {
-      // no source server group, no need to resize
-      return ImmutableList.of();
-    }
-
-    Map<String, Object> resizeContext = optionalResizeContext.get();
-    resizeContext.put("pinMinimumCapacity", true);
-
-    return ImmutableList.of(
-        new StageDefinition(
-            String.format("Pin %s", resizeContext.get("serverGroupName")),
-            resizeServerGroupStage,
-            resizeContext));
   }
 
   @Override
@@ -93,25 +64,9 @@ public class GceDeployStagePreProcessor implements DeployStagePreProcessor {
   }
 
   @Override
-  public ImmutableList<StageDefinition> onFailureStageDefinitions(Stage stage) {
-    StageData stageData = stage.mapTo(StageData.class);
-
-    StageDefinition unpinServerGroupStage = buildUnpinServerGroupStage(stageData);
-    if (unpinServerGroupStage == null) {
-      return ImmutableList.of();
-    }
-
-    return ImmutableList.of(unpinServerGroupStage);
-  }
-
-  @Override
   public boolean supports(Stage stage) {
     StageData stageData = stage.mapTo(StageData.class);
     return stageData.getCloudProvider().equals("gce");
-  }
-
-  private static boolean shouldPinSourceServerGroup(String strategy) {
-    return Strategy.fromStrategyKey(strategy) == Strategy.RED_BLACK;
   }
 
   private Optional<Map<String, Object>> getResizeContext(StageData stageData) {
@@ -133,31 +88,5 @@ public class GceDeployStagePreProcessor implements DeployStagePreProcessor {
     } catch (TargetServerGroup.NotFoundException e) {
       return Optional.empty();
     }
-  }
-
-  @Nullable
-  private StageDefinition buildUnpinServerGroupStage(StageData stageData) {
-    if (!shouldPinSourceServerGroup(stageData.getStrategy())) {
-      return null;
-    }
-
-    if (stageData.getScaleDown()) {
-      // source server group has been scaled down, no need to unpin if deploy was successful
-      return null;
-    }
-
-    Optional<Map<String, Object>> optionalResizeContext = getResizeContext(stageData);
-    if (!optionalResizeContext.isPresent()) {
-      // no source server group, no need to unpin
-      return null;
-    }
-
-    Map<String, Object> resizeContext = optionalResizeContext.get();
-    resizeContext.put("unpinMinimumCapacity", true);
-
-    return new StageDefinition(
-        String.format("Unpin %s", resizeContext.get("serverGroupName")),
-        resizeServerGroupStage,
-        resizeContext);
   }
 }


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4812

- When deploying to AWS, only the rolling red/black strategy pins the source server group's min capacity to its desired capacity (see [AwsDeployStagePreProcessor](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/AwsDeployStagePreProcessor.groovy#L155) and this [conversation](https://github.com/spinnaker/orca/pull/3173#discussion_r325905128) for details on how/why).
- This change brings the GCE implementation of red/black to parity with the AWS implementation: we will no longer pin the source server group's min capacity to its desired capacity. The potential drawback to this is that during the period when both the source and target server groups are taking traffic, the autoscaler may scale down the source server group as it will only be taking 50% of the traffic: in the case a rollback is necessary, it will need to scale back up. However, as Netflix has experienced, the potential downsides of pinning the source server group are much worse, as there are many unpredictable ways to get into a state where the server group is never unpinned (see Netflix post-mortem [here](https://twitter.com/FakeRyanGosling/status/1106714429247221761)).
- The other upside of bringing the GCE red/black to parity with the AWS red/black is the maintainability of the common strategy code, which @marchello2000 is currently refactoring.
- In the next Spinnaker release (1.17), I will summarize the rationale behind this change in the release notes so that any GCE users relying on the existing functionality are aware of the change.