### PR TITLE
feat(admin): Add queue admin EPs

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/admin/web/QueueAdminController.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/admin/web/QueueAdminController.kt
@@ -15,11 +15,15 @@
  */
 package com.netflix.spinnaker.orca.q.admin.web
 
+import com.netflix.spinnaker.orca.q.StartWaitingExecutions
 import com.netflix.spinnaker.orca.q.admin.HydrateQueueCommand
 import com.netflix.spinnaker.orca.q.admin.HydrateQueueInput
 import com.netflix.spinnaker.orca.q.admin.HydrateQueueOutput
+import com.netflix.spinnaker.q.Message
+import com.netflix.spinnaker.q.Queue
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import java.time.Instant
 import javax.ws.rs.QueryParam
@@ -27,10 +31,11 @@ import javax.ws.rs.QueryParam
 @RestController
 @RequestMapping("/admin/queue")
 class QueueAdminController(
-  private val hydrateCommand: HydrateQueueCommand
+  private val hydrateCommand: HydrateQueueCommand,
+  private val queue: Queue
 ) {
 
-  @RequestMapping(value = ["/hydrate"], method = [(RequestMethod.POST)])
+  @PostMapping(value = ["/hydrate"])
   fun hydrateQueue(
     @QueryParam("dryRun") dryRun: Boolean?,
     @QueryParam("executionId") executionId: String?,
@@ -43,4 +48,39 @@ class QueueAdminController(
       if (endMs != null) Instant.ofEpochMilli(endMs) else null,
       dryRun ?: true
     ))
+
+  /**
+   * Posts StartWaitingExecutions message for the given pipeline message into the queue.
+   * This is useful when doing DB migration. If an execution is running from an old DB
+   * and a new execution is queue in the new DB it will be correctly buffered/pended.
+   * However, the old orca instance (pointed to old DB) won't know about these pending
+   * executions and thus won't kick them off. To the user this looks like an execution
+   * that will never start.
+   */
+  @PostMapping(value = ["kickPending"])
+  fun kickPendingExecutions(
+    @QueryParam("pipelineConfigId") pipelineConfigId: String,
+    @QueryParam("purge") purge: Boolean?
+  ) {
+
+    queue.push(StartWaitingExecutions(pipelineConfigId, purge ?: false))
+  }
+
+  /**
+   * Push any message into the queue.
+   *
+   * Note: you must specify the message type in the body to ensure it gets parse correctly, e.g.:
+   *
+   * {
+   *   "kind": "startWaitingExecutions",
+   *   "pipelineConfigId": "1acd0724-082e-4b8d-a987-9df7f8baf03f",
+   *   "purge": false
+   * }
+   */
+  @PostMapping(value = ["pushMessage"])
+  fun pushMessageIntoQueue(
+    @RequestBody message: Message
+  ) {
+    queue.push(message)
+  }
 }


### PR DESCRIPTION
Adds two endpoints:
1. Generic endpoint to post any message into the queue
2. A simplified EP to specifically post `StartWaitingExecutions` into the queue
