### PR TITLE
feat(dynamicBackoff): Dynamically configurable task backoff

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.model.Task
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.model.SystemNotification
 import groovy.transform.CompileStatic
@@ -38,7 +39,7 @@ import java.time.Clock
 @Slf4j
 @Component
 @CompileStatic
-class MonitorKatoTask implements RetryableTask {
+class MonitorKatoTask implements RetryableTask, CloudProviderAware {
 
   /**
    * How long to continue trying to look up a task that reports a 404 Not Found.

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/clouddriver/utils/CloudProviderAware.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/clouddriver/utils/CloudProviderAware.java
@@ -21,6 +21,8 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,18 +34,22 @@ public interface CloudProviderAware {
     return DEFAULT_CLOUD_PROVIDER;
   }
 
+  @Nullable
   default String getCloudProvider(Stage stage) {
     return getCloudProvider(stage.getContext());
   }
 
+  @Nullable
   default String getCloudProvider(Map<String, Object> context) {
     return (String) context.getOrDefault("cloudProvider", getDefaultCloudProvider());
   }
 
+  @Nullable
   default String getCredentials(Stage stage) {
     return getCredentials(stage.getContext());
   }
 
+  @Nullable
   default String getCredentials(Map<String, Object> context) {
     return (String)
         context.getOrDefault(
@@ -75,5 +81,13 @@ public interface CloudProviderAware {
 
   default List<String> getRegions(Stage stage) {
     return getRegions(stage.getContext());
+  }
+
+  default boolean hasCloudProvider(@Nonnull Stage stage) {
+    return getCloudProvider(stage) != null;
+  }
+
+  default boolean hasCredentials(@Nonnull Stage stage) {
+    return getCredentials(stage) != null;
   }
 }

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/RunKayentaCanaryTask.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/RunKayentaCanaryTask.kt
@@ -52,6 +52,11 @@ class RunKayentaCanaryTask(
       CanaryExecutionRequest(context.scopes, context.scoreThresholds, context.siteLocal)
     )["canaryExecutionId"] as String
 
-    return TaskResult.builder(SUCCEEDED).context("canaryPipelineExecutionId", canaryPipelineExecutionId).build()
+    val outputs = mapOf(
+      "canaryPipelineExecutionId" to canaryPipelineExecutionId,
+      "canaryConfigId" to context.canaryConfigId
+    )
+
+    return TaskResult.builder(SUCCEEDED).context("canaryPipelineExecutionId", canaryPipelineExecutionId).outputs(outputs).build()
   }
 }

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/Tasks.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/Tasks.kt
@@ -19,7 +19,9 @@ package com.netflix.spinnaker.orca.q
 import com.netflix.spinnaker.orca.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.Task
+import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 
 interface DummyTask : RetryableTask
+interface DummyCloudProviderAwareTask : RetryableTask, CloudProviderAware
 interface InvalidTask : Task
 interface DummyTimeoutOverrideTask : OverridableTimeoutRetryableTask

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.ExecutionStatus.CANCELED
 import com.netflix.spinnaker.orca.ExecutionStatus.FAILED_CONTINUE
@@ -33,6 +34,7 @@ import com.netflix.spinnaker.orca.RetryableTask
 import com.netflix.spinnaker.orca.Task
 import com.netflix.spinnaker.orca.TaskExecutionInterceptor
 import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.exceptions.TimeoutException
 import com.netflix.spinnaker.orca.ext.beforeStages
@@ -75,7 +77,8 @@ class RunTaskHandler(
   private val clock: Clock,
   private val exceptionHandlers: List<ExceptionHandler>,
   private val taskExecutionInterceptors: List<TaskExecutionInterceptor>,
-  private val registry: Registry
+  private val registry: Registry,
+  private val dynamicConfigService: DynamicConfigService
 ) : OrcaMessageHandler<RunTask>, ExpressionAware, AuthenticationAware {
 
   override fun handle(message: RunTask) {
@@ -170,12 +173,6 @@ class RunTaskHandler(
     }
   }
 
-  private fun maxBackoff(): Long =
-    taskExecutionInterceptors.fold(Long.MAX_VALUE) {
-      backoff, interceptor ->
-      Math.min(backoff, interceptor.maxTaskBackoff())
-    }
-
   private fun trackResult(stage: Stage, thisInvocationStartTimeMs: Long, taskModel: com.netflix.spinnaker.orca.pipeline.model.Task, status: ExecutionStatus) {
     val commonTags = MetricsTagHelper.commonTags(stage, taskModel, status)
     val detailedTags = MetricsTagHelper.detailedTaskTags(stage, taskModel, status)
@@ -209,10 +206,58 @@ class RunTaskHandler(
   private fun Task.backoffPeriod(taskModel: com.netflix.spinnaker.orca.pipeline.model.Task, stage: Stage): TemporalAmount =
     when (this) {
       is RetryableTask -> Duration.ofMillis(
-        Math.min(getDynamicBackoffPeriod(stage, Duration.ofMillis(System.currentTimeMillis() - (taskModel.startTime
-          ?: 0))), maxBackoff())
+        retryableBackOffPeriod(taskModel, stage).coerceAtMost(taskExecutionInterceptors.maxBackoff())
       )
-      else -> Duration.ofSeconds(1)
+      else -> Duration.ofMillis(1000)
+    }
+
+  /**
+   * The max back off value always wins.  For example, given the following dynamic configs:
+   * `tasks.global.backOffPeriod = 5000`
+   * `tasks.aws.backOffPeriod = 80000`
+   * `tasks.aws.someAccount.backoffPeriod = 60000`
+   * `tasks.aws.backoffPeriod` will be used (given the criteria matches and unless the default dynamicBackOffPeriod is greater).
+   */
+  private fun RetryableTask.retryableBackOffPeriod(
+    taskModel: com.netflix.spinnaker.orca.pipeline.model.Task,
+    stage: Stage
+  ): Long {
+    val dynamicBackOffPeriod = getDynamicBackoffPeriod(
+      stage, Duration.ofMillis(System.currentTimeMillis() - (taskModel.startTime ?: 0))
+    )
+    val backOffs: MutableList<Long> = mutableListOf(
+      dynamicBackOffPeriod,
+      dynamicConfigService.getConfig(
+        Long::class.java,
+        "tasks.global.backOffPeriod",
+        dynamicBackOffPeriod)
+    )
+
+    if (this is CloudProviderAware && hasCloudProvider(stage)) {
+      backOffs.add(
+        dynamicConfigService.getConfig(
+          Long::class.java,
+          "tasks.${getCloudProvider(stage)}.backOffPeriod",
+          dynamicBackOffPeriod
+        )
+      )
+      if (hasCredentials(stage)) {
+        backOffs.add(
+          dynamicConfigService.getConfig(
+            Long::class.java,
+            "tasks.${getCloudProvider(stage)}.${getCredentials(stage)}.backOffPeriod",
+            dynamicBackOffPeriod
+          )
+        )
+      }
+    }
+
+    return backOffs.max() ?: dynamicBackOffPeriod
+  }
+
+  private fun List<TaskExecutionInterceptor>.maxBackoff(): Long =
+    this.fold(Long.MAX_VALUE) { backoff, interceptor ->
+      backoff.coerceAtMost(interceptor.maxTaskBackoff())
     }
 
   private fun formatTimeout(timeout: Long): String {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.orca.ExecutionStatus.CANCELED
 import com.netflix.spinnaker.orca.ExecutionStatus.FAILED_CONTINUE
 import com.netflix.spinnaker.orca.ExecutionStatus.PAUSED
@@ -25,6 +26,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus.SKIPPED
 import com.netflix.spinnaker.orca.ExecutionStatus.STOPPED
 import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
+import com.netflix.spinnaker.orca.TaskExecutionInterceptor
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.fixture.pipeline
@@ -34,12 +36,14 @@ import com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWindow
 import com.netflix.spinnaker.orca.pipeline.model.DefaultTrigger
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 import com.netflix.spinnaker.orca.pipeline.model.Execution.PausedDetails
+import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.model.Stage.STAGE_TIMEOUT_OVERRIDE_KEY
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.q.CompleteTask
 import com.netflix.spinnaker.orca.q.DummyTask
+import com.netflix.spinnaker.orca.q.DummyCloudProviderAwareTask
 import com.netflix.spinnaker.orca.q.DummyTimeoutOverrideTask
 import com.netflix.spinnaker.orca.q.InvalidTask
 import com.netflix.spinnaker.orca.q.InvalidTaskType
@@ -71,7 +75,6 @@ import org.jetbrains.spek.api.lifecycle.CachingMode.GROUP
 import org.jetbrains.spek.subject.SubjectSpek
 import org.threeten.extra.Minutes
 import java.time.Duration
-import kotlin.collections.emptyList
 import kotlin.collections.first
 import kotlin.collections.forEach
 import kotlin.collections.hashMapOf
@@ -87,10 +90,13 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
   val repository: ExecutionRepository = mock()
   val stageNavigator: StageNavigator = mock()
   val task: DummyTask = mock()
+  val cloudProviderAwareTask: DummyCloudProviderAwareTask = mock()
   val timeoutOverrideTask: DummyTimeoutOverrideTask = mock()
   val exceptionHandler: ExceptionHandler = mock()
   val clock = fixedClock()
   val contextParameterProcessor = ContextParameterProcessor()
+  val dynamicConfigService: DynamicConfigService = mock()
+  val taskExecutionInterceptors: List<TaskExecutionInterceptor> = listOf(mock())
 
   subject(GROUP) {
     RunTaskHandler(
@@ -98,15 +104,16 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       repository,
       stageNavigator,
       contextParameterProcessor,
-      listOf(task, timeoutOverrideTask),
+      listOf(task, timeoutOverrideTask, cloudProviderAwareTask),
       clock,
       listOf(exceptionHandler),
-      emptyList(),
-      NoopRegistry()
+      taskExecutionInterceptors,
+      NoopRegistry(),
+      dynamicConfigService
     )
   }
 
-  fun resetMocks() = reset(queue, repository, task, timeoutOverrideTask, exceptionHandler)
+  fun resetMocks() = reset(queue, repository, task, timeoutOverrideTask, cloudProviderAwareTask, exceptionHandler)
 
   describe("running a task") {
 
@@ -120,12 +127,15 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           }
         }
       }
-      val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+      val stage = pipeline.stages.first()
+      val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
       and("has no context updates outputs") {
         val taskResult = TaskResult.SUCCEEDED
 
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
           whenever(task.execute(any())) doReturn taskResult
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
         }
@@ -156,6 +166,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
         val taskResult = TaskResult.builder(SUCCEEDED).context(stageOutputs).build()
 
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
           whenever(task.execute(any())) doReturn taskResult
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
         }
