### PR TITLE
feat(peering): Add ability to peer a set of specific executions

### DIFF
--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
@@ -86,6 +86,24 @@ class PeeringAgent(
     }
   }
 
+  /**
+   * This variant of peerExecutions can be used by an external system as a "hint" that a given execution should be
+   * peered immediately.
+   * This is useful for user actions (e.g. cancel/skip wait/manual judge/delete/etc) where waiting for the peering agent
+   * would result in a suboptimal experience
+   */
+  public fun peerExecutions(executionType: Execution.ExecutionType, executionIds: List<String>) {
+    try {
+      val migrationResult = executionCopier.copyInParallel(executionType, executionIds, ExecutionState.ACTIVE)
+
+      if (migrationResult.hadErrors) {
+        log.error("Failed to peer specific executions: {}", executionIds.joinToString())
+      }
+    } catch (e: Exception) {
+      log.error("Failed to peer specific executions: {}", executionIds.joinToString(), e)
+    }
+  }
+
   private fun peerExecutions(executionType: Execution.ExecutionType) {
     val mostRecentUpdatedTime = when (executionType) {
       Execution.ExecutionType.ORCHESTRATION -> completedOrchestrationsMostRecentUpdatedTime


### PR DESCRIPTION
This change allows an external caller (coming soon!) to ask the peering agent to peer specific executions
This is useful for shortcircuiting the peering delay for user actions such as cancel/delete/etc
