### PR TITLE
refactor(artifacts): Use builder to create artifacts

### DIFF
--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
@@ -79,7 +79,7 @@ class CompletedBakeTaskSpec extends Specification {
     region = "us-west-1"
     bakeId = "b-5af233wjj78mwt2f420wt8ey3w"
     ami = "ami-280c3b6d"
-    artifact = new Artifact(reference: ami)
+    artifact = Artifact.builder().reference(ami).build()
   }
 
   def "fails if the bake is not found"() {

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -1107,7 +1107,7 @@ class CreateBakeTaskSpec extends Specification {
     def bakeResult = task.bakeFromContext(stage, selectedBakeryService)
 
     then:
-    2 * task.artifactResolver.getBoundArtifactForId(stage, _) >> new Artifact()
+    2 * task.artifactResolver.getBoundArtifactForId(stage, _) >> Artifact.builder().build()
     1 * task.artifactResolver.getAllArtifacts(_) >> []
     bakeResult.getPackageArtifacts().size() == 2
   }
@@ -1135,7 +1135,7 @@ class CreateBakeTaskSpec extends Specification {
     def bakeResult = task.bakeFromContext(stage, selectedBakeryService)
 
     then:
-    0 * task.artifactResolver.getBoundArtifactForId(*_) >> new Artifact()
+    0 * task.artifactResolver.getBoundArtifactForId(*_) >> Artifact.builder().build()
     1 * task.artifactResolver.getAllArtifacts(_) >> []
     bakeResult.getPackageArtifacts().size() == 0
   }
@@ -1164,7 +1164,7 @@ class CreateBakeTaskSpec extends Specification {
 
     then:
     noExceptionThrown()
-    2 * task.artifactResolver.getBoundArtifactForId(stage, _) >> new Artifact()
+    2 * task.artifactResolver.getBoundArtifactForId(stage, _) >> Artifact.builder().build()
     1 * task.artifactResolver.getAllArtifacts(_) >> []
     bakeResult.getPackageArtifacts().size() == 2
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -257,7 +257,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
     }.flatten()
 
     List<Artifact> artifacts = imageSummaries.collect { placement, summaries ->
-      Artifact artifact = new Artifact()
+      Artifact artifact = Artifact.builder().build()
       summaries.findResults { summary ->
         if (config.imageNamePattern && !(summary.imageName ==~ config.imageNamePattern)) {
           return null
@@ -282,12 +282,14 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
           log.error("Unable to merge server group image/build info (summary: ${summary})", e)
         }
 
-        artifact.metadata = metadata
-        artifact.name = summary.imageName
-        artifact.location = location
-        artifact.type = "${cloudProvider}/image"
-        artifact.reference = "${summary.imageId}"
-        artifact.uuid = UUID.randomUUID().toString()
+        artifact = Artifact.builder()
+          .metadata(metadata)
+          .name(summary.imageName)
+          .location(location)
+          .type("${cloudProvider}/image")
+          .reference("${cloudProvider}/image")
+          .uuid(UUID.randomUUID().toString())
+          .build()
       }
       return artifact
     }.flatten()

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
@@ -99,15 +99,14 @@ public class FindImageFromTagsTask extends AbstractCloudProviderAwareTask implem
       // This is either all or nothing
     }
 
