### PR TITLE
fix(clusterCalc): changing ceiling calculation to round for healthyDeployPercentage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
@@ -141,7 +141,7 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
         throw new NumberFormatException("targetHealthyDeployPercentage must be an integer between 0 and 100")
       }
 
-      def newTargetDesiredSize = Math.ceil(percentage * targetDesiredSize / 100D) as Integer
+      def newTargetDesiredSize = Math.max(Math.round(percentage * targetDesiredSize / 100D), 1) as Integer
       splainer.add("setting targetDesiredSize=${newTargetDesiredSize} based on configured targetHealthyDeployPercentage=${percentage}% of previous targetDesiredSize=${targetDesiredSize}")
       targetDesiredSize = newTargetDesiredSize
     } else if (stage.context.desiredPercentage != null) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
@@ -177,11 +177,13 @@ class WaitForUpInstancesTaskSpec extends Specification {
     89      | 9       | 10    || true
     90      | 9       | 10    || true
     90      | 8       | 10    || false
-    91      | 9       | 10    || false
+    91      | 9       | 10    || true
+    95      | 9       | 10    || false
 
-    // verify ceiling
+    // verify round
     90      | 10      | 11    || true
-    90      | 8       | 9     || false
+    90      | 8       | 9     || true
+    95      | 8       | 9     || false
 
   }
 


### PR DESCRIPTION
Changing the calculation for determent the number of healthy clusters from ceiling to round.