### PR TITLE
fix(dependent pipelines): failure to trigger a dependend pipeline shouldn't affect others

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
@@ -74,37 +74,52 @@ class DependentPipelineExecutionListener implements ExecutionListener {
       // Resolve templated pipelines if enabled.
       allPipelines = allPipelines.collect { pipeline ->
        if (V2Util.isV2Pipeline(pipeline)) {
-         return V2Util.planPipeline(contextParameterProcessor, executionPreprocessors, pipeline)
+         try {
+           return V2Util.planPipeline(contextParameterProcessor, executionPreprocessors, pipeline)
+         } catch (Exception e) {
+           log.error("Failed to plan V2 templated pipeline {}", pipeline.getOrDefault("id", "<UNKNOWN ID>"), e)
+           return null
+         }
        } else {
          return pipeline
        }
-      }
+      }.findAll({ pipeline ->
+        pipeline != null
+      })
     }
 
-    allPipelines.findAll { !it.disabled }
+    allPipelines.findAll { (it != null) && (!it.disabled) }
       .each {
       it.triggers.each { trigger ->
-        if (trigger.enabled &&
-          trigger.type == 'pipeline' &&
-          trigger.pipeline &&
-          trigger.pipeline == execution.pipelineConfigId &&
-          trigger.status.contains(status)
-        ) {
-          User authenticatedUser = null
+        try {
+          if (trigger.enabled &&
+            trigger.type == 'pipeline' &&
+            trigger.pipeline &&
+            trigger.pipeline == execution.pipelineConfigId &&
+            trigger.status.contains(status)
+          ) {
+            User authenticatedUser = null
 
-          if (fiatStatus.enabled && trigger.runAsUser) {
-            authenticatedUser = new User()
-            authenticatedUser.setEmail(trigger.runAsUser)
+            if (fiatStatus.enabled && trigger.runAsUser) {
+              authenticatedUser = new User()
+              authenticatedUser.setEmail(trigger.runAsUser)
+            }
+
+            dependentPipelineStarter.trigger(
+              it,
+              execution.trigger?.user as String,
+              execution,
+              [:],
+              null,
+              authenticatedUser
+            )
           }
-
-          dependentPipelineStarter.trigger(
-            it,
-            execution.trigger?.user as String,
-            execution,
-            [:],
-            null,
-            authenticatedUser
-          )
+        }
+        catch (Exception e) {
+          log.error(
+            "Failed to process triggers for pipeline {} while triggering dependent pipelines",
+            it.getOrDefault("id", "<UNKNOWN ID>"),
+            e)
         }
       }
     }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
@@ -83,9 +83,7 @@ class DependentPipelineExecutionListener implements ExecutionListener {
        } else {
          return pipeline
        }
-      }.findAll({ pipeline ->
-        pipeline != null
-      })
+      }
     }
 
     allPipelines.findAll { (it != null) && (!it.disabled) }


### PR DESCRIPTION
Failure in planning a, say, a single v2 templated pipeline will cause no dependent pipelines to start.
This is due to exception not being localized to each individual pipeline
