### PR TITLE
feature(pipeline): Increase timeout for jenkins jobs to 4 hours

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit
 class MonitorJenkinsJobTask implements OverridableTimeoutRetryableTask {
 
   long backoffPeriod = 10000
-  long timeout = TimeUnit.HOURS.toMillis(2)
+  long timeout = TimeUnit.HOURS.toMillis(4)
 
   @Autowired
   BuildService buildService


### PR DESCRIPTION
I increased this to 4 hours. Some of our teams have jobs that last for more than 3 hours.

Ideally, I would raise it even more if you don't mind. But if you do mind, then 4 hours is good enough.