### PR TITLE
feat(sql): add support for a secondary sql execution repo

### DIFF
--- a/orca-queue-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlPendingExecutionConfiguration.kt
+++ b/orca-queue-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlPendingExecutionConfiguration.kt
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration
 import java.time.Clock
 
 @Configuration
-@EnableConfigurationProperties(com.netflix.spinnaker.kork.sql.config.SqlProperties::class)
+@EnableConfigurationProperties(SqlProperties::class)
 class SqlPendingExecutionConfiguration {
 
   @Bean

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlActiveExecutionsMonitor.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/telemetry/SqlActiveExecutionsMonitor.kt
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.ORCHEST
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
 import com.netflix.spinnaker.orca.sql.pipeline.persistence.ExecutionStatisticsRepository
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
@@ -30,7 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger
 @Component
 @ConditionalOnProperty("monitor.active-executions.redis", havingValue = "false")
 class SqlActiveExecutionsMonitor(
-  private val executionRepository: ExecutionStatisticsRepository,
+  @Qualifier("sqlExecutionRepository") private val executionRepository: ExecutionStatisticsRepository,
   registry: Registry,
   @Value("\${monitor.active-executions.refresh.frequency.ms:60000}") refreshFrequencyMs: Long
 ) {


### PR DESCRIPTION
This makes it possible to conditionally create a secondary SqlExecutionRepository,
pointing at a specific named connection pool.

This also makes it possible to look up beans in DualExecutionRepository by name,
not just by class, which comes in handy when we want 2 SqlExecutionRepository beans.