### PR TITLE
feat(EvaluateVariables): Support complex objects in EvaluateVariables stage

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/EvaluateVariablesStage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/EvaluateVariablesStage.java
@@ -51,10 +51,10 @@ public class EvaluateVariablesStage implements StageDefinitionBuilder {
 
   public static class Variable {
     private String key;
-    private String value;
+    private Object value;
 
     @JsonCreator
-    public Variable(@JsonProperty("key") String key, @JsonProperty("value") String value) {
+    public Variable(@JsonProperty("key") String key, @JsonProperty("value") Object value) {
       this.key = key;
       this.value = value;
     }
@@ -63,7 +63,7 @@ public class EvaluateVariablesStage implements StageDefinitionBuilder {
       this.key = key;
     }
 
-    public void setValue(String value) {
+    public void setValue(Object value) {
       this.value = value;
     }
 
@@ -71,7 +71,7 @@ public class EvaluateVariablesStage implements StageDefinitionBuilder {
       return key;
     }
 
-    public String getValue() {
+    public Object getValue() {
       return value;
     }
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTask.java
@@ -44,7 +44,7 @@ public class EvaluateVariablesTask implements Task {
     EvaluateVariablesStage.EvaluateVariablesStageContext context =
         stage.mapTo(EvaluateVariablesStage.EvaluateVariablesStageContext.class);
 
-    Map<String, String> outputs = new HashMap<>();
+    Map<String, Object> outputs = new HashMap<>();
     for (EvaluateVariablesStage.Variable v : context.getVariables()) {
       outputs.put(v.getKey(), v.getValue());
     }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTaskSpec.groovy
@@ -44,4 +44,39 @@ class EvaluateVariablesTaskSpec extends Specification {
     result.outputs.get("myKey1") == "ohWow"
     result.outputs.get("myKey2") == "myMy"
   }
+
+  void "Supports values that are complex objects"() {
+    setup:
+    def simpleValue = "A simple string";
+    def simpleArray = ["string1", "string2", "string3"];
+    def objectArray = [ [id: "15"], [id: "25"], [id: "45"] ];
+    def someStuff = [
+      nestedValue: 'value',
+      number: 1,
+      nestedHash: [
+        nestedNested: 'nestedNestedValue',
+        nestedArray: [1, 2, 3, 4, 5],
+      ]
+    ]
+
+    def stage = stage {
+      refId = "1"
+      type = "evaluateVariables"
+      context["variables"] = [
+        ["key": "simpleValue", "value": simpleValue],
+        ["key": "simpleArray", "value": simpleArray],
+        ["key": "objectArray", "value": objectArray],
+        ["key": "hashMap", "value": someStuff]
+      ]
+    }
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.outputs.get("simpleValue") == simpleValue
+    result.outputs.get("simpleArray") == simpleArray
+    result.outputs.get("objectArray") == objectArray
+    result.outputs.get("hashMap") == someStuff
+  }
 }


### PR DESCRIPTION
You can create an adhoc spel expression that resolves to a complex object...

<img width="344" alt="Screen Shot 2019-10-16 at 8 35 03 PM" src="https://user-images.githubusercontent.com/2053478/66975812-8d4c0780-f054-11e9-98a8-6816e5882e51.png">

... and we will happily expand the entire object.

<img width="767" alt="Screen Shot 2019-10-16 at 8 33 54 PM" src="https://user-images.githubusercontent.com/2053478/66975905-d308d000-f054-11e9-8b7c-4d5e265cc075.png">


However, if you try to do the same thing in Evaluate Variables stage, you get an error:

```
java.lang.IllegalArgumentException: Unable to map context to class com.netflix.spinnaker.orca.pipeline.EvaluateVariablesStage$EvaluateVariablesStageContext
...
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.lang.String` out of START_ARRAY token
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: com.netflix.spinnaker.orca.pipeline.EvaluateVariablesStage$EvaluateVariablesStageContext[\"variables\"]
```

This PR changes `Variable` type from `[ key: string, value: string ]` to `[key: string, value: object]`