-    Artifact artifact = new Artifact();
-    artifact.setName(imageDetails.getImageName());
-    artifact.setReference(imageDetails.getImageId());
-    artifact.setLocation(imageDetails.getRegion());
-    artifact.setType(cloudProvider + "/image");
-    artifact.setMetadata(metadata);
-    artifact.setUuid(UUID.randomUUID().toString());
-
-    return artifact;
+    return Artifact.builder()
+        .name(imageDetails.getImageName())
+        .reference(imageDetails.getImageId())
+        .location(imageDetails.getRegion())
+        .type(cloudProvider + "/image")
+        .metadata(metadata)
+        .uuid(UUID.randomUUID().toString())
+        .build();
   }
 
   @Override

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/CFRollingRedBlackStrategyTest.java
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/CFRollingRedBlackStrategyTest.java
@@ -286,7 +286,7 @@ class CFRollingRedBlackStrategyTest {
     List<Object> targetPercentageList = Stream.of(50, 75, 100).collect(Collectors.toList());
     context.put("manifest", manifest);
     context.put("targetPercentages", targetPercentageList);
-    Artifact boundArtifactForStage = new Artifact();
+    Artifact boundArtifactForStage = Artifact.builder().build();
     Map<String, Object> application = new HashMap<>();
     application.put("instances", "4");
     application.put("memory", "64M");
@@ -325,7 +325,7 @@ class CFRollingRedBlackStrategyTest {
     assertThat(deployServerGroupStage.getContext().get("capacity")).isEqualTo(zeroCapacity);
     assertThat(deployServerGroupStage.getContext().get("manifest")).isEqualTo(expectedManifest);
     verify(artifactResolver)
-        .getBoundArtifactForStage(deployServerGroupStage, artifactId, new Artifact());
+        .getBoundArtifactForStage(deployServerGroupStage, artifactId, Artifact.builder().build());
     verify(oortService).fetchArtifact(boundArtifactForStage);
   }
 
@@ -352,7 +352,7 @@ class CFRollingRedBlackStrategyTest {
         new ResizeStrategy.Capacity(initialSourceCapacity.getMax(), 0, 0);
 
     Stage deployServerGroupStage = new Stage(new Execution(PIPELINE, "unit"), "type", context);
-    Artifact boundArtifactForStage = new Artifact();
+    Artifact boundArtifactForStage = Artifact.builder().build();
     Map<String, Object> application = new HashMap<>();
     application.put("instances", "4");
     application.put("memory", "64M");
@@ -402,7 +402,7 @@ class CFRollingRedBlackStrategyTest {
     assertThat(deployServerGroupStage.getContext().get("capacity")).isEqualTo(zeroCapacity);
     assertThat(deployServerGroupStage.getContext().get("manifest")).isEqualTo(expectedManifest);
     verify(artifactResolver)
-        .getBoundArtifactForStage(deployServerGroupStage, artifactId, new Artifact());
+        .getBoundArtifactForStage(deployServerGroupStage, artifactId, Artifact.builder().build());
     verify(oortService).fetchArtifact(boundArtifactForStage);
   }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ConsumeArtifactTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ConsumeArtifactTaskSpec.groovy
@@ -33,7 +33,7 @@ class ConsumeArtifactTaskSpec extends Specification {
 
   def oortService = Mock(OortService)
   def artifactResolver = Stub(ArtifactResolver) {
-    getBoundArtifactForId(*_) >> new Artifact()
+    getBoundArtifactForId(*_) >> Artifact.builder().build()
   }
 
   @Subject

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/GetPipelinesFromArtifactTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/pipeline/GetPipelinesFromArtifactTaskSpec.groovy
@@ -47,7 +47,7 @@ class GetPipelinesFromArtifactTaskSpec extends Specification {
     def result = task.execute(new Stage(Execution.newPipeline("orca"), "whatever", context))
 
     then:
-    1 * artifactResolver.getBoundArtifactForStage(_, '123', _) >> new Artifact().builder().type('http/file')
+    1 * artifactResolver.getBoundArtifactForStage(_, '123', _) >> Artifact.builder().type('http/file')
       .reference('url1').build()
     1 * oortService.fetchArtifact(_) >> new Response("url1", 200, "reason1", [],
       new TypedString(pipelineJson))
@@ -66,7 +66,7 @@ class GetPipelinesFromArtifactTaskSpec extends Specification {
     def result = task.execute(new Stage(Execution.newPipeline("orca"), "whatever", context))
 
     then:
-    1 * artifactResolver.getBoundArtifactForStage(_, '123', _) >> new Artifact().builder().type('http/file')
+    1 * artifactResolver.getBoundArtifactForStage(_, '123', _) >> Artifact.builder().type('http/file')
       .reference('url1').build()
     1 * oortService.fetchArtifact(_) >> new Response("url1", 200, "reason1", [],
       new TypedString(pipelineJson))

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTaskSpec.groovy
@@ -106,7 +106,7 @@ class DeployCloudFormationTaskSpec extends Specification {
     def result = deployCloudFormationTask.execute(stage)
 
     then:
-    (_..1) * artifactResolver.getBoundArtifactForStage(stage, 'id', null) >> new Artifact()
+    (_..1) * artifactResolver.getBoundArtifactForStage(stage, 'id', null) >> Artifact.builder().build()
     (_..1) * oortService.fetchArtifact(_) >> new Response("url", 200, "reason", Collections.emptyList(), template)
     thrown(expectedException)
 
@@ -141,7 +141,7 @@ class DeployCloudFormationTaskSpec extends Specification {
     def result = deployCloudFormationTask.execute(stage)
 
     then:
-    1 * artifactResolver.getBoundArtifactForStage(stage, stackArtifactId, _) >> new Artifact()
+    1 * artifactResolver.getBoundArtifactForStage(stage, stackArtifactId, _) >> Artifact.builder().build()
     1 * oortService.fetchArtifact(_) >> new Response("url", 200, "reason", Collections.emptyList(), new TypedString(template))
     1 * katoService.requestOperations("aws", {
       it.get(0).get("deployCloudFormation").containsKey("templateBody")

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/ecs/EcsServerGroupCreatorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/ecs/EcsServerGroupCreatorSpec.groovy
@@ -140,7 +140,7 @@ class EcsServerGroupCreatorSpec extends Specification {
     def taskDefArtifact = [
       artifactId: testArtifactId
     ]
-    Artifact resolvedArtifact = new Artifact().builder().type('s3/object').name('s3://testfile.json').build()
+    Artifact resolvedArtifact = Artifact.builder().type('s3/object').name('s3://testfile.json').build()
     mockResolver.getBoundArtifactForStage(stage, testArtifactId, null) >> resolvedArtifact
     // define container mappings inputs
     def (testReg,testRepo,testTag) = ["myregistry.io","myrepo","latest"]

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreatorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreatorSpec.groovy
@@ -137,9 +137,7 @@ class GoogleServerGroupCreatorSpec extends Specification {
       context.putAll(ctx)
     }
     artifactResolver.getBoundArtifactForId(*_) >> {
-      Artifact artifact = new Artifact();
-      artifact.setName("santaImage")
-      return artifact
+      return Artifact.builder().name("santaImage").build()
     }
     ops = new GoogleServerGroupCreator(artifactResolver: artifactResolver).getOperations(stage)
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunnerSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunnerSpec.groovy
@@ -140,7 +140,7 @@ class KubernetesJobRunnerSpec extends Specification {
       )
     }
     1 * artifactResolver.getBoundArtifactForStage(_, _, _) >> {
-      return new Artifact()
+      return Artifact.builder().build()
     }
     op.manifest == manifest
     op.requiredArtifacts == []

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/tasks/artifacts/FindArtifactFromExecutionTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/tasks/artifacts/FindArtifactFromExecutionTaskSpec.groovy
@@ -30,8 +30,8 @@ import spock.lang.Subject
 class FindArtifactFromExecutionTaskSpec extends Specification {
   def PIPELINE = "my pipeline"
   def EXECUTION_CRITERIA = new ExecutionRepository.ExecutionCriteria().setStatuses(Collections.singletonList("SUCCEEDED"))
-  def ARTIFACT_A = new Artifact(type: "kubernetes/replicaSet")
-  def ARTIFACT_B = new Artifact(type: "kubernetes/configMap")
+  def ARTIFACT_A = Artifact.builder().type("kubernetes/replicaSet").build()
+  def ARTIFACT_B = Artifact.builder().type("kubernetes/configMap").build()
 
   ArtifactResolver artifactResolver = Mock(ArtifactResolver)
   Execution execution = Mock(Execution)
@@ -41,7 +41,7 @@ class FindArtifactFromExecutionTaskSpec extends Specification {
 
   def "finds a single artifact"() {
     given:
-    def expectedArtifacts = [new ExpectedArtifact(matchArtifact: ARTIFACT_A)]
+    def expectedArtifacts = [ExpectedArtifact.builder().matchArtifact(ARTIFACT_A).build()]
     def pipelineArtifacts = [ARTIFACT_A, ARTIFACT_B]
     Set resolvedArtifacts = [ARTIFACT_A]
     def stage = new Stage(execution, "findArtifactFromExecution", [
@@ -64,7 +64,7 @@ class FindArtifactFromExecutionTaskSpec extends Specification {
 
   def "finds multiple artifacts"() {
     given:
-    def expectedArtifacts = [new ExpectedArtifact(matchArtifact: ARTIFACT_A), new ExpectedArtifact(matchArtifact: ARTIFACT_B)]
+    def expectedArtifacts = [ExpectedArtifact.builder().matchArtifact(ARTIFACT_A).build(), ExpectedArtifact.builder().matchArtifact(ARTIFACT_B).build()]
     def pipelineArtifacts = [ARTIFACT_A, ARTIFACT_B]
     Set resolvedArtifacts = [ARTIFACT_A, ARTIFACT_B]
     def stage = new Stage(execution, "findArtifactFromExecution", [

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/ArtifactExpressionFunctionProviderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/ArtifactExpressionFunctionProviderSpec.groovy
@@ -31,12 +31,12 @@ import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 class ArtifactExpressionFunctionProviderSpec extends Specification {
   @Shared
   def pipeline1 = pipeline {
-    def matchArtifact1 = new Artifact(type: "docker/image", "name": "artifact1")
-    def boundArtifact = new Artifact(type: "docker/image", "name": "artifact1", "reference": "artifact1")
+    def matchArtifact1 = Artifact.builder().type("docker/image").name("artifact1").build()
+    def boundArtifact = Artifact.builder().type("docker/image").name("artifact1").reference("artifact1").build()
 
     trigger = new DefaultTrigger("manual", "artifact1")
     trigger.resolvedExpectedArtifacts = [
-      new ExpectedArtifact(matchArtifact: matchArtifact1, boundArtifact: boundArtifact),
+      ExpectedArtifact.builder().matchArtifact(matchArtifact1).boundArtifact(boundArtifact).build()
     ]
   }
 

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
@@ -182,10 +182,7 @@ class DependentPipelineStarterSpec extends Specification {
                             ]
                           ]]
     ];
-    Artifact testArtifact = new Artifact(
-      type: "gcs/object",
-      name: "gs://test/file.yaml"
-    )
+    Artifact testArtifact = Artifact.builder().type("gcs/object").name("gs://test/file.yaml").build()
     def parentPipeline = pipeline {
       name = "parent"
       trigger = new DefaultTrigger("webhook", null, "test", [:], [testArtifact]);
@@ -244,10 +241,7 @@ class DependentPipelineStarterSpec extends Specification {
                             ]
                           ]]
     ];
-    Artifact testArtifact = new Artifact(
-      type: "gcs/object",
-      name: "gs://test/file.yaml"
-    )
+    Artifact testArtifact = Artifact.builder().type("gcs/object").name("gs://test/file.yaml").build()
     def parentPipeline = pipeline {
       name = "parent"
       trigger = new DefaultTrigger("webhook", null, "test")
@@ -316,14 +310,8 @@ class DependentPipelineStarterSpec extends Specification {
                             ]
                           ]]
     ]
-    Artifact testArtifact1 = new Artifact(
-      type: "gcs/object",
-      name: "gs://test/file.yaml"
-    )
-    Artifact testArtifact2 = new Artifact(
-      type: "docker/image",
-      name: "gcr.io/project/image"
-    )
+    Artifact testArtifact1 = Artifact.builder().type("gcs/object").name("gs://test/file.yaml").build()
+    Artifact testArtifact2 = Artifact.builder().type("docker/image").name("gcr.io/project/image").build()
     def parentPipeline = pipeline {
       name = "parent"
       trigger = new DefaultTrigger("webhook", null, "test", [:], [testArtifact1, testArtifact2])
@@ -511,16 +499,14 @@ class DependentPipelineStarterSpec extends Specification {
     def priorExecution = pipeline {
       id = "01DCKTEZPRCMFV1H35EDFC62RG"
       trigger = new DefaultTrigger("manual", null, "user@acme.com", [:], [
-        new Artifact([
-          customKind: false,
-          metadata: [
-            fileName: "wait.0.1.yml",
-          ],
-          name: "wait",
-          reference: "https://artifactory.acme.com/spinnaker-pac/wait.0.1.yml",
-          type: "spinnaker-pac",
-          version: "0.1"
-        ])
+        Artifact.builder()
+        .customKind(false)
+        .metadata([fileName: "wait.0.1.yml"])
+        .name("wait")
+        .reference("https://artifactory.acme.com/spinnaker-pac/wait.0.1.yml")
+        .type("spinnaker-pac")
+        .version("spinnaker-pac")
+        .build()
       ])
     }
     def parentPipeline = pipeline {
@@ -649,12 +635,12 @@ class DependentPipelineStarterSpec extends Specification {
 
     ], PipelineTemplate)
 
-    Artifact testArtifact = new Artifact(
-      type: "http/file",
-      name: "artifact-name",
-      customKind: true,
-      reference: "a-reference"
-    )
+    Artifact testArtifact = Artifact.builder()
+      .type("http/file")
+      .name("artifact-name")
+      .customKind(true)
+      .reference("a-reference")
+      .build()
     def parentPipeline = pipeline {
       name = "parent"
       trigger = new DefaultTrigger("webhook", null, "test", [:], [testArtifact])


### PR DESCRIPTION
The all-arg and no-arg constructors for Artifact and ExpectedArtifact were deprecated in spinnaker/kork#429. Replace their usages with a builder.