### PR TITLE
feat(monitored deploy): Support rollback on failure

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ScaleDownClusterStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ScaleDownClusterStage.java
@@ -21,11 +21,14 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideC
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractWaitForClusterWideClouddriverTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.ScaleDownClusterTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.WaitForScaleDownClusterTask;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ScaleDownClusterStage extends AbstractClusterWideClouddriverOperationStage {
+  public static final String PIPELINE_CONFIG_TYPE =
+      StageDefinitionBuilder.getType(ScaleDownClusterStage.class);
 
   @Autowired
   public ScaleDownClusterStage(DynamicConfigService dynamicConfigService) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/monitoreddeploy/EvaluateDeploymentHealthStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/monitoreddeploy/EvaluateDeploymentHealthStage.java
@@ -39,6 +39,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConditionalOnProperty(value = "monitored-deploy.enabled")
 public class EvaluateDeploymentHealthStage implements StageDefinitionBuilder {
+  public static final String PIPELINE_CONFIG_TYPE =
+      StageDefinitionBuilder.getType(EvaluateDeploymentHealthStage.class);
+
   @Override
   public void taskGraph(Stage stage, TaskNode.Builder builder) {
     builder.withTask("evaluateDeploymentHealth", EvaluateDeploymentHealthTask.class);

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/monitoreddeploy/NotifyDeployCompletedStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/monitoreddeploy/NotifyDeployCompletedStage.java
@@ -34,6 +34,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConditionalOnProperty(value = "monitored-deploy.enabled")
 public class NotifyDeployCompletedStage implements StageDefinitionBuilder {
+  public static final String PIPELINE_CONFIG_TYPE =
+      StageDefinitionBuilder.getType(NotifyDeployCompletedStage.class);
+
   @Override
   public void taskGraph(Stage stage, TaskNode.Builder builder) {
     builder.withTask("notifyDeployCompleted", NotifyDeployCompletedTask.class);

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/monitoreddeploy/NotifyDeployStartingStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/monitoreddeploy/NotifyDeployStartingStage.java
@@ -34,6 +34,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConditionalOnProperty(value = "monitored-deploy.enabled")
 public class NotifyDeployStartingStage implements StageDefinitionBuilder {
+  public static final String PIPELINE_CONFIG_TYPE =
+      StageDefinitionBuilder.getType(NotifyDeployStartingStage.class);
+
   @Override
   public void taskGraph(Stage stage, TaskNode.Builder builder) {
     builder.withTask("notifyDeployStarting", NotifyDeployStartingTask.class);

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
@@ -110,7 +110,7 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage {
     def additionalRollbackContext = [:]
 
     def strategy = Strategy.fromStrategyKey(stageData.strategy)
-    if ((strategy == Strategy.ROLLING_RED_BLACK) || (strategy == Strategy.MONITORED)) {
+    if (strategy == Strategy.ROLLING_RED_BLACK) {
       // rollback is always supported regardless of where the failure occurred
       strategySupportsRollback = true
       additionalRollbackContext.enableAndDisableOnly = true
@@ -156,7 +156,7 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage {
     super.onFailureStages(stage, graph)
   }
 
-  private static class StageData {
+  static class StageData {
     String application
     String account
     String credentials
@@ -186,7 +186,7 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage {
     }
   }
 
-  private static class Rollback {
+  static class Rollback {
     Boolean onFailure
     Boolean destroyLatest
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
@@ -91,7 +91,7 @@ class ExplicitRollback implements Rollback {
     Map disableServerGroupContext = new HashMap(parentStage.context)
     disableServerGroupContext.serverGroupName = rollbackServerGroupName
     def disableServerGroupStage = newStage(
-      parentStage.execution, disableServerGroupStage.type, "disable", disableServerGroupContext, parentStage, SyntheticStageOwner.STAGE_AFTER
+      parentStage.execution, disableServerGroupStage.type, "Disable ${disableServerGroupContext.serverGroupName} due to rollback", disableServerGroupContext, parentStage, SyntheticStageOwner.STAGE_AFTER
     )
 
     if (disableOnly) {
@@ -105,7 +105,7 @@ class ExplicitRollback implements Rollback {
     enableServerGroupContext.targetHealthyDeployPercentage = targetHealthyRollbackPercentage
     enableServerGroupContext.serverGroupName = restoreServerGroupName
     def enableServerGroupStage = newStage(
-      parentStage.execution, enableServerGroupStage.type, "enable", enableServerGroupContext, parentStage, SyntheticStageOwner.STAGE_AFTER
+      parentStage.execution, enableServerGroupStage.type, "Enable ${enableServerGroupContext.serverGroupName} due to rollback", enableServerGroupContext, parentStage, SyntheticStageOwner.STAGE_AFTER
     )
 
     if (enableAndDisableOnly) {
@@ -254,7 +254,7 @@ class ExplicitRollback implements Rollback {
     return newStage(
       parentStage.execution,
       applySourceServerGroupCapacityStage.type,
-      "Restore Min Capacity From Snapshot",
+      "Restore Min Capacity From Snapshot due to rollback",
       applySourceServerGroupCapacityContext,
       parentStage,
       SyntheticStageOwner.STAGE_AFTER

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategySpec.groovy
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies
+
+import com.netflix.spinnaker.config.DeploymentMonitorDefinition
+import com.netflix.spinnaker.config.DeploymentMonitorServiceProvider
+import com.netflix.spinnaker.moniker.Moniker
+import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.RollbackClusterStage
+import com.netflix.spinnaker.orca.clouddriver.pipeline.monitoreddeploy.NotifyDeployCompletedStage
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DestroyServerGroupStage
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.PinServerGroupStage
+import spock.lang.Specification
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class MonitoredDeployStrategySpec extends Specification {
+  def "composes correct failure flow when no deployment monitor specified"() {
+    given:
+    def pipeline = configureBasicPipeline()
+    def strategy = createStrategy()
+    def stage = pipeline.stageByRef("2-deploy1")
+    stage.context.remove("deploymentMonitor")
+    def sourceServerGroupName = pipeline.stageByRef("1-create").context.source.serverGroupName
+
+    when:
+    def failureStages = strategy.composeOnFailureStages(stage)
+
+    then: 'should unpin source'
+    failureStages.size() == 1
+    failureStages[0].type == PinServerGroupStage.TYPE
+    failureStages[0].context.serverGroupName == sourceServerGroupName
+    failureStages[0].name == "Unpin ${sourceServerGroupName}"
+  }
+
+  def "composes correct failure flow when no rollback requested"() {
+    given:
+    def pipeline = configureBasicPipeline()
+    def strategy = createStrategy()
+
+    when: 'rollback not explicitly specified'
+    def stage = pipeline.stageByRef("2-deploy1")
+    def failureStages = strategy.composeOnFailureStages(stage)
+
+    then: 'should unpin source and notify monitor of completion'
+    failureStages.size() == 2
+    failureStages[0].type == PinServerGroupStage.TYPE
+    failureStages[1].type == NotifyDeployCompletedStage.PIPELINE_CONFIG_TYPE
+
+    when: 'no rollback is explicitly specified'
+    stage.context.failureActions = [
+      destroyInstances: false,
+      rollback: "None"
+    ]
+    failureStages = strategy.composeOnFailureStages(stage)
+
+    then: 'should unpin source and notify monitor of completion'
+    failureStages.size() == 2
+    failureStages[0].type == PinServerGroupStage.TYPE
+    failureStages[1].type == NotifyDeployCompletedStage.PIPELINE_CONFIG_TYPE
+  }
+
+  def "composes correct failure flow when automatic rollback is requested"() {
+    given:
+    def pipeline = configureBasicPipeline()
+    def strategy = createStrategy()
+    def deployedServerGroupMoniker = "test-dev"
+    def deployedServerGroupName = "${deployedServerGroupMoniker}-v006".toString()
+
+    when: 'no target server group is created (yet)'
+    def stage = pipeline.stageByRef("2-deploy1")
+    stage.context.failureActions = [
+      destroyInstances: false,
+      rollback: "Automatic"
+    ]
+    def failureStages = strategy.composeOnFailureStages(stage)
+
+    then: 'should unpin source and notify monitor of completion'
+    failureStages.size() == 2
+    failureStages[0].type == PinServerGroupStage.TYPE
+    failureStages[1].type == NotifyDeployCompletedStage.PIPELINE_CONFIG_TYPE
+
+    when: 'a target server group has been created'
+    stage.context."deploy.server.groups" = [
+      "us-east-1": [deployedServerGroupName]
+    ]
+    failureStages = strategy.composeOnFailureStages(stage)
+
+    then: 'should rollback, unpin source, and then notify monitor of completion'
+    failureStages.size() == 3
+    failureStages[0].type == RollbackClusterStage.PIPELINE_CONFIG_TYPE
+    failureStages[0].context.serverGroup == deployedServerGroupName
+    failureStages[0].name == "Rollback ${deployedServerGroupMoniker}"
+    failureStages[1].type == PinServerGroupStage.TYPE
+    failureStages[2].type == NotifyDeployCompletedStage.PIPELINE_CONFIG_TYPE
+
+    when: 'the user also requested to destroy the new server group'
+    stage.context.failureActions.destroyInstances = true
+    failureStages = strategy.composeOnFailureStages(stage)
+
+    then: 'should rollback, unpin source, and then notify monitor of completion'
+    failureStages.size() == 4
+    failureStages[0].type == RollbackClusterStage.PIPELINE_CONFIG_TYPE
+    failureStages[1].type == DestroyServerGroupStage.PIPELINE_CONFIG_TYPE
+    failureStages[1].name == "Destroy ${deployedServerGroupName} due to rollback"
+    failureStages[1].context.serverGroupName == deployedServerGroupName
+    failureStages[2].type == PinServerGroupStage.TYPE
+    failureStages[3].type == NotifyDeployCompletedStage.PIPELINE_CONFIG_TYPE
+  }
+
+  private def configureBasicPipeline() {
+    Moniker moniker = new Moniker(app: "unit", stack: "tests")
+    def fallbackCapacity = [min: 1, desired: 2, max: 3]
+
+    def pipeline = pipeline {
+      application = "testapp"
+      stage {
+        refId = "1-create"
+        type = "createServerGroup"
+        context = [
+          refId : "stage_createASG",
+          source: [
+            serverGroupName  : "test-dev-v005",
+            asgName          : "test-dev-v005",
+            region           : "us-east-1",
+            useSourceCapacity: false,
+            account          : "test"
+          ]
+        ]
+
+        stage {
+          refId = "2-deploy1"
+          parent
+          context = [
+            refId                        : "stage",
+            account                      : "testAccount",
+            application                  : "unit",
+            stack                        : "tests",
+            moniker                      : moniker,
+            cloudProvider                : "aws",
+            region                       : "north",
+            capacity                     : fallbackCapacity,
+            targetHealthyDeployPercentage: 90,
+            deploymentMonitor: [
+              id: "simpletestmonitor"
+            ]
+          ]
+        }
+      }
+    }
+
+    return pipeline
+  }
+
+  private def createStrategy() {
+    def serviceProviderStub = Stub(DeploymentMonitorServiceProvider) {
+      getDefinitionById(_) >> {
+        def deploymentMonitor = new DeploymentMonitorDefinition()
+
+        return deploymentMonitor
+      }
+    }
+
+    def strategy = new MonitoredDeployStrategy(
+      deploymentMonitorServiceProvider: serviceProviderStub
+    )
+
+    return strategy
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/EvaluateDeploymentHealthTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/EvaluateDeploymentHealthTaskSpec.groovy
@@ -59,7 +59,6 @@ class EvaluateDeploymentHealthTaskSpec extends Specification {
 
         return deploymentMonitor
       }
-
     }
 
     def task = new EvaluateDeploymentHealthTask(serviceProviderStub, new NoopRegistry())


### PR DESCRIPTION
Add rollback support to monitored deploy strategy.
It's slightly different from the default you get with CreateServerGroup, hence it is removed from there for this strategy
