### PR TITLE
fix(kayenta): Make sure we destroy canary clusters

### DIFF
--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/CleanupCanaryClustersStage.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/CleanupCanaryClustersStage.kt
@@ -68,6 +68,9 @@ class CleanupCanaryClustersStage : StageDefinitionBuilder {
     }
 
     disableStages.forEach {
+      // Continue the stages even if disabling one of the clusters fails - subsequent stages will delete them
+      // but we need to make sure they run
+      it.allowSiblingStagesToContinueOnFailure = true
       graph.connect(it, waitStage)
     }
 


### PR DESCRIPTION
This is a follow up to https://github.com/spinnaker/orca/pull/3259 because I rebased my local changes incorrectly.

Sometimes, `DisableClusterStage` can fail. We don't want failures in `DisableClusterStage`
preventing the subsequent `ShrinkCluster` from trying to run and clean up the canary+baseline clusters

This change buids on top of the functionality introduced in https://github.com/spinnaker/orca/pull/3252
to allow sibling stages to run even if a stage fails (correct error code will be propagated to the execution if this happens so it's clear to the user)
