### PR TITLE
feat(gcb): Ability to invoke existing GCB triggers

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.orca.igor;
 
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuild;
+import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildRepoSource;
 import java.util.List;
 import java.util.Map;
 import retrofit.http.*;
@@ -78,4 +79,10 @@ public interface IgorService {
   @GET("/gcb/builds/{account}/{buildId}/artifacts")
   List<Artifact> getGoogleCloudBuildArtifacts(
       @Path("account") String account, @Path("buildId") String buildId);
+
+  @POST("/gcb/triggers/{account}/{triggerId}/run")
+  GoogleCloudBuild runGoogleCloudBuildTrigger(
+      @Path("account") String account,
+      @Path("triggerId") String triggerId,
+      @Body GoogleCloudBuildRepoSource repoSource);
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildRepoSource.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildRepoSource.java
@@ -1,0 +1,26 @@
+package com.netflix.spinnaker.orca.igor.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleCloudBuildRepoSource {
+  private final String branchName;
+  private final String commitSha;
+  private final String tagName;
+
+  @JsonCreator
+  public GoogleCloudBuildRepoSource(
+      @JsonProperty("branchName") String branchName,
+      @JsonProperty("commitSha") String commitSha,
+      @JsonProperty("tagName") String tagName) {
+    this.branchName = branchName;
+    this.commitSha = commitSha;
+    this.tagName = tagName;
+  }
+}

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildRepoSource.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildRepoSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Andres Castano.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.orca.igor.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
@@ -29,6 +29,8 @@ public class GoogleCloudBuildStageDefinition implements RetryableStageDefinition
   private final Map<String, Object> buildDefinition;
   private final String buildDefinitionSource;
   private final GoogleCloudBuildDefinitionArtifact buildDefinitionArtifact;
+  private final String triggerId;
+  private final GoogleCloudBuildRepoSource repoSource;
   private final int consecutiveErrors;
 
   // There does not seem to be a way to auto-generate a constructor using our current version of
@@ -41,6 +43,8 @@ public class GoogleCloudBuildStageDefinition implements RetryableStageDefinition
       @JsonProperty("buildDefinitionSource") String buildDefinitionSource,
       @JsonProperty("buildDefinitionArtifact")
           GoogleCloudBuildDefinitionArtifact buildDefinitionArtifact,
+      @JsonProperty("triggerId") String triggerId,
+      @JsonProperty("repoSource") GoogleCloudBuildRepoSource repoSource,
       @JsonProperty("consecutiveErrors") Integer consecutiveErrors) {
     this.account = account;
     this.buildInfo = build;
@@ -49,6 +53,9 @@ public class GoogleCloudBuildStageDefinition implements RetryableStageDefinition
     this.buildDefinitionArtifact =
         Optional.ofNullable(buildDefinitionArtifact)
             .orElse(new GoogleCloudBuildDefinitionArtifact(null, null, null));
+    this.repoSource =
+        Optional.ofNullable(repoSource).orElse(new GoogleCloudBuildRepoSource(null, null, null));
+    this.triggerId = triggerId;
     this.consecutiveErrors = Optional.ofNullable(consecutiveErrors).orElse(0);
   }
 

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/GoogleCloudBuildStageDefinition.java
@@ -27,7 +27,7 @@ public class GoogleCloudBuildStageDefinition implements RetryableStageDefinition
   private final String account;
   private final GoogleCloudBuild buildInfo;
   private final Map<String, Object> buildDefinition;
-  private final String buildDefinitionSource;
+  private final BuildDefinitionSource buildDefinitionSource;
   private final GoogleCloudBuildDefinitionArtifact buildDefinitionArtifact;
   private final String triggerId;
   private final GoogleCloudBuildRepoSource repoSource;
@@ -49,7 +49,7 @@ public class GoogleCloudBuildStageDefinition implements RetryableStageDefinition
     this.account = account;
     this.buildInfo = build;
     this.buildDefinition = buildDefinition;
-    this.buildDefinitionSource = buildDefinitionSource;
+    this.buildDefinitionSource = BuildDefinitionSource.fromString(buildDefinitionSource);
     this.buildDefinitionArtifact =
         Optional.ofNullable(buildDefinitionArtifact)
             .orElse(new GoogleCloudBuildDefinitionArtifact(null, null, null));
@@ -72,6 +72,20 @@ public class GoogleCloudBuildStageDefinition implements RetryableStageDefinition
       this.artifact = artifact;
       this.artifactAccount = artifactAccount;
       this.artifactId = artifactId;
+    }
+  }
+
+  public enum BuildDefinitionSource {
+    STAGE,
+    ARTIFACT,
+    TRIGGER;
+
+    public static BuildDefinitionSource fromString(String buildDefinitionSource) {
+      try {
+        return valueOf(buildDefinitionSource.toUpperCase());
+      } catch (NullPointerException | IllegalArgumentException e) {
+        return STAGE;
+      }
     }
   }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
@@ -30,7 +30,6 @@ import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
 import java.io.IOException;
 import java.util.Map;
-import java.util.Optional;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -57,15 +56,14 @@ public class StartGoogleCloudBuildTask implements Task {
         stage.mapTo(GoogleCloudBuildStageDefinition.class);
 
     GoogleCloudBuild result;
-    String source = Optional.ofNullable(stageDefinition.getBuildDefinitionSource()).orElse("");
-    switch (source) {
-      case "artifact":
+    switch (stageDefinition.getBuildDefinitionSource()) {
+      case ARTIFACT:
         result =
             igorService.createGoogleCloudBuild(
                 stageDefinition.getAccount(),
                 getBuildDefinitionFromArtifact(stage, stageDefinition));
         break;
-      case "trigger":
+      case TRIGGER:
         result =
             igorService.runGoogleCloudBuildTrigger(
                 stageDefinition.getAccount(),

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTaskSpec.groovy
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.igor.IgorService
 import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuild
-import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildRepoSource
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver


### PR DESCRIPTION
Added ability to call existing GCB triggers.
This is part of: spinnaker/spinnaker#5076

1. Enhanced `GoogleCloudBuildStageDefinition.java` to include the necessary fields for `igor` cloud build trigger endpoint:
   - triggerId
   - repoSource


2. Modified `StartGoogleCloudBuildTask.java` to check for the new build definition source and call the corresponding methods in `igorService`