### PR TITLE
fix(wait stage): Make wait stage restartable

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/WaitStage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/WaitStage.java
@@ -22,9 +22,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask;
 import java.time.Duration;
-import java.time.Instant;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -33,44 +33,33 @@ public class WaitStage implements StageDefinitionBuilder {
   public static String STAGE_TYPE = "wait";
 
   @Override
-  public void taskGraph(Stage stage, TaskNode.Builder builder) {
+  public void taskGraph(@NotNull Stage stage, TaskNode.Builder builder) {
     builder.withTask("wait", WaitTask.class);
   }
 
   public static final class WaitStageContext {
     private final Long waitTime;
     private final boolean skipRemainingWait;
-    private final Instant startTime;
 
     @JsonCreator
     public WaitStageContext(
         @JsonProperty("waitTime") @Nullable Long waitTime,
-        @JsonProperty("skipRemainingWait") @Nullable Boolean skipRemainingWait,
-        @JsonProperty("startTime") @Nullable Instant startTime) {
+        @JsonProperty("skipRemainingWait") @Nullable Boolean skipRemainingWait) {
       this.waitTime = waitTime;
       this.skipRemainingWait = skipRemainingWait == null ? false : skipRemainingWait;
-      this.startTime = startTime;
     }
 
     public WaitStageContext(@Nonnull Long waitTime) {
-      this(waitTime, false, null);
-    }
-
-    public @Nullable Long getWaitTime() {
-      return waitTime;
+      this(waitTime, false);
     }
 
     @JsonIgnore
-    public @Nullable Duration getWaitDuration() {
-      return waitTime == null ? null : Duration.ofSeconds(waitTime);
+    public Duration getWaitDuration() {
+      return waitTime == null ? Duration.ZERO : Duration.ofSeconds(waitTime);
     }
 
     public boolean isSkipRemainingWait() {
       return skipRemainingWait;
-    }
-
-    public @Nullable Instant getStartTime() {
-      return startTime;
     }
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/WaitStage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/WaitStage.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask;
 import java.time.Duration;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -33,7 +32,7 @@ public class WaitStage implements StageDefinitionBuilder {
   public static String STAGE_TYPE = "wait";
 
   @Override
-  public void taskGraph(@NotNull Stage stage, TaskNode.Builder builder) {
+  public void taskGraph(@Nonnull Stage stage, TaskNode.Builder builder) {
     builder.withTask("wait", WaitTask.class);
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitTask.java
@@ -16,9 +16,6 @@
 
 package com.netflix.spinnaker.orca.pipeline.tasks;
 
-import static com.netflix.spinnaker.orca.ExecutionStatus.RUNNING;
-import static java.util.Collections.singletonMap;
-
 import com.netflix.spinnaker.orca.RetryableTask;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.pipeline.WaitStage;
@@ -44,17 +41,14 @@ public class WaitTask implements RetryableTask {
   public @Nonnull TaskResult execute(@Nonnull Stage stage) {
     WaitStage.WaitStageContext context = stage.mapTo(WaitStage.WaitStageContext.class);
 
-    if (context.getWaitTime() == null) {
-      return TaskResult.SUCCEEDED;
-    }
-
     Instant now = clock.instant();
 
-    if (context.isSkipRemainingWait()) {
+    if (context.isSkipRemainingWait() || context.getWaitDuration().isZero()) {
       return TaskResult.SUCCEEDED;
-    } else if (context.getStartTime() == null || context.getStartTime() == Instant.EPOCH) {
-      return TaskResult.builder(RUNNING).context(singletonMap("startTime", now)).build();
-    } else if (context.getStartTime().plus(context.getWaitDuration()).isBefore(now)) {
+    } else if (stage.getStartTime() != null
+        && Instant.ofEpochMilli(stage.getStartTime())
+            .plus(context.getWaitDuration())
+            .isBefore(now)) {
       return TaskResult.SUCCEEDED;
     } else {
       return TaskResult.RUNNING;
@@ -73,10 +67,12 @@ public class WaitTask implements RetryableTask {
     if (context.isSkipRemainingWait()) {
       return 0L;
     }
+
     // Return a backoff time that reflects the requested waitTime
-    if (context.getStartTime() != null && context.getWaitDuration() != null) {
+    if (stage.getStartTime() != null && context.getWaitDuration() != null) {
       Instant now = clock.instant();
-      Instant completion = context.getStartTime().plus(context.getWaitDuration());
+      Instant completion =
+          Instant.ofEpochMilli(stage.getStartTime()).plus(context.getWaitDuration());
 
       if (completion.isAfter(now)) {
         return completion.toEpochMilli() - now.toEpochMilli();

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitTask.java
@@ -43,7 +43,7 @@ public class WaitTask implements RetryableTask {
 
     Instant now = clock.instant();
 
-    if (context.isSkipRemainingWait() || context.getWaitDuration().isZero()) {
+    if (context.isSkipRemainingWait()) {
       return TaskResult.SUCCEEDED;
     } else if (stage.getStartTime() != null
         && Instant.ofEpochMilli(stage.getStartTime())
@@ -69,7 +69,7 @@ public class WaitTask implements RetryableTask {
     }
 
     // Return a backoff time that reflects the requested waitTime
-    if (stage.getStartTime() != null && context.getWaitDuration() != null) {
+    if (stage.getStartTime() != null) {
       Instant now = clock.instant();
       Instant completion =
           Instant.ofEpochMilli(stage.getStartTime()).plus(context.getWaitDuration());

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/WaitTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/WaitTaskSpec.groovy
@@ -39,6 +39,7 @@ class WaitTaskSpec extends Specification {
       refId = "1"
       type = "wait"
       context["waitTime"] = wait
+      startTime = clock.instant().toEpochMilli()
     }
 
     when:
@@ -46,8 +47,6 @@ class WaitTaskSpec extends Specification {
 
     then:
     result.status == RUNNING
-    result.context.startTime != null
-    stage.context.putAll(result.context)
 
     when:
     clock.incrementBy(Duration.ofSeconds(10))
@@ -57,8 +56,6 @@ class WaitTaskSpec extends Specification {
 
     then:
     result.status == SUCCEEDED
-    result.context.startTime == null
-
   }
 
   void "should return backoff based on waitTime"() {
@@ -67,19 +64,18 @@ class WaitTaskSpec extends Specification {
       refId = "1"
       type = "wait"
       context["waitTime"] = wait
+      startTime = clock.instant().toEpochMilli()
     }
 
     when:
     def result = task.execute(stage)
 
     and:
-    stage.context.putAll(result.context)
     def backOff = task.getDynamicBackoffPeriod(stage, null)
 
     then:
     result.status == RUNNING
     backOff == TimeUnit.SECONDS.toMillis(wait)
-
   }
 
   void "should skip waiting when marked in context"() {
@@ -88,6 +84,7 @@ class WaitTaskSpec extends Specification {
       refId = "1"
       type = "wait"
       context["waitTime"] = 1_000_000
+      startTime = clock.instant().toEpochMilli()
     }
 
     when:
@@ -95,7 +92,6 @@ class WaitTaskSpec extends Specification {
 
     then:
     result.status == RUNNING
-    stage.context.putAll(result.context)
 
     when:
     clock.incrementBy(Duration.ofSeconds(10))


### PR DESCRIPTION
Noticed that when I restarted a WaitStage it didn't actually wait.
That's because it caches the stage `startTime`.
Not sure why it does since the stage should have actual start time the time the task runs, so making the wait task use that instead of caching it's own time.
