### PR TITLE
fix(interlink): apply events to a queue+repo operator

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -36,9 +36,7 @@ import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
 import com.netflix.spinnaker.orca.libdiffs.ComparableLooseVersion;
 import com.netflix.spinnaker.orca.libdiffs.DefaultComparableLooseVersion;
 import com.netflix.spinnaker.orca.listeners.*;
-import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory;
-import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilder;
-import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory;
+import com.netflix.spinnaker.orca.pipeline.*;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
 import java.time.Clock;
@@ -225,5 +223,11 @@ public class OrcaConfiguration {
   public ForceExecutionCancellationCommand forceExecutionCancellationCommand(
       ExecutionRepository executionRepository, Clock clock) {
     return new ForceExecutionCancellationCommand(executionRepository, clock);
+  }
+
+  @Bean
+  public CompoundExecutionOperator compoundExecutionOperator(
+      ExecutionRepository repository, ExecutionRunner runner, RetrySupport retrySupport) {
+    return new CompoundExecutionOperator(repository, runner, retrySupport);
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
@@ -91,16 +91,8 @@ public class CompoundExecutionOperator {
       ExecutionType executionType,
       String executionId) {
     try {
-      retrySupport.retry(
-          () -> {
-            runnerAction.run();
-            return true;
-          },
-          5,
-          Duration.ofMillis(100),
-          false);
-
-      repositoryAction.run();
+      runWithRetries(runnerAction);
+      runWithRetries(repositoryAction);
     } catch (Exception e) {
       log.error(
           "Failed to {} execution with executionType={} and executionId={}",
@@ -109,5 +101,16 @@ public class CompoundExecutionOperator {
           executionId,
           e);
     }
+  }
+
+  private void runWithRetries(Runnable action) {
+    retrySupport.retry(
+        () -> {
+          action.run();
+          return true;
+        },
+        5,
+        Duration.ofMillis(100),
+        false);
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline;
+
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.time.Duration;
+import javax.annotation.Nullable;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CompoundExecutionOperator {
+  private ExecutionRepository repository;
+  private ExecutionRunner runner;
+  private RetrySupport retrySupport;
+
+  public CompoundExecutionOperator(
+      ExecutionRepository repository, ExecutionRunner runner, RetrySupport retrySupport) {
+    this.repository = repository;
+    this.runner = runner;
+    this.retrySupport = retrySupport;
+  }
+
+  public void cancel(ExecutionType executionType, String executionId) {
+    cancel(
+        executionType,
+        executionId,
+        AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"),
+        null);
+  }
+
+  public void cancel(ExecutionType executionType, String executionId, String user, String reason) {
+    doInternal(
+        () -> runner.cancel(repository.retrieve(executionType, executionId), user, reason),
+        () -> repository.cancel(executionType, executionId, user, reason),
+        "cancel",
+        executionType,
+        executionId);
+  }
+
+  public void delete(ExecutionType executionType, String executionId) {
+    repository.delete(executionType, executionId);
+  }
+
+  public void pause(
+      @NonNull ExecutionType executionType,
+      @NonNull String executionId,
+      @Nullable String pausedBy) {
+    doInternal(
+        () -> runner.reschedule(repository.retrieve(executionType, executionId)),
+        () -> repository.pause(executionType, executionId, pausedBy),
+        "pause",
+        executionType,
+        executionId);
+  }
+
+  public void resume(
+      @NonNull ExecutionType executionType,
+      @NonNull String executionId,
+      @Nullable String user,
+      @NonNull Boolean ignoreCurrentStatus) {
+    doInternal(
+        () -> runner.unpause(repository.retrieve(executionType, executionId)),
+        () -> repository.resume(executionType, executionId, user, ignoreCurrentStatus),
+        "resume",
+        executionType,
+        executionId);
+  }
+
+  private void doInternal(
+      Runnable runnerAction,
+      Runnable repositoryAction,
+      String action,
+      ExecutionType executionType,
+      String executionId) {
+    try {
+      retrySupport.retry(
+          () -> {
+            runnerAction.run();
+            return true;
+          },
+          5,
+          Duration.ofMillis(100),
+          false);
+
+      repositoryAction.run();
+    } catch (Exception e) {
+      log.error(
+          "Failed to {} execution with executionType={} and executionId={}",
+          action,
+          executionType,
+          executionId,
+          e);
+    }
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionRunner.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionRunner.java
@@ -21,22 +21,21 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface ExecutionRunner {
-  void start(@Nonnull Execution execution) throws Exception;
+  void start(@Nonnull Execution execution);
 
-  default void restart(@Nonnull Execution execution, @Nonnull String stageId) throws Exception {
+  default void restart(@Nonnull Execution execution, @Nonnull String stageId) {
     throw new UnsupportedOperationException();
   }
 
-  default void reschedule(@Nonnull Execution execution) throws Exception {
+  default void reschedule(@Nonnull Execution execution) {
     throw new UnsupportedOperationException();
   }
 
-  default void unpause(@Nonnull Execution execution) throws Exception {
+  default void unpause(@Nonnull Execution execution) {
     throw new UnsupportedOperationException();
   }
 
-  default void cancel(@Nonnull Execution execution, @Nonnull String user, @Nullable String reason)
-      throws Exception {
+  default void cancel(@Nonnull Execution execution, @Nonnull String user, @Nullable String reason) {
     throw new UnsupportedOperationException();
   }
 }

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/config/InterlinkConfiguration.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/config/InterlinkConfiguration.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.kork.pubsub.config.PubsubConfig;
 import com.netflix.spinnaker.orca.interlink.Interlink;
 import com.netflix.spinnaker.orca.interlink.MessageFlagger;
 import com.netflix.spinnaker.orca.interlink.aws.InterlinkAmazonMessageHandler;
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import java.time.Clock;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +47,9 @@ public class InterlinkConfiguration {
   @Bean
   @ConditionalOnProperty({"pubsub.enabled", "pubsub.amazon.enabled"})
   public AmazonPubsubMessageHandlerFactory amazonPubsubMessageHandlerFactory(
-      ObjectMapper objectMapper, ExecutionRepository repository) {
+      ObjectMapper objectMapper,
+      ExecutionRepository repository,
+      CompoundExecutionOperator executionOperator) {
     return new AmazonPubsubMessageHandlerFactory() {
       @Override
       public AmazonPubsubMessageHandler create(
@@ -57,7 +60,7 @@ public class InterlinkConfiguration {
           return null;
         }
 
-        return new InterlinkAmazonMessageHandler(objectMapper, repository);
+        return new InterlinkAmazonMessageHandler(objectMapper, repository, executionOperator);
       }
     };
   }

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/aws/InterlinkAmazonMessageHandler.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/aws/InterlinkAmazonMessageHandler.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.kork.pubsub.aws.NotificationMessage;
 import com.netflix.spinnaker.kork.pubsub.aws.api.AmazonPubsubMessageHandler;
 import com.netflix.spinnaker.orca.interlink.InterlinkMessageHandlingException;
 import com.netflix.spinnaker.orca.interlink.events.InterlinkEvent;
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,11 +32,15 @@ import lombok.extern.slf4j.Slf4j;
 public class InterlinkAmazonMessageHandler implements AmazonPubsubMessageHandler {
   private final ObjectMapper objectMapper;
   private final ExecutionRepository executionRepository;
+  private final CompoundExecutionOperator executionOperator;
 
   public InterlinkAmazonMessageHandler(
-      ObjectMapper objectMapper, ExecutionRepository executionRepository) {
+      ObjectMapper objectMapper,
+      ExecutionRepository executionRepository,
+      CompoundExecutionOperator executionOperator) {
     this.objectMapper = objectMapper;
     this.executionRepository = executionRepository;
+    this.executionOperator = executionOperator;
   }
 
   @Override
@@ -55,7 +60,7 @@ public class InterlinkAmazonMessageHandler implements AmazonPubsubMessageHandler
   @VisibleForTesting
   void handleInternal(InterlinkEvent event) {
     if (executionRepository.handlesPartition(event.getPartition())) {
-      event.applyTo(executionRepository);
+      event.applyTo(executionOperator);
     } else {
       log.debug(
           "Execution repository with local partition {} does not handle this event's partition {}, "

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/CancelInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/CancelInterlinkEvent.java
@@ -18,10 +18,13 @@ package com.netflix.spinnaker.orca.interlink.events;
 
 import static com.netflix.spinnaker.orca.interlink.events.InterlinkEvent.EventType.CANCEL;
 
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import javax.annotation.Nullable;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Data
 @AllArgsConstructor
@@ -46,7 +49,7 @@ public class CancelInterlinkEvent implements InterlinkEvent {
   }
 
   @Override
-  public void applyTo(ExecutionRepository executionRepository) {
-    executionRepository.cancel(executionType, executionId, canceledBy, cancellationReason);
+  public void applyTo(CompoundExecutionOperator executionOperator) {
+    executionOperator.cancel(executionType, executionId, canceledBy, cancellationReason);
   }
 }

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/DeleteInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/DeleteInterlinkEvent.java
@@ -18,10 +18,13 @@ package com.netflix.spinnaker.orca.interlink.events;
 
 import static com.netflix.spinnaker.orca.interlink.events.InterlinkEvent.EventType.DELETE;
 
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import javax.annotation.Nullable;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Data
 @AllArgsConstructor
@@ -39,7 +42,7 @@ public class DeleteInterlinkEvent implements InterlinkEvent {
   }
 
   @Override
-  public void applyTo(ExecutionRepository executionRepository) {
-    executionRepository.delete(executionType, executionId);
+  public void applyTo(CompoundExecutionOperator executionOperator) {
+    executionOperator.delete(executionType, executionId);
   }
 }

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
@@ -19,8 +19,8 @@ package com.netflix.spinnaker.orca.interlink.events;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import javax.validation.constraints.NotNull;
 
 /** Common interface for all interlink event messages */
@@ -55,7 +55,7 @@ public interface InterlinkEvent {
     return this;
   }
 
-  void applyTo(ExecutionRepository executionRepository);
+  void applyTo(CompoundExecutionOperator executionOperator);
 
   @JsonIgnore
   @NotNull

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PauseInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PauseInterlinkEvent.java
@@ -18,10 +18,13 @@ package com.netflix.spinnaker.orca.interlink.events;
 
 import static com.netflix.spinnaker.orca.interlink.events.InterlinkEvent.EventType.PAUSE;
 
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import javax.annotation.Nullable;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Data
 @AllArgsConstructor
@@ -43,7 +46,7 @@ public class PauseInterlinkEvent implements InterlinkEvent {
   }
 
   @Override
-  public void applyTo(ExecutionRepository executionRepository) {
-    executionRepository.pause(executionType, executionId, pausedBy);
+  public void applyTo(CompoundExecutionOperator executionOperator) {
+    executionOperator.pause(executionType, executionId, pausedBy);
   }
 }

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/ResumeInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/ResumeInterlinkEvent.java
@@ -18,10 +18,13 @@ package com.netflix.spinnaker.orca.interlink.events;
 
 import static com.netflix.spinnaker.orca.interlink.events.InterlinkEvent.EventType.RESUME;
 
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import com.netflix.spinnaker.orca.pipeline.model.Execution;
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import javax.annotation.Nullable;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Data
 @AllArgsConstructor
@@ -46,7 +49,7 @@ public class ResumeInterlinkEvent implements InterlinkEvent {
   }
 
   @Override
-  public void applyTo(ExecutionRepository executionRepository) {
-    executionRepository.resume(executionType, executionId, user, ignoreCurrentStatus);
+  public void applyTo(CompoundExecutionOperator executionOperator) {
+    executionOperator.resume(executionType, executionId, user, ignoreCurrentStatus);
   }
 }

--- a/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/InterlinkSpec.groovy
+++ b/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/InterlinkSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.interlink
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.interlink.events.*
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import spock.lang.Shared
 import spock.lang.Specification
@@ -54,13 +55,13 @@ class InterlinkSpec extends Specification {
   @Unroll
   def "event type #event.getEventType() applies the `#methodName` method"() {
     given:
-    def executionRepo = Mock(ExecutionRepository)
+    def executionOperator = Mock(CompoundExecutionOperator)
 
     when:
-    event.applyTo(executionRepo)
+    event.applyTo(executionOperator)
 
     then:
-    1 * executionRepo."$methodName"(*_)
+    1 * executionOperator."$methodName"(*_)
 
     where:
     event  | methodName

--- a/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/aws/InterlinkAmazonMessageHandlerSpec.groovy
+++ b/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/aws/InterlinkAmazonMessageHandlerSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.interlink.aws
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.interlink.events.DeleteInterlinkEvent
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import spock.lang.Specification
 
@@ -28,9 +29,11 @@ class InterlinkAmazonMessageHandlerSpec extends Specification {
   def 'checks if the execution repo handles the partition of the event'() {
     given:
     def executionRepo = Mock(ExecutionRepository)
+    def executionOperator = Mock(CompoundExecutionOperator)
     def handler = new InterlinkAmazonMessageHandler(
         Mock(ObjectMapper),
-        executionRepo
+        executionRepo,
+        executionOperator
     )
 
     when:
@@ -38,13 +41,13 @@ class InterlinkAmazonMessageHandlerSpec extends Specification {
 
     then:
     1 * executionRepo.handlesPartition("local") >> true
-    1 * executionRepo.delete(PIPELINE, "id")
+    1 * executionOperator.delete(PIPELINE, "id")
 
     when:
     handler.handleInternal(new DeleteInterlinkEvent(PIPELINE, "id").withPartition("foreign"))
 
     then:
     1 * executionRepo.handlesPartition("foreign") >> false
-    0 * executionRepo.delete(PIPELINE, "id")
+    0 * executionOperator.delete(PIPELINE, "id")
   }
 }


### PR DESCRIPTION
For some actions (like cancel, resume, pause), it is not sufficient to invoke the correspond execution repository call, we also need to create some events on the message queue (e.g. to actually cancel running tasks).

The task controller already has the logic to update both the queue and the execution repo, so I'm lifting some of it in a common but somewhat awkwardly named CompoundExecutionOperator. As a result, the same logic will be executed by the task controller and interlink events.
