### PR TITLE
feat(managed-delivery): Include detailed error info in ImportDeliveryConfig

### DIFF
--- a/orca-keel/orca-keel.gradle
+++ b/orca-keel/orca-keel.gradle
@@ -20,6 +20,7 @@ dependencies {
   implementation(project(":orca-core"))
   implementation(project(":orca-retrofit"))
   implementation(project(":orca-igor"))
+  implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
   implementation("org.springframework:spring-web")
   implementation("org.springframework.boot:spring-boot-autoconfigure")

--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/KeelService.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/KeelService.kt
@@ -20,9 +20,11 @@ import com.netflix.spinnaker.orca.keel.model.DeliveryConfig
 import retrofit.client.Response
 import retrofit.http.Body
 import retrofit.http.Header
+import retrofit.http.Headers
 import retrofit.http.POST
 
 interface KeelService {
   @POST("/delivery-configs/")
+  @Headers("Accept: application/json")
   fun publishDeliveryConfig(@Body deliveryConfig: DeliveryConfig, @Header(value = "X-SPINNAKER-USER") user: String): Response
 }

--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
@@ -115,9 +115,9 @@ constructor(
         // just give up on 4xx errors, which are unlikely to resolve with retries
         buildError(
           // ...but give users a hint about 401 errors from igor/scm
-          if (response.status == 401 && URL(e.url).host.contains("igor")) {
+          if (response.status == 401 && e.fromIgor) {
             UNAUTHORIZED_SCM_ACCESS_MESSAGE
-          } else if (response.status == 400 && URL(e.url).host.contains("keel") && response.body.length() > 0) {
+          } else if (response.status == 400 && e.fromKeel && response.body.length() > 0) {
             objectMapper.readValue<Map<String, Any?>>(response.body.`in`())
           } else {
             "Non-retryable HTTP response ${e.response?.status} received from downstream service: ${e.friendlyMessage}"
@@ -168,6 +168,18 @@ constructor(
       "HTTP ${response.status} ${response.url}: ${cause?.message ?: message}"
     } else {
       "$message: ${cause?.message ?: ""}"
+    }
+
+  val RetrofitError.fromIgor: Boolean
+    get() {
+      val parsedUrl = URL(url)
+      return parsedUrl.host.contains("igor") || parsedUrl.port == 8085
+    }
+
+  val RetrofitError.fromKeel: Boolean
+    get() {
+      val parsedUrl = URL(url)
+      return parsedUrl.host.contains("keel") || parsedUrl.port == 8087
     }
 
   data class ImportDeliveryConfigContext(

--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
@@ -111,13 +111,14 @@ constructor(
           "Network error talking to downstream service, attempt ${context.attempt} of ${context.maxRetries}: ${e.friendlyMessage}")
       }
       e.response?.status in 400..499 -> {
+        val response = e.response!!
         // just give up on 4xx errors, which are unlikely to resolve with retries
         buildError(
           // ...but give users a hint about 401 errors from igor/scm
-          if (e.response?.status == 401 && URL(e.url).host.contains("igor")) {
+          if (response.status == 401 && URL(e.url).host.contains("igor")) {
             UNAUTHORIZED_SCM_ACCESS_MESSAGE
-          } else if (e.response?.status == 400 && URL(e.url).host.contains("keel") && e.response!!.body.length() > 0) {
-            objectMapper.readValue<Map<String, Any?>>(e.response!!.body.`in`())
+          } else if (response.status == 400 && URL(e.url).host.contains("keel") && response.body.length() > 0) {
+            objectMapper.readValue<Map<String, Any?>>(response.body.`in`())
           } else {
             "Non-retryable HTTP response ${e.response?.status} received from downstream service: ${e.friendlyMessage}"
           }

--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
@@ -149,12 +149,13 @@ constructor(
   }
 
   private fun buildError(error: Any): TaskResult {
-    if (error is Map<*, *>) {
-      log.error(error["message"]?.toString())
+    val normalizedError = if (error is Map<*, *>) {
+      error["error"] ?: error
     } else {
-      log.error(error.toString())
+      error.toString()
     }
-    return TaskResult.builder(ExecutionStatus.TERMINAL).context(mapOf("error" to error)).build()
+    log.error(normalizedError.toString())
+    return TaskResult.builder(ExecutionStatus.TERMINAL).context(mapOf("error" to normalizedError)).build()
   }
 
   override fun getBackoffPeriod() = TimeUnit.SECONDS.toMillis(30)

--- a/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
+++ b/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
@@ -103,18 +103,16 @@ internal class ImportDeliveryConfigTaskTests : JUnit5Minutests {
       )
 
     val parsingError = mapOf(
-      "error" to mapOf(
+      "message" to "Parsing error",
+      "details" to mapOf(
         "message" to "Parsing error",
-        "details" to mapOf(
-          "message" to "Parsing error",
-          "path" to listOf(
-            mapOf(
-              "type" to "SomeClass",
-              "field" to "someField"
-            )
-          ),
-          "pathExpression" to ".someField"
-        )
+        "path" to listOf(
+          mapOf(
+            "type" to "SomeClass",
+            "field" to "someField"
+          )
+        ),
+        "pathExpression" to ".someField"
       )
     )
   }

--- a/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
+++ b/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
@@ -36,9 +36,12 @@ import io.mockk.mockk
 import io.mockk.verify
 import retrofit.RetrofitError
 import retrofit.client.Response
+import retrofit.converter.JacksonConverter
+import retrofit.mime.TypedInput
 import strikt.api.expectThat
 import strikt.api.expectThrows
 import strikt.assertions.contains
+import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 import java.lang.IllegalArgumentException
@@ -98,6 +101,22 @@ internal class ImportDeliveryConfigTaskTests : JUnit5Minutests {
           context
         )
       )
+
+    val parsingError = mapOf(
+      "error" to mapOf(
+        "message" to "Parsing error",
+        "details" to mapOf(
+          "message" to "Parsing error",
+          "path" to listOf(
+            mapOf(
+              "type" to "SomeClass",
+              "field" to "someField"
+            )
+          ),
+          "pathExpression" to ".someField"
+        )
+      )
+    )
   }
 
   private fun ManifestLocation.toMap() =
@@ -289,6 +308,31 @@ internal class ImportDeliveryConfigTaskTests : JUnit5Minutests {
           val result = execute(manifestLocation.toMap())
           expectThat(result.status).isEqualTo(ExecutionStatus.TERMINAL)
           expectThat(result.context["error"]).isEqualTo(UNAUTHORIZED_SCM_ACCESS_MESSAGE)
+        }
+      }
+
+      context("delivery config parsing error") {
+        modifyFixture {
+          with(scmService) {
+            every {
+              getDeliveryConfigManifest(
+                manifestLocation.repoType,
+                manifestLocation.projectKey,
+                manifestLocation.repositorySlug,
+                manifestLocation.directory,
+                manifestLocation.manifest,
+                manifestLocation.ref
+              )
+            } throws RetrofitError.httpError("http://keel",
+              Response("http://keel", 400, "", emptyList(), JacksonConverter(ObjectMapper()).toBody(parsingError) as TypedInput),
+              null, null)
+          }
+        }
+
+        test("task fails and includes the error details returned by keel") {
+          val result = execute(manifestLocation.toMap())
+          expectThat(result.status).isEqualTo(ExecutionStatus.TERMINAL)
+          expectThat(result.context["error"]).isA<Map<String, Any>>().isEqualTo(parsingError)
         }
       }
 


### PR DESCRIPTION
Include detailed error information added to keel in https://github.com/spinnaker/keel/pull/821 so it can be displayed in the UI.

Another piece to https://github.com/spinnaker/keel/issues/818