### PR TITLE
fix(cloudformation): Support Cloudformation templates as lists

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTask.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -107,6 +108,11 @@ public class DeployCloudFormationTask extends AbstractCloudProviderAwareTask imp
     Object templateBody = task.get("templateBody");
     if (templateBody instanceof Map && !((Map) templateBody).isEmpty()) {
       templateBody = new Yaml().dump(templateBody);
+      task.put("templateBody", templateBody);
+    } else if (templateBody instanceof List && !((List) templateBody).isEmpty()) {
+      templateBody =
+          ((List<?>) templateBody)
+              .stream().map(part -> new Yaml().dump(part)).collect(Collectors.joining("\n---\n"));
       task.put("templateBody", templateBody);
     }
     if (!(templateBody instanceof String) || Strings.isNullOrEmpty((String) templateBody)) {


### PR DESCRIPTION
Something has changed between Spinnaker 1.15.6 and 1.16.0 with regard to how Cloudformation templates entered into the inline editor in Deck are parsed. Updating Orca to account for this change.