### PR TITLE
fix(rollback): Ignore disabled server groups in automatic rollbacks

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
@@ -121,6 +121,11 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage {
       additionalRollbackContext.disableOnly = true
     }
 
+    // When initiating a rollback automatically as part of deployment failure handling, only rollback to a server
+    // group that's enabled, as any disabled ones, even if newer, were likely manually marked so for being "bad"
+    // (e.g. as part of a manual rollback).
+    additionalRollbackContext.disregardDisabledCandidates = true
+
     if (strategySupportsRollback) {
       graph.add {
         it.type = rollbackClusterStage.type

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
@@ -124,7 +124,7 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage {
     // When initiating a rollback automatically as part of deployment failure handling, only rollback to a server
     // group that's enabled, as any disabled ones, even if newer, were likely manually marked so for being "bad"
     // (e.g. as part of a manual rollback).
-    additionalRollbackContext.disregardDisabledCandidates = true
+    additionalRollbackContext.onlyEnabledServerGroups = true
 
     if (strategySupportsRollback) {
       graph.add {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategy.groovy
@@ -211,12 +211,12 @@ class MonitoredDeployStrategy implements Strategy {
         resizeContext.capacity = savedCapacity // will scale to a percentage of that static capacity
       }
 
-      log.info("Adding `Grow to $p% of Desired Size` stage with context $resizeContext [executionId=${stage.execution.id}]")
+      log.info("Adding `Grow new server group to $p% of Desired Size` stage with context $resizeContext [executionId=${stage.execution.id}]")
 
       def resizeStage = newStage(
         stage.execution,
         ResizeServerGroupStage.TYPE,
-        "Grow to $p% of Desired Size",
+        "Grow new server group to $p% of Desired Size",
         resizeContext,
         stage,
         SyntheticStageOwner.STAGE_AFTER

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategy.groovy
@@ -459,7 +459,11 @@ class MonitoredDeployStrategy implements Strategy {
         serverGroup              : stageData.serverGroup,
         stageTimeoutMs           : MINUTES.toMillis(30), // timebox a rollback to 30 minutes
         additionalRollbackContext: [
-          enableAndDisableOnly: true
+          enableAndDisableOnly: true,
+          // When initiating a rollback automatically as part of deployment failure handling, only rollback to a server
+          // group that's enabled, as any disabled ones, even if newer, were likely manually marked so for being "bad"
+          // (e.g. as part of a manual rollback).
+          disregardDisabledCandidates: true
         ]
       ],
       parent,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategy.groovy
@@ -463,7 +463,7 @@ class MonitoredDeployStrategy implements Strategy {
           // When initiating a rollback automatically as part of deployment failure handling, only rollback to a server
           // group that's enabled, as any disabled ones, even if newer, were likely manually marked so for being "bad"
           // (e.g. as part of a manual rollback).
-          disregardDisabledCandidates: true
+          onlyEnabledServerGroups: true
         ]
       ],
       parent,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategy.groovy
@@ -211,12 +211,12 @@ class MonitoredDeployStrategy implements Strategy {
         resizeContext.capacity = savedCapacity // will scale to a percentage of that static capacity
       }
 
-      log.info("Adding `Grow new server group to $p% of Desired Size` stage with context $resizeContext [executionId=${stage.execution.id}]")
+      log.info("Adding `Grow ${internalStageData.newServerGroup} to $p% of Desired Size` stage with context $resizeContext [executionId=${stage.execution.id}]")
 
       def resizeStage = newStage(
         stage.execution,
         ResizeServerGroupStage.TYPE,
-        "Grow new server group to $p% of Desired Size",
+        "Grow ${internalStageData.newServerGroup} to $p% of Desired Size",
         resizeContext,
         stage,
         SyntheticStageOwner.STAGE_AFTER
@@ -231,7 +231,7 @@ class MonitoredDeployStrategy implements Strategy {
           useNameAsLabel   : true,     // hint to deck that it should _not_ override the name
         ]
 
-        log.info("Adding `Disable $p% of Desired Size` stage with context $disableContext [executionId=${stage.execution.id}]")
+        log.info("Adding `Disable $p% of Traffic on ${source.serverGroupName}` stage with context $disableContext [executionId=${stage.execution.id}]")
 
         def disablePortionStage = newStage(
           stage.execution,

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
@@ -89,8 +89,8 @@ class CreateServerGroupStageSpec extends Specification {
     false                   | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] | false      || [[source: "parent"]]
     true                    | "redblack"        | ["us-west-1": ["myapplication-stack-v001"]] | false      || [[source: "parent"]]      // only rollback if task has failed
     true                    | "highlander"      | ["us-west-1": ["myapplication-stack-v001"]] | false      || [[source: "parent"]]      // highlander is not supported
-    true                    | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] | false      || [expectedRollbackContext([enableAndDisableOnly: true]), [source: "parent"]]
-    true                    | "redblack"        | ["us-west-1": ["myapplication-stack-v001"]] | true       || [expectedRollbackContext([disableOnly: true]), [source: "parent"]]
+    true                    | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] | false      || [expectedRollbackContext([enableAndDisableOnly: true, disregardDisabledCandidates: true]), [source: "parent"]]
+    true                    | "redblack"        | ["us-west-1": ["myapplication-stack-v001"]] | true       || [expectedRollbackContext([disableOnly: true, disregardDisabledCandidates:true]), [source: "parent"]]
   }
 
   def "should build DestroyStage when 'rollbackDestroyLatest' is enabled"() {
@@ -127,7 +127,7 @@ class CreateServerGroupStageSpec extends Specification {
     true                    | null              | ["us-west-1": ["myapplication-stack-v001"]] || [expectedDestroyContext()]
     false                   | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] || []
     true                    | "highlander"      | ["us-west-1": ["myapplication-stack-v001"]] || [expectedDestroyContext()] // highlander does not support rollback
-    true                    | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] || [expectedRollbackContext([enableAndDisableOnly: true]), expectedDestroyContext()]
+    true                    | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] || [expectedRollbackContext([enableAndDisableOnly: true, disregardDisabledCandidates: true]), expectedDestroyContext()]
   }
 
   Map expectedRollbackContext(Map<String, Object> additionalRollbackContext) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
@@ -89,8 +89,8 @@ class CreateServerGroupStageSpec extends Specification {
     false                   | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] | false      || [[source: "parent"]]
     true                    | "redblack"        | ["us-west-1": ["myapplication-stack-v001"]] | false      || [[source: "parent"]]      // only rollback if task has failed
     true                    | "highlander"      | ["us-west-1": ["myapplication-stack-v001"]] | false      || [[source: "parent"]]      // highlander is not supported
-    true                    | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] | false      || [expectedRollbackContext([enableAndDisableOnly: true, disregardDisabledCandidates: true]), [source: "parent"]]
-    true                    | "redblack"        | ["us-west-1": ["myapplication-stack-v001"]] | true       || [expectedRollbackContext([disableOnly: true, disregardDisabledCandidates:true]), [source: "parent"]]
+    true                    | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] | false      || [expectedRollbackContext([enableAndDisableOnly: true, onlyEnabledServerGroups: true]), [source: "parent"]]
+    true                    | "redblack"        | ["us-west-1": ["myapplication-stack-v001"]] | true       || [expectedRollbackContext([disableOnly: true, onlyEnabledServerGroups:true]), [source: "parent"]]
   }
 
   def "should build DestroyStage when 'rollbackDestroyLatest' is enabled"() {
@@ -127,7 +127,7 @@ class CreateServerGroupStageSpec extends Specification {
     true                    | null              | ["us-west-1": ["myapplication-stack-v001"]] || [expectedDestroyContext()]
     false                   | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] || []
     true                    | "highlander"      | ["us-west-1": ["myapplication-stack-v001"]] || [expectedDestroyContext()] // highlander does not support rollback
-    true                    | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] || [expectedRollbackContext([enableAndDisableOnly: true, disregardDisabledCandidates: true]), expectedDestroyContext()]
+    true                    | "rollingredblack" | ["us-west-1": ["myapplication-stack-v001"]] || [expectedRollbackContext([enableAndDisableOnly: true, onlyEnabledServerGroups: true]), expectedDestroyContext()]
   }
 
   Map expectedRollbackContext(Map<String, Object> additionalRollbackContext) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
