### PR TITLE
fix(aws/cloudformation): Stage won't try to execute deleted change sets.

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/ExecuteCloudFormationChangeSetTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/ExecuteCloudFormationChangeSetTask.java
@@ -55,6 +55,9 @@ public class ExecuteCloudFormationChangeSetTask extends AbstractCloudProviderAwa
             Optional.ofNullable(stage.getContext().get("actionOnReplacement"))
                 .orElse(ACTION_ON_REPLACEMENT_FAIL);
 
+    boolean isChangeSetDeletion =
+        (boolean) Optional.ofNullable(stage.getContext().get("deleteChangeSet")).orElse(false);
+
     Optional<Map> currentChangeSet = getCurrentChangeSet(stage);
     if (currentChangeSet.isPresent()) {
       if (isAnyChangeSetReplacement(currentChangeSet.get())) {
@@ -64,7 +67,11 @@ public class ExecuteCloudFormationChangeSetTask extends AbstractCloudProviderAwa
           case ACTION_ON_REPLACEMENT_FAIL:
             throw new RuntimeException("ChangeSet has a replacement, failing!");
         }
+      } else if (isChangeSetDeletion) {
+        return TaskResult.SUCCEEDED;
       }
+    } else {
+      return TaskResult.SUCCEEDED;
     }
 
     String cloudProvider = getCloudProvider(stage);

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTask.java
@@ -65,17 +65,22 @@ public class WaitForCloudFormationCompletionTask implements OverridableTimeoutRe
               + stackId
               + " with status "
               + stack.get("stackStatus"));
+
       boolean isChangeSet =
           (boolean) Optional.ofNullable(stage.getContext().get("isChangeSet")).orElse(false);
       boolean isChangeSetExecution =
           (boolean)
               Optional.ofNullable(stage.getContext().get("isChangeSetExecution")).orElse(false);
+      boolean isChangeSetDeletion =
+          (boolean) Optional.ofNullable(stage.getContext().get("deleteChangeSet")).orElse(false);
+
       log.info("Deploying a CloudFormation ChangeSet for stackId " + stackId + ": " + isChangeSet);
 
       String status =
-          (isChangeSet && !isChangeSetExecution)
+          (isChangeSet && !isChangeSetExecution && !isChangeSetDeletion)
               ? getChangeSetInfo(stack, stage.getContext(), "status")
               : getStackInfo(stack, "stackStatus");
+
       if (isComplete(status)) {
         return TaskResult.builder(ExecutionStatus.SUCCEEDED).outputs(stack).build();
       } else if (isEmptyChangeSet(stage, stack)) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/ExecuteCloudFormationChangeSetTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/ExecuteCloudFormationChangeSetTaskSpec.groovy
@@ -126,6 +126,33 @@ class ExecuteCloudFormationChangeSetTaskSpec extends Specification {
 
   }
 
+  def "should end up succesfully when the changeset has been deleted in previous tasks"() {
+    given:
+    def pipeline = Execution.newPipeline('orca')
+    def context = [
+      'cloudProvider': 'aws',
+      'isChangeSet': true,
+      'deleteChangeSet': true,
+      'changeSetName': 'deletedOne'
+    ]
+    def stage = new Stage(pipeline, 'test', 'test', context)
+    def outputs = [
+      changeSets: [
+        [
+          name: 'deletedOne',
+          changes: []
+        ]
+      ]
+    ]
+    stage.setOutputs(outputs)
+
+    when:
+    def result = executeCloudFormationChangeSetTask.execute(stage)
+
+    then:
+    result.status == ExecutionStatus.SUCCEEDED
+
+  }
   def "should throw and exception when is a changeset and is set to fail"() {
     given:
     def pipeline = Execution.newPipeline('orca')


### PR DESCRIPTION
By default empty cloud formation changeSets are deleted to keep things tidy. 
There is an unexpected behavior when the user has the executionChangeSet flag enabled and uploads an empty changeSet, the changeset gets deleted and then tries to be executed, causing the stage to fail as the changeSet cannot be found anymore.

This change skips the execution when s a previous changeSet deletion (empty changeSet) is found.

It covers the most used case as we allow to apply empty cloud formation changesets from git and if there are no infra changes proceed with the application deployment without any failure. 