### PR TITLE
chore(plugins): adding plugins dir and application name

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -3,5 +3,6 @@ MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/orca-web/build/install/orca /opt/orca
 RUN apk --no-cache add --update bash openjdk8-jre
 RUN adduser -D -S spinnaker
+RUN mkdir plugins && chown -R 100:100 plugins
 USER spinnaker
 CMD ["/opt/orca/bin/orca"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -3,5 +3,6 @@ MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/orca-web/build/install/orca /opt/orca
 RUN apt-get update && apt-get -y install openjdk-8-jre-headless wget
 RUN adduser --disabled-login --system spinnaker
+RUN mkdir plugins && chown -R 102:nogroup plugins
 USER spinnaker
 CMD ["/opt/orca/bin/orca"]


### PR DESCRIPTION
This creates the default plugins directory so plugins can be downloaded and placed locally. I needed to add the spring.application.name in gradle.properties as well, otherwise plugins would fail to start when running in a container.