### PR TITLE
refactor(kubernetes): clean up bake manifest error messaging

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import lombok.Getter;
 
@@ -48,12 +49,12 @@ public class BakeManifestContext {
       @JsonProperty("namespace") String namespace,
       @Nullable @JsonProperty("inputArtifact") CreateBakeManifestTask.InputArtifact inputArtifact,
       @JsonProperty("rawOverrides") Boolean rawOverrides) {
-    this.inputArtifacts = inputArtifacts == null ? new ArrayList<>() : inputArtifacts;
+    this.inputArtifacts = Optional.of(inputArtifacts).orElse(new ArrayList<>());
     // Kustomize stage configs provide a single input artifact
     if (this.inputArtifacts.isEmpty() && inputArtifact != null) {
       this.inputArtifacts.add(inputArtifact);
     }
-    this.expectedArtifacts = expectedArtifacts;
+    this.expectedArtifacts = Optional.of(expectedArtifacts).orElse(new ArrayList<>());
     this.overrides = overrides;
     this.evaluateOverrideExpressions = evaluateOverrideExpressions;
     this.templateRenderer = templateRenderer;

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.bakery.tasks.manifests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -25,8 +26,7 @@ import lombok.Getter;
 
 @Getter
 public class BakeManifestContext {
-  @Nullable private final List<CreateBakeManifestTask.InputArtifactPair> inputArtifacts;
-  @Nullable private final CreateBakeManifestTask.InputArtifactPair inputArtifact;
+  private final List<CreateBakeManifestTask.InputArtifact> inputArtifacts;
   private final List<ExpectedArtifact> expectedArtifacts;
   private final Map<String, Object> overrides;
   private final Boolean evaluateOverrideExpressions;
@@ -39,24 +39,26 @@ public class BakeManifestContext {
   // Jackson can use to deserialize.
   public BakeManifestContext(
       @Nullable @JsonProperty("inputArtifacts")
-          List<CreateBakeManifestTask.InputArtifactPair> inputArtifacts,
+          List<CreateBakeManifestTask.InputArtifact> inputArtifacts,
       @JsonProperty("expectedArtifacts") List<ExpectedArtifact> expectedArtifacts,
       @JsonProperty("overrides") Map<String, Object> overrides,
       @JsonProperty("evaluateOverrideExpressions") Boolean evaluateOverrideExpressions,
       @JsonProperty("templateRenderer") String templateRenderer,
       @JsonProperty("outputName") String outputName,
       @JsonProperty("namespace") String namespace,
-      @Nullable @JsonProperty("inputArtifact")
-          CreateBakeManifestTask.InputArtifactPair inputArtifact,
+      @Nullable @JsonProperty("inputArtifact") CreateBakeManifestTask.InputArtifact inputArtifact,
       @JsonProperty("rawOverrides") Boolean rawOverrides) {
-    this.inputArtifacts = inputArtifacts;
+    this.inputArtifacts = inputArtifacts == null ? new ArrayList<>() : inputArtifacts;
+    // Kustomize stage configs provide a single input artifact
+    if (this.inputArtifacts.isEmpty() && inputArtifact != null) {
+      this.inputArtifacts.add(inputArtifact);
+    }
     this.expectedArtifacts = expectedArtifacts;
     this.overrides = overrides;
     this.evaluateOverrideExpressions = evaluateOverrideExpressions;
     this.templateRenderer = templateRenderer;
     this.outputName = outputName;
     this.namespace = namespace;
-    this.inputArtifact = inputArtifact;
     this.rawOverrides = rawOverrides;
   }
 }

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
@@ -105,7 +105,7 @@ public class CreateBakeManifestTask implements RetryableTask {
 
     List<ExpectedArtifact> expectedArtifacts = context.getExpectedArtifacts();
 
-    if (expectedArtifacts == null || expectedArtifacts.size() != 1) {
+    if (expectedArtifacts.size() != 1) {
       throw new IllegalArgumentException(
           "Exactly one expected artifact must be supplied. Please ensure that your Bake stage config's `expectedArtifacts` list contains exactly one artifact.");
     }

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.orca.bakery.tasks.manifests;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import com.netflix.spinnaker.orca.ExecutionStatus;
@@ -34,8 +33,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,45 +55,48 @@ public class CreateBakeManifestTask implements RetryableTask {
     return 300000;
   }
 
-  @Autowired(required = false)
-  BakeryService bakery;
+  @Nullable private final BakeryService bakery;
 
-  @Autowired ArtifactResolver artifactResolver;
+  private final ArtifactResolver artifactResolver;
 
-  @Autowired ObjectMapper objectMapper;
+  private final ContextParameterProcessor contextParameterProcessor;
 
-  @Autowired ContextParameterProcessor contextParameterProcessor;
+  @Autowired
+  public CreateBakeManifestTask(
+      ArtifactResolver artifactResolver,
+      ContextParameterProcessor contextParameterProcessor,
+      Optional<BakeryService> bakery) {
+    this.artifactResolver = artifactResolver;
+    this.contextParameterProcessor = contextParameterProcessor;
+    this.bakery = bakery.orElse(null);
+  }
 
   @Nonnull
   @Override
   public TaskResult execute(@Nonnull Stage stage) {
-    BakeManifestContext context = stage.mapTo(BakeManifestContext.class);
-
-    List<InputArtifactPair> inputArtifactsObj = context.getInputArtifacts();
-    List<Artifact> inputArtifacts;
-
-    // kustomize depends on a single input artifact so we may not have a list here
-    // but we still want the resolution provided by the stream below
-    if (inputArtifactsObj == null || inputArtifactsObj.isEmpty()) {
-      if (context.getInputArtifact() != null) {
-        inputArtifactsObj.add(context.getInputArtifact());
-      } else {
-        throw new IllegalArgumentException("At least one input artifact to bake must be supplied");
-      }
+    if (bakery == null) {
+      throw new IllegalStateException(
+          "A BakeryService must be configured in order to run a Bake Manifest task.");
     }
 
-    inputArtifacts =
-        inputArtifactsObj.stream()
+    BakeManifestContext context = stage.mapTo(BakeManifestContext.class);
+
+    List<InputArtifact> inputArtifacts = context.getInputArtifacts();
+    if (inputArtifacts.isEmpty()) {
+      throw new IllegalArgumentException("At least one input artifact to bake must be supplied");
+    }
+
+    List<Artifact> resolvedInputArtifacts =
+        inputArtifacts.stream()
             .map(
                 p -> {
                   Artifact a =
                       artifactResolver.getBoundArtifactForStage(stage, p.getId(), p.getArtifact());
                   if (a == null) {
                     throw new IllegalArgumentException(
-                        stage.getExecution().getId()
-                            + ": Input artifact "
-                            + p.getId()
-                            + " could not be found in the execution");
+                        String.format(
+                            "Input artifact (id: %s, account: %s) could not be found in execution (id: %s).",
+                            p.getId(), p.getAccount(), stage.getExecution().getId()));
                   }
                   a.setArtifactAccount(p.getAccount());
                   return a;
@@ -101,13 +105,9 @@ public class CreateBakeManifestTask implements RetryableTask {
 
     List<ExpectedArtifact> expectedArtifacts = context.getExpectedArtifacts();
 
-    if (expectedArtifacts == null || expectedArtifacts.isEmpty()) {
+    if (expectedArtifacts == null || expectedArtifacts.size() != 1) {
       throw new IllegalArgumentException(
-          "At least one expected artifact to baked manifest must be supplied");
-    }
-
-    if (expectedArtifacts.size() > 1) {
-      throw new IllegalArgumentException("Too many artifacts provided as expected");
+          "Exactly one expected artifact must be supplied. Please ensure that your Bake stage config's `expectedArtifacts` list contains exactly one artifact.");
     }
 
     String outputArtifactName = expectedArtifacts.get(0).getMatchArtifact().getName();
@@ -126,10 +126,11 @@ public class CreateBakeManifestTask implements RetryableTask {
     switch (context.getTemplateRenderer().toUpperCase()) {
       case "HELM2":
         request =
-            new HelmBakeManifestRequest(context, inputArtifacts, outputArtifactName, overrides);
+            new HelmBakeManifestRequest(
+                context, resolvedInputArtifacts, outputArtifactName, overrides);
         break;
       case "KUSTOMIZE":
-        Artifact inputArtifact = inputArtifacts.get(0);
+        Artifact inputArtifact = resolvedInputArtifacts.get(0);
         request = new KustomizeBakeManifestRequest(context, inputArtifact, outputArtifactName);
         break;
       default:
@@ -146,7 +147,7 @@ public class CreateBakeManifestTask implements RetryableTask {
   }
 
   @Data
-  protected static class InputArtifactPair {
+  static class InputArtifact {
     String id;
     String account;
     Artifact artifact;

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/BakerySelectorSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/BakerySelectorSpec.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.orca.bakery.api.BakeStatus
 import com.netflix.spinnaker.orca.bakery.api.BakeryService
 import com.netflix.spinnaker.orca.bakery.api.BaseImage
 import com.netflix.spinnaker.orca.bakery.api.manifests.BakeManifestRequest
-import com.netflix.spinnaker.orca.bakery.api.manifests.helm.HelmBakeManifestRequest
 import com.netflix.spinnaker.orca.bakery.config.BakeryConfigurationProperties
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import retrofit.http.Body


### PR DESCRIPTION
Related to https://github.com/spinnaker/spinnaker/issues/4752

While investigating Retrofit errors in the Bake Manifest stage, found a few small code improvements:

- Move conversion of singular `inputArtifact` (Kustomize only) to list from `CreateBakeManifestTask.execute` into `BakeManifestContext` constructor. Also handle defaulting of `inputArtifacts` to empty list so that it doesn't need to be `@Nullable`. I think this lets the task be a little dumber about the Kubernetes vs. Helm inputs.
- In `CreateBakeManifestTask`, replace field injection with constructor injection. Because the `BakeryService` bean is not required, make it `Optional` per Stack Overflow [advice](https://stackoverflow.com/questions/42135102/how-to-set-autowired-constructor-params-as-required-false-individually) (curious if you guys agree with SO here or if there's another pattern we prefer?).
- Improve error messaging around 1) Attempting to run a Bake (Manifest) task without a configured `BakeryService`, 2) Attempting to produce more or less than one expected artifact, 3) Supplying unresolvable input artifacts.
- Remove a couple unused imports.

Additional changes in Rosco will improve error handling when the bake fails, either because the request times out or the input artifact cannot be downloaded. ([PR](https://github.com/spinnaker/rosco/pull/453))