@@ -178,6 +190,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
         val taskResult = TaskResult.builder(SUCCEEDED).outputs(outputs).build()
 
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
           whenever(task.execute(any())) doReturn taskResult
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
         }
@@ -203,6 +217,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
         val taskResult = TaskResult.builder(SUCCEEDED).outputs(outputs).build()
 
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
           whenever(task.execute(any())) doReturn taskResult
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
         }
@@ -233,13 +249,19 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           }
         }
       }
-      val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+      val stage = pipeline.stages.first()
+      val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
       val taskResult = TaskResult.RUNNING
       val taskBackoffMs = 30_000L
+      val maxBackOffLimit = 120_000L
 
       beforeGroup {
+        taskExecutionInterceptors.forEach { whenever(it.maxTaskBackoff()) doReturn maxBackOffLimit }
+        taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+        taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
         whenever(task.execute(any())) doReturn taskResult
         whenever(task.getDynamicBackoffPeriod(any(), any())) doReturn taskBackoffMs
+        whenever(dynamicConfigService.getConfig(eq(Long::class.java), eq("tasks.global.backOffPeriod"), any())) doReturn 0L
         whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
       }
 
@@ -266,11 +288,14 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             }
           }
         }
-        val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+        val stage = pipeline.stages.first()
+        val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
         val taskResult = TaskResult.ofStatus(taskStatus)
 
         and("no overrides are in place") {
           beforeGroup {
+            taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+            taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
             whenever(task.execute(any())) doReturn taskResult
             whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
           }
@@ -351,7 +376,9 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           }
         }
       }
