### PR TITLE
fix(spel): make contextParameterProcess.process side-effect free

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
@@ -189,6 +189,13 @@ public class ContextParameterProcessor {
   }
 
   private Map<String, Object> precomputeValues(Map<String, Object> context) {
+    // Copy the data over so we don't mutate the original context!
+    if (context instanceof StageContext) {
+      context = new StageContext((StageContext) context);
+    } else {
+      context = new HashMap<>(context);
+    }
+
     Object rawTrigger = context.get("trigger");
     Trigger trigger;
     if (rawTrigger != null && !(rawTrigger instanceof Trigger)) {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessorSpec.groovy
@@ -1056,7 +1056,10 @@ class ContextParameterProcessorSpec extends Specification {
     when:
     def result = contextParameterProcessor.process(stage.context, ctx, true)
 
-    then:
+    then: "doesn't mutate the context"
+    ctx == contextParameterProcessor.buildExecutionContext(stage)
+
+    and: "looks up results from prior stages"
     result.manifests == [
       [
         kind: 'ReplicaSet',


### PR DESCRIPTION
With SpEL v4 Eval Vars calls process once for each variable, that doesn't work because .process has sideeffects and mutates context in a way that prevents it from running twice (bad, bad).
The culprit is `precomputeValues` which expands and does naughty things with the trigger. Making a copy of the context is a simple way to prevent the sideeffects


Also, as part of this i noticed that if `StartStageHandler` fails the error handling is not great and we are stuck with a zombie pipeline