### PR TITLE
feat(manualjudgment): Select roles that can execute manual judgement …

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
@@ -70,6 +70,7 @@ class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage 
     @Override
     TaskResult execute(Stage stage) {
       StageData stageData = stage.mapTo(StageData)
+      def stageAuthorized = stage.context.get('isAuthorized')
       String notificationState
       ExecutionStatus executionStatus
 
@@ -86,6 +87,12 @@ class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage 
           notificationState = "manualJudgment"
           executionStatus = ExecutionStatus.RUNNING
           break
+      }
+      if (!stageAuthorized) {
+        notificationState = "manualJudgment"
+        executionStatus = ExecutionStatus.RUNNING
+        stage.context.put("judgmentStatus", "")
+        stage.context.put("instructions", "User does not have permissions to continue")
       }
 
       Map outputs = processNotifications(stage, stageData, notificationState)

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
@@ -41,10 +41,10 @@ class ManualJudgmentStageSpec extends Specification {
     where:
     context                      || expectedStatus
     [:]                          || ExecutionStatus.RUNNING
-    [judgmentStatus: "continue"] || ExecutionStatus.SUCCEEDED
-    [judgmentStatus: "Continue"] || ExecutionStatus.SUCCEEDED
-    [judgmentStatus: "stop"]     || ExecutionStatus.TERMINAL
-    [judgmentStatus: "STOP"]     || ExecutionStatus.TERMINAL
+    [judgmentStatus: "continue",isAuthorized: true] || ExecutionStatus.SUCCEEDED
+    [judgmentStatus: "Continue",isAuthorized: true] || ExecutionStatus.SUCCEEDED
+    [judgmentStatus: "stop",isAuthorized: true]     || ExecutionStatus.TERMINAL
+    [judgmentStatus: "STOP",isAuthorized: true]     || ExecutionStatus.TERMINAL
     [judgmentStatus: "unknown"]  || ExecutionStatus.RUNNING
   }
 
@@ -79,7 +79,8 @@ class ManualJudgmentStageSpec extends Specification {
       notifications: [
         new Notification(type: "email", address: "test@netflix.com", when: [ notificationState ])
       ],
-      judgmentStatus: judgmentStatus
+      judgmentStatus: judgmentStatus,
+      isAuthorized: true
     ]))
 
     then:


### PR DESCRIPTION
…#4792

Added ability to add roles to manual judgment stage.
This is part of: spinnaker/spinnaker#4792.

Enhanced OperationsController.groovy to

Get the application roles, stage roles and the user roles.
Check each of the user roles whether they are contained in the stage and application roles.
If yes/no, set a isAuthorized flag to true/false in each of the stage. By default, all the stages except Manual Judgment are true.

Enhanced ManualJudgmentStage.groovy to

Check for the flag in ManualJudgmentStage.groovy whether to execute to the next stage or not.
If yes/no, continue with the next stages/continues running the same stage.

Enhanced ManualJudgmentStageSpec.groovy to

Modified the testcases.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