@@ -111,8 +111,8 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
     buildAdditionalStageContext("servergroup-v002", true)   | false                || true                   || false                 || "servergroup-v000" || "my_image-0"
   }
 
-  def buildAdditionalStageContext(String serverGroup, boolean disregardDisabledCandidates) {
-    [moniker: null, serverGroup: serverGroup, additionalRollbackContext: [disregardDisabledCandidates: disregardDisabledCandidates]]
+  private static def buildAdditionalStageContext(String serverGroup, boolean onlyEnabledServerGroups) {
+    [moniker: null, serverGroup: serverGroup, additionalRollbackContext: [onlyEnabledServerGroups: onlyEnabledServerGroups]]
   }
 
   def "should build PREVIOUS_IMAGE rollback context when there are _only_ entity tags"() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
@@ -76,7 +76,7 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
       return buildResponse([
         serverGroups: [
           buildServerGroup("servergroup-v000", "us-west-2", 50, false, [name: "my_image-0"], [:], 5),
-          // disabled server groups should be skipped when evaluating rollback candidates
+          // disabled server groups should be skipped when evaluating rollback candidates, but only on automatic rollbacks after a failed deployment
           buildServerGroup("servergroup-v001", "us-west-2", 100, true, [name: "my_image-1"], [:], 5),
           buildServerGroup("servergroup-v002", "us-west-2", 150, false, [name: "my_image-2"], [:], 5)
         ]
@@ -87,7 +87,7 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
 
     result.context == [
       imagesToRestore: [
-        [region: "us-west-2", image: "my_image-0", rollbackMethod: "EXPLICIT"]
+        [region: "us-west-2", image: expectedImage, rollbackMethod: "EXPLICIT"]
       ]
     ]
     result.outputs == [
@@ -97,16 +97,22 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
       rollbackContexts: [
         "us-west-2": [
           rollbackServerGroupName        : "servergroup-v002",
-          restoreServerGroupName         : "servergroup-v000",
+          restoreServerGroupName         : expectedCandidate,
           targetHealthyRollbackPercentage: 100
         ]
       ]
     ]
 
     where:
-    additionalStageContext                           | areEntityTagsEnabled || shouldFetchServerGroup || shouldFetchEntityTags
-    [:]                                              | true                 || false                  || true       // stage context includes moniker, no need to fetch server group
-    [moniker: null, serverGroup: "servergroup-v002"] | false                || true                   || false
+    additionalStageContext                                  | areEntityTagsEnabled || shouldFetchServerGroup || shouldFetchEntityTags || expectedCandidate  || expectedImage
+    [:]                                                     | true                 || false                  || true                  || "servergroup-v001" || "my_image-1"
+    [moniker: null, serverGroup: "servergroup-v002"]        | false                || true                   || false                 || "servergroup-v001" || "my_image-1"
+    buildAdditionalStageContext("servergroup-v002", false)  | false                || true                   || false                 || "servergroup-v001" || "my_image-1"
+    buildAdditionalStageContext("servergroup-v002", true)   | false                || true                   || false                 || "servergroup-v000" || "my_image-0"
+  }
+
+  def buildAdditionalStageContext(String serverGroup, boolean disregardDisabledCandidates) {
+    [moniker: null, serverGroup: serverGroup, additionalRollbackContext: [disregardDisabledCandidates: disregardDisabledCandidates]]
   }
 
   def "should build PREVIOUS_IMAGE rollback context when there are _only_ entity tags"() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
@@ -64,7 +64,7 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    (shouldFetchServerGroup ? 1 : 0) * oortService.getServerGroup("test", "us-west-2", "servergroup-v001") >> {
+    (shouldFetchServerGroup ? 1 : 0) * oortService.getServerGroup("test", "us-west-2", "servergroup-v002") >> {
       return buildResponse([
         moniker: [
           app    : "app",
@@ -75,8 +75,10 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
     1 * oortService.getCluster("app", "test", "app-stack-details", "aws") >> {
       return buildResponse([
         serverGroups: [
-          buildServerGroup("servergroup-v000", "us-west-2", 50, true, [name: "my_image-0"], [:], 5),
-          buildServerGroup("servergroup-v001", "us-west-2", 100, false, [name: "my_image-1"], [:], 5)
+          buildServerGroup("servergroup-v000", "us-west-2", 50, false, [name: "my_image-0"], [:], 5),
+          // disabled server groups should be skipped when evaluating rollback candidates
+          buildServerGroup("servergroup-v001", "us-west-2", 100, true, [name: "my_image-1"], [:], 5),
+          buildServerGroup("servergroup-v002", "us-west-2", 150, false, [name: "my_image-2"], [:], 5)
         ]
       ])
     }
@@ -94,7 +96,7 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
       ],
       rollbackContexts: [
         "us-west-2": [
-          rollbackServerGroupName        : "servergroup-v001",
+          rollbackServerGroupName        : "servergroup-v002",
           restoreServerGroupName         : "servergroup-v000",
           targetHealthyRollbackPercentage: 100
         ]
@@ -104,7 +106,7 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
     where:
     additionalStageContext                           | areEntityTagsEnabled || shouldFetchServerGroup || shouldFetchEntityTags
     [:]                                              | true                 || false                  || true       // stage context includes moniker, no need to fetch server group
-    [moniker: null, serverGroup: "servergroup-v001"] | false                || true                   || false
+    [moniker: null, serverGroup: "servergroup-v002"] | false                || true                   || false
   }
 
   def "should build PREVIOUS_IMAGE rollback context when there are _only_ entity tags"() {


### PR DESCRIPTION
We observed that, when a `RollbackClusterStage` was executed to rollback a failed deployment, the `DetermineRollbackCandidatesTask` was including disabled server groups when determining the target server group to rollback to, despite explicit class comments to the contrary. It did filter out disabled server groups when determining the newest server group, but not when actually determining the one to rollback to.

This was easily reproducible by creating 2 server groups `v000` and `v001` in a cluster, then disabling `v001`, then using a pipeline to deploy a new server group `v002` to the cluster. When this deployment failed, instead of rolling back to `v000`, we would rollback to the disabled group `v001`.

The fix should be self-explanatory given the context above.

Update: upon further consideration, we realized that changing this behavior might affect existing pipelines with a `RollbackClusterStage`, and so a condition was added to only exclude disabled server groups if the stage was initiated as part of an automatic rollback from a failed deployment stage.