### PR TITLE
fix(peering): Don't use `null` partition on local db during peering

### DIFF
--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
@@ -112,6 +112,7 @@ class PeeringAgent(
     log.debug("Starting active $executionType copy for peering")
 
     val activePipelineIds = srcDB.getActiveExecutionIds(executionType, peeredId)
+      .plus(srcDB.getActiveExecutionIds(executionType, null))
 
     if (activePipelineIds.isNotEmpty()) {
       log.debug("Found ${activePipelineIds.size} active $executionType, copying all")
@@ -139,6 +140,7 @@ class PeeringAgent(
 
     // Compute diff
     val completedPipelineKeys = srcDB.getCompletedExecutionIds(executionType, peeredId, updatedAfter)
+      .plus(srcDB.getCompletedExecutionIds(executionType, null, updatedAfter))
     val migratedPipelineKeys = destDB.getCompletedExecutionIds(executionType, peeredId, updatedAfter)
 
     val completedPipelineKeysMap = completedPipelineKeys

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/SqlRawAccess.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/SqlRawAccess.kt
@@ -32,12 +32,12 @@ abstract class SqlRawAccess(
   /**
    *  Returns a list of execution IDs and their update_at times for completed executions
    */
-  abstract fun getCompletedExecutionIds(executionType: Execution.ExecutionType, partitionName: String, updatedAfter: Long): List<ExecutionDiffKey>
+  abstract fun getCompletedExecutionIds(executionType: Execution.ExecutionType, partitionName: String?, updatedAfter: Long): List<ExecutionDiffKey>
 
   /**
    *  Returns a list of execution IDs for active (not completed) executions
    */
-  abstract fun getActiveExecutionIds(executionType: Execution.ExecutionType, partitionName: String): List<String>
+  abstract fun getActiveExecutionIds(executionType: Execution.ExecutionType, partitionName: String?): List<String>
 
   /**
    * Returns a list of stage IDs that belong to the given executions


### PR DESCRIPTION
For historical reasons, `partition=null` is set on all current executions (since sqlrepo runs without a partition).
So when checking if an execution is local we need to check if `parition == MY_PARTITION` OR `partition is null`.
However, this check is not correct when copying from the peer. From the peer we need to get `partition == peerId or partition is null`,
but locally it must always be `partition == peerId` because we force set the partition during copy.
Without that we would think that we need to delete all our local executions since they would not show up in the peer query
This change fixes this issue