-      val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+      val stage = pipeline.stages.first()
+      val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
+      val taskResult = TaskResult.ofStatus(TERMINAL)
 
       and("it is not recoverable") {
         val exceptionDetails = ExceptionHandler.Response(
@@ -363,6 +390,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
 
         and("the task should fail the pipeline") {
           beforeGroup {
+            taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+            taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doThrow RuntimeException("o noes") }
             whenever(task.execute(any())) doThrow RuntimeException("o noes")
             whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
             whenever(exceptionHandler.handles(any())) doReturn true
@@ -483,9 +512,11 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           }
         }
       }
+      val stage = pipeline.stages.first()
       val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
 
       beforeGroup {
+        taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
         whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
       }
 
@@ -524,9 +555,11 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           }
         }
       }
-      val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+      val stage = pipeline.stages.first()
+      val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
       beforeGroup {
+        taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
         whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
       }
 
@@ -565,9 +598,11 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           }
         }
       }
+      val stage = pipeline.stages.first()
       val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
 
       beforeGroup {
+        taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
         whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
       }
 
@@ -599,9 +634,11 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             }
           }
         }
-        val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+        val stage = pipeline.stages.first()
+        val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
           whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
         }
@@ -635,9 +672,11 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             context["continuePipeline"] = true
           }
         }
-        val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+        val stage = pipeline.stages.first()
+        val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
           whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
         }
