### PR TITLE
fix(monitored deploy): make reason singular

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/MonitoredDeployBaseTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/MonitoredDeployBaseTask.java
@@ -27,7 +27,6 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.Mo
 import com.netflix.spinnaker.orca.deploymentmonitor.models.DeploymentStep;
 import com.netflix.spinnaker.orca.deploymentmonitor.models.EvaluateHealthResponse;
 import com.netflix.spinnaker.orca.deploymentmonitor.models.StatusExplanation;
-import com.netflix.spinnaker.orca.deploymentmonitor.models.StatusReason;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -218,13 +217,11 @@ public class MonitoredDeployBaseTask implements RetryableTask {
 
   TaskResult buildTaskResult(
       TaskResult.TaskResultBuilder taskResultBuilder, EvaluateHealthResponse response) {
-    List<StatusReason> statusReasons =
-        Optional.ofNullable(response.getStatusReasons()).orElse(Collections.emptyList());
 
     String summary =
         summaryMapping.getOrDefault(
             response.getNextStep().getDirective(), "Health evaluation results are unknown");
-    StatusExplanation explanation = new StatusExplanation(summary, statusReasons);
+    StatusExplanation explanation = new StatusExplanation(summary, response.getStatusReason());
 
     return taskResultBuilder.context("deploymentMonitorReasons", explanation).build();
   }

--- a/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/orca/deploymentmonitor/models/EvaluateHealthResponse.java
+++ b/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/orca/deploymentmonitor/models/EvaluateHealthResponse.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.deploymentmonitor.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
 import lombok.Data;
 
 @Data
@@ -58,5 +57,5 @@ public class EvaluateHealthResponse {
   }
 
   private DeploymentStep nextStep;
-  private List<StatusReason> statusReasons;
+  private StatusReason statusReason;
 }

--- a/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/orca/deploymentmonitor/models/StatusExplanation.java
+++ b/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/orca/deploymentmonitor/models/StatusExplanation.java
@@ -16,21 +16,19 @@
 
 package com.netflix.spinnaker.orca.deploymentmonitor.models;
 
-import java.util.Collections;
-import java.util.List;
 import lombok.Data;
 
 @Data
 public class StatusExplanation {
   private String summary;
-  private List<StatusReason> reasons;
+  private StatusReason reason;
 
   public StatusExplanation(String summary) {
-    this(summary, Collections.emptyList());
+    this(summary, null);
   }
 
-  public StatusExplanation(String summary, List<StatusReason> reasons) {
+  public StatusExplanation(String summary, StatusReason reason) {
     this.summary = summary;
-    this.reasons = reasons;
+    this.reason = reason;
   }
 }


### PR DESCRIPTION
there is no point having an array of reasons from deployment monitor, making it a single object
