### PR TITLE
feat(tasks): attach notifications to execution

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -241,7 +241,11 @@ public class ExecutionLauncher {
     }
 
     if (config.get("trigger") != null) {
-      orchestration.setTrigger(objectMapper.convertValue(config.get("trigger"), Trigger.class));
+      Trigger trigger = objectMapper.convertValue(config.get("trigger"), Trigger.class);
+      orchestration.setTrigger(trigger);
+      if (!trigger.getNotifications().isEmpty()) {
+        orchestration.setNotifications(trigger.getNotifications());
+      }
     }
 
     orchestration.setBuildTime(clock.millis());

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -286,10 +286,14 @@ public class Execution implements Serializable {
     this.source = source;
   }
 
-  private final List<Map<String, Object>> notifications = new ArrayList<>();
+  private List<Map<String, Object>> notifications = new ArrayList<>();
 
   public @Nonnull List<Map<String, Object>> getNotifications() {
     return notifications;
+  }
+
+  public void setNotifications(List<Map<String, Object>> notifications) {
+    this.notifications = notifications;
   }
 
   private final Map<String, Object> initialConfig = new HashMap<>();


### PR DESCRIPTION
Why should pipelines get all the fun? If task triggers contain notifications, let's attach them to the execution. 

This is needed for https://github.com/spinnaker/echo/pull/668