### PR TITLE
feat(monitoreddeploy): allow overriding maxAnalysisMinutes and failOnError

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/MonitoredDeployBaseTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/MonitoredDeployBaseTask.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.MonitoredDeployStageData;
 import com.netflix.spinnaker.orca.deploymentmonitor.models.DeploymentStep;
 import com.netflix.spinnaker.orca.deploymentmonitor.models.EvaluateHealthResponse;
+import com.netflix.spinnaker.orca.deploymentmonitor.models.MonitoredDeployInternalStageData;
 import com.netflix.spinnaker.orca.deploymentmonitor.models.StatusExplanation;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import java.io.InputStreamReader;
@@ -43,7 +44,7 @@ import retrofit.client.Header;
 import retrofit.client.Response;
 
 public class MonitoredDeployBaseTask implements RetryableTask {
-  private static final int MAX_RETRY_COUNT = 3;
+  static final int MAX_RETRY_COUNT = 3;
   protected final Logger log = LoggerFactory.getLogger(getClass());
   protected Registry registry;
   private DeploymentMonitorServiceProvider deploymentMonitorServiceProvider;
@@ -84,24 +85,29 @@ public class MonitoredDeployBaseTask implements RetryableTask {
 
   @Override
   public long getDynamicTimeout(Stage stage) {
+    MonitoredDeployInternalStageData stageData =
+        stage.mapTo(MonitoredDeployInternalStageData.class);
+
+    // If stage has an override, use that
+    Integer stageOverride = stageData.getDeploymentMonitor().getMaxAnalysisMinutesOverride();
+    if ((stageOverride != null) && (stageOverride > 0)) {
+      return Duration.ofMinutes(stageOverride).toMillis();
+    }
+
     DeploymentMonitorDefinition monitorDefinition = getDeploymentMonitorDefinition(stage);
 
-    final Duration defaultTimeout = Duration.ofMinutes(60);
-    long timeout;
-
     try {
-      timeout = TimeUnit.MINUTES.toMillis(monitorDefinition.getMaxAnalysisMinutes());
+      return Duration.ofMinutes(monitorDefinition.getMaxAnalysisMinutes()).toMillis();
     } catch (Exception e) {
       log.error(
           "Failed to compute timeout for {}, returning {} min",
           getClass().getSimpleName(),
-          defaultTimeout.toMinutes(),
+          DeploymentMonitorDefinition.DEFAULT_MAX_ANALYSIS_MINUTES,
           e);
 
-      timeout = defaultTimeout.toMillis();
+      return Duration.ofMinutes(DeploymentMonitorDefinition.DEFAULT_MAX_ANALYSIS_MINUTES)
+          .toMillis();
     }
-
-    return timeout;
   }
 
   @Override
@@ -110,7 +116,7 @@ public class MonitoredDeployBaseTask implements RetryableTask {
     String message;
     DeploymentMonitorDefinition monitorDefinition = getDeploymentMonitorDefinition(stage);
 
-    if (monitorDefinition.isFailOnError()) {
+    if (shouldFailOnError(stage, monitorDefinition)) {
       message =
           "Deployment monitor failed to evaluate health in the allotted time, assuming failure because the monitor is configured to failOnError";
       taskStatus = ExecutionStatus.TERMINAL;
@@ -138,10 +144,10 @@ public class MonitoredDeployBaseTask implements RetryableTask {
           getRetrofitLogMessage(e.getResponse()),
           e);
 
-      return handleError(context, e, true, monitorDefinition);
+      return handleError(stage, e, true, monitorDefinition);
     } catch (DeploymentMonitorInvalidDataException e) {
 
-      return handleError(context, e, false, monitorDefinition);
+      return handleError(stage, e, false, monitorDefinition);
     } catch (Exception e) {
       log.error("Exception while executing {}, aborting deployment", getClass().getSimpleName(), e);
 
@@ -156,7 +162,7 @@ public class MonitoredDeployBaseTask implements RetryableTask {
   }
 
   private TaskResult handleError(
-      MonitoredDeployStageData context,
+      Stage stage,
       Exception e,
       boolean retryAllowed,
       DeploymentMonitorDefinition monitorDefinition) {
@@ -165,7 +171,9 @@ public class MonitoredDeployBaseTask implements RetryableTask {
         .increment();
 
     if (retryAllowed) {
-      int currentRetryCount = context.getDeployMonitorHttpRetryCount();
+      MonitoredDeployInternalStageData stageData =
+          stage.mapTo(MonitoredDeployInternalStageData.class);
+      int currentRetryCount = stageData.getDeployMonitorHttpRetryCount();
 
       if (currentRetryCount < MAX_RETRY_COUNT) {
         log.warn(
@@ -180,7 +188,7 @@ public class MonitoredDeployBaseTask implements RetryableTask {
       }
     }
 
-    if (monitorDefinition.isFailOnError()) {
+    if (shouldFailOnError(stage, monitorDefinition)) {
       registry
           .counter("deploymentMonitor.fatalErrors", "monitorId", monitorDefinition.getId())
           .increment();
@@ -210,7 +218,7 @@ public class MonitoredDeployBaseTask implements RetryableTask {
             "Failed to get a valid response from deployment monitor %s, proceeding anyway because this deployment monitor is configured to not failOnError",
             monitorDefinition.getName());
 
-    return buildTaskResult(TaskResult.builder(ExecutionStatus.SUCCEEDED), userMessage);
+    return buildTaskResult(TaskResult.builder(ExecutionStatus.FAILED_CONTINUE), userMessage);
   }
 
   TaskResult buildTaskResult(
@@ -264,6 +272,14 @@ public class MonitoredDeployBaseTask implements RetryableTask {
     }
 
     return String.format("status: %s\nheaders: %s\nresponse body: %s", status, headers, body);
+  }
+
+  private boolean shouldFailOnError(Stage stage, DeploymentMonitorDefinition definition) {
+    MonitoredDeployInternalStageData stageData =
+        stage.mapTo(MonitoredDeployInternalStageData.class);
+
+    return Optional.ofNullable(stageData.getDeploymentMonitor().getFailOnErrorOverride())
+        .orElse(definition.isFailOnError());
   }
 
   void sanitizeAndLogResponse(

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/NotifyDeployCompletedTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/NotifyDeployCompletedTaskSpec.groovy
@@ -25,10 +25,10 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.RollbackClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.monitoreddeploy.NotifyDeployCompletedStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.CreateServerGroupStage
-import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.DeploymentMonitor
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.MonitoredDeployStageData
 import com.netflix.spinnaker.orca.deploymentmonitor.DeploymentMonitorService
 import com.netflix.spinnaker.orca.deploymentmonitor.models.DeploymentCompletedRequest
+import com.netflix.spinnaker.orca.deploymentmonitor.models.DeploymentMonitorStageConfig
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import retrofit.client.Response
@@ -64,7 +64,7 @@ class NotifyDeployCompletedTaskSpec extends Specification {
     def task = new NotifyDeployCompletedTask(serviceProviderStub, new NoopRegistry())
 
     MonitoredDeployStageData stageData = new MonitoredDeployStageData()
-    stageData.deploymentMonitor = new DeploymentMonitor()
+    stageData.deploymentMonitor = new DeploymentMonitorStageConfig()
     stageData.deploymentMonitor.id = "LogMonitorId"
     stageData.application = pipe.application
 
@@ -125,7 +125,7 @@ class NotifyDeployCompletedTaskSpec extends Specification {
     def task = new NotifyDeployCompletedTask(serviceProviderStub, new NoopRegistry())
 
     MonitoredDeployStageData stageData = new MonitoredDeployStageData()
-    stageData.deploymentMonitor = new DeploymentMonitor()
+    stageData.deploymentMonitor = new DeploymentMonitorStageConfig()
     stageData.deploymentMonitor.id = "LogMonitorId"
     stageData.application = pipe.application
 

--- a/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/config/DeploymentMonitorDefinition.java
+++ b/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/config/DeploymentMonitorDefinition.java
@@ -21,6 +21,8 @@ import lombok.Data;
 
 @Data
 public class DeploymentMonitorDefinition {
+  public static final int DEFAULT_MAX_ANALYSIS_MINUTES = 30;
+
   /** Unique ID of this deployment monitor */
   private String id;
 
@@ -37,7 +39,7 @@ public class DeploymentMonitorDefinition {
    * Maximum number of minutes this deployment monitor is allowed to respond to the /evaluateHealth
    * request. Failure to respond in this time frame will result in deployment failure.
    */
-  private int maxAnalysisMinutes = 30;
+  private int maxAnalysisMinutes = DEFAULT_MAX_ANALYSIS_MINUTES;
 
   /** true to terminate if the deployment monitor repeatedly fails with HTTP errors */
   private boolean failOnError = true;

--- a/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/orca/deploymentmonitor/models/DeploymentMonitorStageConfig.java
+++ b/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/orca/deploymentmonitor/models/DeploymentMonitorStageConfig.java
@@ -16,24 +16,13 @@
 
 package com.netflix.spinnaker.orca.deploymentmonitor.models;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import lombok.Data;
 
-// Stuff used in intermediate stages
 @Data
-public class MonitoredDeployInternalStageData {
-  private String newServerGroup;
-  private String oldServerGroup;
-  private String account;
-  private String region;
-  private String cloudProvider;
-  private int currentProgress;
-  private boolean hasDeploymentFailed;
-  private DeploymentMonitorStageConfig deploymentMonitor;
-  private int deployMonitorHttpRetryCount;
-
-  public Map toContextMap() {
-    return new ObjectMapper().convertValue(this, Map.class);
-  }
+public class DeploymentMonitorStageConfig {
+  private String id;
+  private Map<String, Object> parameters;
+  private Integer maxAnalysisMinutesOverride;
+  private Boolean failOnErrorOverride;
 }

--- a/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/orca/deploymentmonitor/models/RequestBase.java
+++ b/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/orca/deploymentmonitor/models/RequestBase.java
@@ -90,6 +90,6 @@ public class RequestBase {
     account = stageData.getAccount();
     region = stageData.getRegion();
     cloudProvider = stageData.getCloudProvider();
-    parameters = stageData.getParameters();
+    parameters = stageData.getDeploymentMonitor().getParameters();
   }
 }


### PR DESCRIPTION
Allow overriding `maxAnalysisMinutes` and `failOnError` values from within the stage
(defaults come from monitor config in orca.yml)

