### PR TITLE
fix(notifications): Fix regression from #3280

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
@@ -104,9 +104,8 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
   }
 
   private void processSpelInNotifications(Execution execution) {
-    Map executionMap = objectMapper.convertValue(execution, Map)
-
     List<Map<String, Object>> spelProcessedNotifications = execution.notifications.collect({
+      Map executionMap = objectMapper.convertValue(execution, Map)
       contextParameterProcessor.process(it, executionMap, true)
     })
     execution.notifications = spelProcessedNotifications


### PR DESCRIPTION
https://github.com/spinnaker/orca/pull/3280 introduced a regression where if there are multiple notifications
and the execution has SCM info (e.g. jenkins trigger) the pipeline notifications won't get sent out.

Why you ask? Side-effects, my friends!

`contextParameterProcessor.process` actually MUTATES the context that is passed in (it extracts the scm info which starts out as a list and then replaces it with an actual `SourceControl` object :mindblown:)
see https://github.com/spinnaker/orca/blob/master/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java#L170
I wanted to not jackson map the whole execution every single notification we eval so I cached and there-in lay my mistake...

This change does not reuse the executionContext map avoiding this problem

