### PR TITLE
fix(tasks): limit task maxBackoff time to 2min

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskExecutionInterceptor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskExecutionInterceptor.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca;
 
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import java.util.concurrent.TimeUnit;
 
 /**
  * TaskExecutionInterceptor is a hook point to customize the specific execution of a task.
@@ -37,7 +38,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage;
 public interface TaskExecutionInterceptor {
 
   default long maxTaskBackoff() {
-    return Long.MAX_VALUE;
+    return TimeUnit.MINUTES.toMillis(2);
   }
 
   default Stage beforeTaskExecution(Task task, Stage stage) {


### PR DESCRIPTION
- The `maxTaskBackoff` for `RetryableTask` `RunTask` messages was previously limited via `LockExtendingTaskExecutionInterceptor` which was removed by https://github.com/spinnaker/orca/pull/3136. This makes the prior backoff constraint the default as it assists with patching and cancellation of in-flight executions.