### PR TITLE
fix(cfn): include credentials on the task sent to clouddriver

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeleteCloudFormationChangeSetTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeleteCloudFormationChangeSetTask.java
@@ -66,6 +66,7 @@ public class DeleteCloudFormationChangeSetTask extends AbstractCloudProviderAwar
       task.put("stackName", stackName);
       task.put("changeSetName", changeSetName);
       task.put("region", region);
+      task.put("credentials", getCredentials(stage));
 
       Map<String, Map> operation =
           new ImmutableMap.Builder<String, Map>().put(TASK_NAME, task).build();

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeleteCloudFormationChangeSetTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeleteCloudFormationChangeSetTaskSpec.groovy
@@ -58,7 +58,12 @@ class DeleteCloudFormationChangeSetTaskSpec extends Specification {
 
     then:
     1 * katoService.requestOperations("aws", {
-      it.get(0).get("deleteCloudFormationChangeSet") != null
+      def task = it.get(0).get("deleteCloudFormationChangeSet")
+      task != null
+      task.get("stackName").equals(context.get("stackName"))
+      task.get("changeSetName").equals(context.get("changeSetName"))
+      task.get("region").equals(context.get("regions")[0])
+      task.get("credentials").equals(context.get("credentials"))
     }) >> Observable.just(taskId)
     result.getStatus() == ExecutionStatus.SUCCEEDED
 


### PR DESCRIPTION
Clouddriver expects the credentials to be on the kato task context we
sent from Orca. That was not the case for the DeleteCloudFormationTask
so it was failing in Clouddriver.

This patch adds the credentials field so clouddriver can do the
task conversion properly.