### PR TITLE
fix(notifications): Evaluate SpEL expressions in pipeline notifications

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
@@ -54,6 +54,8 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
   void beforeExecution(Persister persister, Execution execution) {
     try {
       if (execution.status != ExecutionStatus.SUSPENDED) {
+        processSpelInNotifications(execution)
+
         if (execution.type == PIPELINE) {
           addApplicationNotifications(execution)
         }
@@ -80,6 +82,8 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
                       boolean wasSuccessful) {
     try {
       if (execution.status != ExecutionStatus.SUSPENDED) {
+        processSpelInNotifications(execution)
+
         if (execution.type == PIPELINE) {
           addApplicationNotifications(execution)
         }
@@ -97,6 +101,15 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
     } catch (Exception e) {
       log.error("Failed to send pipeline end event: ${execution?.id}", e)
     }
+  }
+
+  private void processSpelInNotifications(Execution execution) {
+    Map executionMap = objectMapper.convertValue(execution, Map)
+
+    List<Map<String, Object>> spelProcessedNotifications = execution.notifications.collect({
+      contextParameterProcessor.process(it, executionMap, true)
+    })
+    execution.notifications = spelProcessedNotifications
   }
 
   /**


### PR DESCRIPTION
If a pipeline notification uses a SpEL expression which can't be evaluated at pipeline submission time (e.g. `${authentication.user}`)
that expression will not be evaluated prior to sending a notification. And the notification will have the raw expression present.

Ironically, app-level notifications don't suffer from this illness - they are properly evaluated and resolved prior to sending the notification.
This change adds explicit eval of notifications on the current execution
