### PR TITLE
fix(notifications+spel): follow up to #3311

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
@@ -132,9 +132,7 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
 
     if (notifications) {
       notifications.getPipelineNotifications().each { appNotification ->
-        Map executionMap = objectMapper.convertValue(pipeline, Map)
-
-        appNotification = contextParameterProcessor.process(appNotification, executionMap, true)
+        appNotification = contextParameterProcessor.process(appNotification, contextParameterProcessor.buildExecutionContext(pipeline), true)
 
         Map<String, Object> targetMatch = pipeline.notifications.find { pipelineNotification ->
           def addressMatches = appNotification.address && pipelineNotification.address && pipelineNotification.address == appNotification.address


### PR DESCRIPTION
This change makes the app notifications consistent with pipeline notifications in terms of how they are processed with SpEL
Related change: https://github.com/spinnaker/orca/pull/3311

The context wasn't being constructed properly so expression like `{execution.id}` would work in notification defined on a pipeline but not on the app.
This was because the context was `{execution: {id: ...,}}` vs. `{id: ...,}`.
This change makes the two consistent (and also consisten with all other places we use spel where context = `{execution: ..., trigger: ...,}`
