### PR TITLE
fix(webhooks): Construct Webhook status check URL honoring the origin…

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookService.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookService.groovy
@@ -70,7 +70,7 @@ class WebhookService {
     )
     HttpHeaders headers = buildHttpHeaders(customHeaders)
     HttpEntity<Object> httpEntity = new HttpEntity<>(headers)
-    return restTemplateProvider.getRestTemplate().exchange(validatedUri, HttpMethod.GET, httpEntity, Object)
+    return restTemplateProvider.getRestTemplate(url).exchange(validatedUri, HttpMethod.GET, httpEntity, Object)
   }
 
   List<WebhookProperties.PreconfiguredWebhook> getPreconfiguredWebhooks() {

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
@@ -160,7 +160,6 @@ class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
       return TaskResult.builder(statusMap[result.toString().toUpperCase()]).context(responsePayload).build()
     }
 
-    stage.context
     return TaskResult.builder(ExecutionStatus.RUNNING).context(response ? responsePayload : originalResponse).build()
   }
 


### PR DESCRIPTION

- Change here is to make the status check URL of a webhook to have the same protocol/scheme of the webhook.
- RestTemplate provider keys on the URL as a whole and it is important to keep the scheme as is from the original webhook so that the same RestTemplate provider as webhook will be used for making the status check call.