### PR TITLE
fix(stats): mpt tracking

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/Execution.java
@@ -513,5 +513,15 @@ public class Execution implements Serializable {
     public void setType(@Nonnull String type) {
       this.type = type;
     }
+
+    private String version;
+
+    public @Nonnull String getVersion() {
+      return version;
+    }
+
+    public void setVersion(@Nonnull String version) {
+      this.version = version;
+    }
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/V2Util.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/V2Util.java
@@ -16,9 +16,12 @@
 
 package com.netflix.spinnaker.orca.pipelinetemplate;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.kork.web.exceptions.ValidationException;
 import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor;
 import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
+import com.netflix.spinnaker.orca.pipeline.model.Execution.PipelineSource;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
 import java.util.Collections;
 import java.util.HashMap;
@@ -73,6 +76,13 @@ public class V2Util {
         throw new ValidationException(
             "Missing template variable values for the following variables: %s", failedTemplateVars);
       }
+    }
+
+    if (!spelEvaluatedPipeline.containsKey("source")) {
+      Execution.PipelineSource source = new PipelineSource();
+      source.setType("templatedPipeline");
+      source.setVersion("v2");
+      spelEvaluatedPipeline.put("source", new ObjectMapper().convertValue(source, Map.class));
     }
 
     return spelEvaluatedPipeline;

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
@@ -42,6 +42,7 @@ public class V1SchemaExecutionGenerator implements ExecutionGenerator {
       Map<String, String> source = new HashMap<>();
       source.put("id", template.getSource());
       source.put("type", "templatedPipeline");
+      source.put("version", "v1");
       pipeline.put("source", source);
     }
     if (request.getExecutionId() != null) {

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -127,7 +127,8 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
       notifications: [],
       source: [
         id: source("simple-001.yml"),
-        type: "templatedPipeline"
+        type: "templatedPipeline",
+        version: "v1"
       ],
       stages: [
         [

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-expected.json
@@ -3,7 +3,8 @@
   "name": "Stage dependsOn test",
   "source": {
     "id": "dependsOn-template.yml",
-    "type": "templatedPipeline"
+    "type": "templatedPipeline",
+    "version": "v1"
   },
   "stages": [
     {

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-expected.json
@@ -5,7 +5,8 @@
   "name": "My super awesome pipeline",
   "source": {
     "id": "example-root.yml,example-child.yml",
-    "type": "templatedPipeline"
+    "type": "templatedPipeline",
+    "version": "v1"
   },
   "stages": [
     {

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-expected.json
@@ -5,7 +5,8 @@
   "name": "My super awesome pipeline",
   "source": {
     "id": "exampleCombined-template.yml",
-    "type": "templatedPipeline"
+    "type": "templatedPipeline",
+    "version": "v1"
   },
   "stages": [
     {

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/inheritance-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/inheritance-expected.json
@@ -5,7 +5,8 @@
   "name": "MPT Inheritance Test",
   "source": {
     "id": "inheritance-root.yml",
-    "type": "templatedPipeline"
+    "type": "templatedPipeline",
+    "version": "v1"
   },
   "stages": [
     {

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/stageReplacement-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/stageReplacement-expected.json
@@ -7,7 +7,8 @@
   "notifications": [],
   "source": {
     "id": "stageReplacement-template.yml",
-    "type": "templatedPipeline"
+    "type": "templatedPipeline",
+    "version": "v1"
   },
   "stages": [
     {


### PR DESCRIPTION
Part of https://github.com/spinnaker/spinnaker/issues/5302

Goes in tandem with https://github.com/spinnaker/echo/pull/740

MPT V1 pipelines have a `source` field that can point to a remote resource. This PR adds to that field the version, and then uses that new version field in the V2 impl as well. This allows us to know when a pipeline execution came from either MPT V1 or V2 when collecting usage stats.