### PR TITLE
fix(expression): various fixes related to SpEL v4

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -214,6 +214,7 @@ public class ExecutionLauncher {
                 ? null
                 : objectMapper.convertValue(config.get("source"), Execution.PipelineSource.class))
         .withSpelEvaluator(getString(config, "spelEvaluator"))
+        .withTemplateVariables((Map<String, Object>) config.get("templateVariables"))
         .build();
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluator.java
@@ -43,7 +43,7 @@ public class PipelineExpressionEvaluator {
         "v4",
         "Evaluates expressions at stage start; supports sequential evaluation of variables in Evaluate Variables stage",
         true),
-    V3("v3", "Evaluates expressions as soon as possible, not recommended", true, true),
+    V3("v3", "Evaluates expressions as soon as possible, not recommended", true, false),
     V2("v2", "DO NOT USE", true, true);
 
     SpelEvaluatorVersion(String key, String description, boolean supported) {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -318,6 +318,16 @@ public class Execution implements Serializable {
     this.spelEvaluator = spelEvaluatorVersion;
   }
 
+  private Map<String, Object> templateVariables = null;
+
+  public @Nullable Map<String, Object> getTemplateVariables() {
+    return templateVariables;
+  }
+
+  public void setTemplateVariables(@Nullable Map<String, Object> templateVariables) {
+    this.templateVariables = templateVariables;
+  }
+
   @Nullable
   public Stage namedStage(String type) {
     return stages.stream().filter(it -> it.getType().equals(type)).findFirst().orElse(null);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
@@ -137,5 +137,11 @@ public class PipelineBuilder {
     return this;
   }
 
+  public PipelineBuilder withTemplateVariables(Map<String, Object> templateVariables) {
+    pipeline.setTemplateVariables(templateVariables);
+
+    return this;
+  }
+
   private final Execution pipeline;
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesStageSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesStageSpec.groovy
@@ -35,10 +35,10 @@ class EvaluateVariablesStageSpec extends Specification {
     setup:
     def summary = new ExpressionEvaluationSummary()
     def correctVars = [
-      [key: "a", value: 10, sourceValue: "{1+2+3+4}"],
-      [key: "b", value: 24, sourceValue: "{1*2*3*4}"],
-      [key: "product", value: 240, sourceValue: "{a * b}"],
-      [key: "nonworking", value: 'this one should fail: ${a * c}', sourceValue: 'this one should fail: {a * c}']
+      [key: "a", value: 10, sourceValue: "{1+2+3+4}", description: null],
+      [key: "b", value: 24, sourceValue: "{1*2*3*4}", description: null],
+      [key: "product", value: 240, sourceValue: "{a * b}", description: "product of a(10) and b(24)"],
+      [key: "nonworking", value: 'this one should fail: ${a * c}', sourceValue: 'this one should fail: {a * c}', description: null]
     ]
 
     def stage = stage {
@@ -47,7 +47,7 @@ class EvaluateVariablesStageSpec extends Specification {
       context["variables"] = [
         [key: "a", value: '${1+2+3+4}'],
         [key: "b", value: '${1*2*3*4}'],
-        [key: "product", value: '${a * b}'],
+        [key: "product", value: '${a * b}', description: 'product of a(${a}) and b(${b})'],
         [key: "nonworking", value: 'this one should fail: ${a * c}']
       ]
     }
@@ -58,7 +58,7 @@ class EvaluateVariablesStageSpec extends Specification {
     then:
     shouldContinue == false
     stage.context.variables == correctVars
-    summary.totalEvaluated == correctVars.size()
+    summary.totalEvaluated == 5
     summary.failureCount == 1
   }
 }

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/util/ExpressionUtilsSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/util/ExpressionUtilsSpec.groovy
@@ -43,17 +43,17 @@ class ExpressionUtilsSpec extends Specification {
     when:
     def result = utils.evaluateVariables(execution, ['1', '2'], 'v4',
       [
-        [key: 'var1', value: '${varFromStage1}'],
-        [key: 'var2', value: '${varFromStage2}'],
+        [key: 'var1', value: '${varFromStage1}', description: 'nothing here'],
+        [key: 'var2', value: '${varFromStage2}', description: 'should be ${varFromStage2}'],
         [key: 'sum', value: '${var1 + var2}']
       ])
 
     then:
     result.size() == 2
     result.result == [
-      [key: 'var1', value: 100, sourceValue: '{varFromStage1}'],
-      [key: 'var2', value: 200, sourceValue: '{varFromStage2}'],
-      [key: 'sum', value: 300, sourceValue: '{var1 + var2}']
+      [key: 'var1', value: 100, sourceValue: '{varFromStage1}', description: 'nothing here'],
+      [key: 'var2', value: 200, sourceValue: '{varFromStage2}', description: 'should be 200'],
+      [key: 'sum', value: 300, sourceValue: '{var1 + var2}', description: null]
     ]
   }
 
@@ -71,9 +71,9 @@ class ExpressionUtilsSpec extends Specification {
     then:
     result.size() == 2
     result.result == [
-      [key: 'var1', value: 100, sourceValue: '{varFromStage1}'],
-      [key: 'var2', value: '${varFromStage2}', sourceValue: '{varFromStage2}'],
-      [key: 'sum', value: '${var1 + var2}', sourceValue: '{var1 + var2}']
+      [key: 'var1', value: 100, sourceValue: '{varFromStage1}', description: null],
+      [key: 'var2', value: '${varFromStage2}', sourceValue: '{varFromStage2}', description: null],
+      [key: 'sum', value: '${var1 + var2}', sourceValue: '{var1 + var2}', description: null]
     ]
     result.detail.size() == 2
     result.detail.containsKey('varFromStage2')


### PR DESCRIPTION
* Fix MPTv2 with SpEL v4.
  The issue here was that `templateVariables.*` would need to be expanded in stages at pipeline creation.
  Since this is not possible anymore, `templateVariables.*` are now added to the execution and used in the evaluation context during stage execution.
  Thus the template variables are evaluated at runtime instead of creation time.
* Made SpEL v3 not deprecated (in the capabilities)
* Added description to variable in the eval vars stage