### PR TITLE
fix(test): Fix flaky queue integration test

### DIFF
--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/ExecutionLatch.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/ExecutionLatch.kt
@@ -43,7 +43,7 @@ class ExecutionLatch(private val predicate: Predicate<ExecutionComplete>) :
     }
   }
 
-  fun await() = latch.await(5, TimeUnit.SECONDS)
+  fun await() = latch.await(10, TimeUnit.SECONDS)
 }
 
 fun ConfigurableApplicationContext.runToCompletion(execution: Execution, launcher: (Execution) -> Unit, repository: ExecutionRepository) {


### PR DESCRIPTION
The test are starting to fail quite frequently with an assertion failure "Pipeline did not complete".  This is because we assert that an execution has started within 5 seconds of requesting it, which appears to fail frequently when running in constrained CPU environments.

Double the timeout to 10 seconds to alleviate the issue, though a better fix would probably be to avoid having an arbitrary timeout at all.  (Perhaps the test function would wait until the queue is quiescent before proceeding?)