### PR TITLE
perf(pipelines): Use new endpoint to fetch pipeline config

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -54,8 +54,8 @@ interface Front50Service {
   @GET("/pipelines/{applicationName}")
   List<Map<String, Object>> getPipelines(@Path("applicationName") String applicationName, @Query("refresh") boolean refresh)
 
-  @GET("/pipelines/{pipelineId}/history")
-  List<Map<String, Object>> getPipelineHistory(@Path("pipelineId") String pipelineId, @Query("limit") int limit)
+  @GET("/pipelines/{pipelineId}/get")
+  Map<String, Object> getPipeline(@Path("pipelineId") String pipelineId)
 
   @POST("/pipelines")
   Response savePipeline(@Body Map pipeline)

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/EnabledPipelineValidator.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/EnabledPipelineValidator.java
@@ -60,20 +60,17 @@ public class EnabledPipelineValidator implements PipelineValidator {
       try {
         // attempt an optimized lookup via pipeline history vs fetching all pipelines for the
         // application and filtering
-        List<Map<String, Object>> pipelineConfigHistory =
-            front50Service.getPipelineHistory(pipeline.getPipelineConfigId(), 1);
+        Map<String, Object> pipelineConfig =
+            front50Service.getPipeline(pipeline.getPipelineConfigId());
 
-        if (!pipelineConfigHistory.isEmpty()) {
-          Map<String, Object> pipelineConfig = pipelineConfigHistory.get(0);
-          if ((boolean) pipelineConfig.getOrDefault("disabled", false)) {
-            throw new PipelineIsDisabled(
-                pipelineConfig.get("id").toString(),
-                pipelineConfig.get("application").toString(),
-                pipelineConfig.get("name").toString());
-          }
-
-          return;
+        if ((boolean) pipelineConfig.getOrDefault("disabled", false)) {
+          throw new PipelineIsDisabled(
+              pipelineConfig.get("id").toString(),
+              pipelineConfig.get("application").toString(),
+              pipelineConfig.get("name").toString());
         }
+
+        return;
       } catch (RetrofitError ignored) {
         // treat a failure to fetch pipeline config history as non-fatal and fallback to the
         // previous behavior

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/pipeline/EnabledPipelineValidatorSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/pipeline/EnabledPipelineValidatorSpec.groovy
@@ -39,7 +39,7 @@ class EnabledPipelineValidatorSpec extends Specification {
     validator.checkRunnable(execution)
 
     then:
-    1 * front50Service.getPipelineHistory(execution.pipelineConfigId, 1) >> []
+    1 * front50Service.getPipeline(execution.pipelineConfigId) >> { throw notFoundError() }
     1 * front50Service.getPipelines(execution.application, false) >> []
 
     notThrown(PipelineValidationFailed)
@@ -56,8 +56,7 @@ class EnabledPipelineValidatorSpec extends Specification {
     validator.checkRunnable(execution)
 
     then:
-    1 * front50Service.getPipelineHistory(execution.pipelineConfigId, 1) >> [
-    ]
+    1 * front50Service.getPipeline(execution.pipelineConfigId) >> { throw notFoundError() }
     1 * front50Service.getPipelines(execution.application, false) >> [
         [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: false]
     ]
@@ -69,14 +68,7 @@ class EnabledPipelineValidatorSpec extends Specification {
     validator.checkRunnable(execution)
 
     then:
-    1 * front50Service.getPipelineHistory(execution.pipelineConfigId, 1) >> {
-      throw RetrofitError.httpError(
-          "http://localhost",
-          new Response("http://localhost", HTTP_NOT_FOUND, "Not Found", [], null),
-          null,
-          null
-      )
-    }
+    1 * front50Service.getPipeline(execution.pipelineConfigId) >> { throw notFoundError() }
     1 * front50Service.getPipelines(execution.application, false) >> [
         [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: false]
     ]
@@ -88,9 +80,7 @@ class EnabledPipelineValidatorSpec extends Specification {
     validator.checkRunnable(execution)
 
     then:
-    1 * front50Service.getPipelineHistory(execution.pipelineConfigId, 1) >> [
-        [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: false]
-    ]
+    1 * front50Service.getPipeline(execution.pipelineConfigId) >> [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: false]
     0 * _
 
     notThrown(PipelineValidationFailed)
@@ -107,8 +97,7 @@ class EnabledPipelineValidatorSpec extends Specification {
     validator.checkRunnable(execution)
 
     then:
-    1 * front50Service.getPipelineHistory(execution.pipelineConfigId, 1) >> [
-    ]
+    1 * front50Service.getPipeline(execution.pipelineConfigId) >> { throw notFoundError() }
     1 * front50Service.getPipelines(execution.application, false) >> [
         [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: true]
     ]
@@ -120,9 +109,7 @@ class EnabledPipelineValidatorSpec extends Specification {
     validator.checkRunnable(execution)
 
     then:
-    1 * front50Service.getPipelineHistory(execution.pipelineConfigId, 1) >> [
-        [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: true]
-    ]
+    1 * front50Service.getPipeline(execution.pipelineConfigId) >> [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: true]
     0 * _
 
     thrown(EnabledPipelineValidator.PipelineIsDisabled)
@@ -181,9 +168,7 @@ class EnabledPipelineValidatorSpec extends Specification {
     validator.checkRunnable(execution)
 
     then:
-    1 * front50Service.getPipelineHistory(execution.pipelineConfigId, 1) >> [
-        [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: false]
-    ]
+    1 * front50Service.getPipeline(execution.pipelineConfigId) >> [id: execution.pipelineConfigId, application: execution.application, name: "whatever", disabled: false]
 
     notThrown(PipelineValidationFailed)
 
@@ -194,4 +179,14 @@ class EnabledPipelineValidatorSpec extends Specification {
       trigger = new DefaultTrigger("manual", null, "fzlem", [strategy: "kthxbye"])
     }
   }
+
+  def notFoundError() {
+    RetrofitError.httpError(
+      "http://localhost",
+      new Response("http://localhost", HTTP_NOT_FOUND, "Not Found", [], null),
+      null,
+      null
+    )
+  }
+
 }

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -744,11 +744,7 @@ class OperationsControllerSpec extends Specification {
     executionLauncher.start(*_) >> { ExecutionType type, String json ->
       startedPipeline = mapper.readValue(json, Execution)
     }
-    front50Service.getPipelineHistory("1234", 1) >> {
-      [
-        [id: '1234', stages: []]
-      ]
-    }
+    front50Service.getPipeline("1234") >> [id: '1234', stages: []]
 
     Map trigger = [
       type      : "manual",


### PR DESCRIPTION
All calls from orca to the front50 /pipelines/id/history endpoint pass limit=1. Replace these with the new endpoint /pipelines/id/get that gets the current state of the pipeline config and does so more performantly than the history endpoint.

Requires front50 >= 2.11.0, which is when this new endpoint was added.