### PR TITLE
fix(webhook): Don't try to deserialize fields we don't really need

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStage.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStage.groovy
@@ -104,20 +104,26 @@ class WebhookStage implements StageDefinitionBuilder {
   }
 
   static class WebhookResponseStageData {
-    String statusEndpoint
-    Integer statusCodeValue
     String statusCode
-    Map body
     WebhookMonitorResponseStageData monitor
     String error
+
+    // NOTE: The fields below exist in the context because they are inserted by the CreateWebhookTask but they aren't
+    //       consumed by Spinnaker so they are commented out below - they are here for informational purposes only
+    //String statusEndpoint
+    //Integer statusCodeValue
+    //Map body
   }
 
   static class WebhookMonitorResponseStageData {
-    Integer statusCodeValue
-    String statusCode
-    Map body
     String error
-    String progressMessage
-    Number percentComplete
+
+    // NOTE: The fields below exist in the context because they are inserted by the MonitorWebhookTask but they aren't
+    //       consumed by Spinnaker so they are commented out below - they are here for informational purposes only
+    //Integer statusCodeValue
+    //String statusCode
+    //Map body
+    //String progressMessage
+    //Number percentComplete
   }
 }

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
@@ -75,6 +75,7 @@ class CreateWebhookTask implements RetryableTask {
           }
         } catch (JsonParseException | JsonMappingException ex) {
           // Just leave body as string, probs not JSON
+          log.warn("Failed to parse webhook payload as JSON", ex)
         }
 
         outputs.webhook << [body: body]


### PR DESCRIPTION
An assumption was made that body is a can be jackon parsed into a JSON object.
But that's not always the case, in fact, we actually account for it in the original parse:
https://github.com/spinnaker/orca/blob/master/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy#L71
But then disregard it in StageContext mapping

This change removes those fields from being parsed since we don't actually need them for anything
inside the stage (they were added in the attempt to be fully typed)