@@ -666,9 +705,11 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             }
           }
         }
-        val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+        val stage = pipeline.stages.first()
+        val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
           whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
         }
@@ -704,9 +745,11 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             }
           }
         }
-        val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+        val stage = pipeline.stages.first()
+        val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
           whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
         }
@@ -738,9 +781,11 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             }
           }
         }
-        val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+        val stage = pipeline.stages.first()
+        val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
           whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
         }
@@ -776,9 +821,11 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             }
           }
         }
-        val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+        val stage = pipeline.stages.first()
+        val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
           whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
         }
@@ -822,9 +869,11 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             }
           }
         }
-        val message = RunTask(pipeline.type, pipeline.id, pipeline.application, pipeline.stages.first().id, "1", DummyTask::class.java)
+        val stage = pipeline.stages.first()
+        val message = RunTask(pipeline.type, pipeline.id, pipeline.application, stage.id, "1", DummyTask::class.java)
 
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
           whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
         }
@@ -899,11 +948,12 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           }
         }
       }
-
-      val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+      val stage = pipeline.stages.first()
+      val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
       given("the task returns fail_continue") {
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
           whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
           whenever(task.onTimeout(any())) doReturn TaskResult.ofStatus(FAILED_CONTINUE)
@@ -926,6 +976,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
 
       given("the task returns terminal") {
         beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
           whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
           whenever(task.onTimeout(any())) doReturn TaskResult.ofStatus(TERMINAL)
@@ -990,9 +1041,13 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
                 }
               }
             }
-            val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+            val stage = pipeline.stages.first()
+            val taskResult = TaskResult.RUNNING
+            val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
             beforeGroup {
+              taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+              taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
               whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
               whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
             }
@@ -1023,9 +1078,13 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
                   }
                 }
               }
-              val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
+              val stage = pipeline.stages.first()
+              val taskResult = TaskResult.RUNNING
+              val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
               beforeGroup {
+                taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+                taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
                 whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
                 whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
               }
@@ -1062,9 +1121,13 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
                   }
                 }
               }
+              val stage = pipeline.stages.first()
+              val taskResult = TaskResult.RUNNING
               val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTask::class.java)
 
               beforeGroup {
+                taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+                taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
                 whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
                 whenever(task.getDynamicTimeout(any())) doReturn timeout.toMillis()
               }
@@ -1173,9 +1236,13 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
                 }
               }
             }
-            val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stages.first().id, "1", DummyTimeoutOverrideTask::class.java)
+            val stage = pipeline.stages.first()
+            val taskResult = TaskResult.RUNNING
+            val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTimeoutOverrideTask::class.java)
 
             beforeGroup {
+              taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(timeoutOverrideTask, stage)) doReturn stage }
+              taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(timeoutOverrideTask, stage, taskResult)) doReturn taskResult }
               whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
               whenever(timeoutOverrideTask.timeout) doReturn timeout.toMillis()
             }
@@ -1216,10 +1283,14 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             }
           }
         }
+        val stage = pipeline.stages.first()
+        val taskResult = TaskResult.SUCCEEDED
         val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stageByRef("1").id, "1", DummyTask::class.java)
 
         beforeGroup {
-          whenever(task.execute(any())) doReturn TaskResult.SUCCEEDED
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
+          whenever(task.execute(any())) doReturn taskResult
           whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
         }
 
@@ -1256,10 +1327,14 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
               }
             }
           }
+          val stage = pipeline.stages.first()
+          val taskResult = TaskResult.SUCCEEDED
           val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stageByRef("1").id, "1", DummyTask::class.java)
 
           beforeGroup {
-            whenever(task.execute(any())) doReturn TaskResult.SUCCEEDED
+            taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+            taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
+            whenever(task.execute(any())) doReturn taskResult
             whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
           }
 
@@ -1305,10 +1380,14 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           }
         }
       }
+      val stage = pipeline.stageByRef("2")
+      val taskResult = TaskResult.SUCCEEDED
       val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stageByRef("2").id, "1", DummyTask::class.java)
 
       beforeGroup {
-        whenever(task.execute(any())) doReturn TaskResult.SUCCEEDED
+        taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+        taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
+        whenever(task.execute(any())) doReturn taskResult
         whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
       }
 
@@ -1340,10 +1419,14 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           }
         }
       }
+      val stage = pipeline.stages.first()
+      val taskResult = TaskResult.SUCCEEDED
       val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stageByRef("1").id, "1", DummyTask::class.java)
 
       beforeGroup {
-        whenever(task.execute(any())) doReturn TaskResult.SUCCEEDED
+        taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+        taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
+        whenever(task.execute(any())) doReturn taskResult
         whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
       }
 
