### PR TITLE
fix(bakeManifest): add option for rawOverrides

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/manifests/helm/HelmBakeManifestRequest.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/manifests/helm/HelmBakeManifestRequest.java
@@ -40,6 +40,9 @@ public class HelmBakeManifestRequest extends BakeManifestRequest {
 
   private List<Artifact> values;
 
+  @JsonProperty("rawOverrides")
+  private Boolean rawOverrides;
+
   public HelmBakeManifestRequest(
       BakeManifestContext bakeManifestContext,
       List<Artifact> inputArtifacts,
@@ -52,5 +55,6 @@ public class HelmBakeManifestRequest extends BakeManifestRequest {
     this.setOverrides(overrides);
     this.setNamespace(bakeManifestContext.getNamespace());
     this.setInputArtifacts(inputArtifacts);
+    this.setRawOverrides(bakeManifestContext.getRawOverrides());
   }
 }

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
@@ -33,7 +33,7 @@ public class BakeManifestContext {
   private final String templateRenderer;
   private final String outputName;
   private final String namespace;
-
+  private final Boolean rawOverrides;
   // There does not seem to be a way to auto-generate a constructor using our current version of
   // Lombok (1.16.20) that
   // Jackson can use to deserialize.
@@ -47,7 +47,8 @@ public class BakeManifestContext {
       @JsonProperty("outputName") String outputName,
       @JsonProperty("namespace") String namespace,
       @Nullable @JsonProperty("inputArtifact")
-          CreateBakeManifestTask.InputArtifactPair inputArtifact) {
+          CreateBakeManifestTask.InputArtifactPair inputArtifact,
+      @JsonProperty("rawOverrides") Boolean rawOverrides) {
     this.inputArtifacts = inputArtifacts;
     this.expectedArtifacts = expectedArtifacts;
     this.overrides = overrides;
@@ -56,5 +57,6 @@ public class BakeManifestContext {
     this.outputName = outputName;
     this.namespace = namespace;
     this.inputArtifact = inputArtifact;
+    this.rawOverrides = rawOverrides;
   }
 }


### PR DESCRIPTION
adds an option to bake manifest for rawOverrides. this will be passed
onto rosco to enable the --set option in helm.