### PR TITLE
fix(perf): Make `getAncestors` call faster

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -38,7 +38,6 @@ import com.fasterxml.jackson.databind.node.TreeTraversingParser;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
@@ -46,17 +45,7 @@ import com.netflix.spinnaker.orca.pipeline.model.support.RequisiteStageRefIdDese
 import de.huxhorn.sulky.ulid.ULID;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -366,14 +355,10 @@ public class Stage implements Serializable {
    */
   public List<Stage> ancestors() {
     if (execution != null) {
-      Set<String> visited = Sets.newHashSetWithExpectedSize(execution.getStages().size());
-      return ImmutableList.<Stage>builder()
-          .add(this)
-          .addAll(getAncestorsImpl(visited, false))
-          .build();
-    } else {
-      return emptyList();
+      return getAncestorsImpl(false);
     }
+
+    return emptyList();
   }
 
   /**
@@ -385,81 +370,73 @@ public class Stage implements Serializable {
    */
   public List<Stage> directAncestors() {
     if (execution != null) {
-      Set<String> visited = Sets.newHashSetWithExpectedSize(execution.getStages().size());
-      return ImmutableList.<Stage>builder()
-          .add(this)
-          .addAll(getAncestorsImpl(visited, true))
-          .build();
-    } else {
-      return emptyList();
+      return getAncestorsImpl(true);
     }
+
+    return emptyList();
   }
 
   /**
    * Worker method to get the list of all ancestors (parents and, optionally, prerequisite stages)
    * of the current stage.
    *
-   * @param visited list of visited nodes
    * @param directParentOnly true to only include direct parents of the stage, false to also include
    *     stages this stage depends on (via requisiteRefIds)
    * @return list of ancestor stages
    */
-  private List<Stage> getAncestorsImpl(Set<String> visited, boolean directParentOnly) {
-    visited.add(this.refId);
+  private ImmutableList<Stage> getAncestorsImpl(boolean directParentOnly) {
+    Set<String> visited = new HashSet<>();
+    ImmutableList.Builder<Stage> allAncestorStages = ImmutableList.builder();
+    Queue<Stage> toVisit = new ArrayDeque<>();
 
-    if (!requisiteStageRefIds.isEmpty() && !directParentOnly) {
-      // Get stages this stage depends on via requisiteStageRefIds:
-      List<Stage> previousStages =
-          execution.getStages().stream()
-              .filter(it -> requisiteStageRefIds.contains(it.refId))
-              .filter(it -> !visited.contains(it.refId))
-              .collect(toList());
-      List<Stage> syntheticStages =
-          execution.getStages().stream()
-              .filter(
-                  s ->
-                      previousStages.stream()
-                          .map(Stage::getId)
-                          .anyMatch(id -> id.equals(s.parentStageId)))
-              .collect(toList());
-      return ImmutableList.<Stage>builder()
-          .addAll(previousStages)
-          .addAll(syntheticStages)
-          .addAll(
-              previousStages.stream()
-                  .flatMap(it -> it.getAncestorsImpl(visited, directParentOnly).stream())
-                  .collect(toList()))
-          .build();
-    } else if (parentStageId != null && !visited.contains(parentStageId)) {
-      // Get parent stages, but exclude already visited ones:
+    toVisit.add(this);
 
-      List<Stage> ancestors = new ArrayList<>();
-      if (getSyntheticStageOwner() == SyntheticStageOwner.STAGE_AFTER) {
-        ancestors.addAll(
-            execution.getStages().stream()
-                .filter(
-                    it ->
-                        parentStageId.equals(it.parentStageId)
-                            && it.getSyntheticStageOwner() == SyntheticStageOwner.STAGE_BEFORE)
-                .collect(toList()));
+    while (!toVisit.isEmpty()) {
+      Stage curStage = toVisit.remove();
+
+      if (visited.contains(curStage.id)) {
+        continue;
       }
 
-      ancestors.addAll(
-          execution.getStages().stream()
-              .filter(it -> it.id.equals(parentStageId))
-              .findFirst()
-              .<List<Stage>>map(
-                  parent ->
-                      ImmutableList.<Stage>builder()
-                          .add(parent)
-                          .addAll(parent.getAncestorsImpl(visited, directParentOnly))
-                          .build())
-              .orElse(emptyList()));
+      visited.add(curStage.id);
+      allAncestorStages.add(curStage);
 
-      return ancestors;
-    } else {
-      return emptyList();
+      // 1. Find all stages we depend on through requisiteStageRefIds and push them on the queue
+      if (!curStage.requisiteStageRefIds.isEmpty() && !directParentOnly) {
+        List<Stage> refIdPriorStages =
+            execution.getStages().stream()
+                .filter(it -> curStage.requisiteStageRefIds.contains(it.refId))
+                .collect(toList());
+
+        toVisit.addAll(refIdPriorStages);
+      }
+
+      // 2. If we have a parent stage
+      if (curStage.parentStageId != null && !visited.contains(curStage.parentStageId)) {
+        // 2.1 AND we are an STAGE_AFTER, find all the stages with same parent as us but that are
+        // marked STAGE_BEFORE
+        if (curStage.getSyntheticStageOwner() == SyntheticStageOwner.STAGE_AFTER) {
+          toVisit.addAll(
+              execution.getStages().stream()
+                  .filter(
+                      it ->
+                          curStage.parentStageId.equals(it.parentStageId)
+                              && it.getSyntheticStageOwner() == SyntheticStageOwner.STAGE_BEFORE)
+                  .collect(toList()));
+        }
+
+        // 2.2 Add our direct parent to the queue
+        try {
+          toVisit.add(curStage.getParent());
+        } catch (IllegalArgumentException e) {
+          // It's not really possible for the parent not to exist.. But unittests beg to differ
+          // Not logging anything here since not having a parent would have failed and logged in
+          // other places
+        }
+      }
     }
+
+    return allAncestorStages.build();
   }
 
   /**


### PR DESCRIPTION
This change unrolls the recursion of the `getAncestorImpl` call into an imperative call.
getAncestors is actually called A TON! (especially since all `context.get` evaluations depend on it).
If the execution depth is large (e.g. canary with many stages) this call can take a while and, in some cases, throw a StackOverflow excetion.
Additionally, I added some logic to cache the `getAncesors` calls in the expression evaluation as it can't change

For context: `getAncestors` is executed 64 times for a simple wait stage execution

Results:
Time for `getAncestors` was reduced by a factor of 7x (1000 executions on 100 stage pipeline went from 7.2s to 0.9s)
Furthermore, due to caching the number of calls to `getAncestors` is reduces by ~3 (from 64 to 19)

So a total improvement time about 21x

As another example, planning a kayenta stage with 300 intervals went from 23.6s to 1.2s

