### PR TITLE
fix(cf): cf rolling red black did not resize old SG correctly

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/CFRollingRedBlackStrategy.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/CFRollingRedBlackStrategy.java
@@ -291,9 +291,13 @@ public class CFRollingRedBlackStrategy implements Strategy, ApplicationContextAw
       stages.add(disableStage);
 
       // scale old back to original
+      ResizeStrategy.Capacity resetCapacity = new ResizeStrategy.Capacity();
+      resetCapacity.setMax(sourceCapacity.getMax());
+      resetCapacity.setMin(0);
+      resetCapacity.setDesired(0);
       Map<String, Object> scaleSourceContext =
           getScalingContext(
-              stage, cleanupConfig, baseContext, sourceCapacity, 100, source.getServerGroupName());
+              stage, cleanupConfig, baseContext, resetCapacity, 100, source.getServerGroupName());
       scaleSourceContext.put("scaleStoppedServerGroup", true);
       log.info(
           "Adding `Grow source to 100% of original size` stage with context {} [executionId={}]",


### PR DESCRIPTION
After some investigating it looks like the problem is that when attempting to restore the old number of instances for the old server group, the following task waits on the wrong number of server groups to be up. The old server group remains disabled (in cf terms - stopped) but the task waits for the old number of up instances.

fix for spinnaker/spinnaker#4786

![Screen Shot 2019-10-03 at 11 25 54 AM](https://user-images.githubusercontent.com/8474965/66140734-9eb2ff80-e5d0-11e9-83b1-52d8a13e8df4.png)
