### PR TITLE
fix(bakery): Include cloudProvider in CompleteBakeTask output results

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
@@ -44,6 +44,9 @@ class CompletedBakeTask implements Task {
       imageId: bake.ami ?: bake.imageName,
       artifacts: bake.artifact ? [bake.artifact] : []
     ]
+    if (stage.context.cloudProvider) {
+      results.cloudProvider = stage.context.cloudProvider
+    }
     /**
      * TODO:
      * It would be good to standardize on the key here. "imageId" works for all providers.

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
@@ -142,6 +142,7 @@ public class CreateBakeManifestTask implements RetryableTask {
 
     Map<String, Object> outputs = new HashMap<>();
     outputs.put("artifacts", Collections.singleton(result));
+    outputs.put("cloudProvider", "kubernetes"); // Needed for stat collection.
 
     return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).outputs(outputs).build();
   }


### PR DESCRIPTION
The nightly stats are showing both the `bake` and `bakeManifest` stages do not detect any `cloudProvider`s. This adds it in at least for GCE - the next nightly run will confirm it for AMIs and the hardcoded `bakeManifest`, which @ethanfrogers confirmed for me is always used for kubernetes (famous last words ;-)