### PR TITLE
fix(pipeline): allow mid-task spel evaluation to reference prior stage outputs

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
@@ -119,7 +119,7 @@ public class CreateBakeManifestTask implements RetryableTask {
 
       overrides =
           contextParameterProcessor.process(
-              overrides, contextParameterProcessor.buildExecutionContext(stage, true), true);
+              overrides, contextParameterProcessor.buildExecutionContext(stage), true);
     }
 
     BakeManifestRequest request;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluator.java
@@ -128,9 +128,7 @@ public class ManifestEvaluator implements CloudProviderAware {
         if (!context.isSkipExpressionEvaluation()) {
           manifestWrapper =
               contextParameterProcessor.process(
-                  manifestWrapper,
-                  contextParameterProcessor.buildExecutionContext(stage, true),
-                  true);
+                  manifestWrapper, contextParameterProcessor.buildExecutionContext(stage), true);
 
           if (manifestWrapper.containsKey("expressionEvaluationSummary")) {
             throw new IllegalStateException(

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupport.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/OptionalStageSupport.java
@@ -99,7 +99,7 @@ public class OptionalStageSupport {
           contextParameterProcessor
               .process(
                   singletonMap("expression", format("${%s}", this.expression)),
-                  contextParameterProcessor.buildExecutionContext(stage, true),
+                  contextParameterProcessor.buildExecutionContext(stage),
                   true)
               .get("expression")
               .toString();

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ExpressionPreconditionTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ExpressionPreconditionTask.java
@@ -55,7 +55,7 @@ public class ExpressionPreconditionTask implements PreconditionTask {
     Map<String, Object> result =
         contextParameterProcessor.process(
             singletonMap("expression", "${" + stageData.expression + '}'),
-            contextParameterProcessor.buildExecutionContext(stage, true),
+            contextParameterProcessor.buildExecutionContext(stage),
             true);
 
     String expression = result.get("expression").toString();

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -156,7 +156,7 @@ public class ArtifactResolver {
 
     Map<String, Object> evaluatedBoundArtifactMap =
         contextParameterProcessor.process(
-            boundArtifactMap, contextParameterProcessor.buildExecutionContext(stage, true), true);
+            boundArtifactMap, contextParameterProcessor.buildExecutionContext(stage), true);
 
     return objectMapper.convertValue(evaluatedBoundArtifactMap, Artifact.class);
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
@@ -99,11 +99,9 @@ public class ContextParameterProcessor {
     return result;
   }
 
-  public Map<String, Object> buildExecutionContext(Stage stage, boolean includeStageContext) {
+  public StageContext buildExecutionContext(Stage stage) {
     Map<String, Object> augmentedContext = new HashMap<>();
-    if (includeStageContext) {
-      augmentedContext.putAll(stage.getContext());
-    }
+    augmentedContext.putAll(stage.getContext());
     if (stage.getExecution().getType() == PIPELINE) {
       augmentedContext.put(
           "trigger",
@@ -112,7 +110,7 @@ public class ContextParameterProcessor {
       augmentedContext.put("execution", stage.getExecution());
     }
 
-    return augmentedContext;
+    return new StageContext(stage, augmentedContext);
   }
 
   public static boolean containsExpression(String value) {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
@@ -803,7 +803,7 @@ class ContextParameterProcessorSpec extends Specification {
     }
 
     def stage = pipe.stageByRef("2")
-    def ctx = contextParameterProcessor.buildExecutionContext(stage, true)
+    def ctx = contextParameterProcessor.buildExecutionContext(stage)
 
     when:
     def result = contextParameterProcessor.process(stage.context, ctx, true)
@@ -825,7 +825,7 @@ class ContextParameterProcessorSpec extends Specification {
     }
 
     def stage = pipe.stageByRef("1")
-    def ctx = contextParameterProcessor.buildExecutionContext(stage, true)
+    def ctx = contextParameterProcessor.buildExecutionContext(stage)
 
     when:
     def result = contextParameterProcessor.process(stage.context, ctx, true)
@@ -854,7 +854,7 @@ class ContextParameterProcessorSpec extends Specification {
     pipe.setAuthentication(new Execution.AuthenticationDetails('joeyjoejoejuniorshabadoo@host.net'))
 
     def stage = pipe.stages.find { it.name == "Wait1" }
-    def ctx = contextParameterProcessor.buildExecutionContext(stage, true)
+    def ctx = contextParameterProcessor.buildExecutionContext(stage)
 
     when:
     def result = contextParameterProcessor.process(stage.context, ctx, true)
@@ -881,7 +881,7 @@ class ContextParameterProcessorSpec extends Specification {
 
     and:
     def stage = pipe.stages.find { it.type == "bake" }
-    def ctx = contextParameterProcessor.buildExecutionContext(stage, true)
+    def ctx = contextParameterProcessor.buildExecutionContext(stage)
 
     when:
     def result = contextParameterProcessor.process(stage.context, ctx, true)
@@ -911,7 +911,7 @@ class ContextParameterProcessorSpec extends Specification {
 
     and:
     def stage = pipe.stageByRef("1")
-    def ctx = contextParameterProcessor.buildExecutionContext(stage, true)
+    def ctx = contextParameterProcessor.buildExecutionContext(stage)
 
     when:
     def result = contextParameterProcessor.process(stage.context, ctx, true)
@@ -942,7 +942,7 @@ class ContextParameterProcessorSpec extends Specification {
   }
 
   @Unroll
-  def "Does not evaluate expressions that refer to outputs of prior stages"() {
+  def "Correctly evaluates expressions that refer to outputs of prior stages"() {
     given:
     def execution = pipeline {
       stage {
@@ -974,7 +974,7 @@ class ContextParameterProcessorSpec extends Specification {
     }
 
     def stage = execution.stageByRef("2")
-    def ctx = contextParameterProcessor.buildExecutionContext(stage, true)
+    def ctx = contextParameterProcessor.buildExecutionContext(stage)
 
     when:
     def result = contextParameterProcessor.process(stage.context, ctx, true)
@@ -983,8 +983,8 @@ class ContextParameterProcessorSpec extends Specification {
     result.manifests == [
       [
         kind: 'ReplicaSet',
-        name: '${keyA}',
-        namespace: '${keyB}'
+        name: 'valueA',
+        namespace: 'valueB'
       ]
     ]
   }


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4932

- chore(pipeline): add buildExecutionContext test to ContextParameterProcessorSpec

  Adds test to demonstrate that currently, the context returned by `ContextParameterProcessor.buildExecutionContext`, when used as the context for `ContextParameterProcessor.process`, does not allow for the evaluation of variables that refer to the outputs of a prior stage.

- fix(pipeline): allow mid-task SpEL evaluation to reference prior stage outputs

  Changes `ContextParameterProcessor.buildExecutionContext` to return `StageContext`, which extends a `ForwardingMap` in order to override `get` to search the stage's ancestors' outputs if a given key does not exist on the delegate object. Uses the `Map` previously returned by this method as the delegate. Removes the `includeStageContext` argument since all existing consumers want stage context included. Updates `ExpressionAware` interface to use updated `buildExecutionContext` per todo.

To do: Investigate whether tasks like `ExpressionPreconditionTask` even need to explicitly take another pass at expression evaluation, since presumably any resolvable variables were evaluated in the `StartTaskHandler`. I think only if the task itself fetches an artifact that may contain SpEL should we need another evaluation pass?