### PR TITLE
refactor(kubernetes): clean up source manifest resolution

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.artifacts.CleanupArtifactsTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.*;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestContext.TrafficManagement;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ResolveDeploySourceManifestTask;
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.pipeline.TaskNode;
@@ -46,6 +47,7 @@ public class DeployManifestStage implements StageDefinitionBuilder {
   @Override
   public void taskGraph(@Nonnull Stage stage, @Nonnull TaskNode.Builder builder) {
     builder
+        .withTask(ResolveDeploySourceManifestTask.TASK_NAME, ResolveDeploySourceManifestTask.class)
         .withTask(DeployManifestTask.TASK_NAME, DeployManifestTask.class)
         .withTask("monitorDeploy", MonitorKatoTask.class)
         .withTask(PromoteManifestKatoOutputsTask.TASK_NAME, PromoteManifestKatoOutputsTask.class)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/PatchManifestStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/PatchManifestStage.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestForceCacheRefreshTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.PatchManifestTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.PromoteManifestKatoOutputsTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ResolvePatchSourceManifestTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ResolveTargetManifestTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.WaitForManifestStableTask;
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
@@ -36,6 +37,7 @@ public class PatchManifestStage implements StageDefinitionBuilder {
   public void taskGraph(Stage stage, TaskNode.Builder builder) {
     builder
         .withTask(ResolveTargetManifestTask.TASK_NAME, ResolveTargetManifestTask.class)
+        .withTask(ResolvePatchSourceManifestTask.TASK_NAME, ResolvePatchSourceManifestTask.class)
         .withTask(PatchManifestTask.TASK_NAME, PatchManifestTask.class)
         .withTask("monitorPatch", MonitorKatoTask.class)
         .withTask(PromoteManifestKatoOutputsTask.TASK_NAME, PromoteManifestKatoOutputsTask.class)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
@@ -39,12 +39,10 @@ public final class DeployManifestTask extends AbstractCloudProviderAwareTask imp
   public static final String TASK_NAME = "deployManifest";
 
   private final KatoService katoService;
-  private final ManifestEvaluator manifestEvaluator;
 
   @Autowired
-  public DeployManifestTask(KatoService katoService, ManifestEvaluator manifestEvaluator) {
+  public DeployManifestTask(KatoService katoService) {
     this.katoService = katoService;
-    this.manifestEvaluator = manifestEvaluator;
   }
 
   @Override
@@ -57,14 +55,10 @@ public final class DeployManifestTask extends AbstractCloudProviderAwareTask imp
 
   private ImmutableMap<String, Map> getOperation(Stage stage) {
     DeployManifestContext context = stage.mapTo(DeployManifestContext.class);
-    ManifestEvaluator.Result result = manifestEvaluator.evaluate(stage, context);
 
     Map<String, Object> task = new HashMap<>(stage.getContext());
 
     task.put("source", "text");
-    task.put("manifests", result.getManifests());
-    task.put("requiredArtifacts", result.getRequiredArtifacts());
-    task.put("optionalArtifacts", result.getOptionalArtifacts());
     if (context.getTrafficManagement().isEnabled()) {
       task.put("services", context.getTrafficManagement().getOptions().getServices());
       task.put("enableTraffic", context.getTrafficManagement().getOptions().isEnableTraffic());

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
@@ -17,28 +17,45 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.Task;
 import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.KatoService;
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nonnull;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
-@RequiredArgsConstructor
-public class DeployManifestTask extends AbstractCloudProviderAwareTask implements Task {
+@NonnullByDefault
+public final class DeployManifestTask extends AbstractCloudProviderAwareTask implements Task {
   public static final String TASK_NAME = "deployManifest";
 
+  private final KatoService katoService;
   private final ManifestEvaluator manifestEvaluator;
 
-  @Nonnull
+  @Autowired
+  public DeployManifestTask(KatoService katoService, ManifestEvaluator manifestEvaluator) {
+    this.katoService = katoService;
+    this.manifestEvaluator = manifestEvaluator;
+  }
+
   @Override
-  public TaskResult execute(@Nonnull Stage stage) {
+  public TaskResult execute(Stage stage) {
+    ImmutableMap<String, Map> operation = getOperation(stage);
+    TaskId taskId = executeOperation(stage, operation);
+    ImmutableMap<String, Object> outputs = getOutputs(stage, taskId);
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).build();
+  }
+
+  private ImmutableMap<String, Map> getOperation(Stage stage) {
     DeployManifestContext context = stage.mapTo(DeployManifestContext.class);
     ManifestEvaluator.Result result = manifestEvaluator.evaluate(stage, context);
 
@@ -48,8 +65,7 @@ public class DeployManifestTask extends AbstractCloudProviderAwareTask implement
     task.put("manifests", result.getManifests());
     task.put("requiredArtifacts", result.getRequiredArtifacts());
     task.put("optionalArtifacts", result.getOptionalArtifacts());
-
-    if (context.getTrafficManagement() != null && context.getTrafficManagement().isEnabled()) {
+    if (context.getTrafficManagement().isEnabled()) {
       task.put("services", context.getTrafficManagement().getOptions().getServices());
       task.put("enableTraffic", context.getTrafficManagement().getOptions().isEnableTraffic());
       task.put("strategy", context.getTrafficManagement().getOptions().getStrategy().name());
@@ -60,6 +76,21 @@ public class DeployManifestTask extends AbstractCloudProviderAwareTask implement
       task.put("enableTraffic", true);
     }
 
-    return manifestEvaluator.buildTaskResult(TASK_NAME, stage, task);
+    return ImmutableMap.of(TASK_NAME, task);
+  }
+
+  private TaskId executeOperation(Stage stage, ImmutableMap<String, Map> operation) {
+    return katoService
+        .requestOperations(getCloudProvider(stage), ImmutableList.of(operation))
+        .toBlocking()
+        .first();
+  }
+
+  private ImmutableMap<String, Object> getOutputs(Stage stage, TaskId taskId) {
+    return new ImmutableMap.Builder<String, Object>()
+        .put("kato.result.expected", true)
+        .put("kato.last.task.id", taskId)
+        .put("deploy.account.name", Objects.requireNonNull(getCredentials(stage)))
+        .build();
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluator.java
@@ -16,11 +16,15 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Collections.emptyList;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.orca.ExecutionStatus;
@@ -28,160 +32,229 @@ import com.netflix.spinnaker.orca.TaskResult;
 import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestContext.BindArtifact;
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
 import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
 import java.io.InputStream;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import retrofit.client.Response;
 
+/** This class handles resolving a list of manifests and associated artifacts. */
 @Component
-@Slf4j
-@RequiredArgsConstructor
+@NonnullByDefault
 public class ManifestEvaluator implements CloudProviderAware {
   private static final ThreadLocal<Yaml> yamlParser =
       ThreadLocal.withInitial(() -> new Yaml(new SafeConstructor()));
 
   private final ArtifactUtils artifactUtils;
-  private final OortService oort;
-  private final ObjectMapper objectMapper;
   private final ContextParameterProcessor contextParameterProcessor;
-  private final KatoService kato;
+  private final KatoService katoService;
+  private final ObjectMapper objectMapper;
+  private final OortService oortService;
+  private final RetrySupport retrySupport;
 
-  private final RetrySupport retrySupport = new RetrySupport();
+  @Autowired
+  public ManifestEvaluator(
+      ArtifactUtils artifactUtils,
+      ContextParameterProcessor contextParameterProcessor,
+      KatoService katoService,
+      ObjectMapper objectMapper,
+      OortService oortService,
+      RetrySupport retrySupport) {
+    this.artifactUtils = artifactUtils;
+    this.contextParameterProcessor = contextParameterProcessor;
+    this.katoService = katoService;
+    this.objectMapper = objectMapper;
+    this.oortService = oortService;
+    this.retrySupport = retrySupport;
+  }
 
   @RequiredArgsConstructor
   @Getter
   public static class Result {
-    private final List<Map<Object, Object>> manifests;
-    private final List<Artifact> requiredArtifacts;
-    private final List<Artifact> optionalArtifacts;
+    private final ImmutableList<Map<Object, Object>> manifests;
+    private final ImmutableList<Artifact> requiredArtifacts;
+    private final ImmutableList<Artifact> optionalArtifacts;
   }
 
+  /**
+   * Resolves manifests and associated artifacts as a {@link Result}. Handles determining the input
+   * source of a manifest, downloading the manifest if it is an artifact, optionally processing it
+   * for SpEL, and composing the required and optional artifacts associated with the manifest.
+   *
+   * @param stage The stage to consider when resolving manifests and artifacts.
+   * @param context The stage-specific manifest context to consider when resolving manifests and
+   *     artifacts.
+   * @return The result of the manifest and artifact resolution {@link Result}.
+   */
   public Result evaluate(Stage stage, ManifestContext context) {
-    Iterable<Object> rawManifests;
-    List<Map<Object, Object>> manifests = Collections.emptyList();
-    if (ManifestContext.Source.Artifact.equals(context.getSource())) {
-      Artifact manifestArtifact =
-          artifactUtils.getBoundArtifactForStage(
-              stage, context.getManifestArtifactId(), context.getManifestArtifact());
-
-      if (manifestArtifact == null) {
-        throw new IllegalArgumentException("No manifest artifact was specified.");
-      }
-
-      // Once the legacy artifacts feature is removed, all trigger expected artifacts will be
-      // required to define an account up front.
-      if (context.getManifestArtifactAccount() != null) {
-        manifestArtifact.setArtifactAccount(context.getManifestArtifactAccount());
-      }
-
-      if (manifestArtifact.getArtifactAccount() == null) {
-        throw new IllegalArgumentException("No manifest artifact account was specified.");
-      }
-
-      log.info("Using {} as the manifest", manifestArtifact);
-
-      rawManifests =
-          retrySupport.retry(
-              () -> {
-                Response manifestText = oort.fetchArtifact(manifestArtifact);
-                try (InputStream body = manifestText.getBody().in()) {
-                  return yamlParser.get().loadAll(body);
-                } catch (Exception e) {
-                  log.warn("Failure fetching/parsing manifests from {}", manifestArtifact, e);
-                  // forces a retry
-                  throw new IllegalStateException(e);
-                }
-              },
-              10,
-              200,
-              true); // retry 10x, starting at .2s intervals);
-
-      List<Object> unevaluatedManifests =
-          StreamSupport.stream(rawManifests.spliterator(), false)
-              .map(
-                  m -> {
-                    try {
-                      return Collections.singletonList(objectMapper.convertValue(m, Map.class));
-                    } catch (Exception e) {
-                      return objectMapper.convertValue(
-                          m, new TypeReference<List<Map<Object, Object>>>() {});
-                    }
-                  })
-              .flatMap(Collection::stream)
-              .collect(Collectors.toList());
-
-      if (!unevaluatedManifests.isEmpty()) {
-        Map<String, Object> manifestWrapper = new HashMap<>();
-        manifestWrapper.put("manifests", unevaluatedManifests);
-
-        if (!context.isSkipExpressionEvaluation()) {
-          manifestWrapper =
-              contextParameterProcessor.process(
-                  manifestWrapper, contextParameterProcessor.buildExecutionContext(stage), true);
-
-          if (manifestWrapper.containsKey(PipelineExpressionEvaluator.SUMMARY)) {
-            throw new IllegalStateException(
-                "Failure evaluating manifest expressions: "
-                    + manifestWrapper.get(PipelineExpressionEvaluator.SUMMARY));
-          }
-        }
-        manifests = (List<Map<Object, Object>>) manifestWrapper.get("manifests");
-      }
-    } else {
-      manifests = context.getManifests();
-    }
-
-    List<Artifact> requiredArtifacts = new ArrayList<>();
-    for (String id : Optional.ofNullable(context.getRequiredArtifactIds()).orElse(emptyList())) {
-      Artifact requiredArtifact = artifactUtils.getBoundArtifactForId(stage, id);
-      if (requiredArtifact == null) {
-        throw new IllegalStateException(
-            "No artifact with id '" + id + "' could be found in the pipeline context.");
-      }
-
-      requiredArtifacts.add(requiredArtifact);
-    }
-
-    // resolve SpEL expressions in artifacts defined inline in the stage
-    for (ManifestContext.BindArtifact artifact :
-        Optional.ofNullable(context.getRequiredArtifacts()).orElse(emptyList())) {
-      Artifact requiredArtifact =
-          artifactUtils.getBoundArtifactForStage(
-              stage, artifact.getExpectedArtifactId(), artifact.getArtifact());
-
-      if (requiredArtifact == null) {
-        throw new IllegalStateException(
-            "No artifact with id '"
-                + artifact.getExpectedArtifactId()
-                + "' could be found in the pipeline context.");
-      }
-
-      requiredArtifacts.add(requiredArtifact);
-    }
-
-    log.info("Artifacts {} are bound to the manifest", requiredArtifacts);
-
-    return new Result(manifests, requiredArtifacts, artifactUtils.getArtifacts(stage));
+    return new Result(
+        getManifests(stage, context),
+        getRequiredArtifacts(stage, context),
+        getOptionalArtifacts(stage));
   }
 
+  private ImmutableList<Map<Object, Object>> getManifests(Stage stage, ManifestContext context) {
+    if (ManifestContext.Source.Artifact.equals(context.getSource())) {
+      return getManifestsFromArtifact(stage, context);
+    }
+    return getManifestsFromText(context);
+  }
+
+  private ImmutableList<Map<Object, Object>> getManifestsFromText(ManifestContext context) {
+    List<Map<Object, Object>> textManifests =
+        Optional.ofNullable(context.getManifests())
+            .orElseThrow(() -> new IllegalArgumentException("No text manifest was specified."));
+    return ImmutableList.copyOf(textManifests);
+  }
+
+  private ImmutableList<Map<Object, Object>> getManifestsFromArtifact(
+      Stage stage, ManifestContext context) {
+    Artifact manifestArtifact = getManifestArtifact(stage, context);
+
+    Iterable<Object> rawManifests =
+        retrySupport.retry(
+            fetchAndParseManifestYaml(manifestArtifact), 10, Duration.ofMillis(200), true);
+
+    ImmutableList<Map<Object, Object>> unevaluatedManifests =
+        StreamSupport.stream(rawManifests.spliterator(), false)
+            .map(this::coerceManifestToList)
+            .flatMap(Collection::stream)
+            .collect(toImmutableList());
+
+    if (context.isSkipExpressionEvaluation()) {
+      return unevaluatedManifests;
+    }
+
+    return getSpelEvaluatedManifests(unevaluatedManifests, stage);
+  }
+
+  private ImmutableList<Map<Object, Object>> coerceManifestToList(Object manifest) {
+    if (manifest instanceof List) {
+      return ImmutableList.copyOf(
+          objectMapper.convertValue(manifest, new TypeReference<List<Map<Object, Object>>>() {}));
+    }
+    Map<Object, Object> singleManifest =
+        (Map<Object, Object>) objectMapper.convertValue(manifest, Map.class);
+    return ImmutableList.of(singleManifest);
+  }
+
+  private Supplier<Iterable<Object>> fetchAndParseManifestYaml(Artifact manifestArtifact) {
+    return () -> {
+      Response manifestText = oortService.fetchArtifact(manifestArtifact);
+      try (InputStream body = manifestText.getBody().in()) {
+        return yamlParser.get().loadAll(body);
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+    };
+  }
+
+  private Artifact getManifestArtifact(Stage stage, ManifestContext context) {
+    Artifact manifestArtifact =
+        Optional.ofNullable(
+                artifactUtils.getBoundArtifactForStage(
+                    stage, context.getManifestArtifactId(), context.getManifestArtifact()))
+            .orElseThrow(() -> new IllegalArgumentException("No manifest artifact was specified."));
+
+    // Once the legacy artifacts feature is removed, all trigger expected artifacts will be
+    // required to define an account up front.
+    if (context.getManifestArtifactAccount() != null) {
+      manifestArtifact.setArtifactAccount(context.getManifestArtifactAccount());
+    }
+
+    if (manifestArtifact.getArtifactAccount() == null) {
+      throw new IllegalArgumentException("No manifest artifact account was specified.");
+    }
+
+    return manifestArtifact;
+  }
+
+  private ImmutableList<Map<Object, Object>> getSpelEvaluatedManifests(
+      ImmutableList<Map<Object, Object>> unevaluatedManifests, Stage stage) {
+    Map<String, Object> manifestWrapper = new HashMap<>();
+    manifestWrapper.put("manifests", unevaluatedManifests);
+
+    manifestWrapper =
+        contextParameterProcessor.process(
+            manifestWrapper, contextParameterProcessor.buildExecutionContext(stage), true);
+
+    if (manifestWrapper.containsKey(PipelineExpressionEvaluator.SUMMARY)) {
+      throw new IllegalStateException(
+          String.format(
+              "Failure evaluating manifest expressions: %s",
+              manifestWrapper.get(PipelineExpressionEvaluator.SUMMARY)));
+    }
+
+    List<Map<Object, Object>> evaluatedManifests =
+        (List<Map<Object, Object>>) manifestWrapper.get("manifests");
+    return ImmutableList.copyOf(evaluatedManifests);
+  }
+
+  private ImmutableList<Artifact> getRequiredArtifacts(Stage stage, ManifestContext context) {
+    Stream<Artifact> requiredArtifactsFromId =
+        Optional.ofNullable(context.getRequiredArtifactIds()).orElse(emptyList()).stream()
+            .map(artifactId -> resolveRequiredArtifactById(stage, artifactId));
+
+    Stream<Artifact> requiredArtifacts =
+        Optional.ofNullable(context.getRequiredArtifacts()).orElse(emptyList()).stream()
+            .map(artifact -> resolveRequiredArtifact(stage, artifact));
+
+    return Streams.concat(requiredArtifactsFromId, requiredArtifacts).collect(toImmutableList());
+  }
+
+  private Artifact resolveRequiredArtifactById(Stage stage, String artifactId) {
+    return Optional.ofNullable(artifactUtils.getBoundArtifactForId(stage, artifactId))
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    String.format(
+                        "No artifact with id %s could be found in the pipeline context.",
+                        artifactId)));
+  }
+
+  private Artifact resolveRequiredArtifact(Stage stage, BindArtifact artifact) {
+    return Optional.ofNullable(
+            artifactUtils.getBoundArtifactForStage(
+                stage, artifact.getExpectedArtifactId(), artifact.getArtifact()))
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    String.format(
+                        "No artifact with id %s could be found in the pipeline context.",
+                        artifact.getExpectedArtifactId())));
+  }
+
+  private ImmutableList<Artifact> getOptionalArtifacts(Stage stage) {
+    return ImmutableList.copyOf(artifactUtils.getArtifacts(stage));
+  }
+
+  // todo(mneterval): remove this task-specific logic from this class
   public TaskResult buildTaskResult(String taskName, Stage stage, Map<String, Object> task) {
     Map<String, Map> operation =
         new ImmutableMap.Builder<String, Map>().put(taskName, task).build();
 
     TaskId taskId =
-        kato.requestOperations(getCloudProvider(stage), Collections.singletonList(operation))
+        katoService
+            .requestOperations(getCloudProvider(stage), Collections.singletonList(operation))
             .toBlocking()
             .first();
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PatchManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PatchManifestTask.java
@@ -16,36 +16,53 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.Task;
 import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.clouddriver.KatoService;
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.PatchManifestContext.MergeStrategy;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
-@RequiredArgsConstructor
-public class PatchManifestTask extends AbstractCloudProviderAwareTask implements Task {
+@NonnullByDefault
+public final class PatchManifestTask extends AbstractCloudProviderAwareTask implements Task {
   public static final String TASK_NAME = "patchManifest";
 
+  private final KatoService katoService;
   private final ManifestEvaluator manifestEvaluator;
 
-  @Nonnull
+  @Autowired
+  public PatchManifestTask(KatoService katoService, ManifestEvaluator manifestEvaluator) {
+    this.katoService = katoService;
+    this.manifestEvaluator = manifestEvaluator;
+  }
+
   @Override
-  public TaskResult execute(@Nonnull Stage stage) {
+  public TaskResult execute(Stage stage) {
+    ImmutableMap<String, Map> operation = getOperation(stage);
+    TaskId taskId = executeOperation(stage, operation);
+    ImmutableMap<String, Object> outputs = getOutputs(stage, taskId);
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).build();
+  }
+
+  private ImmutableMap<String, Map> getOperation(Stage stage) {
     PatchManifestContext context = stage.mapTo(PatchManifestContext.class);
     MergeStrategy mergeStrategy = context.getOptions().getMergeStrategy();
     ManifestEvaluator.Result result = manifestEvaluator.evaluate(stage, context);
     List<Map<Object, Object>> patchBody = result.getManifests();
 
-    if (patchBody == null || patchBody.isEmpty()) {
+    if (patchBody.isEmpty()) {
       throw new IllegalArgumentException(
           "The Patch (Manifest) stage requires a valid patch body. Please add a patch body inline or with an artifact.");
     }
@@ -60,6 +77,21 @@ public class PatchManifestTask extends AbstractCloudProviderAwareTask implements
     task.put("requiredArtifacts", result.getRequiredArtifacts());
     task.put("allArtifacts", result.getOptionalArtifacts());
 
-    return manifestEvaluator.buildTaskResult(TASK_NAME, stage, task);
+    return ImmutableMap.of(TASK_NAME, task);
+  }
+
+  private TaskId executeOperation(Stage stage, ImmutableMap<String, Map> operation) {
+    return katoService
+        .requestOperations(getCloudProvider(stage), ImmutableList.of(operation))
+        .toBlocking()
+        .first();
+  }
+
+  private ImmutableMap<String, Object> getOutputs(Stage stage, TaskId taskId) {
+    return new ImmutableMap.Builder<String, Object>()
+        .put("kato.result.expected", true)
+        .put("kato.last.task.id", taskId)
+        .put("deploy.account.name", Objects.requireNonNull(getCredentials(stage)))
+        .build();
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PatchManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PatchManifestTask.java
@@ -40,12 +40,10 @@ public final class PatchManifestTask extends AbstractCloudProviderAwareTask impl
   public static final String TASK_NAME = "patchManifest";
 
   private final KatoService katoService;
-  private final ManifestEvaluator manifestEvaluator;
 
   @Autowired
-  public PatchManifestTask(KatoService katoService, ManifestEvaluator manifestEvaluator) {
+  public PatchManifestTask(KatoService katoService) {
     this.katoService = katoService;
-    this.manifestEvaluator = manifestEvaluator;
   }
 
   @Override
@@ -59,8 +57,7 @@ public final class PatchManifestTask extends AbstractCloudProviderAwareTask impl
   private ImmutableMap<String, Map> getOperation(Stage stage) {
     PatchManifestContext context = stage.mapTo(PatchManifestContext.class);
     MergeStrategy mergeStrategy = context.getOptions().getMergeStrategy();
-    ManifestEvaluator.Result result = manifestEvaluator.evaluate(stage, context);
-    List<Map<Object, Object>> patchBody = result.getManifests();
+    List<Map<Object, Object>> patchBody = context.getManifests();
 
     if (patchBody.isEmpty()) {
       throw new IllegalArgumentException(
@@ -74,8 +71,6 @@ public final class PatchManifestTask extends AbstractCloudProviderAwareTask impl
     Map<String, Object> task = new HashMap<>(stage.getContext());
     task.put("source", "text");
     task.put("patchBody", mergeStrategy == MergeStrategy.JSON ? patchBody : patchBody.get(0));
-    task.put("requiredArtifacts", result.getRequiredArtifacts());
-    task.put("allArtifacts", result.getOptionalArtifacts());
 
     return ImmutableMap.of(TASK_NAME, task);
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolveDeploySourceManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolveDeploySourceManifestTask.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@NonnullByDefault
+public final class ResolveDeploySourceManifestTask implements Task {
+  public static final String TASK_NAME = "resolveDeploySourceManifest";
+
+  private final ManifestEvaluator manifestEvaluator;
+
+  @Autowired
+  public ResolveDeploySourceManifestTask(ManifestEvaluator manifestEvaluator) {
+    this.manifestEvaluator = manifestEvaluator;
+  }
+
+  @Override
+  public TaskResult execute(Stage stage) {
+    DeployManifestContext context = stage.mapTo(DeployManifestContext.class);
+    ManifestEvaluator.Result result = manifestEvaluator.evaluate(stage, context);
+    ImmutableMap<String, Object> outputs = getOutputs(result);
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).outputs(outputs).build();
+  }
+
+  private ImmutableMap<String, Object> getOutputs(ManifestEvaluator.Result result) {
+    return new ImmutableMap.Builder<String, Object>()
+        .put("manifests", result.getManifests())
+        .put("requiredArtifacts", result.getRequiredArtifacts())
+        .put("optionalArtifacts", result.getOptionalArtifacts())
+        .build();
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolvePatchSourceManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolvePatchSourceManifestTask.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.orca.ExecutionStatus;
+import com.netflix.spinnaker.orca.Task;
+import com.netflix.spinnaker.orca.TaskResult;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@NonnullByDefault
+public final class ResolvePatchSourceManifestTask implements Task {
+  public static final String TASK_NAME = "resolvePatchSourceManifest";
+
+  private final ManifestEvaluator manifestEvaluator;
+
+  @Autowired
+  public ResolvePatchSourceManifestTask(ManifestEvaluator manifestEvaluator) {
+    this.manifestEvaluator = manifestEvaluator;
+  }
+
+  @Override
+  public TaskResult execute(Stage stage) {
+    PatchManifestContext context = stage.mapTo(PatchManifestContext.class);
+    ManifestEvaluator.Result result = manifestEvaluator.evaluate(stage, context);
+    ImmutableMap<String, Object> outputs = getOutputs(result);
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).outputs(outputs).build();
+  }
+
+  private ImmutableMap<String, Object> getOutputs(ManifestEvaluator.Result result) {
+    return new ImmutableMap.Builder<String, Object>()
+        .put("manifests", result.getManifests())
+        .put("requiredArtifacts", result.getRequiredArtifacts())
+        .put("allArtifacts", result.getOptionalArtifacts())
+        .build();
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTaskSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
@@ -38,7 +39,7 @@ class DeployManifestTaskSpec extends Specification {
 
   @Subject
   DeployManifestTask task = new DeployManifestTask(new ManifestEvaluator(artifactUtils,
-    Mock(OortService), new ObjectMapper(), Mock(ContextParameterProcessor), katoService))
+    Mock(ContextParameterProcessor), katoService, new ObjectMapper(), Mock(OortService), new RetrySupport()))
 
   def "enables traffic when the trafficManagement field is absent"() {
     given:
@@ -122,6 +123,7 @@ class DeployManifestTaskSpec extends Specification {
       account: "my-k8s-account",
       cloudProvider: "kubernetes",
       source: "text",
+      manifests: []
     ] + extraParams)
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTaskSpec.groovy
@@ -38,8 +38,8 @@ class DeployManifestTaskSpec extends Specification {
   }
 
   @Subject
-  DeployManifestTask task = new DeployManifestTask(new ManifestEvaluator(artifactUtils,
-    Mock(ContextParameterProcessor), katoService, new ObjectMapper(), Mock(OortService), new RetrySupport()))
+  DeployManifestTask task = new DeployManifestTask(katoService, new ManifestEvaluator(artifactUtils,
+    Mock(ContextParameterProcessor), new ObjectMapper(), Mock(OortService), new RetrySupport()))
 
   def "enables traffic when the trafficManagement field is absent"() {
     given:

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTaskSpec.groovy
@@ -16,15 +16,10 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.orca.clouddriver.KatoService
-import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.model.Stage
-import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils
-import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import rx.Observable
 import spock.lang.Specification
 import spock.lang.Subject
@@ -33,13 +28,9 @@ class DeployManifestTaskSpec extends Specification {
   String TASK_ID = "12345"
 
   KatoService katoService = Mock(KatoService)
-  def artifactUtils = Stub(ArtifactUtils) {
-    getArtifacts(*_) >> []
-  }
 
   @Subject
-  DeployManifestTask task = new DeployManifestTask(katoService, new ManifestEvaluator(artifactUtils,
-    Mock(ContextParameterProcessor), new ObjectMapper(), Mock(OortService), new RetrySupport()))
+  DeployManifestTask task = new DeployManifestTask(katoService)
 
   def "enables traffic when the trafficManagement field is absent"() {
     given:

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunnerSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunnerSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.providers.kubernetes
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestEvaluator
@@ -111,8 +112,9 @@ class KubernetesJobRunnerSpec extends Specification {
     OortService oortService = Mock(OortService)
     ContextParameterProcessor contextParameterProcessor = Mock(ContextParameterProcessor)
     KatoService katoService = Mock(KatoService)
+    RetrySupport retrySupport = new RetrySupport()
     ManifestEvaluator manifestEvaluator = new ManifestEvaluator(
-      artifactUtils, oortService, objectMapper, contextParameterProcessor, katoService
+      artifactUtils, contextParameterProcessor, katoService, objectMapper, oortService, retrySupport
     )
     def stage = new Stage(Execution.newPipeline("test"), "runJob", [
       credentials: "abc", cloudProvider: "kubernetes",
@@ -142,8 +144,11 @@ class KubernetesJobRunnerSpec extends Specification {
     1 * artifactUtils.getBoundArtifactForStage(_, _, _) >> {
       return Artifact.builder().build()
     }
+    1 * artifactUtils.getArtifacts(_) >> {
+      return []
+    }
     op.manifest == manifest
     op.requiredArtifacts == []
-    op.optionalArtifacts == null
+    op.optionalArtifacts == []
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunnerSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunnerSpec.groovy
@@ -111,10 +111,9 @@ class KubernetesJobRunnerSpec extends Specification {
     ObjectMapper objectMapper = new ObjectMapper()
     OortService oortService = Mock(OortService)
     ContextParameterProcessor contextParameterProcessor = Mock(ContextParameterProcessor)
-    KatoService katoService = Mock(KatoService)
     RetrySupport retrySupport = new RetrySupport()
     ManifestEvaluator manifestEvaluator = new ManifestEvaluator(
-      artifactUtils, contextParameterProcessor, katoService, objectMapper, oortService, retrySupport
+      artifactUtils, contextParameterProcessor, objectMapper, oortService, retrySupport
     )
     def stage = new Stage(Execution.newPipeline("test"), "runJob", [
       credentials: "abc", cloudProvider: "kubernetes",

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunnerSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunnerSpec.groovy
@@ -113,7 +113,7 @@ class KubernetesJobRunnerSpec extends Specification {
     ContextParameterProcessor contextParameterProcessor = Mock(ContextParameterProcessor)
     RetrySupport retrySupport = new RetrySupport()
     ManifestEvaluator manifestEvaluator = new ManifestEvaluator(
-      artifactUtils, contextParameterProcessor, objectMapper, oortService, retrySupport
+      artifactUtils, contextParameterProcessor, oortService, retrySupport
     )
     def stage = new Stage(Execution.newPipeline("test"), "runJob", [
       credentials: "abc", cloudProvider: "kubernetes",

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestContext.BindArtifact;
@@ -64,7 +65,12 @@ final class ManifestEvaluatorTest {
   void setup() {
     manifestEvaluator =
         new ManifestEvaluator(
-            artifactUtils, oortService, new ObjectMapper(), contextParameterProcessor, katoService);
+            artifactUtils,
+            contextParameterProcessor,
+            katoService,
+            new ObjectMapper(),
+            oortService,
+            new RetrySupport());
   }
 
   @Test
@@ -77,16 +83,15 @@ final class ManifestEvaluatorTest {
     assertThat(result.getManifests()).isEqualTo(manifests);
   }
 
-  // todo(mneterval): throw an error for null text manifests when text source specified
-  // @Test
-  // void nullTextManifestFailure() {
-  //   Stage stage = new Stage();
-  //   DeployManifestContext context =
-  // DeployManifestContext.builder().source(Source.Text).manifests(null).build();
-  //
-  //   assertThatThrownBy(() -> manifestEvaluator.evaluate(stage, context))
-  //     .isInstanceOf(IllegalArgumentException.class);
-  // }
+  @Test
+  void nullTextManifestFailure() {
+    Stage stage = new Stage();
+    DeployManifestContext context =
+        DeployManifestContext.builder().source(Source.Text).manifests(null).build();
+
+    assertThatThrownBy(() -> manifestEvaluator.evaluate(stage, context))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 
   @Test
   void artifactManifestSuccess() {

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
@@ -63,11 +62,7 @@ final class ManifestEvaluatorTest {
   void setup() {
     manifestEvaluator =
         new ManifestEvaluator(
-            artifactUtils,
-            contextParameterProcessor,
-            new ObjectMapper(),
-            oortService,
-            new RetrySupport());
+            artifactUtils, contextParameterProcessor, oortService, new RetrySupport());
   }
 
   @Test

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.orca.clouddriver.KatoService;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestContext.BindArtifact;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestContext.Source;
+import com.netflix.spinnaker.orca.pipeline.model.Stage;
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils;
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import retrofit.client.Response;
+import retrofit.mime.TypedString;
+
+@ExtendWith(MockitoExtension.class)
+final class ManifestEvaluatorTest {
+  private ManifestEvaluator manifestEvaluator;
+
+  @Mock private ArtifactUtils artifactUtils;
+  @Mock private ContextParameterProcessor contextParameterProcessor;
+  @Mock private KatoService katoService;
+  @Mock private OortService oortService;
+
+  private final List<Map<Object, Object>> manifests =
+      ImmutableList.of(
+          ImmutableMap.builder()
+              .put("metadata", ImmutableMap.builder().put("name", "my-manifest").build())
+              .build());
+
+  private final TypedString manifestString =
+      new TypedString("{'metadata': {'name': 'my-manifest'}}");
+
+  @BeforeEach
+  void setup() {
+    manifestEvaluator =
+        new ManifestEvaluator(
+            artifactUtils, oortService, new ObjectMapper(), contextParameterProcessor, katoService);
+  }
+
+  @Test
+  void textManifestSuccess() {
+    Stage stage = new Stage();
+    DeployManifestContext context =
+        DeployManifestContext.builder().source(Source.Text).manifests(manifests).build();
+    ManifestEvaluator.Result result = manifestEvaluator.evaluate(stage, context);
+
+    assertThat(result.getManifests()).isEqualTo(manifests);
+  }
+
+  // todo(mneterval): throw an error for null text manifests when text source specified
+  // @Test
+  // void nullTextManifestFailure() {
+  //   Stage stage = new Stage();
+  //   DeployManifestContext context =
+  // DeployManifestContext.builder().source(Source.Text).manifests(null).build();
+  //
+  //   assertThatThrownBy(() -> manifestEvaluator.evaluate(stage, context))
+  //     .isInstanceOf(IllegalArgumentException.class);
+  // }
+
+  @Test
+  void artifactManifestSuccess() {
+    Stage stage = new Stage();
+    Artifact manifestArtifact = Artifact.builder().artifactAccount("my-artifact-account").build();
+    DeployManifestContext context =
+        DeployManifestContext.builder()
+            .source(Source.Artifact)
+            .manifestArtifact(manifestArtifact)
+            .skipExpressionEvaluation(true)
+            .build();
+
+    when(artifactUtils.getBoundArtifactForStage(stage, null, manifestArtifact))
+        .thenReturn(manifestArtifact);
+    when(oortService.fetchArtifact(manifestArtifact))
+        .thenReturn(new Response("http://my-url", 200, "", ImmutableList.of(), manifestString));
+
+    ManifestEvaluator.Result result = manifestEvaluator.evaluate(stage, context);
+    assertThat(result.getManifests()).isEqualTo(manifests);
+  }
+
+  @Test
+  void artifactManifestByIdSuccess() {
+    Stage stage = new Stage();
+    Artifact manifestArtifact =
+        Artifact.builder()
+            .artifactAccount("my-artifact-account")
+            .name("my-manifest-artifact")
+            .build();
+    DeployManifestContext context =
+        DeployManifestContext.builder()
+            .manifestArtifactId("my-manifest-artifact-id")
+            .skipExpressionEvaluation(true)
+            .source(Source.Artifact)
+            .build();
+
+    when(artifactUtils.getBoundArtifactForStage(stage, "my-manifest-artifact-id", null))
+        .thenReturn(manifestArtifact);
+    when(oortService.fetchArtifact(manifestArtifact))
+        .thenReturn(new Response("http://my-url", 200, "", ImmutableList.of(), manifestString));
+
+    ManifestEvaluator.Result result = manifestEvaluator.evaluate(stage, context);
+    assertThat(result.getManifests()).isEqualTo(manifests);
+  }
+
+  @Test
+  void artifactManifestMissingFailure() {
+    Stage stage = new Stage();
+    DeployManifestContext context =
+        DeployManifestContext.builder()
+            .source(Source.Artifact)
+            .manifestArtifactId("my-manifest-artifact-id")
+            .build();
+    when(artifactUtils.getBoundArtifactForStage(stage, "my-manifest-artifact-id", null))
+        .thenReturn(null);
+
+    assertThatThrownBy(() -> manifestEvaluator.evaluate(stage, context))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void artifactManifestNoAccountFailure() {
+    Stage stage = new Stage();
+    Artifact manifestArtifact = Artifact.builder().build();
+    DeployManifestContext context =
+        DeployManifestContext.builder()
+            .source(Source.Artifact)
+            .manifestArtifactId("my-artifact-id")
+            .skipExpressionEvaluation(true)
+            .build();
+
+    when(artifactUtils.getBoundArtifactForStage(stage, "my-artifact-id", null))
+        .thenReturn(manifestArtifact);
+
+    assertThatThrownBy(() -> manifestEvaluator.evaluate(stage, context))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void artifactManifestSkipSpelEvaluation() {
+    Stage stage = new Stage();
+    Artifact manifestArtifact =
+        Artifact.builder()
+            .artifactAccount("my-artifact-account")
+            .name("my-manifest-artifact")
+            .build();
+    DeployManifestContext context =
+        DeployManifestContext.builder()
+            .manifestArtifactId("my-manifest-artifact-id")
+            .skipExpressionEvaluation(true)
+            .source(Source.Artifact)
+            .build();
+
+    when(artifactUtils.getBoundArtifactForStage(stage, "my-manifest-artifact-id", null))
+        .thenReturn(manifestArtifact);
+    when(oortService.fetchArtifact(manifestArtifact))
+        .thenReturn(new Response("http://my-url", 200, "", ImmutableList.of(), manifestString));
+
+    manifestEvaluator.evaluate(stage, context);
+    verifyNoInteractions(contextParameterProcessor);
+  }
+
+  @Test
+  void requiredArtifacts() {
+    Stage stage = new Stage();
+    Artifact artifactA = Artifact.builder().name("artifact-a").build();
+    Artifact artifactB = Artifact.builder().name("artifact-b").build();
+    BindArtifact bindArtifact = new BindArtifact();
+    bindArtifact.setExpectedArtifactId("b");
+    bindArtifact.setArtifact(artifactB);
+    DeployManifestContext context =
+        DeployManifestContext.builder()
+            .source(Source.Text)
+            .manifests(manifests)
+            .requiredArtifactIds(ImmutableList.of("a"))
+            .requiredArtifacts(ImmutableList.of(bindArtifact))
+            .skipExpressionEvaluation(true)
+            .build();
+
+    when(artifactUtils.getBoundArtifactForId(stage, "a")).thenReturn(artifactA);
+    when(artifactUtils.getBoundArtifactForStage(stage, "b", artifactB)).thenReturn(artifactB);
+
+    ManifestEvaluator.Result result = manifestEvaluator.evaluate(stage, context);
+    assertThat(result.getRequiredArtifacts()).isEqualTo(ImmutableList.of(artifactA, artifactB));
+  }
+
+  @Test
+  void optionalArtifacts() {
+    Stage stage = new Stage();
+    DeployManifestContext context =
+        DeployManifestContext.builder().source(Source.Text).manifests(manifests).build();
+    ImmutableList<Artifact> optionalArtifacts =
+        ImmutableList.of(Artifact.builder().name("optional-artifact").build());
+
+    when(artifactUtils.getArtifacts(stage)).thenReturn(optionalArtifacts);
+
+    ManifestEvaluator.Result result = manifestEvaluator.evaluate(stage, context);
+    assertThat(result.getOptionalArtifacts()).isEqualTo(optionalArtifacts);
+  }
+}

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.core.RetrySupport;
-import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestContext.BindArtifact;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestContext.Source;
@@ -49,7 +48,6 @@ final class ManifestEvaluatorTest {
 
   @Mock private ArtifactUtils artifactUtils;
   @Mock private ContextParameterProcessor contextParameterProcessor;
-  @Mock private KatoService katoService;
   @Mock private OortService oortService;
 
   private final List<Map<Object, Object>> manifests =
@@ -67,7 +65,6 @@ final class ManifestEvaluatorTest {
         new ManifestEvaluator(
             artifactUtils,
             contextParameterProcessor,
-            katoService,
             new ObjectMapper(),
             oortService,
             new RetrySupport());

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryDeployServiceTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryDeployServiceTaskTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestEvaluator;
@@ -61,8 +62,8 @@ class CloudFoundryDeployServiceTaskTest {
         .thenReturn(Observable.just(new TaskId("taskid")));
 
     ManifestEvaluator manifestEvaluator = mock(ManifestEvaluator.class);
-    List<Map<Object, Object>> returnedManifests =
-        Collections.singletonList(Collections.singletonMap("serviceNameInstance", "foo"));
+    ImmutableList<Map<Object, Object>> returnedManifests =
+        ImmutableList.of(Collections.singletonMap("serviceNameInstance", "foo"));
     when(manifestEvaluator.evaluate(any(), any()))
         .thenReturn(new ManifestEvaluator.Result(returnedManifests, null, null));
 


### PR DESCRIPTION
The goal of this refactor is to make Orca's input manifest resolution easier to reason about so that we can enhance it with [label filtration](https://github.com/spinnaker/spinnaker/issues/3695).

- **refactor(kubernetes): add tests for ManifestEvaluator**

  Adds tests documenting the functionality of `ManifestEvaluator.evaluate` to ensure we don't break anything in the next commit.

- **refactor(kubernetes): clean up ManifestEvaluator**

  Divides the functionality of `ManifestEvaluator.evaluate` into private methods responsible for a single bit of work. Adds immutability and cleans up streams where possible.

- **refactor(kubernetes): move task-specific ManifestEvaluator logic to tasks**

  Removes `ManifestEvaluator.buildTaskResult`, which makes a call to Clouddriver to initiate a task and composes the task outputs. Since this logic is only consumed by the Deploy and Patch (Manifest) tasks, push that logic to those tasks. Divide Deploy and Patch (Manifest) tasks, which currently house all of their logic in the `execute` method, into three methods each: `getOperation`, `executeOperation`, and `getOutputs`. Since something that doesn't really fit into any of those three categories doesn't seem like it belongs in these tasks, hopefully that explicit naming will help us not overload these tasks in the future. In the next commit, we'll pull out manifest resolution, which belongs in a task of its own.

- **refactor(kubernetes): extract source manifest resolution to own task**

  Adds a new tasks responsible only for resolving a source manifest and its associated artifacts for Deploy and Patch (Manifest) stages. Ideally these stages could share one task, but since tasks cannot be parameterized and we need to deserialize the Patch and Deploy (Manifest) stage's context with different implementations of `ManifestContext` (and the Patch and Deploy operations expect the `optionalArtifacts` to be on different context keys), delegate to deploy- and patch-specific resolution tasks.