### PR TITLE
fix(stage): entity tags task succeeds

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTask.groovy
@@ -46,7 +46,7 @@ class AddServerGroupEntityTagsTask extends AbstractCloudProviderAwareTask implem
     try {
       List<Map> tagOperations = buildTagOperations(stage)
       if (!tagOperations) {
-        return TaskResult.ofStatus(ExecutionStatus.SKIPPED)
+        return TaskResult.ofStatus(ExecutionStatus.SUCCEEDED)
       }
       TaskId taskId = kato.requestOperations(tagOperations).toBlocking().first()
       return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(new HashMap<String, Object>() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTaskSpec.groovy
@@ -52,7 +52,7 @@ class AddServerGroupEntityTagsTaskSpec extends Specification {
     1 * katoService.requestOperations(_) >> { throw new RuntimeException("something went wrong") }
   }
 
-  void "skips tagging when no tag generators or generators do not produce any tags"() {
+  void "just completes when no tag generators or generators do not produce any tags"() {
     given:
     AddServerGroupEntityTagsTask emptyTask = new AddServerGroupEntityTagsTask(kato: katoService, tagGenerators: [])
 
@@ -65,7 +65,7 @@ class AddServerGroupEntityTagsTaskSpec extends Specification {
     def result = emptyTask.execute(stage)
 
     then:
-    result.status == ExecutionStatus.SKIPPED
+    result.status == ExecutionStatus.SUCCEEDED
     0 * _
   }
 }


### PR DESCRIPTION
We don't actually handle returning `SKIPPED` for status here. It makes it so the stage always fails because `SKIPPED` isn't a valid status. I choose to return `SUCCEEDED` because there were 0 tags, so it's a success. I don't think that tags are required for all spinnakers so i don't think it's correct to fail the stage if there are no tags.