### PR TITLE
feat(expressions): Enhance expression evaluation order

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluator.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
+import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
@@ -130,10 +131,10 @@ public class ManifestEvaluator implements CloudProviderAware {
               contextParameterProcessor.process(
                   manifestWrapper, contextParameterProcessor.buildExecutionContext(stage), true);
 
-          if (manifestWrapper.containsKey("expressionEvaluationSummary")) {
+          if (manifestWrapper.containsKey(PipelineExpressionEvaluator.SUMMARY)) {
             throw new IllegalStateException(
                 "Failure evaluating manifest expressions: "
-                    + manifestWrapper.get("expressionEvaluationSummary"));
+                    + manifestWrapper.get(PipelineExpressionEvaluator.SUMMARY));
           }
         }
         manifests = (List<Map<Object, Object>>) manifestWrapper.get("manifests");

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/capabilities/models/ExpressionSpelEvaluatorDefinition.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/capabilities/models/ExpressionSpelEvaluatorDefinition.java
@@ -23,6 +23,7 @@ import lombok.Data;
 public class ExpressionSpelEvaluatorDefinition {
   private String versionKey;
   private String description;
+  private boolean isDeprecated;
 
   public ExpressionSpelEvaluatorDefinition() {}
 
@@ -30,5 +31,6 @@ public class ExpressionSpelEvaluatorDefinition {
       PipelineExpressionEvaluator.SpelEvaluatorVersion version) {
     this.versionKey = version.getKey();
     this.description = version.getDescription();
+    this.isDeprecated = version.isDeprecated();
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.config.PluginsAutoConfiguration;
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.kork.expressions.ExpressionFunctionProvider;
 import com.netflix.spinnaker.orca.StageResolver;
 import com.netflix.spinnaker.orca.Task;
@@ -137,8 +138,11 @@ public class OrcaConfiguration {
 
   @Bean
   public ContextParameterProcessor contextParameterProcessor(
-      List<ExpressionFunctionProvider> expressionFunctionProviders, PluginManager pluginManager) {
-    return new ContextParameterProcessor(expressionFunctionProviders, pluginManager);
+      List<ExpressionFunctionProvider> expressionFunctionProviders,
+      PluginManager pluginManager,
+      DynamicConfigService dynamicConfigService) {
+    return new ContextParameterProcessor(
+        expressionFunctionProviders, pluginManager, dynamicConfigService);
   }
 
   @Bean

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -213,6 +213,7 @@ public class ExecutionLauncher {
             (config.get("source") == null)
                 ? null
                 : objectMapper.convertValue(config.get("source"), Execution.PipelineSource.class))
+        .withSpelEvaluator(getString(config, "spelEvaluator"))
         .build();
   }
 
@@ -253,6 +254,7 @@ public class ExecutionLauncher {
         AuthenticationDetails.build().orElse(new AuthenticationDetails()));
     orchestration.setOrigin((String) config.getOrDefault("origin", "unknown"));
     orchestration.setStartTimeExpiry((Long) config.get("startTimeExpiry"));
+    orchestration.setSpelEvaluator(getString(config, "spelEvaluator"));
 
     return orchestration;
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/StageDefinitionBuilder.java
@@ -21,11 +21,13 @@ import static com.netflix.spinnaker.orca.pipeline.TaskNode.GraphType.FULL;
 
 import com.google.common.base.CaseFormat;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.kork.expressions.ExpressionEvaluationSummary;
 import com.netflix.spinnaker.orca.pipeline.TaskNode.TaskGraph;
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilder;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import com.netflix.spinnaker.orca.pipeline.model.SyntheticStageOwner;
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -68,6 +70,18 @@ public interface StageDefinitionBuilder {
   /** @return the stage type this builder handles. */
   default @Nonnull String getType() {
     return getType(this.getClass());
+  }
+
+  /**
+   * Allows the stage to process SpEL expression in its own context in a custom way
+   *
+   * @return true to continue processing, false to stop generic processing of expressions
+   */
+  default boolean processExpressions(
+      @Nonnull Stage stage,
+      @Nonnull ContextParameterProcessor contextParameterProcessor,
+      @Nonnull ExpressionEvaluationSummary summary) {
+    return true;
   }
 
   /** Implementations can override this if they need any special cleanup on restart. */

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.pipeline.expressions;
 
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.expressions.ExpressionEvaluationSummary;
 import com.netflix.spinnaker.kork.expressions.ExpressionFunctionProvider;
@@ -38,25 +39,32 @@ public class PipelineExpressionEvaluator {
   public static final String ERROR = "Failed Expression Evaluation";
 
   public enum SpelEvaluatorVersion {
-    V4("v4", "Supports sequential evaluation of variables in Evaluate Variables stage", false),
-    V3("v3", "", true);
+    V4("v4", "Supports sequential evaluation of variables in Evaluate Variables stage", true),
+    V3("v3", "", true, true),
+    V2("v2", "", true, true);
 
     SpelEvaluatorVersion(String key, String description, boolean supported) {
+      this(key, description, supported, false);
+    }
+
+    SpelEvaluatorVersion(String key, String description, boolean supported, boolean deprecated) {
       this.key = key;
       this.description = description;
       this.isSupported = supported;
+      this.isDeprecated = deprecated;
     }
 
     String key;
     String description;
     boolean isSupported;
-
-    public boolean equalsTo(String key) {
-      return (this.key.compareToIgnoreCase(key) == 0);
-    }
+    boolean isDeprecated;
 
     public boolean getIsSupported() {
       return isSupported;
+    }
+
+    public boolean isDeprecated() {
+      return isDeprecated;
     }
 
     public String getKey() {
@@ -65,6 +73,34 @@ public class PipelineExpressionEvaluator {
 
     public String getDescription() {
       return description;
+    }
+
+    public static SpelEvaluatorVersion fromStringKey(String key) {
+      if (Strings.isNullOrEmpty(key)) {
+        return Default();
+      }
+
+      for (SpelEvaluatorVersion spelVersion : values()) {
+        if (key.equalsIgnoreCase(spelVersion.key)) {
+          return spelVersion;
+        }
+      }
+
+      return Default();
+    }
+
+    public static boolean isSupported(String version) {
+      for (SpelEvaluatorVersion spelEvaluatorVersion : values()) {
+        if (version.equals(spelEvaluatorVersion.key)) {
+          return spelEvaluatorVersion.isSupported;
+        }
+      }
+
+      return false;
+    }
+
+    public static SpelEvaluatorVersion Default() {
+      return V3;
     }
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
@@ -39,9 +39,12 @@ public class PipelineExpressionEvaluator {
   public static final String ERROR = "Failed Expression Evaluation";
 
   public enum SpelEvaluatorVersion {
-    V4("v4", "Supports sequential evaluation of variables in Evaluate Variables stage", true),
-    V3("v3", "", true, true),
-    V2("v2", "", true, true);
+    V4(
+        "v4",
+        "Evaluates expressions at stage start; supports sequential evaluation of variables in Evaluate Variables stage",
+        true),
+    V3("v3", "Evaluates expressions as soon as possible, not recommended", true, true),
+    V2("v2", "DO NOT USE", true, true);
 
     SpelEvaluatorVersion(String key, String description, boolean supported) {
       this(key, description, supported, false);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -308,6 +308,16 @@ public class Execution implements Serializable {
     return systemNotifications;
   }
 
+  private String spelEvaluator;
+
+  public @Nullable String getSpelEvaluator() {
+    return spelEvaluator;
+  }
+
+  public void setSpelEvaluator(@Nullable String spelEvaluatorVersion) {
+    this.spelEvaluator = spelEvaluatorVersion;
+  }
+
   @Nullable
   public Stage namedStage(String type) {
     return stages.stream().filter(it -> it.getType().equals(type)).findFirst().orElse(null);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
@@ -131,5 +131,11 @@ public class PipelineBuilder {
     return this;
   }
 
+  public PipelineBuilder withSpelEvaluator(String spelEvaluatorVersion) {
+    pipeline.setSpelEvaluator(spelEvaluatorVersion);
+
+    return this;
+  }
+
   private final Execution pipeline;
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/V2Util.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/V2Util.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.pipelinetemplate;
 
 import com.netflix.spinnaker.kork.web.exceptions.ValidationException;
 import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor;
+import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,11 +55,12 @@ public class V2Util {
     augmentedContext.put("trigger", pipeline.get("trigger"));
     augmentedContext.put(
         "templateVariables", pipeline.getOrDefault("templateVariables", Collections.EMPTY_MAP));
+
     Map<String, Object> spelEvaluatedPipeline =
-        contextParameterProcessor.process(pipeline, augmentedContext, true);
+        contextParameterProcessor.processPipeline(pipeline, augmentedContext, true);
 
     Map<String, Object> expressionEvalSummary =
-        (Map<String, Object>) spelEvaluatedPipeline.get("expressionEvaluationSummary");
+        (Map<String, Object>) spelEvaluatedPipeline.get(PipelineExpressionEvaluator.SUMMARY);
     if (expressionEvalSummary != null) {
       List<String> failedTemplateVars =
           expressionEvalSummary.entrySet().stream()

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/capabilities/CapabilitiesServiceSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/capabilities/CapabilitiesServiceSpec.groovy
@@ -56,6 +56,6 @@ class CapabilitiesServiceSpec extends Specification {
     def spelVersions = capabilities.spelEvaluators.collect({ it.versionKey })
     spelVersions == supportedSpelEvaluators
     spelVersions.contains(PipelineExpressionEvaluator.SpelEvaluatorVersion.V3.key)
-    !spelVersions.contains(PipelineExpressionEvaluator.SpelEvaluatorVersion.V4.key)
+    spelVersions.contains(PipelineExpressionEvaluator.SpelEvaluatorVersion.V4.key)
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesStageSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesStageSpec.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.tasks
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.expressions.ExpressionEvaluationSummary
+import com.netflix.spinnaker.orca.pipeline.EvaluateVariablesStage
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class EvaluateVariablesStageSpec extends Specification {
+  ContextParameterProcessor contextParameterProcessor = new ContextParameterProcessor()
+
+  @Subject
+  evaluateVariablesStage = new EvaluateVariablesStage(new ObjectMapper())
+
+  void "Should sequentially eval variables"() {
+    setup:
+    def summary = new ExpressionEvaluationSummary()
+    def correctVars = [
+      [key: "a", value: 10, sourceValue: "{1+2+3+4}"],
+      [key: "b", value: 24, sourceValue: "{1*2*3*4}"],
+      [key: "product", value: 240, sourceValue: "{a * b}"],
+      [key: "nonworking", value: 'this one should fail: ${a * c}', sourceValue: 'this one should fail: {a * c}']
+    ]
+
+    def stage = stage {
+      refId = "1"
+      type = "evaluateVariables"
+      context["variables"] = [
+        [key: "a", value: '${1+2+3+4}'],
+        [key: "b", value: '${1*2*3*4}'],
+        [key: "product", value: '${a * b}'],
+        [key: "nonworking", value: 'this one should fail: ${a * c}']
+      ]
+    }
+
+    when:
+    def shouldContinue = evaluateVariablesStage.processExpressions(stage, contextParameterProcessor, summary)
+
+    then:
+    shouldContinue == false
+    stage.context.variables == correctVars
+    summary.totalEvaluated == correctVars.size()
+    summary.failureCount == 1
+  }
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -146,7 +146,7 @@ class DependentPipelineStarter implements ApplicationContextAware {
     }
 
     def augmentedContext = [trigger: pipelineConfig.trigger]
-    def processedPipeline = contextParameterProcessor.process(pipelineConfig, augmentedContext, false)
+    def processedPipeline = contextParameterProcessor.processPipeline(pipelineConfig, augmentedContext, false)
 
     json = objectMapper.writeValueAsString(processedPipeline)
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import com.netflix.spinnaker.orca.events.TaskComplete
 import com.netflix.spinnaker.orca.ext.isManuallySkipped
 import com.netflix.spinnaker.orca.ext.nextTask
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.model.Task
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
@@ -48,6 +49,7 @@ import java.util.concurrent.TimeUnit
 class CompleteTaskHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
+  override val stageDefinitionBuilderFactory: StageDefinitionBuilderFactory,
   override val contextParameterProcessor: ContextParameterProcessor,
   @Qualifier("queueEventPublisher") private val publisher: ApplicationEventPublisher,
   private val clock: Clock,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
@@ -21,7 +21,9 @@ import com.netflix.spinnaker.kork.expressions.ExpressionEvaluationSummary
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
+import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator.ERROR
 import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator.SpelEvaluatorVersion
+import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator.SUMMARY
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.model.StageContext
@@ -132,7 +134,7 @@ interface ExpressionAware {
   private fun processEntries(stage: Stage, summary: ExpressionEvaluationSummary): StageContext {
     var shouldContinueProcessing = true
 
-    val spelVersion = SpelEvaluatorVersion.fromStringKey(stage.execution.spelEvaluator)
+    val spelVersion = contextParameterProcessor.getEffectiveSpelVersionToUse(stage.execution.spelEvaluator)
     if (SpelEvaluatorVersion.V4 == spelVersion) {
       // Let the stage process its expressions first if it wants (e.g. see EvaluateVariables stage)
       val stageBuilder = stageDefinitionBuilderFactory.builderFor(stage)

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/ExpressionAware.kt
@@ -20,7 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.kork.expressions.ExpressionEvaluationSummary
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
-import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
+import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator.SpelEvaluatorVersion
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.model.StageContext
@@ -39,6 +40,7 @@ interface ExpressionAware {
     val mapper: ObjectMapper = OrcaObjectMapper.getInstance()
   }
 
+  val stageDefinitionBuilderFactory: StageDefinitionBuilderFactory
   val log: Logger
     get() = LoggerFactory.getLogger(javaClass)
 
@@ -77,7 +79,7 @@ interface ExpressionAware {
     // the error is still shown
     if (hasFailedExpressions()) {
       try {
-        val failedExpressions = this.context[PipelineExpressionEvaluator.SUMMARY] as MutableMap<String, *>
+        val failedExpressions = this.context[SUMMARY] as MutableMap<String, *>
 
         val keysToRemove: List<String> = failedExpressions.keys.filter { expressionKey ->
           (evalSummary.wasAttempted(expressionKey) && !evalSummary.hasFailed(expressionKey))
@@ -99,7 +101,7 @@ interface ExpressionAware {
     when {
       hasFailedExpressions() ->
         try {
-          val expressionEvaluationSummary = this.context[PipelineExpressionEvaluator.SUMMARY] as Map<*, *>
+          val expressionEvaluationSummary = this.context[SUMMARY] as Map<*, *>
           val evaluationErrors: List<String> = expressionEvaluationSummary.values.flatMap { (it as List<*>).map { (it as Map<*, *>)["description"] as String } }
           this.context["exception"] = mergedExceptionErrors(this.context["exception"] as Map<*, *>?, evaluationErrors)
         } catch (e: Exception) {
@@ -109,8 +111,8 @@ interface ExpressionAware {
   }
 
   fun Stage.hasFailedExpressions(): Boolean =
-    (PipelineExpressionEvaluator.SUMMARY in this.context) &&
-    ((this.context[PipelineExpressionEvaluator.SUMMARY] as Map<*, *>).size > 0)
+    (SUMMARY in this.context) &&
+      ((this.context[SUMMARY] as Map<*, *>).size > 0)
 
   fun Stage.shouldFailOnFailedExpressionEvaluation(): Boolean {
     return this.hasFailedExpressions() && this.context.containsKey("failOnFailedExpressions") &&
@@ -119,21 +121,35 @@ interface ExpressionAware {
 
   private fun mergedExceptionErrors(exception: Map<*, *>?, errors: List<String>): Map<*, *> =
     if (exception == null) {
-      mapOf("details" to ExceptionHandler.responseDetails(PipelineExpressionEvaluator.ERROR, errors))
+      mapOf("details" to ExceptionHandler.responseDetails(ERROR, errors))
     } else {
-      val details = exception["details"] as MutableMap<*, *>? ?: mutableMapOf("details" to mutableMapOf("errors" to mutableListOf<String>()))
+      val details = exception["details"] as MutableMap<*, *>?
+        ?: mutableMapOf("details" to mutableMapOf("errors" to mutableListOf<String>()))
       val mergedErrors: List<*> = (details["errors"] as List<*>? ?: mutableListOf<String>()) + errors
       mapOf("details" to mapOf("errors" to mergedErrors))
     }
 
-  private fun processEntries(stage: Stage, summary: ExpressionEvaluationSummary): StageContext =
-    StageContext(stage, contextParameterProcessor.process(
-      stage.context,
-      contextParameterProcessor.buildExecutionContext(stage),
-      true,
-      summary
-    )
-    )
+  private fun processEntries(stage: Stage, summary: ExpressionEvaluationSummary): StageContext {
+    var shouldContinueProcessing = true
+
+    val spelVersion = SpelEvaluatorVersion.fromStringKey(stage.execution.spelEvaluator)
+    if (SpelEvaluatorVersion.V4 == spelVersion) {
+      // Let the stage process its expressions first if it wants (e.g. see EvaluateVariables stage)
+      val stageBuilder = stageDefinitionBuilderFactory.builderFor(stage)
+      shouldContinueProcessing = stageBuilder.processExpressions(stage, contextParameterProcessor, summary)
+    }
+
+    if (shouldContinueProcessing) {
+      return StageContext(stage, contextParameterProcessor.process(
+        stage.context,
+        contextParameterProcessor.buildExecutionContext(stage),
+        true,
+        summary
+      ))
+    }
+
+    return StageContext(stage, stage.context)
+  }
 
   private operator fun StageContext.plus(map: Map<String, Any?>): StageContext =
     StageContext(this).apply { putAll(map) }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -41,6 +41,7 @@ import com.netflix.spinnaker.orca.ext.beforeStages
 import com.netflix.spinnaker.orca.ext.failureStatus
 import com.netflix.spinnaker.orca.ext.isManuallySkipped
 import com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWindow
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType
 import com.netflix.spinnaker.orca.pipeline.model.Stage
@@ -72,6 +73,7 @@ class RunTaskHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   override val stageNavigator: StageNavigator,
+  override val stageDefinitionBuilderFactory: StageDefinitionBuilderFactory,
   override val contextParameterProcessor: ContextParameterProcessor,
   private val tasks: Collection<Task>,
   private val clock: Clock,

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandler.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.q.handler
 import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
 import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.events.TaskStarted
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.q.RunTask
@@ -34,6 +35,7 @@ class StartTaskHandler(
   override val queue: Queue,
   override val repository: ExecutionRepository,
   override val contextParameterProcessor: ContextParameterProcessor,
+  override val stageDefinitionBuilderFactory: StageDefinitionBuilderFactory,
   @Qualifier("queueEventPublisher") private val publisher: ApplicationEventPublisher,
   private val taskResolver: TaskResolver,
   private val clock: Clock

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
@@ -24,9 +24,12 @@ import com.netflix.spinnaker.orca.ExecutionStatus.REDIRECT
 import com.netflix.spinnaker.orca.ExecutionStatus.SKIPPED
 import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
+import com.netflix.spinnaker.orca.StageResolver
+import com.netflix.spinnaker.orca.api.SimpleStage
 import com.netflix.spinnaker.orca.events.TaskComplete
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
+import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 import com.netflix.spinnaker.orca.pipeline.model.Task
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
@@ -67,9 +70,10 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
   val repository: ExecutionRepository = mock()
   val publisher: ApplicationEventPublisher = mock()
   val clock = fixedClock()
+  val stageResolver = StageResolver(emptyList(), emptyList<SimpleStage<Object>>())
 
   subject(GROUP) {
-    CompleteTaskHandler(queue, repository, ContextParameterProcessor(), publisher, clock, NoopRegistry())
+    CompleteTaskHandler(queue, repository, DefaultStageDefinitionBuilderFactory(stageResolver), ContextParameterProcessor(), publisher, clock, NoopRegistry())
   }
 
   fun resetMocks() = reset(queue, repository, publisher)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -26,12 +26,15 @@ import com.netflix.spinnaker.orca.ExecutionStatus.SKIPPED
 import com.netflix.spinnaker.orca.ExecutionStatus.STOPPED
 import com.netflix.spinnaker.orca.ExecutionStatus.SUCCEEDED
 import com.netflix.spinnaker.orca.ExecutionStatus.TERMINAL
+import com.netflix.spinnaker.orca.StageResolver
 import com.netflix.spinnaker.orca.TaskExecutionInterceptor
 import com.netflix.spinnaker.orca.TaskResult
+import com.netflix.spinnaker.orca.api.SimpleStage
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
 import com.netflix.spinnaker.orca.fixture.task
+import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWindow
 import com.netflix.spinnaker.orca.pipeline.model.DefaultTrigger
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
@@ -97,12 +100,14 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
   val contextParameterProcessor = ContextParameterProcessor()
   val dynamicConfigService: DynamicConfigService = mock()
   val taskExecutionInterceptors: List<TaskExecutionInterceptor> = listOf(mock())
+  val stageResolver = StageResolver(emptyList(), emptyList<SimpleStage<Object>>())
 
   subject(GROUP) {
     RunTaskHandler(
       queue,
       repository,
       stageNavigator,
+      DefaultStageDefinitionBuilderFactory(stageResolver),
       contextParameterProcessor,
       listOf(task, timeoutOverrideTask, cloudProviderAwareTask),
       clock,

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandlerTest.kt
@@ -17,10 +17,13 @@
 package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.ExecutionStatus.RUNNING
+import com.netflix.spinnaker.orca.StageResolver
 import com.netflix.spinnaker.orca.TaskResolver
+import com.netflix.spinnaker.orca.api.SimpleStage
 import com.netflix.spinnaker.orca.events.TaskStarted
 import com.netflix.spinnaker.orca.fixture.pipeline
 import com.netflix.spinnaker.orca.fixture.stage
+import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
@@ -53,10 +56,11 @@ object StartTaskHandlerTest : SubjectSpek<StartTaskHandler>({
   val repository: ExecutionRepository = mock()
   val publisher: ApplicationEventPublisher = mock()
   val taskResolver = TaskResolver(emptyList())
+  val stageResolver = StageResolver(emptyList(), emptyList<SimpleStage<Object>>())
   val clock = fixedClock()
 
   subject(GROUP) {
-    StartTaskHandler(queue, repository, ContextParameterProcessor(), publisher, taskResolver, clock)
+    StartTaskHandler(queue, repository, ContextParameterProcessor(), DefaultStageDefinitionBuilderFactory(stageResolver), publisher, taskResolver, clock)
   }
 
   fun resetMocks() = reset(queue, repository, publisher)

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -52,6 +52,7 @@ dependencies {
   implementation(project(":orca-mine"))
   implementation(project(":orca-pipelinetemplate"))
   implementation(project(":orca-qos"))
+  implementation(project(":orca-queue"))
   implementation(project(":orca-queue-redis"))
   implementation(project(":orca-queue-sql"))
   implementation(project(":orca-redis"))

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -179,7 +179,7 @@ class OperationsController {
       trigger: pipeline.trigger,
       templateVariables: pipeline.templateVariables ?: [:]
     ]
-    def processedPipeline = contextParameterProcessor.process(pipeline, augmentedContext, false)
+    def processedPipeline = contextParameterProcessor.processPipeline(pipeline, augmentedContext, false)
     processedPipeline.trigger = objectMapper.convertValue(processedPipeline.trigger, Trigger)
 
     if (pipelineError == null) {

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/util/ExpressionUtils.java
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/util/ExpressionUtils.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.util;
+
+import com.google.common.base.Strings;
+import com.netflix.spinnaker.kork.exceptions.UserException;
+import com.netflix.spinnaker.orca.pipeline.EvaluateVariablesStage;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory;
+import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import com.netflix.spinnaker.orca.q.handler.ExpressionAware;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExpressionUtils implements ExpressionAware {
+  private ContextParameterProcessor contextParameterProcessor;
+  private StageDefinitionBuilderFactory stageDefinitionBuilderFactory;
+
+  @Autowired
+  public ExpressionUtils(
+      ContextParameterProcessor contextParameterProcessor,
+      StageDefinitionBuilderFactory stageDefinitionBuilderFactory) {
+    this.contextParameterProcessor = contextParameterProcessor;
+    this.stageDefinitionBuilderFactory = stageDefinitionBuilderFactory;
+  }
+
+  public Map<String, Object> evaluateVariables(
+      @Nonnull Execution execution,
+      @Nonnull List<String> requisiteStageRefIds,
+      @Nullable String spelVersionOverride,
+      @Nonnull List<Map<String, String>> expressions) {
+    // Create a stage that is downstream from the specified one, because we want to make sure that
+    // 'outputs'
+    // form the specified stage are included in the evaluation
+    Map<String, Object> stageContext = new HashMap<>();
+    stageContext.put("refId", "_AD_HOC_EVALUATE_VARIABLES_STAGE_");
+    stageContext.put("requisiteStageRefIds", requisiteStageRefIds);
+    stageContext.put("variables", expressions);
+
+    if (!Strings.isNullOrEmpty(spelVersionOverride)) {
+      if (!PipelineExpressionEvaluator.SpelEvaluatorVersion.isSupported(spelVersionOverride)) {
+        throw new UserException(
+            "SpEL evaluator version " + spelVersionOverride + " is not supported");
+      }
+
+      execution.setSpelEvaluator(spelVersionOverride);
+    }
+
+    Stage evalVarsStage = new Stage(execution, EvaluateVariablesStage.STAGE_TYPE, stageContext);
+
+    evalVarsStage = ExpressionAware.DefaultImpls.withMergedContext(this, evalVarsStage);
+    ExpressionAware.DefaultImpls.includeExpressionEvaluationSummary(this, evalVarsStage);
+
+    Map<String, Object> result = new HashMap<>();
+    result.put("result", evalVarsStage.getContext().get("variables"));
+    result.put("detail", evalVarsStage.getContext().get(PipelineExpressionEvaluator.SUMMARY));
+
+    return result;
+  }
+
+  @NotNull
+  @Override
+  public ContextParameterProcessor getContextParameterProcessor() {
+    return contextParameterProcessor;
+  }
+
+  @NotNull
+  @Override
+  public StageDefinitionBuilderFactory getStageDefinitionBuilderFactory() {
+    return stageDefinitionBuilderFactory;
+  }
+
+  @Override
+  public boolean shouldFailOnFailedExpressionEvaluation(@NotNull Stage stage) {
+    return false;
+  }
+
+  // NOTE: the following unfortunate method is needed because `withMergedContext` is a Kotlin
+  // extension method
+  // implemented on an interface. The interface provides all default implementations so technically
+  // no overrides are needed
+  // but we are not compiling with the JvmDefault option (which may bring about it's own set of
+  // problems)
+  // Hence, the following methods just defer to the "DefaultImpls"
+  @Override
+  public void includeExpressionEvaluationSummary(@NotNull Stage stage) {
+    DefaultImpls.includeExpressionEvaluationSummary(this, stage);
+  }
+
+  @Override
+  public boolean hasFailedExpressions(@NotNull Stage stage) {
+    return DefaultImpls.hasFailedExpressions(this, stage);
+  }
+
+  @Override
+  @Nonnull
+  public Stage withMergedContext(@NotNull Stage stage) {
+    return DefaultImpls.withMergedContext(this, stage);
+  }
+
+  @Override
+  @Nonnull
+  public Logger getLog() {
+    return DefaultImpls.getLog(this);
+  }
+}

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/web/config/WebConfiguration.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/web/config/WebConfiguration.groovy
@@ -36,7 +36,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 @Configuration
-@ComponentScan(basePackages = 'com.netflix.spinnaker.orca.controllers')
+@ComponentScan(['com.netflix.spinnaker.orca.controllers', 'com.netflix.spinnaker.orca.util'])
 @CompileStatic
 @EnableFiatAutoConfig
 class WebConfiguration extends WebMvcConfigurerAdapter {

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/util/ExpressionUtilsSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/util/ExpressionUtilsSpec.groovy
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.pipeline.EvaluateVariablesStage
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.model.Stage
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
+import spock.lang.Specification
+
+import javax.annotation.Nonnull
+
+class ExpressionUtilsSpec extends Specification {
+  private ExpressionUtils utils = new ExpressionUtils(
+    new ContextParameterProcessor(),
+    new StageDefinitionBuilderFactory() {
+      @Override
+      StageDefinitionBuilder builderFor(@Nonnull Stage stage) {
+        return new EvaluateVariablesStage(new ObjectMapper())
+      }
+    });
+
+  def 'should evaluate variables correctly with v4'() {
+    Execution execution = createExecution()
+
+    when:
+    def result = utils.evaluateVariables(execution, ['1', '2'], 'v4',
+      [
+        [key: 'var1', value: '${varFromStage1}'],
+        [key: 'var2', value: '${varFromStage2}'],
+        [key: 'sum', value: '${var1 + var2}']
+      ])
+
+    then:
+    result.size() == 2
+    result.result == [
+      [key: 'var1', value: 100, sourceValue: '{varFromStage1}'],
+      [key: 'var2', value: 200, sourceValue: '{varFromStage2}'],
+      [key: 'sum', value: 300, sourceValue: '{var1 + var2}']
+    ]
+  }
+
+  def 'should correctly use refIds'() {
+    Execution execution = createExecution()
+
+    when:
+    def result = utils.evaluateVariables(execution, ['1'], 'v4',
+      [
+        [key: 'var1', value: '${varFromStage1}'],
+        [key: 'var2', value: '${varFromStage2}'],
+        [key: 'sum', value: '${var1 + var2}']
+      ])
+
+    then:
+    result.size() == 2
+    result.result == [
+      [key: 'var1', value: 100, sourceValue: '{varFromStage1}'],
+      [key: 'var2', value: '${varFromStage2}', sourceValue: '{varFromStage2}'],
+      [key: 'sum', value: '${var1 + var2}', sourceValue: '{var1 + var2}']
+    ]
+    result.detail.size() == 2
+    result.detail.containsKey('varFromStage2')
+    result.detail.containsKey('var1 + var2')
+  }
+
+  def 'should fail to evaluate variables that depend on prior variables in same stage when in v3'() {
+    Execution execution = createExecution()
+
+    when:
+    def result = utils.evaluateVariables(execution, ['1', '2'], 'v3',
+      [
+        [key: 'var1', value: '${varFromStage1}'],
+        [key: 'var2', value: '${varFromStage2}'],
+        [key: 'sum', value: '${var1 + var2}']
+      ])
+
+    then:
+    result.size() == 2
+    result.result == [
+      [key: 'var1', value: 100],
+      [key: 'var2', value: 200],
+      [key: 'sum', value: '${var1 + var2}']
+    ]
+    result.detail.size() == 1
+    result.detail.containsKey('var1 + var2')
+  }
+
+  private static def createExecution() {
+    def execution = new Execution(Execution.ExecutionType.PIPELINE, "test")
+    def stage1 = new Stage(execution, "evaluateVariables")
+    stage1.refId = "1"
+    stage1.outputs = [varFromStage1: 100]
+    execution.stages.add(stage1)
+
+    def stage2 = new Stage(execution, "evaluateVariables")
+    stage2.refId = "2"
+    stage2.outputs = [varFromStage2: 200]
+    execution.stages.add(stage2)
+
+    return execution
+  }
+}


### PR DESCRIPTION
Today, expressions are evaluated indiscriminately.
This change allows for a few useful changes:
1. Only evaluate SpEL expressions in a stage when that stage runs.
  This allows for the SpEL expressions to such as `Instant.now()` to be used and produce correct value during stage execution
2. Allow evaluating SpEL expressions in the `EvaluateVariables` stage in order.
  This allows for defining variables that depend on ones defined earlier.
3. We can now capture expressions before they are evaluated during stage execution and perform useful actions.
  For example, prior to this change, it was impossible to know what was the "source" expression in the `CheckPrecondition` stage (this is especially annoying when the expression evaluates to `false`)
  Now, it is possible to capture the expression and make it clear to the end-user what went wrong.

All of this is, for now, an opt-in behavior by setting `spelEvaluator: "v4"` on the pipeline

Things still to do:

- [x] Add EP to evaluate expressions like EvaluateVariables stage
- [ ] Fixup CheckPreconditions stage to capture expressions
- [x] deal with v2 spelevaluator