### PR TITLE
chore(retrofit): Expose OK3Client using api dependency

### DIFF
--- a/orca-retrofit/orca-retrofit.gradle
+++ b/orca-retrofit/orca-retrofit.gradle
@@ -19,6 +19,7 @@ apply from: "$rootDir/gradle/groovy.gradle"
 dependencies {
   api("com.squareup.retrofit:retrofit")
   api("com.squareup.retrofit:converter-jackson")
+  api("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
 
   implementation(project(":orca-core"))
   implementation("com.squareup.okhttp:okhttp")
@@ -26,7 +27,6 @@ dependencies {
   implementation("com.squareup.okhttp:okhttp-apache")
   implementation("com.netflix.spinnaker.kork:kork-web")
   implementation("io.reactivex:rxjava")
-  implementation("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
 
   testImplementation("com.squareup.retrofit:retrofit-mock")
 }


### PR DESCRIPTION
`orca-retrofit` configuration provides a bean of type `Ok3Client` which is useful to create new Retrofit client when extending Orca and retaining metrics, user agent, etc.

However, the class is defined `com.jakewharton.retrofit:retrofit1-okhttp3-client` and is not exposed as `api` dependency, so we'll have to add it ourselves (which is not ideal as this package is not tracked `orca-bom`). This PR fixes that.