### PR TITLE
Revert "chore(java11): Switch the default containers to use Java 11."

### DIFF
--- a/Dockerfile.java8
+++ b/Dockerfile.java8
@@ -1,7 +1,0 @@
-FROM alpine:3.11
-MAINTAINER delivery-engineering@netflix.com
-COPY --from=compile /compiled_sources/orca-web/build/install/orca /opt/orca
-RUN apk --no-cache add --update bash openjdk8-jre
-RUN adduser -D -S spinnaker
-USER spinnaker
-CMD ["/opt/orca/bin/orca"]

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,7 +1,7 @@
 FROM alpine:3.11
 MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/orca-web/build/install/orca /opt/orca
-RUN apk --no-cache add --update bash openjdk11-jre
+RUN apk --no-cache add --update bash openjdk8-jre
 RUN adduser -D -S spinnaker
 USER spinnaker
 CMD ["/opt/orca/bin/orca"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/orca-web/build/install/orca /opt/orca
-RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget
+RUN apt-get update && apt-get -y install openjdk-8-jre-headless wget
 RUN adduser --disabled-login --system spinnaker
 USER spinnaker
 CMD ["/opt/orca/bin/orca"]

--- a/Dockerfile.ubuntu-java8
+++ b/Dockerfile.ubuntu-java8
@@ -1,7 +1,0 @@
-FROM ubuntu:bionic
-MAINTAINER delivery-engineering@netflix.com
-COPY --from=compile /compiled_sources/orca-web/build/install/orca /opt/orca
-RUN apt-get update && apt-get -y install openjdk-8-jre-headless wget
-RUN adduser --disabled-login --system spinnaker
-USER spinnaker
-CMD ["/opt/orca/bin/orca"]


### PR DESCRIPTION
Reverts spinnaker/orca#3367

Java 11 has issues with kork's `PluginLoader`.