### PR TITLE
fix(bake): Fix the fix for inconsistent names in parallel bakes

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -164,9 +164,9 @@ class BakeStage implements StageDefinitionBuilder {
       if (failOnImageNameMismatchEnabled()) {
         // find distinct image names in bake stages that are actually related to the stage passed into the task
         def distinctImageNames = relatedBakeStages
-          .findAll { it.parentStageId == stage.id && (it.context.ami || it.context.imageId) }
+          .findAll { childStage -> childStage.parentStageId == stage.id && childStage.context.imageName }
           .stream()
-          .map { childStage -> childStage.context['imageName'] }
+          .map { childStage -> childStage.context.imageName }
           .distinct()
           .collect(Collectors.toList())
 

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -141,6 +141,9 @@ class BakeStage implements StageDefinitionBuilder {
         it.parentStageId == stage.parentStageId && it.status == ExecutionStatus.RUNNING
       }
 
+      // FIXME? (lpollo): I don't know why we do this, but we include in relatedStages all parallel bake stages in the
+      //  same pipeline, not just the ones related to the stage passed to this task, which means this list actually
+      //  contains *unrelated* bake stages...
       def relatedBakeStages = stage.execution.stages.findAll {
         it.type == PIPELINE_CONFIG_TYPE && bakeInitializationStages*.id.contains(it.parentStageId)
       }
@@ -159,8 +162,11 @@ class BakeStage implements StageDefinitionBuilder {
       ]
 
       if (failOnImageNameMismatchEnabled()) {
-         List<String> distinctImageNames = globalContext.deploymentDetails.stream()
-          .map({details -> details['imageName']})
+        // find distinct image names in bake stages that are actually related to the stage passed into the task
+        def distinctImageNames = relatedBakeStages
+          .findAll { it.parentStageId == stage.id && (it.context.ami || it.context.imageId) }
+          .stream()
+          .map { childStage -> childStage.context['imageName'] }
           .distinct()
           .collect(Collectors.toList())
 

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -163,7 +163,7 @@ class BakeStage implements StageDefinitionBuilder {
 
       if (failOnImageNameMismatchEnabled()) {
         // find distinct image names in bake stages that are actually related to the stage passed into the task
-        def distinctImageNames = relatedBakeStages
+        List<String> distinctImageNames = relatedBakeStages
           .findAll { childStage -> childStage.parentStageId == stage.id && childStage.context.imageName }
           .stream()
           .map { childStage -> childStage.context.imageName }

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
@@ -172,7 +172,7 @@ class BakeStageSpec extends Specification {
         type = "bake"
         context = [
           "region": "us-east-1",
-          "regions": ["eu-east-1"]
+          "regions": ["us-east-1"]
         ]
         status = ExecutionStatus.RUNNING
       }

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
@@ -120,7 +120,7 @@ class BakeStageSpec extends Specification {
     }
   }
 
-  def "should fail if image names don't match across regions (unless user opts out)"() {
+  def "should fail if image names don't match across regions"() {
     given:
     def pipeline = pipeline {
       stage {
@@ -152,6 +152,51 @@ class BakeStageSpec extends Specification {
 
     then:
     thrown(ConstraintViolationException)
+  }
+
+  def "should NOT fail if image names from unrelated bake stages don't match"() {
+    given:
+    def pipeline = pipeline {
+      stage {
+        id = "1"
+        type = "bake"
+        context = [
+          "region": "us-east-1",
+          "regions": ["us-east-1", "us-west-2"]
+        ]
+        status = ExecutionStatus.RUNNING
+      }
+      // this is a sibling bake stage whose child bake contexts should not be included in stage 1's outputs, but are
+      stage {
+        id = "2"
+        type = "bake"
+        context = [
+          "region": "us-east-1",
+          "regions": ["eu-east-1"]
+        ]
+        status = ExecutionStatus.RUNNING
+      }
+    }
+
+    for (stageId in ["1", "2"]) {
+      def bakeStage = pipeline.stageById(stageId)
+      def graph = StageGraphBuilder.beforeStages(bakeStage)
+      new BakeStage(regionCollector: new RegionCollector()).beforeStages(bakeStage, graph)
+      def childBakeStages = graph.build()
+      childBakeStages.eachWithIndex { it, idx ->
+        it.context.ami = "${idx}"
+        it.context.imageName = "image-from-bake-stage-${stageId}"
+      }
+      pipeline.stages.addAll(childBakeStages)
+    }
+
+    dynamicConfigService.isEnabled("stages.bake.failOnImageNameMismatch", false) >> { true }
+
+    when:
+    new BakeStage.CompleteParallelBakeTask(dynamicConfigService).execute(pipeline.stageById("1"))
+
+    then:
+    notThrown(ConstraintViolationException)
   }
 
   private


### PR DESCRIPTION
This complements #3219 by ensuring that we only look at the image names for parallel bake stages associated with the top-level bake stage that the `CompleteParallelBakeTest` cares about when trying to decide whether to fail a parallel bake on inconsistent image names. This avoids failing the stage if there are unrelated bake stages in the pipeline (which would obviously generate different image names).

While troubleshooting this, I found that this task includes context information from the parallel bake stages of unrelated top-level bake stages in the pipeline, which is clearly visible in the execution JSON of such pipelines. I don't know if that is itself a bug or is by design, so I just left a note in a comment for now, but would be happy to correct that if it's not expected behavior.