### PR TITLE
fix(kayenta): Make sure we destroy canary clusters

### DIFF
--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/CleanupCanaryClustersStage.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/CleanupCanaryClustersStage.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.kayenta.pipeline
 
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.DisableClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.ShrinkClusterStage
+import com.netflix.spinnaker.orca.ext.setContinueOnFailure
 import com.netflix.spinnaker.orca.kayenta.model.ServerGroupSpec
 import com.netflix.spinnaker.orca.kayenta.model.cluster
 import com.netflix.spinnaker.orca.kayenta.model.deployments
@@ -45,12 +46,16 @@ class CleanupCanaryClustersStage : StageDefinitionBuilder {
           it.name = "Disable control cluster ${pair.control.cluster}"
           it.context.putAll(pair.control.toContext)
           it.context["remainingEnabledServerGroups"] = 0
+          // Even if disabling fails, move on to shrink below which will have another go at destroying the server group
+          it.setContinueOnFailure(true)
         },
         graph.add {
           it.type = DisableClusterStage.STAGE_TYPE
           it.name = "Disable experiment cluster ${pair.experiment.cluster}"
           it.context.putAll(pair.experiment.toContext)
           it.context["remainingEnabledServerGroups"] = 0
+          // Even if disabling fails, move on to shrink below which will have another go at destroying the server group
+          it.setContinueOnFailure(true)
         }
       )
     }
@@ -74,6 +79,7 @@ class CleanupCanaryClustersStage : StageDefinitionBuilder {
         it.context.putAll(pair.control.toContext)
         it.context["allowDeleteActive"] = true
         it.context["shrinkToSize"] = 0
+        it.setContinueOnFailure(true)
       }
 
       // destroy experiment cluster
@@ -83,6 +89,7 @@ class CleanupCanaryClustersStage : StageDefinitionBuilder {
         it.context.putAll(pair.experiment.toContext)
         it.context["allowDeleteActive"] = true
         it.context["shrinkToSize"] = 0
+        it.setContinueOnFailure(true)
       }
     }
   }

--- a/orca-kotlin/src/main/kotlin/com/netflix/spinnaker/orca/ext/Stage.kt
+++ b/orca-kotlin/src/main/kotlin/com/netflix/spinnaker/orca/ext/Stage.kt
@@ -131,6 +131,9 @@ fun Stage.shouldFailPipeline(): Boolean =
 fun Stage.shouldContinueOnFailure(): Boolean =
   context["continuePipeline"] == true
 
+fun Stage.setContinueOnFailure(continueOnFailure: Boolean) =
+  context.put("continuePipeline", continueOnFailure)
+
 fun Stage.failureStatus(default: ExecutionStatus = TERMINAL) =
   when {
     shouldContinueOnFailure() -> FAILED_CONTINUE


### PR DESCRIPTION
This change depends on https://github.com/spinnaker/orca/pull/3252

Sometimes, `DisableClusterStage` can fail. We don't want failures in `DisableClusterStage`
preventing the subsequent `ShrinkCluster` from trying to run and clean up the canary+baseline clusters