### PR TITLE
refactor(trigger): Clean-up from adding SourceCodeTrigger

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/GitTrigger.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/GitTrigger.kt
@@ -36,7 +36,7 @@ data class GitTrigger
   override val branch: String,
   override val slug: String,
   val action: String
-) : Trigger, SourceCodeTrigger {
+) : SourceCodeTrigger {
   override var other: Map<String, Any> = mutableMapOf()
   override var resolvedExpectedArtifacts: List<ExpectedArtifact> = mutableListOf()
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/SourceCodeTrigger.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/SourceCodeTrigger.kt
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.orca.pipeline.model
 /**
  * Defines properties that are common across different types of source code triggers.
  */
-interface SourceCodeTrigger {
+interface SourceCodeTrigger : Trigger {
   val source: String
   val project: String
   val branch: String


### PR DESCRIPTION
I missed this in #3357 -- my bad. This is not required, but makes things cleaner.