### PR TITLE
refactor(artifacts): Some minor cleanup of artifact handling

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -23,21 +23,20 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
 import java.util.Optional;
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /** This class handles resolving a collection of {@link ExpectedArtifact} instances. */
-@ParametersAreNonnullByDefault
+@NonnullByDefault
 public final class ArtifactResolver {
-  @Nonnull private final ImmutableList<Artifact> currentArtifacts;
-  @Nonnull private final Supplier<ImmutableList<Artifact>> priorArtifacts;
+  private final ImmutableList<Artifact> currentArtifacts;
+  private final Supplier<ImmutableList<Artifact>> priorArtifacts;
   private final boolean requireUniqueMatches;
 
   private ArtifactResolver(
@@ -178,12 +177,12 @@ public final class ArtifactResolver {
      * expected artifact. If an artifact matches more than one expected artifact, it is returned
      * only once.
      */
-    @Nonnull private final ImmutableList<Artifact> resolvedArtifacts;
+    private final ImmutableList<Artifact> resolvedArtifacts;
     /**
      * This field contains the resolved expected artifacts; each resolved expected artifact is a
      * copy of the input expected artifact with its {@link ExpectedArtifact#getBoundArtifact()} set
      * to the artifact that it matched during resolution.
      */
-    @Nonnull private final ImmutableList<ExpectedArtifact> resolvedExpectedArtifacts;
+    private final ImmutableList<ExpectedArtifact> resolvedExpectedArtifacts;
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.orca.pipeline.util;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -28,6 +27,7 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
 import java.util.Optional;
+import java.util.function.Supplier;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -45,7 +45,7 @@ public final class ArtifactResolver {
       boolean requireUniqueMatches) {
     this.currentArtifacts = ImmutableList.copyOf(currentArtifacts);
     this.priorArtifacts =
-        Suppliers.memoize(Suppliers.compose(ImmutableList::copyOf, priorArtifacts));
+        Suppliers.memoize(Suppliers.compose(ImmutableList::copyOf, priorArtifacts::get));
     this.requireUniqueMatches = requireUniqueMatches;
   }
 


### PR DESCRIPTION
* refactor(artifacts): Simplify error handling of incorrect StageContext 

  Two functions log a warning and return a default value if the input StageContext is not of the correct type. Instead of putting the entire (or bulk of the) function in an if/else block, just check the desired condition and return early if it fails, pulling the rest of the function out of the if/else block.

  In the case of getBoundArtifactForId, just return null early rather than process an empty list that will eventually return null when nothing matches.

* refactor(artifacts): Clean up stream code in ArtifactUtils 

  A lot of stream code is overly nested, primarily because it mixes Optional.map() with Stream.map() and needs to reach into the Optional. Instead use the simpler null-safe stream pattern: Optional.ofNullable(collection).map(Collection::stream).orElse(emptyStream)

* refactor(artifacts): Add Nonnull and Nullable annotations 

  ArtifactUtils is generally good about annotating parameters and return values with Nonnull or Nullable. Add NonnullByDefault to the class so that all methods, parameters, and fields are non-null by default, and explicitly annotate those that are nullable. (Also change a nonnull Boolean to a boolean).

  Likewise, add NonnullByDefault to ArtifactResolver and remove all of the explicit Nonnull annotations.  (Nothing in that class can be null.)

* refactor(artifacts): Simplify getExecutionForPipelineId 

  Let's get out of RxJava Observable land sooner, returning all found executions as a list, and finding the max in the stream. This has two advantages:
  (1) We can similify start_time_or_id to be a Comparator instead of a Function<?,?,?>, and use the Comparator class to generate it.
  (2) (minor) We can just get the .max() of the stream instead of sorting the whole thing and getting the first element

  Also change getExecutionForPipelineId to return an Optional instead of being nullable; this makes the calling code a lot cleaner as well.

* refactor(artifacts): Simplify getAllArtifacts 

  The overload of getAllArtifacts that accepts a filter is only ever called from within the class; make it private.

  It's also overkill to make the parameter be an Optional<Predicate> as we have another overload of the function that doesn't require the parameter at all; if you're calling this one, you should pass in an actual predicate.  This simplifes the callers by unwrapping some Optionals.

  As the includeTrigger boolean is always true; remove the parameter.

  Finally, remove the objectMapper.convertValue() converting the result of trigger.getArtifacts() to List<Artifact>; this is already the type of the return value of that function.

* refactor(artifacts): ArtifactResolver should accept a Java 8 supplier 

  ArtifactResolver was accepting a guava Supplier (as it is using some guava utils to create the memoized supplier). Make things easier on clients by accepting a Java 8 supplier, and converting it to a Guava supplier within the class, hiding this implementation detail from clients.

  None of the callers actually need to change because they are all passing in a lambda which satisfies both functional interfaces, but if at some point in the future a caller has a Supplier<> in a variable, I'd rather it be able to use it directly instead of converting to a guava supplier. (A caller that has a guava supplier will still be able to use it as the guava Supplier interface extends the java 8 Supplier interface.)
