### PR TITLE
fix(webhook): Add cancel to PreconfiguredWebhook

### DIFF
--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -92,6 +92,10 @@ integrations:
 #      failFastStatusCodes:
 #        - 404
 #        - 501
+#      signalCancellation: true
+#      cancelEndpoint: https://my.webhook.com/cancel
+#      cancelMethod: POST
+#      cancelPayload: "{}"
 #      waitForCompletion: true
 #      # The rest of the properties are only used if waitForCompletion == true
 #      statusUrlResolution: webhookResponse # getMethod, locationHeader, webhookResponse

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -634,7 +634,8 @@ class OperationsControllerSpec extends Specification {
   def "should call webhookService and return correct information"() {
     given:
     def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution",
-                                   "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses"]
+                                   "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses",
+                                   "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload"]
 
     when:
     def preconfiguredWebhooks = controller.preconfiguredWebhooks()
@@ -653,7 +654,8 @@ class OperationsControllerSpec extends Specification {
   def "should not return protected preconfigured webhooks if user don't have the role"() {
     given:
     def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution",
-                                   "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses"]
+                                   "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses",
+                                   "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload"]
     executionLauncher.start(*_) >> { ExecutionType type, String json ->
       startedPipeline = mapper.readValue(json, Execution)
       startedPipeline.id = UUID.randomUUID().toString()
@@ -686,7 +688,8 @@ class OperationsControllerSpec extends Specification {
   def "should return protected preconfigured webhooks if user have the role"() {
     given:
     def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution",
-                                   "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses"]
+                                   "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses",
+                                   "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload"]
     executionLauncher.start(*_) >> { ExecutionType type, String json ->
       startedPipeline = mapper.readValue(json, Execution)
       startedPipeline.id = UUID.randomUUID().toString()
@@ -772,7 +775,7 @@ class OperationsControllerSpec extends Specification {
       url: "a", customHeaders: customHeaders, method: HttpMethod.POST, payload: "b",
       failFastStatusCodes: [500, 501], waitForCompletion: true, statusUrlResolution: WebhookProperties.StatusUrlResolution.webhookResponse,
       statusUrlJsonPath: "c", statusJsonPath: "d", progressJsonPath: "e", successStatuses: "f", canceledStatuses: "g", terminalStatuses: "h", parameters: null, parameterData: null,
-      permissions: permissions
+      permissions: permissions, signalCancellation: true, cancelEndpoint: "i", cancelMethod: HttpMethod.POST, cancelPayload: "j"
     )
   }
 }

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -89,6 +89,10 @@ public class WebhookProperties {
     public String canceledStatuses;
     public String terminalStatuses;
     public Map<String, List<String>> permissions;
+    public Boolean signalCancellation;
+    public String cancelEndpoint;
+    public HttpMethod cancelMethod;
+    public String cancelPayload;
 
     public List<String> getPreconfiguredProperties() {
       return ALL_FIELDS.stream()

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookSpec.groovy
@@ -35,7 +35,8 @@ class PreconfiguredWebhookSpec extends Specification {
 
     then:
     fields == ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution", "statusUrlJsonPath",
-      "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses"]
+      "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses",
+      "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload"]
   }
 
   def "getPreconfiguredFields should return empty list if no stage configuration fields are populated"() {
@@ -84,7 +85,8 @@ class PreconfiguredWebhookSpec extends Specification {
       url: "url", customHeaders: customHeaders, method: HttpMethod.POST, payload: "payload",
       failFastStatusCodes: [500, 501], waitForCompletion: true, statusUrlResolution: webhookResponse,
       statusUrlJsonPath: "statusUrlJsonPath", statusJsonPath: "statusJsonPath", progressJsonPath: "progressJsonPath",
-      successStatuses: "successStatuses", canceledStatuses: "canceledStatuses", terminalStatuses: "terminalStatuses"
+      successStatuses: "successStatuses", canceledStatuses: "canceledStatuses", terminalStatuses: "terminalStatuses",
+      signalCancellation: true, cancelEndpoint: "cancelEndpoint", cancelMethod: HttpMethod.POST, cancelPayload: "cancelPayload"
     )
   }
 }

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
@@ -60,7 +60,11 @@ class PreconfiguredWebhookStageSpec extends Specification {
       terminalStatuses: "h",
       parameterValues: null,
       parameterData: null,
-      permissions: null
+      permissions: null,
+      signalCancellation: true,
+      cancelEndpoint: "i",
+      cancelMethod: HttpMethod.POST,
+      cancelPayload: "j"
     ]
   }
 
@@ -81,7 +85,11 @@ class PreconfiguredWebhookStageSpec extends Specification {
       canceledStatuses: "g",
       terminalStatuses: "h",
       parameterValues: null,
-      permissions: null
+      permissions: null,
+      signalCancellation: true,
+      cancelEndpoint: "i",
+      cancelMethod: HttpMethod.POST,
+      cancelPayload: "j"
     ])
 
     when:
@@ -105,7 +113,11 @@ class PreconfiguredWebhookStageSpec extends Specification {
       terminalStatuses: "h",
       parameterValues: null,
       parameterData: null,
-      permissions: null
+      permissions: null,
+      signalCancellation: true,
+      cancelEndpoint: "i",
+      cancelMethod: HttpMethod.POST,
+      cancelPayload: "j"
     ]
   }
 
@@ -115,7 +127,8 @@ class PreconfiguredWebhookStageSpec extends Specification {
     return new WebhookProperties.PreconfiguredWebhook(
       label: label, description: description, type: type, url: "a", customHeaders: customHeaders, method: HttpMethod.POST, payload: "b",
       failFastStatusCodes: [500, 501], waitForCompletion: true, statusUrlResolution: WebhookProperties.StatusUrlResolution.locationHeader,
-      statusUrlJsonPath: "c", statusJsonPath: "d", progressJsonPath: "e", successStatuses: "f", canceledStatuses: "g", terminalStatuses: "h"
+      statusUrlJsonPath: "c", statusJsonPath: "d", progressJsonPath: "e", successStatuses: "f", canceledStatuses: "g", terminalStatuses: "h",
+      signalCancellation: true, cancelEndpoint: "i", cancelMethod: HttpMethod.POST, cancelPayload: "j"
     )
   }
 }


### PR DESCRIPTION
This fixes spinnaker/spinnaker#5220.

The frontend already contains the changes needed to support "Signal on cancellation" but the PreconfiguredWebhook was missing the properties.