### PR TITLE
fix(cfn): Return RUNNING if an error occurred

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/CloudFormationForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/CloudFormationForceCacheRefreshTask.java
@@ -60,8 +60,11 @@ public class CloudFormationForceCacheRefreshTask extends AbstractCloudProviderAw
       data.put("stackName", stackName);
     }
 
-    cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, data);
-
+    try {
+      cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, data);
+    } catch (RetrofitError e) {
+      return TaskResult.RUNNING;
+    }
     return TaskResult.SUCCEEDED;
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/CloudFormationForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/CloudFormationForceCacheRefreshTask.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import retrofit.RetrofitError;
 
 @Component
 public class CloudFormationForceCacheRefreshTask extends AbstractCloudProviderAwareTask


### PR DESCRIPTION
Force cache refreshing was a retryable task. However, it didn't return
RUNNING whenever the cache refresh failed, and thus the task failed
immediately. This patch makes the task return RUNNING whenever there's
an exception refreshing the cache so it actually retries.