### PR TITLE
fix(ci): Properly set artifacts on CI stage output

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/CIStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/CIStageDefinition.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.Getter;
 
@@ -29,6 +30,7 @@ public class CIStageDefinition implements RetryableStageDefinition {
   private final String job;
   private final String propertyFile;
   private final Integer buildNumber;
+  private final Map<String, Object> buildInfo;
   private final boolean waitForCompletion;
   private final List<ExpectedArtifact> expectedArtifacts;
   private final int consecutiveErrors;
@@ -41,6 +43,7 @@ public class CIStageDefinition implements RetryableStageDefinition {
       @JsonProperty("job") String job,
       @JsonProperty("property") String propertyFile,
       @JsonProperty("buildNumber") Integer buildNumber,
+      @JsonProperty("buildInfo") Map<String, Object> buildInfo,
       @JsonProperty("waitForCompletion") Boolean waitForCompletion,
       @JsonProperty("expectedArtifacts") List<ExpectedArtifact> expectedArtifacts,
       @JsonProperty("consecutiveErrors") Integer consecutiveErrors) {
@@ -48,6 +51,7 @@ public class CIStageDefinition implements RetryableStageDefinition {
     this.job = job;
     this.propertyFile = propertyFile;
     this.buildNumber = buildNumber;
+    this.buildInfo = buildInfo;
     this.waitForCompletion = Optional.ofNullable(waitForCompletion).orElse(true);
     this.expectedArtifacts =
         Collections.unmodifiableList(

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/CIStageDefinition.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/CIStageDefinition.java
@@ -17,10 +17,11 @@
 package com.netflix.spinnaker.orca.igor.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import lombok.Getter;
 
@@ -30,7 +31,7 @@ public class CIStageDefinition implements RetryableStageDefinition {
   private final String job;
   private final String propertyFile;
   private final Integer buildNumber;
-  private final Map<String, Object> buildInfo;
+  private final BuildInfo buildInfo;
   private final boolean waitForCompletion;
   private final List<ExpectedArtifact> expectedArtifacts;
   private final int consecutiveErrors;
@@ -43,7 +44,7 @@ public class CIStageDefinition implements RetryableStageDefinition {
       @JsonProperty("job") String job,
       @JsonProperty("property") String propertyFile,
       @JsonProperty("buildNumber") Integer buildNumber,
-      @JsonProperty("buildInfo") Map<String, Object> buildInfo,
+      @JsonProperty("buildInfo") BuildInfo buildInfo,
       @JsonProperty("waitForCompletion") Boolean waitForCompletion,
       @JsonProperty("expectedArtifacts") List<ExpectedArtifact> expectedArtifacts,
       @JsonProperty("consecutiveErrors") Integer consecutiveErrors) {
@@ -51,11 +52,21 @@ public class CIStageDefinition implements RetryableStageDefinition {
     this.job = job;
     this.propertyFile = propertyFile;
     this.buildNumber = buildNumber;
-    this.buildInfo = buildInfo;
+    this.buildInfo = Optional.ofNullable(buildInfo).orElse(new BuildInfo(null));
     this.waitForCompletion = Optional.ofNullable(waitForCompletion).orElse(true);
     this.expectedArtifacts =
         Collections.unmodifiableList(
             Optional.ofNullable(expectedArtifacts).orElse(Collections.emptyList()));
     this.consecutiveErrors = Optional.ofNullable(consecutiveErrors).orElse(0);
+  }
+
+  @Getter
+  public static class BuildInfo {
+    private final ImmutableList<Artifact> artifacts;
+
+    public BuildInfo(@JsonProperty("artifacts") List<Artifact> artifacts) {
+      this.artifacts =
+          Optional.ofNullable(artifacts).map(ImmutableList::copyOf).orElse(ImmutableList.of());
+    }
   }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTask.java
@@ -45,7 +45,7 @@ public class GetBuildArtifactsTask extends RetryableIgorTask<CIStageDefinition> 
             stageDefinition.getMaster(),
             stageDefinition.getJob());
     Map<String, List<Artifact>> outputs =
-        (artifacts != null && !artifacts.isEmpty())
+        (artifacts != null)
             ? Collections.singletonMap("artifacts", artifacts)
             : Collections.emptyMap();
     return TaskResult.builder(ExecutionStatus.SUCCEEDED)

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTask.java
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.orca.igor.tasks;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.orca.ExecutionStatus;
 import com.netflix.spinnaker.orca.TaskResult;
@@ -38,7 +36,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class GetBuildArtifactsTask extends RetryableIgorTask<CIStageDefinition> {
   private final BuildService buildService;
-  private final ObjectMapper objectMapper;
 
   @Override
   protected @Nonnull TaskResult tryExecute(@Nonnull CIStageDefinition stageDefinition) {
@@ -51,13 +48,7 @@ public class GetBuildArtifactsTask extends RetryableIgorTask<CIStageDefinition> 
     if (artifacts == null) {
       artifacts = new ArrayList<>();
     }
-    if (stageDefinition.getBuildInfo() != null
-        && stageDefinition.getBuildInfo().containsKey("artifacts")) {
-      artifacts.addAll(
-          objectMapper.convertValue(
-              stageDefinition.getBuildInfo().get("artifacts"),
-              new TypeReference<ArrayList<Artifact>>() {}));
-    }
+    artifacts.addAll(stageDefinition.getBuildInfo().getArtifacts());
     Map<String, List<Artifact>> outputs = Collections.singletonMap("artifacts", artifacts);
     return TaskResult.builder(ExecutionStatus.SUCCEEDED)
         .context(Collections.emptyMap())

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTask.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -39,16 +38,16 @@ public class GetBuildArtifactsTask extends RetryableIgorTask<CIStageDefinition> 
 
   @Override
   protected @Nonnull TaskResult tryExecute(@Nonnull CIStageDefinition stageDefinition) {
-    if (StringUtils.isEmpty(stageDefinition.getPropertyFile())) {
-      return TaskResult.SUCCEEDED;
-    }
     List<Artifact> artifacts =
         buildService.getArtifacts(
             stageDefinition.getBuildNumber(),
             stageDefinition.getPropertyFile(),
             stageDefinition.getMaster(),
             stageDefinition.getJob());
-    Map<String, List<Artifact>> outputs = Collections.singletonMap("artifacts", artifacts);
+    Map<String, List<Artifact>> outputs =
+        (artifacts != null && !artifacts.isEmpty())
+            ? Collections.singletonMap("artifacts", artifacts)
+            : Collections.emptyMap();
     return TaskResult.builder(ExecutionStatus.SUCCEEDED)
         .context(Collections.emptyMap())
         .outputs(outputs)

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTaskSpec.groovy
@@ -63,28 +63,32 @@ class GetBuildArtifactsTaskSpec extends Specification {
     artifacts.size() == 0
   }
 
-  def "does not fetch artifacts if the property file is empty"() {
+  def "fetches artifacts if the property file is empty"() {
     given:
     def stage = createStage("")
 
     when:
     TaskResult result = task.execute(stage)
+    def artifacts = result.getOutputs().get("artifacts") as List<Artifact>
 
     then:
-    0 * buildService.getArtifacts(*_)
-    result.outputs.size() == 0
+    1 * buildService.getArtifacts(BUILD_NUMBER, "", MASTER, JOB) >> [testArtifact]
+    artifacts.size() == 1
+    artifacts.get(0).getName() == "my-artifact"
   }
 
-  def "does not fetch artifacts if the property file is null"() {
+  def "fetches artifacts if the property file is null"() {
     given:
     def stage = createStage(null)
 
     when:
     TaskResult result = task.execute(stage)
+    def artifacts = result.getOutputs().get("artifacts") as List<Artifact>
 
     then:
-    0 * buildService.getArtifacts(*_)
-    result.outputs.size() == 0
+    1 * buildService.getArtifacts(BUILD_NUMBER, null, MASTER, JOB)  >> [testArtifact]
+    artifacts.size() == 1
+    artifacts.get(0).getName() == "my-artifact"
   }
 
   def createStage(String propertyFile) {

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTaskSpec.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.orca.igor.tasks
 
-import com.fasterxml.jackson.databind.ObjectMapper
+
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.igor.BuildService
@@ -35,7 +35,7 @@ class GetBuildArtifactsTaskSpec extends Specification {
   def PROPERTY_FILE = "my-file"
 
   @Subject
-  GetBuildArtifactsTask task = new GetBuildArtifactsTask(buildService, new ObjectMapper())
+  GetBuildArtifactsTask task = new GetBuildArtifactsTask(buildService)
 
   def "retrieves artifacts and adds them to the stage outputs"() {
     given:

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildArtifactsTaskSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.igor.tasks
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.orca.TaskResult
 import com.netflix.spinnaker.orca.igor.BuildService
@@ -34,9 +35,9 @@ class GetBuildArtifactsTaskSpec extends Specification {
   def PROPERTY_FILE = "my-file"
 
   @Subject
-  GetBuildArtifactsTask task = new GetBuildArtifactsTask(buildService)
+  GetBuildArtifactsTask task = new GetBuildArtifactsTask(buildService, new ObjectMapper())
 
-  def "retreives artifacts and adds them to the stage outputs"() {
+  def "retrieves artifacts and adds them to the stage outputs"() {
     given:
     def stage = createStage(PROPERTY_FILE)
 
@@ -89,6 +90,32 @@ class GetBuildArtifactsTaskSpec extends Specification {
     1 * buildService.getArtifacts(BUILD_NUMBER, null, MASTER, JOB)  >> [testArtifact]
     artifacts.size() == 1
     artifacts.get(0).getName() == "my-artifact"
+  }
+
+  def "adds artifacts found in buildInfo to the output"() {
+    given:
+    def stage = createStage(null)
+    stage.context.buildInfo = [
+        artifacts: [[
+            reference: "another-artifact_0.0.1553618414_amd64.deb",
+            fileName: "another-artifact_0.0.1553618414_amd64.deb",
+            relativePath: "another-artifact_0.0.1553618414_amd64.deb",
+            name: "another-artifact",
+            displayPath: "another-artifact_0.0.1553618414_amd64.deb",
+            type: "deb",
+            version: "0.0.1553618414",
+            decorated: true
+        ]]
+    ]
+
+    when:
+    TaskResult result = task.execute(stage)
+    def artifacts = result.getOutputs().get("artifacts") as List<Artifact>
+
+    then:
+    1 * buildService.getArtifacts(BUILD_NUMBER, null, MASTER, JOB)  >> [testArtifact]
+    artifacts.size() == 2
+    artifacts*.name == ["my-artifact", "another-artifact"]
   }
 
   def createStage(String propertyFile) {


### PR DESCRIPTION
The presence of a property file should not affect whether or not artifacts should be added to the output. The Travis and Wercker integrations in Igor don't even care about this property, and the Jenkins integration also works even if the property file is null or blank.

This will also copy artifacts already present in the `buildInfo` to the stage context, to be more in line with CI triggers (where this already happens).

This fix makes it possible to use the "Find Artifacts from Execution" stage with Travis and Wercker, as well as increasing the usability for use with Jenkins.