### PR TITLE
feat(triggers): add action field to git triggers context

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-#Mon Oct 28 20:24:28 UTC 2019
-fiatVersion=1.7.2
+#Tue Oct 29 18:58:49 UTC 2019
+fiatVersion=1.8.2
 enablePublishing=false
-spinnakerGradleVersion=7.0.1
 korkVersion=6.15.1
-org.gradle.parallel=true
+spinnakerGradleVersion=7.0.1
 keikoVersion=2.14.2
+org.gradle.parallel=true

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineBranchFinderSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineBranchFinderSpec.groovy
@@ -27,10 +27,11 @@ class AppEngineBranchFinderSpec extends Specification {
   @Unroll
   def "(git trigger) should resolve branch in trigger if it matches regex (if provided). If no regex is provided, the branch from the trigger will be used."() {
     given:
-    def trigger = new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", triggerBranch, "orca")
+    def trigger = new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", triggerBranch, "orca","pullrequest")
 
     def operation = [
       trigger: [
+        action : "pullrequest",
         hash   : "c681a6af-1096-4727-ac9e-70d3b2460228",
         source : "github",
         project: "spinnaker",
@@ -50,10 +51,11 @@ class AppEngineBranchFinderSpec extends Specification {
 
   def "(git trigger) should throw appropriate error if method cannot resolve a branch"() {
     given:
-    def trigger = new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca")
+    def trigger = new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca", "push")
 
     def operation = [
       trigger      : [
+        action : "push",
         hash   : "c681a6af-1096-4727-ac9e-70d3b2460228",
         source : "github",
         project: "spinnaker",

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/GitTrigger.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/GitTrigger.kt
@@ -34,7 +34,8 @@ data class GitTrigger
   val source: String,
   val project: String,
   val branch: String,
-  val slug: String
+  val slug: String,
+  val action: String
 ) : Trigger {
   override var other: Map<String, Any> = mutableMapOf()
   override var resolvedExpectedArtifacts: List<ExpectedArtifact> = mutableListOf()

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
@@ -138,7 +138,8 @@ internal class TriggerDeserializer :
           get("source").textValue(),
           get("project").textValue(),
           get("branch").textValue(),
-          get("slug").textValue()
+          get("slug").textValue(),
+          get("action").textValue()
         )
         looksLikeCustom() -> {
           // chooses the first custom deserializer to keep behavior consistent

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
@@ -139,7 +139,7 @@ internal class TriggerDeserializer :
           get("project").textValue(),
           get("branch").textValue(),
           get("slug").textValue(),
-          get("action").textValue()
+          get("action")?.textValue() ?: "undefined"
         )
         looksLikeCustom() -> {
           // chooses the first custom deserializer to keep behavior consistent

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/TriggerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/TriggerSpec.groovy
@@ -242,6 +242,7 @@ class TriggerSpec extends Specification {
       project == "CAD"
       branch == "bladerunner-release"
       slug == "Main"
+      action == "push"
     }
 
     where:
@@ -270,7 +271,8 @@ class TriggerSpec extends Specification {
   "enabled": true,
   "slug": "Main",
   "hash": "adb2554e870ae86622f05de2a15f4539030d87a7",
-  "master": "cbp"
+  "master": "cbp",
+  "action": "push"
 }
 '''
   }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/TriggerSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/TriggerSpec.groovy
@@ -277,6 +277,36 @@ class TriggerSpec extends Specification {
 '''
   }
 
+  def "can parse a Git trigger without optional fields"() {
+    given:
+    def trigger = mapper.readValue(triggerJson, Trigger)
+
+    expect:
+    trigger instanceof GitTrigger
+    with(trigger) {
+      hash == "f5d3cd95665a1aa45842230472c2abf3721bea02"
+      source == "github"
+      project == "spinnaker"
+      branch == "release-0.2.x"
+      slug == "orca"
+      action == "undefined"
+    }
+
+    where:
+    triggerJson = '''
+{
+  "project": "spinnaker",
+  "source": "github",
+  "type": "git",
+  "branch": "release-0.2.x",
+  "user": "[anonymous]",
+  "enabled": true,
+  "slug": "orca",
+  "hash": "f5d3cd95665a1aa45842230472c2abf3721bea02"
+}
+'''
+  }
+
   def "can parse a jenkins trigger"() {
     given:
     def trigger = mapper.readValue(triggerJson, Trigger)

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -371,7 +371,7 @@ class TaskControllerSpec extends Specification {
        trigger: new DockerTrigger("test-account", "test-repo", "1")
       ],
       [pipelineConfigId: "1", id: "test-2", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(2, HOURS).toEpochMilli(),
-       trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca")
+       trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca", "push")
       ],
       [pipelineConfigId: "1", id: "test-3", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(2, HOURS).toEpochMilli(),
        trigger: new JenkinsTrigger("master", "job", 1, "test-property-file")
@@ -419,10 +419,10 @@ class TaskControllerSpec extends Specification {
         trigger: new DockerTrigger("test-account", "test-repo", "1")
       ],
       [pipelineConfigId: "1", id: "test-2", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(1, HOURS).toEpochMilli(),
-        trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca")
+        trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca", "push")
       ],
       [pipelineConfigId: "1", id: "test-3", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(2, HOURS).toEpochMilli(),
-        trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca")
+        trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca", "push")
       ],
       [pipelineConfigId: "1", id: "test-4", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(2, HOURS).toEpochMilli(),
         trigger: new JenkinsTrigger("master", "job", 1, "test-property-file")
@@ -471,10 +471,10 @@ class TaskControllerSpec extends Specification {
        trigger: new DockerTrigger("test-account", "test-repo", "1"), eventId: wrongEventId
       ],
       [pipelineConfigId: "1", id: "test-2", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(1, HOURS).toEpochMilli(),
-       trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca"), eventId: eventId
+       trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca", "push"), eventId: eventId
       ],
       [pipelineConfigId: "1", id: "test-3", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(2, HOURS).toEpochMilli(),
-       trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca"), eventId: wrongEventId
+       trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca", "push"), eventId: wrongEventId
       ],
       [pipelineConfigId: "1", id: "test-4", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(2, HOURS).toEpochMilli(),
        trigger: new JenkinsTrigger("master", "job", 1, "test-property-file"), eventId: eventId
@@ -523,7 +523,7 @@ class TaskControllerSpec extends Specification {
        trigger: new DockerTrigger("test-account", "test-repo", "1")
       ],
       [pipelineConfigId: "1", id: "test-2", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(2, HOURS).toEpochMilli(),
-       trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca")
+       trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca", "push")
       ],
       [pipelineConfigId: "2", id: "test-3", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(2, HOURS).toEpochMilli(),
        trigger: new JenkinsTrigger("master", "job", 1, "test-property-file")
@@ -568,7 +568,7 @@ class TaskControllerSpec extends Specification {
        trigger: new DockerTrigger("test-account", "test-repo", "1")
       ],
       [name: "pipeline2", pipelineConfigId: "2", id: "test-2", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(2, HOURS).toEpochMilli(),
-       trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca")
+       trigger: new GitTrigger("c681a6af-1096-4727-ac9e-70d3b2460228", "github", "spinnaker", "no-match", "orca", "push")
       ],
       [name: "pipeline3", pipelineConfigId: "3", id: "test-3", startTime: clock.instant().minus(daysOfExecutionHistory, DAYS).minus(2, HOURS).toEpochMilli(),
        trigger: new JenkinsTrigger("master", "job", 1, "test-property-file")


### PR DESCRIPTION
When dealing with webhook git triggers the event of the webhook does not reach the pipeline contexts. This PR makes this event available in the contexts of the pipeline execution.

This should no affect the current conditional for matching pipelines (source, project, slug, branch), it is just informative like the hash field.

For example: allow only github events where someone open/close a pull request using check preconditions, or if there is github push event follow a different branch in the pipeline, instead of one for pull request events.

For bitbucket server I used the header [ X-Event-Key ](https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html)

For bitbucket cloud I used the header [X-Event-Key](https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Push)

For gitlab I used the field in the payload named [object_kind](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html)

For github at the moment only supports push and PR, so I used the field named [action](https://developer.github.com/webhooks/#example-delivery) of the payload.

related to https://github.com/spinnaker/echo/pull/693