### PR TITLE
perf(clouddriver): config to pass scoped manifests to clouddriver when checking pending force cache updates

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/CloudDriverCacheStatusService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/CloudDriverCacheStatusService.groovy
@@ -18,9 +18,11 @@ package com.netflix.spinnaker.orca.clouddriver
 
 import retrofit.http.GET
 import retrofit.http.Path
+import retrofit.http.QueryMap
 
 interface CloudDriverCacheStatusService {
   @GET("/cache/{cloudProvider}/{type}")
   Collection<Map> pendingForceCacheUpdates(@Path("cloudProvider") String cloudProvider,
-                                           @Path("type") String type)
+                                           @Path("type") String type,
+                                           @QueryMap Map<String, String> queryParams)
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingCloudDriverCacheStatusService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingCloudDriverCacheStatusService.java
@@ -29,7 +29,8 @@ public class DelegatingCloudDriverCacheStatusService
   }
 
   @Override
-  public Collection<Map> pendingForceCacheUpdates(String cloudProvider, String type) {
-    return getService().pendingForceCacheUpdates(cloudProvider, type);
+  public Collection<Map> pendingForceCacheUpdates(
+      String cloudProvider, String type, Map<String, String> queryParams) {
+    return getService().pendingForceCacheUpdates(cloudProvider, type, queryParams);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTask.groovy
@@ -150,7 +150,7 @@ public class UpsertLoadBalancerForceRefreshTask extends AbstractCloudProviderAwa
     String cloudProvider = getCloudProvider(stage)
 
     Collection<Map> pendingCacheUpdates = retrySupport.retry({
-      cacheStatusService.pendingForceCacheUpdates(cloudProvider, REFRESH_TYPE)
+      cacheStatusService.pendingForceCacheUpdates(cloudProvider, REFRESH_TYPE, [:])
     }, 3, 1000, false)
 
     if (!pendingCacheUpdates.isEmpty() && !context.refreshState.seenPendingCacheUpdates) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
@@ -158,7 +158,8 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
 
     Collection<PendingRefresh> pendingRefreshes =
         objectMapper.convertValue(
-            cacheStatusService.pendingForceCacheUpdates(provider, REFRESH_TYPE),
+            cacheStatusService.pendingForceCacheUpdates(
+                provider, REFRESH_TYPE, Collections.emptyMap()),
             new TypeReference<Collection<PendingRefresh>>() {});
 
     for (ScopedManifest manifest : manifestsToCheck) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
@@ -177,7 +177,7 @@ class ServerGroupCacheForceRefreshTask extends AbstractCloudProviderAwareTask im
                                                   StageData stageData,
                                                   Long startTime) {
 
-    def pendingForceCacheUpdates = cacheStatusService.pendingForceCacheUpdates(cloudProvider, REFRESH_TYPE)
+    def pendingForceCacheUpdates = cacheStatusService.pendingForceCacheUpdates(cloudProvider, REFRESH_TYPE, [:])
     boolean isRecent = (startTime != null) ? pendingForceCacheUpdates.find { it.cacheTime >= startTime } : false
 
     boolean finishedProcessing = true

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTaskSpec.groovy
@@ -89,7 +89,7 @@ class UpsertLoadBalancerForceRefreshTaskSpec extends Specification {
 
     // checks for pending, receives empty list and retries
     when:
-    1 * cloudDriverCacheStatusService.pendingForceCacheUpdates('aws', 'LoadBalancer') >> { [] }
+    1 * cloudDriverCacheStatusService.pendingForceCacheUpdates('aws', 'LoadBalancer', [:]) >> { [] }
     stage.context = result.context
     result = task.execute(stage)
 
@@ -100,7 +100,7 @@ class UpsertLoadBalancerForceRefreshTaskSpec extends Specification {
 
     // sees a pending onDemand key for our load balancers
     when:
-    1 * cloudDriverCacheStatusService.pendingForceCacheUpdates('aws', 'LoadBalancer') >> {
+    1 * cloudDriverCacheStatusService.pendingForceCacheUpdates('aws', 'LoadBalancer', [:]) >> {
       [[id: "aws:loadBalancers:spinnaker:us-west-1:flapjack-frontend"]]
     }
 
@@ -114,7 +114,7 @@ class UpsertLoadBalancerForceRefreshTaskSpec extends Specification {
 
     // onDemand key has been processed, task completes
     when:
-    1 * cloudDriverCacheStatusService.pendingForceCacheUpdates('aws', 'LoadBalancer') >> { [] }
+    1 * cloudDriverCacheStatusService.pendingForceCacheUpdates('aws', 'LoadBalancer', [:]) >> { [] }
     stage.context = result.context
     result = task.execute(stage)
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTaskSpec.groovy
@@ -161,7 +161,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [pendingRefresh(refreshDetails)]
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
@@ -171,7 +171,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshDetails)]
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [processedRefresh(refreshDetails)]
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
@@ -211,7 +211,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [
       processedRefresh(refreshDetails + [account: noMatch]),
       processedRefresh(refreshDetails + [location: noMatch]),
       processedRefresh(refreshDetails + [name: noMatch])
@@ -255,7 +255,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> []
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> []
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
@@ -266,7 +266,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshDetails)]
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [processedRefresh(refreshDetails)]
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
@@ -313,7 +313,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(deploymentRefreshDetails)]
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [pendingRefresh(deploymentRefreshDetails)]
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
@@ -323,7 +323,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(deploymentRefreshDetails)]
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [processedRefresh(deploymentRefreshDetails)]
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
@@ -370,7 +370,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [
       processedRefresh(replicaSetRefreshDetails),
       pendingRefresh(deploymentRefreshDetails)
     ]
@@ -383,7 +383,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [
       processedRefresh(replicaSetRefreshDetails),
       processedRefresh(deploymentRefreshDetails)
     ]
@@ -433,7 +433,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [
       pendingRefresh(replicaSetRefreshDetails)
     ]
     1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, deploymentRefreshDetails) >> mockResponse(HTTP_OK)
