### PR TITLE
fix(titus): use labels as override only for titus health providers

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
@@ -82,9 +82,9 @@ public class DetermineHealthProvidersTask implements RetryableTask, CloudProvide
       if (interestingHealthProviderNames != null) {
         // avoid a `null` value that may cause problems with ImmutableMap usage downstream
         results.put("interestingHealthProviderNames", interestingHealthProviderNames);
-      }
 
-      return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(results).build();
+        return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(results).build();
+      }
     }
 
     if (stage.getContext().containsKey("interestingHealthProviderNames")) {


### PR DESCRIPTION
Today, when determining health providers on Titus, we look at the labels on the source server group.
For AWS, we look at front50 if the app has the platform only override set.
Make Titus work similarly but allow the labels to be used as override (if they exist)

(change courtesy of @dreynaud)