### PR TITLE
feat(managed-delivery): Add support for other types of code triggers

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/GitTrigger.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/GitTrigger.kt
@@ -30,13 +30,13 @@ data class GitTrigger
   override var isRebake: Boolean = false,
   override var isDryRun: Boolean = false,
   override var isStrategy: Boolean = false,
-  val hash: String,
-  val source: String,
-  val project: String,
-  val branch: String,
-  val slug: String,
+  override val hash: String,
+  override val source: String,
+  override val project: String,
+  override val branch: String,
+  override val slug: String,
   val action: String
-) : Trigger {
+) : Trigger, SourceCodeTrigger {
   override var other: Map<String, Any> = mutableMapOf()
   override var resolvedExpectedArtifacts: List<ExpectedArtifact> = mutableListOf()
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/SourceCodeTrigger.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/SourceCodeTrigger.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.model
+
+/**
+ * Defines properties that are common across different types of source code triggers.
+ */
+interface SourceCodeTrigger {
+  val source: String
+  val project: String
+  val branch: String
+  val slug: String
+  val hash: String
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
@@ -31,11 +31,11 @@ import com.netflix.spinnaker.orca.pipeline.model.NexusTrigger
 import com.netflix.spinnaker.orca.pipeline.model.PipelineTrigger
 import com.netflix.spinnaker.orca.pipeline.model.Trigger
 
-internal class TriggerDeserializer :
+class TriggerDeserializer :
   StdDeserializer<Trigger>(Trigger::class.java) {
 
   companion object {
-    val customTriggerSuppliers: MutableList<CustomTriggerDeserializerSupplier> = mutableListOf()
+    val customTriggerSuppliers: MutableSet<CustomTriggerDeserializerSupplier> = mutableSetOf()
   }
 
   override fun deserialize(parser: JsonParser, context: DeserializationContext): Trigger =


### PR DESCRIPTION
This adds support for other types of source code triggers to the delivery config import stage, beyond just git, by introducing a common interface for those types of triggers.

Note: while testing this, I actually found out that, because for some reason we deserialize, then re-serialize, then deserialize the trigger and/or pipeline JSON when triggering pipelines, during that second deserialization pass my new code trigger type, which is private to Netflix and looks almost the same as a `GitTrigger`, ends up getting converted to a `GitTrigger` by `TriggerDeserializer`. This doesn't have any undesired side-effects, but I thought I'd mention it because I wasn't sure this was intended behavior (the back-and-forth serialization, that is).