@@ -1377,10 +1460,14 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           }
         }
       }
-      val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stageByRef("2").id, "1", DummyTask::class.java)
+      val stage = pipeline.stageByRef("2")
+      val taskResult = TaskResult.SUCCEEDED
+      val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
       beforeGroup {
-        whenever(task.execute(any())) doReturn TaskResult.SUCCEEDED
+        taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+        taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
+        whenever(task.execute(any())) doReturn taskResult
         whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
       }
 
@@ -1441,9 +1528,13 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
           context["manualSkip"] = true
         }
       }
-      val message = RunTask(pipeline.type, pipeline.id, "foo", pipeline.stageByRef("1").id, "1", DummyTask::class.java)
+      val stage = pipeline.stageByRef("1")
+      val taskResult = TaskResult.SUCCEEDED
+      val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
 
       beforeGroup {
+        taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+        taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
         whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
       }
 
@@ -1458,4 +1549,69 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
     }
   }
+
+  describe("max configurable back off value") {
+    setOf(
+      BackOff(5_000L, 10_000L, 20_000L, 30_000L, 30_000L),
+      BackOff(10_000L, 20_000L, 30_000L, 5_000L, 30_000L),
+      BackOff(20_000L, 30_000L, 5_000L, 10_000L, 30_000L),
+      BackOff(30_000L, 5_000L, 10_000L, 20_000L, 30_000L),
+      BackOff(20_000L, 5_000L, 10_000L, 30_002L, 30_001L)
+    ).forEach { backOff ->
+      given("the back off values $backOff") {
+        val pipeline = pipeline {
+          stage {
+            type = "whatever"
+            task {
+              id = "1"
+              implementingClass = DummyCloudProviderAwareTask::class.jvmName
+              startTime = clock.instant().toEpochMilli()
+              context["cloudProvider"] = "aws"
+              context["deploy.account.name"] = "someAccount"
+            }
+          }
+        }
+        val stage = pipeline.stages.first()
+        val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyCloudProviderAwareTask::class.java)
+        val taskResult = TaskResult.RUNNING
+
+        beforeGroup {
+          whenever(cloudProviderAwareTask.execute(any())) doReturn taskResult
+          taskExecutionInterceptors.forEach { whenever(it.maxTaskBackoff()) doReturn backOff.limit }
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(cloudProviderAwareTask, stage)) doReturn stage }
+          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(cloudProviderAwareTask, stage, taskResult)) doReturn taskResult }
+
+          whenever(cloudProviderAwareTask.getDynamicBackoffPeriod(any(), any())) doReturn backOff.taskBackOffMs
+          whenever(dynamicConfigService.getConfig(eq(Long::class.java), eq("tasks.global.backOffPeriod"), any())) doReturn backOff.globalBackOffMs
+          whenever(cloudProviderAwareTask.hasCloudProvider(any())) doReturn true
+          whenever(cloudProviderAwareTask.getCloudProvider(any<Stage>())) doReturn "aws"
+          whenever(dynamicConfigService.getConfig(eq(Long::class.java), eq("tasks.aws.backOffPeriod"), any())) doReturn backOff.cloudProviderBackOffMs
+          whenever(cloudProviderAwareTask.hasCredentials(any())) doReturn true
+          whenever(cloudProviderAwareTask.getCredentials(any<Stage>())) doReturn "someAccount"
+          whenever(dynamicConfigService.getConfig(eq(Long::class.java), eq("tasks.aws.someAccount.backOffPeriod"), any())) doReturn backOff.accountBackOffMs
+
+          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
+        }
+
+        afterGroup(::resetMocks)
+
+        action("the handler receives a message") {
+          subject.handle(message)
+        }
+
+        it("selects the max value, unless max value is over limit ${backOff.limit} in which case limit is used") {
+          verify(queue).push(message, Duration.ofMillis(backOff.expectedMaxBackOffMs))
+        }
+      }
+    }
+  }
 })
+
+data class BackOff(
+  val taskBackOffMs: Long,
+  val globalBackOffMs: Long,
+  val cloudProviderBackOffMs: Long,
+  val accountBackOffMs: Long,
+  val expectedMaxBackOffMs: Long,
+  val limit: Long = 30_001L
+)


### PR DESCRIPTION
Task backoff can be configured globally, or drilled down to the cloudProvider and account level.  The relevant max backoff time always wins - if you desire no change of behavior simply do not create a dynamic config entry for a back off.  Note that the max back off time of 2 minutes can not be overridden.

