### PR TITLE
fix(monitored deploy): don't store any context in the task

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/NotifyDeployCompletedTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/NotifyDeployCompletedTask.java
@@ -17,10 +17,13 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.monitoreddeploy;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.config.DeploymentMonitorDefinition;
 import com.netflix.spinnaker.config.DeploymentMonitorServiceProvider;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.MonitoredDeployStageData;
 import com.netflix.spinnaker.orca.deploymentmonitor.models.DeploymentCompletedRequest;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -36,7 +39,10 @@ public class NotifyDeployCompletedTask extends MonitoredDeployBaseTask {
   }
 
   @Override
-  public @Nonnull TaskResult executeInternal() {
+  public @Nonnull TaskResult executeInternal(
+      Stage stage,
+      MonitoredDeployStageData context,
+      DeploymentMonitorDefinition monitorDefinition) {
     // TODO(mvulfson): actually populate the request data
     DeploymentCompletedRequest request = new DeploymentCompletedRequest(stage);
     monitorDefinition.getService().notifyCompleted(request);

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/NotifyDeployStartingTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/NotifyDeployStartingTask.java
@@ -17,11 +17,14 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.monitoreddeploy;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.config.DeploymentMonitorDefinition;
 import com.netflix.spinnaker.config.DeploymentMonitorServiceProvider;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.MonitoredDeployStageData;
 import com.netflix.spinnaker.orca.deploymentmonitor.models.EvaluateHealthResponse;
 import com.netflix.spinnaker.orca.deploymentmonitor.models.RequestBase;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -37,17 +40,22 @@ public class NotifyDeployStartingTask extends MonitoredDeployBaseTask {
   }
 
   @Override
-  public @Nonnull TaskResult executeInternal() {
+  public @Nonnull TaskResult executeInternal(
+      Stage stage,
+      MonitoredDeployStageData context,
+      DeploymentMonitorDefinition monitorDefinition) {
     RequestBase request = new RequestBase(stage);
     EvaluateHealthResponse response = monitorDefinition.getService().notifyStarting(request);
 
-    sanitizeAndLogResponse(response);
+    sanitizeAndLogResponse(response, monitorDefinition, stage.getExecution().getId());
 
-    return buildTaskResult(processDirective(response.getNextStep().getDirective()), response);
+    return buildTaskResult(
+        processDirective(response.getNextStep().getDirective(), monitorDefinition), response);
   }
 
   private TaskResult.TaskResultBuilder processDirective(
-      EvaluateHealthResponse.NextStepDirective directive) {
+      EvaluateHealthResponse.NextStepDirective directive,
+      DeploymentMonitorDefinition monitorDefinition) {
     switch (directive) {
       case COMPLETE:
         log.warn(


### PR DESCRIPTION
Somehow... I forgot that tasks are singletons and shouldn't have any state stored...
Simple refactor to pass along the vars that are needed all the time
