### PR TITLE
fix(kubernetes): fix patchBody typing depending on strategy type

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PatchManifestContext.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PatchManifestContext.java
@@ -16,10 +16,11 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -30,7 +31,7 @@ import lombok.Value;
 @JsonDeserialize(builder = PatchManifestContext.PatchManifestContextBuilder.class)
 @Builder(builderClassName = "PatchManifestContextBuilder", toBuilder = true)
 public class PatchManifestContext implements ManifestContext {
-  private Map<Object, Object> patchBody;
+  private Object patchBody;
   private Source source;
 
   private String manifestArtifactId;
@@ -43,10 +44,51 @@ public class PatchManifestContext implements ManifestContext {
 
   @Builder.Default private boolean skipExpressionEvaluation = false;
 
+  @Builder.Default
+  private PatchManifestContext.Options options = PatchManifestContext.Options.builder().build();
+
+  @Builder(builderClassName = "OptionsBuilder", toBuilder = true)
+  @JsonDeserialize(builder = PatchManifestContext.Options.OptionsBuilder.class)
+  @Value
+  static class Options {
+    @Builder.Default private MergeStrategy mergeStrategy = MergeStrategy.STRATEGIC;
+    @Builder.Default private boolean record = true;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    static class OptionsBuilder {}
+  }
+
+  public enum MergeStrategy {
+    @JsonProperty("strategic")
+    STRATEGIC,
+
+    @JsonProperty("json")
+    JSON,
+
+    @JsonProperty("merge")
+    MERGE
+  }
+
   @Nullable
   @Override
   public List<Map<Object, Object>> getManifests() {
-    return Collections.singletonList(patchBody);
+    /*
+     * Clouddriver expects patchBody to be a List when the mergeStrategy is json, and a Map otherwise.
+     * Prior to Spinnaker 1.15, Deck sent either a List or Map depending on merge strategy, and Orca
+     * deserialized it as an Object. In Spinnaker 1.15 and 1.16, a bug was introduced where patchBody
+     * was deserialized as a Map regardless of merge strategy. Starting in 1.17, Deck will send a List
+     * regardless of merge strategy, but we should handle receiving a Map from pipelines configured
+     * in 1.15 and 1.16.
+     */
+    if (patchBody == null) {
+      return null;
+    }
+    if (patchBody instanceof List) {
+      return (List) patchBody;
+    }
+    List<Map<Object, Object>> manifests = new ArrayList<>();
+    manifests.add((Map<Object, Object>) patchBody);
+    return manifests;
   }
 
   @JsonPOJOBuilder(withPrefix = "")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PatchManifestContext.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PatchManifestContext.java
@@ -19,11 +19,11 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Value;
 
@@ -69,7 +69,7 @@ public class PatchManifestContext implements ManifestContext {
     MERGE
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public List<Map<Object, Object>> getManifests() {
     /*
@@ -81,14 +81,12 @@ public class PatchManifestContext implements ManifestContext {
      * in 1.15 and 1.16.
      */
     if (patchBody == null) {
-      return null;
+      return ImmutableList.of();
     }
     if (patchBody instanceof List) {
-      return (List) patchBody;
+      return ImmutableList.copyOf((List) patchBody);
     }
-    List<Map<Object, Object>> manifests = new ArrayList<>();
-    manifests.add((Map<Object, Object>) patchBody);
-    return manifests;
+    return ImmutableList.of((Map<Object, Object>) patchBody);
   }
 
   @JsonPOJOBuilder(withPrefix = "")

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestContextTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestContextTest.java
@@ -55,7 +55,7 @@ class ManifestContextTest {
   }
 
   @Test
-  void deserializePatchManifestNoArtifacts() throws IOException {
+  void deserializeInlineMapPatchManifest() throws IOException {
     String json =
         "{\n"
             + "  \"manifestArtifactAccount\": \"account\",\n"
@@ -70,8 +70,33 @@ class ManifestContextTest {
     PatchManifestContext context = new ObjectMapper().readValue(json, PatchManifestContext.class);
     assertThat(context.getSource()).isEqualTo(ManifestContext.Source.Text);
     assertThat(context.getManifestArtifactAccount()).isEqualTo("account");
-    assertThat(context.getPatchBody()).containsOnlyKeys("spec");
-    assertThat(context.getPatchBody().get("spec"))
+    assertThat(context.getManifests()).isNotNull();
+    assertThat(context.getManifests().get(0)).containsOnlyKeys("spec");
+    assertThat(context.getManifests().get(0).get("spec"))
+        .isEqualTo(Collections.singletonMap("replicas", "3"));
+  }
+
+  @Test
+  void deserializeInlineListPatchManifest() throws IOException {
+    String json =
+        "{\n"
+            + "  \"manifestArtifactAccount\": \"account\",\n"
+            + "  \"source\": \"text\",\n"
+            + "  \"patchBody\": [\n"
+            + "    {\n"
+            + "         \"spec\": {\n"
+            + "             \"replicas\": \"3\"\n"
+            + "         }\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+
+    PatchManifestContext context = new ObjectMapper().readValue(json, PatchManifestContext.class);
+    assertThat(context.getSource()).isEqualTo(ManifestContext.Source.Text);
+    assertThat(context.getManifestArtifactAccount()).isEqualTo("account");
+    assertThat(context.getManifests()).isNotNull();
+    assertThat(context.getManifests().get(0)).containsOnlyKeys("spec");
+    assertThat(context.getManifests().get(0).get("spec"))
         .isEqualTo(Collections.singletonMap("replicas", "3"));
   }
 }


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5093

Corresponding Deck PR: https://github.com/spinnaker/deck/pull/7600

Clouddriver's patch operation expects Orca to send it a `patchBody` that is a list when the merge strategy is of type `json`, and a map otherwise. Prior to Spinnaker 1.15, Deck also saved the `patchBody` as either a list or map depending on merge strategy. In Spinnaker 1.15, the artifacts rewrite introduced a bug that caused the `patchBody` to be saved as a `Map` regardless of merge strategy, which broke the JSON merge strategy and Deck's YAML editor. This change:

1. Deserializes `patchBody` as an `Object`, and coerces it to a `List` to conform to the shared `ManifestContext` interface.
2. Validates that the list of patches is non-empty and that only JSON-strategy patches have more than one item in the list.
3. Sends Clouddriver the `patchBody` as a `List` when the merge strategy is of type `json`, and a `Map` otherwise.