### PR TITLE
fix(monitored deploy): Give more leniency to scale down operations

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Stage.java
@@ -803,6 +803,17 @@ public class Stage implements Serializable {
     context.put("allowSiblingStagesToContinueOnFailure", propagateFailuresToParent);
   }
 
+  @JsonIgnore
+  public void setContinuePipelineOnFailure(boolean continuePipeline) {
+    context.put("continuePipeline", continuePipeline);
+  }
+
+  @JsonIgnore
+  public boolean getContinuePipelineOnFailure() {
+    StageContext context = (StageContext) getContext();
+    return (boolean) context.getCurrentOnly("continuePipeline", false);
+  }
+
   public static class LastModifiedDetails implements Serializable {
     private String user;
 

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/CleanupCanaryClustersStage.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/pipeline/CleanupCanaryClustersStage.kt
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.kayenta.pipeline
 
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.DisableClusterStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.ShrinkClusterStage
-import com.netflix.spinnaker.orca.ext.setContinueOnFailure
 import com.netflix.spinnaker.orca.kayenta.model.ServerGroupSpec
 import com.netflix.spinnaker.orca.kayenta.model.cluster
 import com.netflix.spinnaker.orca.kayenta.model.deployments
@@ -47,7 +46,7 @@ class CleanupCanaryClustersStage : StageDefinitionBuilder {
           it.context.putAll(pair.control.toContext)
           it.context["remainingEnabledServerGroups"] = 0
           // Even if disabling fails, move on to shrink below which will have another go at destroying the server group
-          it.setContinueOnFailure(true)
+          it.continuePipelineOnFailure = true
         },
         graph.add {
           it.type = DisableClusterStage.STAGE_TYPE
@@ -55,7 +54,7 @@ class CleanupCanaryClustersStage : StageDefinitionBuilder {
           it.context.putAll(pair.experiment.toContext)
           it.context["remainingEnabledServerGroups"] = 0
           // Even if disabling fails, move on to shrink below which will have another go at destroying the server group
-          it.setContinueOnFailure(true)
+          it.continuePipelineOnFailure = true
         }
       )
     }
@@ -82,7 +81,7 @@ class CleanupCanaryClustersStage : StageDefinitionBuilder {
         it.context.putAll(pair.control.toContext)
         it.context["allowDeleteActive"] = true
         it.context["shrinkToSize"] = 0
-        it.setContinueOnFailure(true)
+        it.continuePipelineOnFailure = true
       }
 
       // destroy experiment cluster
@@ -92,7 +91,7 @@ class CleanupCanaryClustersStage : StageDefinitionBuilder {
         it.context.putAll(pair.experiment.toContext)
         it.context["allowDeleteActive"] = true
         it.context["shrinkToSize"] = 0
-        it.setContinueOnFailure(true)
+        it.continuePipelineOnFailure = true
       }
     }
   }

--- a/orca-kotlin/src/main/kotlin/com/netflix/spinnaker/orca/ext/Stage.kt
+++ b/orca-kotlin/src/main/kotlin/com/netflix/spinnaker/orca/ext/Stage.kt
@@ -128,15 +128,9 @@ inline fun <reified O> Stage.mapTo(): O = mapTo(O::class.java)
 fun Stage.shouldFailPipeline(): Boolean =
   context["failPipeline"] in listOf(null, true)
 
-fun Stage.shouldContinueOnFailure(): Boolean =
-  context["continuePipeline"] == true
-
-fun Stage.setContinueOnFailure(continueOnFailure: Boolean) =
-  context.put("continuePipeline", continueOnFailure)
-
 fun Stage.failureStatus(default: ExecutionStatus = TERMINAL) =
   when {
-    shouldContinueOnFailure() -> FAILED_CONTINUE
+    continuePipelineOnFailure -> FAILED_CONTINUE
     shouldFailPipeline() -> default
     else -> STOPPED
   }


### PR DESCRIPTION
During a rolling deploy, if `scaleDown`, `notifyDeployCompleted`, or `shrinkCluster` fail and auto rollback was requested, a rollback will be performed.
This is suboptimal because you can easily argue that these operations are non-critical. In fact at this point the deploy is completed (and the old ASG is disabled).
So these are purely cleanup actions and having a perfectly good deploy fail and rollback due to a cleanup action failing is silly.

This change makes the three stages return `FAILED_CONTINUE` instead `TERMINAL` on failure thus not triggering a rollback.
The pipeline will still be marked as `FAILED_CONTINUE`
