### PR TITLE
fix(kubernetes): Fix Optional ofNullable

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
@@ -49,12 +49,12 @@ public class BakeManifestContext {
       @JsonProperty("namespace") String namespace,
       @Nullable @JsonProperty("inputArtifact") CreateBakeManifestTask.InputArtifact inputArtifact,
       @JsonProperty("rawOverrides") Boolean rawOverrides) {
-    this.inputArtifacts = Optional.of(inputArtifacts).orElse(new ArrayList<>());
+    this.inputArtifacts = Optional.ofNullable(inputArtifacts).orElse(new ArrayList<>());
     // Kustomize stage configs provide a single input artifact
     if (this.inputArtifacts.isEmpty() && inputArtifact != null) {
       this.inputArtifacts.add(inputArtifact);
     }
-    this.expectedArtifacts = Optional.of(expectedArtifacts).orElse(new ArrayList<>());
+    this.expectedArtifacts = Optional.ofNullable(expectedArtifacts).orElse(new ArrayList<>());
     this.overrides = overrides;
     this.evaluateOverrideExpressions = evaluateOverrideExpressions;
     this.templateRenderer = templateRenderer;


### PR DESCRIPTION
This my fault, as [my comment](https://github.com/spinnaker/orca/pull/3244#discussion_r337703561) explicitly suggested using `Optional.of`.

The usages of Optional.of should be Optional.ofNullable.