### PR TITLE
fix(perf): Unexpanding pipeline without StageContext

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -537,7 +537,7 @@ class TaskController {
     )
     return [result: evaluated?.expression, detail: evaluated?.expressionEvaluationSummary]
   }
-  
+
   /**
    * Adds trigger and execution to stage context so that expression evaluation can be tested.
    * This is not great, because it's brittle, but it's very useful to be able to test expressions.
@@ -685,7 +685,7 @@ class TaskController {
     pipelineExecutions.each { pipelineExecution ->
       clearTriggerStages(pipelineExecution.trigger.other) // remove from the "other" field - that is what Jackson works against
       pipelineExecution.getStages().each { stage ->
-        if (stage.context?.group) {
+        if (stage.context?.containsKey("group")) {
           // TODO: consider making "group" a top-level field on the Stage model
           // for now, retain group in the context, as it is needed for collapsing templated pipelines in the UI
           stage.context = [ group: stage.context.group ]


### PR DESCRIPTION
When calling the following endpoint: `v2/applications/{}/pipelines` with `expand=false`
the `TaskController` will try "unexpand" the pipelines by removing "context" from all the stages.
However, there is a wrinkle: during removal of the context we want to preserve the `group` key (if it exists).
In order to check if the key is there, we make a call to `context.group`. The problem is that the `context` is actually a
`StageContext` and the `.group` is actually a `StageContext::get("group")`.
This particular call traverses the entire execution graph to see if `group` exists not only in the current stage context
but also in the outputs of any of it's parent stages. Well, if the stage graph is large this is a O(n^2) operation.

The kicker is that the `group` should never occur in the outputs (and if it does we don't care).
This stage replaces the implicit groovy call to `.get` with an explicit call to `.containsKey` which doesn't traverse the stage hierarchy.

The result (on a 300 stage Kayenta canary pipeline):
Before: 17.2s to fetch the last 2 executions
After:   0.2s to fetch the last 2 executions
