### PR TITLE
feat(kubernetes): support rolling restart operation for deployments

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/RollingRestartManifestStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/RollingRestartManifestStage.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.RollingRestartManif
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -29,7 +30,7 @@ public class RollingRestartManifestStage implements StageDefinitionBuilder {
   public static final String PIPELINE_CONFIG_TYPE = "rollingRestartManifest";
 
   @Override
-  public void taskGraph(Stage stage, TaskNode.Builder builder) {
+  public void taskGraph(@Nonnull Stage stage, TaskNode.Builder builder) {
     builder
         .withTask(RollingRestartManifestTask.TASK_NAME, RollingRestartManifestTask.class)
         .withTask("monitorRollingRestart", MonitorKatoTask.class)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/RollingRestartManifestStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/RollingRestartManifestStage.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.manifest;
+
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestForceCacheRefreshTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.RollingRestartManifestTask;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.pipeline.TaskNode;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RollingRestartManifestStage implements StageDefinitionBuilder {
+  public static final String PIPELINE_CONFIG_TYPE = "rollingRestartManifest";
+
+  @Override
+  public void taskGraph(Stage stage, TaskNode.Builder builder) {
+    builder
+        .withTask(RollingRestartManifestTask.TASK_NAME, RollingRestartManifestTask.class)
+        .withTask("monitorRollingRestart", MonitorKatoTask.class)
+        .withTask(ManifestForceCacheRefreshTask.TASK_NAME, ManifestForceCacheRefreshTask.class);
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/RollingRestartManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/RollingRestartManifestTask.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RollingRestartManifestTask extends GenericUpdateManifestTask {
+  public static final String TASK_NAME = "rollingRestartManifest";
+
+  @Override
+  protected String taskName() {
+    return TASK_NAME;
+  }
+}


### PR DESCRIPTION
Closes spinnaker/spinnaker#4757

As the many comments/emojis on this [Kubernetes feature request](https://github.com/kubernetes/kubernetes/issues/13488) indicate, there are several valid user stories around issuing a rolling restart of a Deployment. The `kubectl rollout restart` command was released with kubectl version 1.15, and we currently use kubectl version 1.16 in Clouddriver. Like the other kubectl rollout commands, it is valid for Deployments, StatefulSets, and DaemonSets. We currently only expose the ad-hoc rollout commands for Deployments in Deck, but could at a later date expose them for StatefulSets and DaemonSets if there is evidence from users that it would be useful.

Related PRs:
Clouddriver: https://github.com/spinnaker/clouddriver/pull/4100
Deck: https://github.com/spinnaker/deck/pull/7538

![863ee1d0-ca4a-4d50-b8ef-870bcfa72908](https://user-images.githubusercontent.com/15936279/67022390-2881c300-f0cf-11e9-8d58-9fd529d0af52.gif)
