### PR TITLE
fix(rollback): pass authentication context and consider errors fatal

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
-import com.netflix.discovery.converters.Auto
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 


### PR DESCRIPTION
This avoids a potentially dangerous scenario where we roll back to a server
group of size 0 and fail to look it up for some reason, e.g. if it is in
a restricted account and we fail to pass the credentials along to clouddriver.
