### PR TITLE
fix(peering): disallow changing partition name and fix cleanup agents

### DIFF
--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/config/PeeringAgentConfigurationProperties.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/config/PeeringAgentConfigurationProperties.kt
@@ -27,4 +27,7 @@ class PeeringAgentConfigurationProperties {
   var threadCount: Int = 30
   var chunkSize: Int = 100
   var clockDriftMs: Long = 5000
+
+  // Only read via dynamicConfigService, here for completeness
+  var maxAllowedDeleteCount: Int = 1000
 }

--- a/orca-sql/src/main/resources/db/changelog-master.yml
+++ b/orca-sql/src/main/resources/db/changelog-master.yml
@@ -41,3 +41,6 @@ databaseChangeLog:
 - include:
     file: changelog/20190911-notification-cluster-lock.yml
     relativeToChangelogFile: true
+- include:
+    file: changelog/20200221-partition-name-table.yml
+    relativeToChangelogFile: true

--- a/orca-sql/src/main/resources/db/changelog/20200221-partition-name-table.yml
+++ b/orca-sql/src/main/resources/db/changelog/20200221-partition-name-table.yml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-partition-name-table
+      author: mvulfson
+      changes:
+        - createTable:
+            tableName: partition_name
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+    rollback:
+      - dropTable:
+          tableName: partition_name

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -60,7 +60,8 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
     0,
     10, // threshold days
     5,  // minimum pipeline executions
-    1
+    1,
+    null
   )
 
   def setupSpec() {

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositorySpec.groovy
@@ -121,6 +121,9 @@ class SqlExecutionRepositorySpec extends ExecutionRepositoryTck<ExecutionReposit
   }
 
   def "persists foreign executions when own partition is not set"() {
+    // Need to clear the DB here
+    cleanup()
+
     given:
     ExecutionRepository repo = createExecutionRepository(null)
     Execution e = new Execution(PIPELINE, "myapp")


### PR DESCRIPTION
This change adds three fixes for peering:
* Once a partition is set on the cluster/db it should never be changed (this is likely a misconfiguration issue)
* Added `where` clause to the pipeline/execution cleanup agents to only clean up executions in it's own partition (if one is set)
* Added prevention to not accidentally delete ALL executions during peering