### PR TITLE
feat(executions): Adding new ADMIN endpoint to import execution

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/AdminController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/AdminController.groovy
@@ -18,11 +18,15 @@
 package com.netflix.spinnaker.orca.controllers
 
 import com.netflix.spinnaker.kork.exceptions.HasAdditionalAttributes
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
 import com.netflix.spinnaker.kork.web.exceptions.ValidationException
 import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.commands.ForceExecutionCancellationCommand
 import com.netflix.spinnaker.orca.eureka.NoDiscoveryApplicationStatusPublisher
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.model.Application
 import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
@@ -30,6 +34,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.ApplicationListener
 import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
@@ -47,6 +52,9 @@ class AdminController {
 
   @Autowired
   ExecutionRepository executionRepository
+
+  @Autowired(required = false)
+  Front50Service front50Service
 
   @Autowired
   ForceExecutionCancellationCommand forceExecutionCancellationCommand
@@ -80,20 +88,32 @@ class AdminController {
   }
 
 
-  @RequestMapping(value = "/executions/", method = RequestMethod.POST)
-  @ResponseStatus(HttpStatus.OK)
-  void createExecution(@RequestBody Execution execution) {
+  @PostMapping(value = "/executions/")
+  @ResponseStatus(HttpStatus.CREATED)
+  Map<String, String> createExecution(@RequestBody Execution execution) {
+
+    if (front50Service && !front50Service.get(execution.application)) {
+      log.warn('No application exists with name: ' + execution.application)
+    }
+
+    try {
+      executionRepository.retrieve(execution.type, execution.id)
+      log.warn('Execution found with id: []', execution.id)
+      throw new InvalidRequestException('Execution already exists with id: ' + execution.id)
+    } catch(ExecutionNotFoundException e) {
+      log.info('Execution not found .. can import it..')
+    }
 
     if (execution.status in [ExecutionStatus.CANCELED, ExecutionStatus.SUCCEEDED, ExecutionStatus.TERMINAL]) {
-      log.info('Importing execution with id: {}, status: {}', execution.id, execution.status)
+      log.info('Importing execution with id: {}, status: {} , stages: {}', execution.id, execution.status, execution.stages.size())
       execution.stages.each {
         it.execution = execution
       }
       executionRepository.store(execution)
-      return
+      return ['executionId': execution.id, 'status': execution.status, 'totalStages': execution.stages.size()]
     }
 
-    throw new IllegalArgumentException('Cannot import provided execution, Status: ' + execution.status)
+    throw new InvalidRequestException('Cannot import provided execution, Status: ' + execution.status)
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/AdminControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/AdminControllerSpec.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.controllers
+
+import com.netflix.spinnaker.orca.ExecutionStatus
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import de.huxhorn.sulky.ulid.ULID
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class AdminControllerSpec extends Specification {
+
+  ExecutionRepository executionRepository = Mock(ExecutionRepository)
+
+  AdminController controller = new AdminController(executionRepository: executionRepository)
+
+  def setup() {
+    executionRepository = Mock(ExecutionRepository)
+    controller = new AdminController(executionRepository: executionRepository)
+  }
+
+  @Unroll
+  def 'should throw error while saving execution with status: #invalidStatus '() {
+      given:
+      Execution execution = new Execution(Execution.ExecutionType.PIPELINE, new ULID().toString(), 'testapp')
+
+      when:
+      execution.status = invalidStatus
+      controller.createExecution(execution)
+
+      then:
+      thrown(IllegalArgumentException)
+
+      where:
+      invalidStatus << [ExecutionStatus.RUNNING, ExecutionStatus.PAUSED, ExecutionStatus.NOT_STARTED]
+  }
+
+  @Unroll
+  def 'should succeed while saving execution with status: #validStatus '() {
+    given:
+    Execution execution = new Execution(Execution.ExecutionType.PIPELINE, new ULID().toString(), 'testapp')
+
+    when:
+    execution.status = validStatus
+    controller.createExecution(execution)
+
+    then:
+    noExceptionThrown()
+
+    where:
+    validStatus << [ExecutionStatus.SUCCEEDED, ExecutionStatus.CANCELED, ExecutionStatus.TERMINAL]
+  }
+
+}


### PR DESCRIPTION
Adding new Admin endpoint to import execution from another spinnaker instance.

Useful to get a execution into other envs for troubleshooting.
Only imports executions with TERMINAL, SUCCEEDED or CANCELLED states.

