### PR TITLE
chore(mysql): add drop database to init script for convenience

### DIFF
--- a/orca-sql-mysql/mysql-setup.sql
+++ b/orca-sql-mysql/mysql-setup.sql
@@ -1,3 +1,4 @@
+DROP DATABASE IF EXISTS orca;
 SET tx_isolation = 'READ-COMMITTED';
 
 CREATE DATABASE orca;


### PR DESCRIPTION
Just added this for convenience so it's easy to reset orca DB - this is only run manually