### PR TITLE
feat(script stage): set a context value REPO_URL in script stage

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartScriptTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartScriptTask.groovy
@@ -81,7 +81,7 @@ class StartScriptTask implements Task {
     }
 
     String queuedBuild = buildService.build(master, job, parameters)
-    TaskResult.builder(ExecutionStatus.SUCCEEDED).context([master: master, job: job, queuedBuild: queuedBuild]).build()
+    TaskResult.builder(ExecutionStatus.SUCCEEDED).context([master: master, job: job, queuedBuild: queuedBuild, REPO_URL: repoUrl?:'default' ]).build()
   }
 
 }


### PR DESCRIPTION
The current implementation of the SCRIPT stage using Jenkins requires that the remote URL of the script be set to something like `mystashrepo/${REPO_URL}.`

Jenkins currently returns the unprocessed remoteURL, and this value causes a SPEL warning when SPEL tries to resolve this value.

```Failed to evaluate [remoteUrl] : ssh://git@mystashrepo/REPO_URL.git not found```

This warning becomes an error in some scenarios and is quite a terrible red herring when debugging pipelines or using the script stage in general. 

This fix will populate the REPO_URL value in the context, which allows the SPEL expression to evaluate and the warning to disappear. 

