### PR TITLE
fix(plugins): Remove unnecessary code

### DIFF
--- a/orca-api/orca-api.gradle
+++ b/orca-api/orca-api.gradle
@@ -26,8 +26,6 @@ test {
 dependencies {
   api "com.netflix.spinnaker.kork:kork-plugins-api"
 
-  implementation("com.google.guava:guava")
-
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -204,10 +204,8 @@ public class OrcaConfiguration {
   @Bean
   public StageResolver stageResolver(
       Collection<StageDefinitionBuilder> stageDefinitionBuilders,
-      Optional<Collection<SimpleStage>> simpleStages,
-      PluginManager pluginManager) {
-    Collection<SimpleStage> stages = simpleStages.orElseGet(ArrayList::new);
-    stages.addAll(pluginManager.getExtensions(SimpleStage.class));
+      Optional<List<SimpleStage>> simpleStages) {
+    List<SimpleStage> stages = simpleStages.orElseGet(ArrayList::new);
     return new StageResolver(stageDefinitionBuilders, stages);
   }
 


### PR DESCRIPTION
* I bashed my head against the wall a little too much on the `SimpleStage` implementation: There's a lot of assumptions made that certain properties are non-null or off a certain type, but the generic type constraints do not enforce anything. I added `Optional` around the use of the problem properties, but didn't bother to harden the generic types or the handling of them - I'm not yet sure what I want to do with this.
* Removed unnecessary creation of `ObjectMapper` in `SimpleTask`.
* Removed `PluginManager` from the `StageResolver`.