### PR TITLE
fix(monitor kato): Retry MonitorKatoTask more aggressively

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,4 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
+continuation_indent_size = 4

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
@@ -47,12 +47,12 @@ class KatoService {
     return Observable.from(katoRestService.requestOperations(requestId(operations), cloudProvider, operations))
   }
 
-  Observable<Task> lookupTask(String id, boolean skipReplica = false) {
+  Task lookupTask(String id, boolean skipReplica = false) {
     if (skipReplica) {
-      return Observable.from(katoRestService.lookupTask(id))
+      return katoRestService.lookupTask(id)
     }
 
-    return Observable.from(cloudDriverTaskStatusService.lookupTask(id))
+    return cloudDriverTaskStatusService.lookupTask(id)
   }
 
   @Nonnull

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/MonitorJobTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/MonitorJobTask.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.job;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.clouddriver.KatoService;
@@ -37,14 +38,18 @@ public class MonitorJobTask extends MonitorKatoTask {
       KatoService katoService,
       Registry registry,
       JobUtils jobUtils,
-      DynamicConfigService dynamicConfigService) {
-    super(katoService, registry, dynamicConfigService);
+      DynamicConfigService dynamicConfigService,
+      RetrySupport retrySupport) {
+    super(katoService, registry, dynamicConfigService, retrySupport);
     this.jobUtils = jobUtils;
   }
 
   public MonitorJobTask(
-      KatoService katoService, Registry registry, DynamicConfigService dynamicConfigService) {
-    super(katoService, registry, dynamicConfigService);
+      KatoService katoService,
+      Registry registry,
+      DynamicConfigService dynamicConfigService,
+      RetrySupport retrySupport) {
+    super(katoService, registry, dynamicConfigService, retrySupport);
     this.jobUtils = null;
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTask.java
@@ -64,7 +64,7 @@ public class CloudFoundryMonitorKatoServicesTask extends AbstractCloudProviderAw
             .orElse(new ArrayList<>());
     Map<String, Object> stageContext = stage.getContext();
 
-    Task katoTask = kato.lookupTask(taskId.getId(), true).toBlocking().first();
+    Task katoTask = kato.lookupTask(taskId.getId(), true);
     ExecutionStatus status = katoStatusToTaskStatus(katoTask);
     List<Map> results =
         Optional.ofNullable(katoTask.getResultObjects()).orElse(Collections.emptyList());

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTaskTest.java
@@ -34,7 +34,6 @@ import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import java.util.*;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
-import rx.Observable;
 
 class CloudFoundryMonitorKatoServicesTaskTest {
   private void testKatoServiceStatus(
@@ -49,14 +48,11 @@ class CloudFoundryMonitorKatoServicesTaskTest {
     String region = "org > space";
     when(katoService.lookupTask(matches(taskIdString), eq(true)))
         .thenReturn(
-            Observable.from(
-                new Task[] {
-                  new Task(
-                      taskIdString,
-                      new Task.Status(completed, failed, false),
-                      resultObjects,
-                      Collections.emptyList())
-                }));
+            new Task(
+                taskIdString,
+                new Task.Status(completed, failed, false),
+                resultObjects,
+                Collections.emptyList()));
 
     CloudFoundryMonitorKatoServicesTask task = new CloudFoundryMonitorKatoServicesTask(katoService);
 


### PR DESCRIPTION
In the past, we would retry the `MonitorKatoTask` with fairly complicated logic of checking if it was a replica or a master we got the 404 from.
This change simplifies that by retrying a whole bunch (always from read replica).

Other than basic resilience, this is needed if/when one performs a clouddriver database migration.
The situation is as follows:
 - the old clouddriver cluster is pointing to the old db
 - the new clouddriver cluster is pointing to the new and old db so it can serve getTask requests in either DB
 - during the deploy (with 0 downtime) both old and new will be in the load balancer taking traffic from orca.
 - if an orca request creates a task in new clouddriver but then hits monitor on the old clouddriver it will fail with a 404

Instead of making the old cluster aware of the new DB, we just add a bunch of retries.
Note: they are not made configurable for the sake of not adding unnecessary complexity (not sure when someone would tweak the number of retries), but if you feel strongly it should be configurable i can change it