@@ -446,7 +446,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [
       processedRefresh(replicaSetRefreshDetails)
     ]
     0 * cacheService._
@@ -498,7 +498,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [
       processedRefresh(replicaSetRefreshDetails),
       pendingRefresh(deploymentRefreshDetails)
     ]
@@ -511,7 +511,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [
       processedRefresh(replicaSetRefreshDetails),
       processedRefresh(deploymentRefreshDetails)
     ]
@@ -553,7 +553,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [pendingRefresh(refreshDetails)]
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
@@ -563,7 +563,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshDetails)]
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [processedRefresh(refreshDetails)]
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }
@@ -607,7 +607,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshResponseDetails)]
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [pendingRefresh(refreshResponseDetails)]
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.RUNNING
 
@@ -617,7 +617,7 @@ class ManifestForceCacheRefreshTaskSpec extends Specification {
     taskResult = task.execute(stage)
 
     then:
-    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshResponseDetails)]
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE, [:]) >> [processedRefresh(refreshResponseDetails)]
     0 * cacheService._
     taskResult.getStatus() == ExecutionStatus.SUCCEEDED
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
@@ -174,7 +174,7 @@ class ServerGroupCacheForceRefreshTaskSpec extends Specification {
     def processingComplete = task.processPendingForceCacheUpdates("executionId", "test", "aws", stageData, 0)
 
     then:
-    1 * task.cacheStatusService.pendingForceCacheUpdates("aws", "ServerGroup") >> { return pendingForceCacheUpdates }
+    1 * task.cacheStatusService.pendingForceCacheUpdates("aws", "ServerGroup", [:]) >> { return pendingForceCacheUpdates }
     processingComplete == expectedProcessingComplete
 
     where:

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -44,6 +44,7 @@ keiko:
 
 tasks:
   useWaitForAllNetflixAWSInstancesDownTask: false
+  optimizeManifestForceCacheRefreshTask: false
 
 logging:
   config: classpath:logback-defaults.xml


### PR DESCRIPTION
`ManifestForceCacheRefreshTask` calls Clouddriver when it tries to `checkPendingRefreshes`. This call is inefficient because it doesn't pass any information about which manifests it cares about. As a result, Clouddriver has to look up everything for a particular `cloudProvider` and `OnDemandType`. 

We discovered this issue when trying to kick off 100 concurrent Kubernetes deploys on Spinnaker, with Clouddriver being backed by Redis. Clouddriver will fire off an excessive amount of `sscan` and `mget` calls to Redis while check pending refreshes, and Redis' CPU utilization will get pegged at 100%. 

With this fix in Clouddriver https://github.com/spinnaker/clouddriver/pull/4180 and this fix in this PR, we dramatically improve Spinnaker's ability to handle concurrent manifest deploys when using Redis. We were able to go from 100 concurrent deploys to over 700 concurrent deploys. 

Furthermore, since these optimizations are data store agnostic, we should be able to see performance gains from the SQL side of things as well.

This PR is separated into 2 commits for easier review:
- https://github.com/spinnaker/orca/commit/c3baf209dfc66b5619d3ffbba740773b6d25bb46
  This adds query params to pendingForceCacheUpdates in CloudDriverCacheStatusService.
  This allows us to use information from scoped manifests to help Clouddriver look up cache data more efficiently.
- https://github.com/spinnaker/orca/commit/027758a047a0114c60210206b0c04b8ac2c060b9
  This adds a configuration to have ManifestForceCacheRefreshTask pass scoped manifests to pendingForceCacheUpdates.
  Clouddriver can use information in scoped manifests to look up cache data more efficiently.