### PR TITLE
fix(wait for up): Fix to allow waiting for 0 instances

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
@@ -141,7 +141,12 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
         throw new NumberFormatException("targetHealthyDeployPercentage must be an integer between 0 and 100")
       }
 
-      def newTargetDesiredSize = Math.max(Math.round(percentage * targetDesiredSize / 100D), 1) as Integer
+      def newTargetDesiredSize = Math.round(percentage * targetDesiredSize / 100D) as Integer
+      if ((newTargetDesiredSize == 0) && (percentage != 0) && (targetDesiredSize > 0)) {
+        // Unless the user specified they want 0% or we actually have 0 instances in the server group,
+        // never allow 0 instances due to rounding
+        newTargetDesiredSize = 1
+      }
       splainer.add("setting targetDesiredSize=${newTargetDesiredSize} based on configured targetHealthyDeployPercentage=${percentage}% of previous targetDesiredSize=${targetDesiredSize}")
       targetDesiredSize = newTargetDesiredSize
     } else if (stage.context.desiredPercentage != null) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
@@ -143,7 +143,7 @@ class WaitForUpInstancesTaskSpec extends Specification {
   void 'should return #hasSucceeded for hasSucceeded when targetHealthyDeployPercentage is #percent and #healthy/#total instances are healthy'() {
     expect:
     def instances = []
-    (1..healthy).each {
+    healthy.times {
       instances << [health: [[state: 'Up']]]
     }
     def serverGroup = [
@@ -172,6 +172,7 @@ class WaitForUpInstancesTaskSpec extends Specification {
     // zero percent (should always return true)
     0       | 1       | 2     || true
     0       | 0       | 100   || true
+    100     | 0       | 0     || true
 
     // >= checks
     89      | 9       | 10    || true
@@ -184,14 +185,13 @@ class WaitForUpInstancesTaskSpec extends Specification {
     90      | 10      | 11    || true
     90      | 8       | 9     || true
     95      | 8       | 9     || false
-
   }
 
   @Unroll
   void 'should return #hasSucceeded for hasSucceeded when desiredPercentage is #percent and #healthy/#total instances are healthy'() {
     expect:
     def instances = []
-    (1..healthy).each {
+    healthy.times {
       instances << [health: [[state: 'Up']]]
     }
     def serverGroup = [
@@ -229,7 +229,7 @@ class WaitForUpInstancesTaskSpec extends Specification {
     90      | 8       | 10    | 10  | 10  || false
     91      | 9       | 10    | 10  | 10  || false
 
-    // verify ceiling
+    // verify round
     90      | 10      | 11    | 10  | 11  || true
     90      | 8       | 9     | 9   | 9   || false
 
@@ -312,7 +312,7 @@ class WaitForUpInstancesTaskSpec extends Specification {
     }
 
     def instances = []
-    (1..healthy).each {
+    healthy.times {
       instances << [health: [[state: 'Up']]]
     }
 
@@ -365,7 +365,7 @@ class WaitForUpInstancesTaskSpec extends Specification {
     }
 
     def instances = []
-    (1..healthy).each {
+    healthy.times {
       instances << [health: [[state: 'Up']]]
     }
 


### PR DESCRIPTION
This is a regression from #3441.
It prevents waiting for 0 instances which is a valid scenario in rolling style deploys.
This should've been caught by a unittest, but the unit tests had a bug which hid this issue (fixed now)
