### PR TITLE
refactor(managed-delivery): Rename publishDeliveryConfig to importDeliveryConfig

### DIFF
--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/pipeline/ImportDeliveryConfigStage.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/pipeline/ImportDeliveryConfigStage.kt
@@ -17,8 +17,9 @@
 package com.netflix.spinnaker.orca.keel.pipeline
 
 import com.netflix.spinnaker.orca.Task
-import com.netflix.spinnaker.orca.keel.task.PublishDeliveryConfigTask
+import com.netflix.spinnaker.orca.keel.task.ImportDeliveryConfigTask
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder.Aliases
 import com.netflix.spinnaker.orca.pipeline.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.Stage
 import org.springframework.stereotype.Component
@@ -29,9 +30,10 @@ import kotlin.reflect.KClass
  * Generally this will be added to a single-stage pipeline with a git trigger to support GitOps flows.
  */
 @Component
-class PublishDeliveryConfigStage : StageDefinitionBuilder {
+@Aliases("publishDeliveryConfig")
+class ImportDeliveryConfigStage : StageDefinitionBuilder {
   override fun taskGraph(stage: Stage, builder: TaskNode.Builder) {
-    builder.withTask("publishDeliveryConfig", PublishDeliveryConfigTask::class)
+    builder.withTask("importDeliveryConfig", ImportDeliveryConfigTask::class)
   }
 
   private fun TaskNode.Builder.withTask(name: String, type: KClass<out Task>) =

--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit
  * to support GitOps flows.
  */
 @Component
-class PublishDeliveryConfigTask
+class ImportDeliveryConfigTask
 constructor(
   private val keelService: KeelService,
   private val scmService: ScmService,

--- a/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
+++ b/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.orca.ExecutionStatus
 import com.netflix.spinnaker.orca.KeelService
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.igor.ScmService
-import com.netflix.spinnaker.orca.keel.task.PublishDeliveryConfigTask
+import com.netflix.spinnaker.orca.keel.task.ImportDeliveryConfigTask
 import com.netflix.spinnaker.orca.pipeline.model.DefaultTrigger
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.GitTrigger
@@ -40,7 +40,7 @@ import strikt.api.expectThrows
 import strikt.assertions.isEqualTo
 import java.lang.IllegalArgumentException
 
-internal class PublishDeliveryConfigTaskTests : JUnit5Minutests {
+internal class ImportDeliveryConfigTaskTests : JUnit5Minutests {
   data class ManifestLocation(
     val repoType: String,
     val projectKey: String,
@@ -85,7 +85,7 @@ internal class PublishDeliveryConfigTaskTests : JUnit5Minutests {
       } returns Response("http://keel", 200, "", emptyList(), null)
     }
 
-    val subject = PublishDeliveryConfigTask(keelService, scmService, objectMapper)
+    val subject = ImportDeliveryConfigTask(keelService, scmService, objectMapper)
 
     fun execute(context: Map<String, Any?>) =
       subject.execute(
@@ -284,7 +284,7 @@ internal class PublishDeliveryConfigTaskTests : JUnit5Minutests {
 
         test("task retries if max retries not reached") {
           var result: TaskResult
-          for (attempt in 1 until PublishDeliveryConfigTask.MAX_RETRIES) {
+          for (attempt in 1 until ImportDeliveryConfigTask.MAX_RETRIES) {
             result = execute(manifestLocation.toMap().also { it["attempt"] = attempt })
             expectThat(result.status).isEqualTo(ExecutionStatus.RUNNING)
             expectThat(result.context["attempt"]).isEqualTo(attempt + 1)
@@ -292,7 +292,7 @@ internal class PublishDeliveryConfigTaskTests : JUnit5Minutests {
         }
 
         test("task fails if max retries reached") {
-          val result = execute(manifestLocation.toMap().also { it["attempt"] = PublishDeliveryConfigTask.MAX_RETRIES })
+          val result = execute(manifestLocation.toMap().also { it["attempt"] = ImportDeliveryConfigTask.MAX_RETRIES })
           expectThat(result.status).isEqualTo(ExecutionStatus.TERMINAL)
         }
       }


### PR DESCRIPTION
As discussed in https://github.com/spinnaker/deck/pull/7733, this renames the `publishDeliveryConfig` stage and associated classes to `importDeliveryConfig` for clarity, since this concept is exposed to users and from their perspective we're not publishing the delivery config anywhere, but rather pulling (i.e. importing) it into Spinnaker.