### PR TITLE
fix(RRB & MD): pin and unpin the correct server group

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/AwsDeployStagePreProcessor.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/AwsDeployStagePreProcessor.groovy
@@ -17,22 +17,13 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws
 
-import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.PinServerGroupStage
-import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.DeployStagePreProcessor
-import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
-import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver
 import com.netflix.spinnaker.orca.kato.pipeline.strategy.Strategy
-import com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategy
 import com.netflix.spinnaker.orca.kato.pipeline.support.StageData
 import com.netflix.spinnaker.orca.pipeline.CheckPreconditionsStage
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-
-import java.util.concurrent.TimeUnit
-
-import static com.netflix.spinnaker.orca.kato.pipeline.support.ResizeStrategySupport.getSource
 
 @Component
 class AwsDeployStagePreProcessor implements DeployStagePreProcessor {
@@ -40,12 +31,6 @@ class AwsDeployStagePreProcessor implements DeployStagePreProcessor {
 
   @Autowired
   ApplySourceServerGroupCapacityStage applySourceServerGroupSnapshotStage
-
-  @Autowired
-  PinServerGroupStage pinServerGroupStage
-
-  @Autowired
-  TargetServerGroupResolver targetServerGroupResolver
 
   @Autowired
   CheckPreconditionsStage checkPreconditionsStage
@@ -93,24 +78,6 @@ class AwsDeployStagePreProcessor implements DeployStagePreProcessor {
       )
     }
 
-    if (shouldPinSourceServerGroup(stageData.strategy)) {
-      def optionalResizeContext = getResizeContext(stageData)
-      if (!optionalResizeContext.isPresent()) {
-        // this means we don't need to resize anything
-        // happens in particular when there is no pre-existing source server group
-        return stageDefinitions
-      }
-
-      def resizeContext = optionalResizeContext.get()
-      resizeContext.pinMinimumCapacity = true
-
-      stageDefinitions << new StageDefinition(
-        name: "Pin ${resizeContext.serverGroupName}",
-        stageDefinitionBuilder: pinServerGroupStage,
-        context: resizeContext
-      )
-    }
-
     return stageDefinitions
   }
 
@@ -129,24 +96,6 @@ class AwsDeployStagePreProcessor implements DeployStagePreProcessor {
       )
     }
 
-    def unpinServerGroupStage = buildUnpinServerGroupStage(stageData, false)
-    if (unpinServerGroupStage) {
-      stageDefinitions << unpinServerGroupStage
-    }
-
-    return stageDefinitions
-  }
-
-  @Override
-  List<StageDefinition> onFailureStageDefinitions(Stage stage) {
-    def stageData = stage.mapTo(StageData)
-    def stageDefinitions = []
-
-    def unpinServerGroupStage = buildUnpinServerGroupStage(stageData, true)
-    if (unpinServerGroupStage) {
-      stageDefinitions << unpinServerGroupStage
-    }
-
     return stageDefinitions
   }
 
@@ -156,74 +105,10 @@ class AwsDeployStagePreProcessor implements DeployStagePreProcessor {
     return stageData.cloudProvider == "aws" // && stageData.useSourceCapacity
   }
 
-  private static boolean shouldPinSourceServerGroup(String strategy) {
-    // TODO-AJ consciously only enabling for rolling red/black -- will add support for other strategies after it's working
-    return (rollingStrategies.contains(Strategy.fromStrategyKey(strategy)))
-  }
-
   private static boolean shouldCheckServerGroupsPreconditions(StageData stageData) {
     // TODO(dreynaud): enabling cautiously for RRB/MD only for testing, but we would ideally roll this out to other strategies
     Strategy strategy = Strategy.fromStrategyKey(stageData.strategy)
 
     return (rollingStrategies.contains(strategy) && (stageData.maxInitialAsgs != -1))
-  }
-
-  private Optional<Map<String, Object>> getResizeContext(StageData stageData) {
-    def cleanupConfig = AbstractDeployStrategyStage.CleanupConfig.fromStage(stageData)
-    def baseContext = [
-      (cleanupConfig.location.singularType()): cleanupConfig.location.value,
-      cluster                                : cleanupConfig.cluster,
-      moniker                                : cleanupConfig.moniker,
-      credentials                            : cleanupConfig.account,
-      cloudProvider                          : cleanupConfig.cloudProvider,
-    ]
-
-    try {
-      def source = getSource(targetServerGroupResolver, stageData, baseContext)
-      if (!source) {
-        return Optional.empty()
-      }
-
-      baseContext.putAll([
-        serverGroupName   : source.serverGroupName,
-        action            : ResizeStrategy.ResizeAction.scale_to_server_group,
-        source            : source,
-        useNameAsLabel    : true     // hint to deck that it should _not_ override the name
-      ])
-      return Optional.of(baseContext)
-    } catch(TargetServerGroup.NotFoundException e) {
-      return Optional.empty()
-    }
-  }
-
-  private StageDefinition buildUnpinServerGroupStage(StageData stageData, boolean deployFailed) {
-    if (!shouldPinSourceServerGroup(stageData.strategy)) {
-      return null
-    }
-
-    if (stageData.scaleDown && !deployFailed) {
-      // source server group has been scaled down, no need to unpin if deploy was successful
-      return null
-    }
-
-    def optionalResizeContext = getResizeContext(stageData)
-    if (!optionalResizeContext.isPresent()) {
-      // no source server group, no need to unpin anything
-      return null
-    }
-
-    def resizeContext = optionalResizeContext.get()
-    resizeContext.unpinMinimumCapacity = true
-
-    if (deployFailed) {
-      // we want to specify a new timeout explicitly here, in case the deploy itself failed because of a timeout
-      resizeContext.stageTimeoutMs = TimeUnit.MINUTES.toMillis(20)
-    }
-
-    return new StageDefinition(
-      name: "Unpin ${resizeContext.serverGroupName} (deployFailed=${deployFailed})".toString(),
-      stageDefinitionBuilder: pinServerGroupStage,
-      context: resizeContext
-    )
   }
 }


### PR DESCRIPTION
During rolling redblack (or monitored deploy), use the determined source server group to pin/unpin.
This used to live in the deploy preprocessor, but the deploy preprocessor runs too early to be useful (it runs before we run determineSourceServerGroup task).
This means it can pick the wrong ASG to pin! in the following scenario:

```
ASG v2 - being deployed
ASG v1 - Disabled
ASG v0 - Enabled
```

before this change, we would pin/unpin `v1` which is clearly wrong ASG to pin.

NOTE: currently the code is duplicated in RRB and MD strategies. I will do another PR with a refactor to make them share code (it's proving harder than anticipated to make this refactor actually nice)

