### PR TITLE
fix(rrb): Store RRB before-cleanup pipeline ID in the right context field

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategy.groovy
@@ -377,7 +377,7 @@ class RollingRedBlackStrategy implements Strategy, ApplicationContextAware {
       def pipelineContext = [
         application        : stageData.pipelineBeforeCleanup.application,
         pipelineApplication: stageData.pipelineBeforeCleanup.application,
-        pipelineId         : stageData.pipelineBeforeCleanup.pipelineId,
+        pipeline           : stageData.pipelineBeforeCleanup.pipelineId,
         pipelineParameters : stageData.pipelineBeforeCleanup.pipelineParameters + [
           "deployedServerGroup": serverGroupCoordinates + [
             serverGroupName: deployedServerGroupName

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/RollingRedBlackStrategySpec.groovy
@@ -157,7 +157,11 @@ class RollingRedBlackStrategySpec extends Specification {
     afterStages.size() == 5
     afterStages.first().type == determineTargetServerGroupStage.type
     afterStages[2].type == pipelineStage.type
+    afterStages[2].context.pipelineApplication == stage.context.pipelineBeforeCleanup.application
+    afterStages[2].context.pipeline == stage.context.pipelineBeforeCleanup.pipelineId
     afterStages[4].type == pipelineStage.type
+    afterStages[4].context.pipelineApplication == stage.context.pipelineBeforeCleanup.application
+    afterStages[4].context.pipeline == stage.context.pipelineBeforeCleanup.pipelineId
   }
 
   def "should correctly determine source during pin/unpin"() {


### PR DESCRIPTION
This is an addendum for #3224, which was causing Rolling Red/Black deployments with a "before cleanup" pipeline to fail as `StartPipelineTask` was looking for `stage.context.pipeline` but the pipeline ID was stored in `stage.context.pipelineId` here.

@marchello2000 and I search for other similar uses of `pipelineId` in the context and it looks like it's safe to make this change here.