### PR TITLE
chore(kayenta): add config id and execution to outputs

### DIFF
--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/RunKayentaCanaryTask.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/RunKayentaCanaryTask.kt
@@ -52,6 +52,11 @@ class RunKayentaCanaryTask(
       CanaryExecutionRequest(context.scopes, context.scoreThresholds, context.siteLocal)
     )["canaryExecutionId"] as String
 
-    return TaskResult.builder(SUCCEEDED).context("canaryPipelineExecutionId", canaryPipelineExecutionId).build()
+    val outputs = mapOf(
+      "canaryPipelineExecutionId" to canaryPipelineExecutionId,
+      "canaryConfigId" to context.canaryConfigId
+    )
+
+    return TaskResult.builder(SUCCEEDED).context("canaryPipelineExecutionId", canaryPipelineExecutionId).outputs(outputs).build()
   }
 }


### PR DESCRIPTION
Adding the config id and execution id to the outputs so that stage notifications can more easily construct a link to the canary report 