### PR TITLE
fix(webhook): Add fail fast status to webhook properties

### DIFF
--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -89,6 +89,9 @@ integrations:
 #        {
 #          "text": "Version ${trigger.buildInfo.artifacts[0].version} deployed"
 #        }
+#      failFastStatusCodes:
+#        - 404
+#        - 501
 #      waitForCompletion: true
 #      # The rest of the properties are only used if waitForCompletion == true
 #      statusUrlResolution: webhookResponse # getMethod, locationHeader, webhookResponse

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -633,7 +633,7 @@ class OperationsControllerSpec extends Specification {
 
   def "should call webhookService and return correct information"() {
     given:
-    def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "waitForCompletion", "statusUrlResolution",
+    def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution",
                                    "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses"]
 
     when:
@@ -652,7 +652,7 @@ class OperationsControllerSpec extends Specification {
 
   def "should not return protected preconfigured webhooks if user don't have the role"() {
     given:
-    def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "waitForCompletion", "statusUrlResolution",
+    def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution",
                                    "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses"]
     executionLauncher.start(*_) >> { ExecutionType type, String json ->
       startedPipeline = mapper.readValue(json, Execution)
@@ -685,7 +685,7 @@ class OperationsControllerSpec extends Specification {
 
   def "should return protected preconfigured webhooks if user have the role"() {
     given:
-    def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "waitForCompletion", "statusUrlResolution",
+    def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution",
                                    "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses"]
     executionLauncher.start(*_) >> { ExecutionType type, String json ->
       startedPipeline = mapper.readValue(json, Execution)
@@ -774,7 +774,7 @@ class OperationsControllerSpec extends Specification {
     return new WebhookProperties.PreconfiguredWebhook(
       label: label, description: description, type: type,
       url: "a", customHeaders: customHeaders, method: HttpMethod.POST, payload: "b",
-      waitForCompletion: true, statusUrlResolution: WebhookProperties.StatusUrlResolution.webhookResponse,
+      failFastStatusCodes: [500, 501], waitForCompletion: true, statusUrlResolution: WebhookProperties.StatusUrlResolution.webhookResponse,
       statusUrlJsonPath: "c", statusJsonPath: "d", progressJsonPath: "e", successStatuses: "f", canceledStatuses: "g", terminalStatuses: "h", parameters: null, parameterData: null,
       permissions: permissions
     )

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -79,6 +79,7 @@ public class WebhookProperties {
     public Map<String, Map<String, String>> parameterData;
     public HttpMethod method;
     public String payload;
+    public List<Integer> failFastStatusCodes;
     public Boolean waitForCompletion;
     public StatusUrlResolution statusUrlResolution;
     public String statusUrlJsonPath; // if webhookResponse above

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookSpec.groovy
@@ -34,7 +34,7 @@ class PreconfiguredWebhookSpec extends Specification {
     def fields = preconfiguredWebhook.preconfiguredProperties
 
     then:
-    fields == ["url", "customHeaders", "method", "payload", "waitForCompletion", "statusUrlResolution", "statusUrlJsonPath",
+    fields == ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution", "statusUrlJsonPath",
       "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses"]
   }
 
@@ -82,7 +82,7 @@ class PreconfiguredWebhookSpec extends Specification {
     customHeaders.put("header", ["value1", "value2"])
     return new WebhookProperties.PreconfiguredWebhook(
       url: "url", customHeaders: customHeaders, method: HttpMethod.POST, payload: "payload",
-      waitForCompletion: true, statusUrlResolution: webhookResponse,
+      failFastStatusCodes: [500, 501], waitForCompletion: true, statusUrlResolution: webhookResponse,
       statusUrlJsonPath: "statusUrlJsonPath", statusJsonPath: "statusJsonPath", progressJsonPath: "progressJsonPath",
       successStatuses: "successStatuses", canceledStatuses: "canceledStatuses", terminalStatuses: "terminalStatuses"
     )

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
@@ -49,6 +49,7 @@ class PreconfiguredWebhookStageSpec extends Specification {
       customHeaders: ["header": ["value1"]],
       method: HttpMethod.POST,
       payload: "b",
+      failFastStatusCodes: [500, 501],
       waitForCompletion: true,
       statusUrlResolution: WebhookProperties.StatusUrlResolution.locationHeader,
       statusUrlJsonPath: "c",
@@ -70,6 +71,7 @@ class PreconfiguredWebhookStageSpec extends Specification {
       customHeaders: ["header": ["value1"]],
       method: HttpMethod.POST,
       payload: "b",
+      failFastStatusCodes: [500, 501],
       waitForCompletion: true,
       statusUrlResolution: WebhookProperties.StatusUrlResolution.webhookResponse,
       statusUrlJsonPath: "c",
@@ -92,6 +94,7 @@ class PreconfiguredWebhookStageSpec extends Specification {
       customHeaders: ["header": ["value1"]],
       method: HttpMethod.POST,
       payload: "b",
+      failFastStatusCodes: [500, 501],
       waitForCompletion: true,
       statusUrlResolution: WebhookProperties.StatusUrlResolution.webhookResponse,
       statusUrlJsonPath: "c",
@@ -111,7 +114,7 @@ class PreconfiguredWebhookStageSpec extends Specification {
     customHeaders.add("header", "value1")
     return new WebhookProperties.PreconfiguredWebhook(
       label: label, description: description, type: type, url: "a", customHeaders: customHeaders, method: HttpMethod.POST, payload: "b",
-      waitForCompletion: true, statusUrlResolution: WebhookProperties.StatusUrlResolution.locationHeader,
+      failFastStatusCodes: [500, 501], waitForCompletion: true, statusUrlResolution: WebhookProperties.StatusUrlResolution.locationHeader,
       statusUrlJsonPath: "c", statusJsonPath: "d", progressJsonPath: "e", successStatuses: "f", canceledStatuses: "g", terminalStatuses: "h"
     )
   }


### PR DESCRIPTION
This fixes  https://github.com/spinnaker/spinnaker/issues/5009

Added `failFastStatus` property to `WebhookProperties.java` since there is no way to preconfigure this value when creating a **Custom webhook Stage**. Refer to the above mentioned issue for more details.

Also updated tests.

This PR contains the backend changes. Front end changes are made in `deck` here https://github.com/spinnaker/deck/pull/7512.