### PR TITLE
feat(stats): Add application details to stage context during applicat…

### DIFF
--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/UpsertApplicationTask.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/UpsertApplicationTask.groovy
@@ -63,7 +63,7 @@ class UpsertApplicationTask extends AbstractFront50Task implements ApplicationNa
     }
 
     outputs.newState = application ?: [:]
-    return TaskResult.builder(ExecutionStatus.SUCCEEDED).outputs(outputs).build()
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).outputs(outputs).build()
   }
 
   @Override


### PR DESCRIPTION
…ion upsert

tag: https://github.com/spinnaker/spinnaker/issues/5168

Needed in order to detect cloud providers for stat collection. This puts the `Application` object in stage context under `newState` and optionally `previousState` if it's an update.