### PR TITLE
config(core): Push halyard config defaults down to base

### DIFF
--- a/halconfig/README.md
+++ b/halconfig/README.md
@@ -1,0 +1,6 @@
+This directory contains skeleton clouddriver configs to which Halyard concatenates
+its generated deployment-specific config.
+
+These configs are **deprecated** and in general should not be further updated. To
+set a default config value, either set the value in `clouddriver-web/config/clouddriver.yml`
+or set a default in the code reading the config property.

--- a/halconfig/README.md
+++ b/halconfig/README.md
@@ -2,5 +2,5 @@ This directory contains skeleton clouddriver configs to which Halyard concatenat
 its generated deployment-specific config.
 
 These configs are **deprecated** and in general should not be further updated. To
-set a default config value, either set the value in `clouddriver-web/config/clouddriver.yml`
+set a default config value, either set the value in `orca-web/config/orca.yml`
 or set a default in the code reading the config property.

--- a/halconfig/orca-bootstrap.yml
+++ b/halconfig/orca-bootstrap.yml
@@ -27,7 +27,3 @@ igor:
 
 redis:
   connection: ${services.redisBootstrap.baseUrl:redis://localhost:6379}
-
-tasks:
-  executionWindow:
-    timezone: ${global.spinnaker.timezone:America/Los_Angeles}

--- a/halconfig/orca.yml
+++ b/halconfig/orca.yml
@@ -1,4 +1,1 @@
 # halconfig
-
-redis:
-  connection: ${services.redis.baseUrl:redis://localhost:6379}

--- a/halconfig/orca.yml
+++ b/halconfig/orca.yml
@@ -1,8 +1,4 @@
 # halconfig
 
-bakery:
-  extractBuildDetails: ${services.rosco.extractBuildDetails:true}
-  allowMissingPackageInstallation: ${services.rosco.allowMissingPackageInstallation:false}
-
 redis:
   connection: ${services.redis.baseUrl:redis://localhost:6379}

--- a/halconfig/orca.yml
+++ b/halconfig/orca.yml
@@ -1,43 +1,8 @@
 # halconfig
 
-server:
-  port: ${services.orca.port:8083}
-  address: ${services.orca.host:localhost}
-
-oort:
-  baseUrl: ${services.clouddriver.baseUrl:http://localhost:7002}
-
-front50:
-  enabled: true
-  baseUrl: ${services.front50.baseUrl:http://localhost:8080}
-
-mort:
-  baseUrl: ${services.clouddriver.baseUrl:http://localhost:7002}
-
-kato:
-  baseUrl: ${services.clouddriver.baseUrl:http://localhost:7002}
-
 bakery:
-  enabled: true
-  baseUrl: ${services.rosco.baseUrl:http://localhost:8087}
   extractBuildDetails: ${services.rosco.extractBuildDetails:true}
   allowMissingPackageInstallation: ${services.rosco.allowMissingPackageInstallation:false}
 
-echo:
-  enabled: true
-  baseUrl: ${services.echo.baseUrl:http://localhost:8089}
-
-igor:
-  enabled: true
-  baseUrl: ${services.igor.baseUrl:http://localhost:8088}
-
-kayenta:
-  enabled: ${services.kayenta.enabled:false}
-  baseUrl: ${services.kayenta.baseUrl:http://localhost:8090}
-
 redis:
   connection: ${services.redis.baseUrl:redis://localhost:6379}
-
-tasks:
-  executionWindow:
-    timezone: ${global.spinnaker.timezone:America/Los_Angeles}

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfigurationProperties.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfigurationProperties.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 public class BakeryConfigurationProperties {
   private String baseUrl;
   private boolean roscoApisEnabled = false;
-  private boolean extractBuildDetails = false;
+  private boolean extractBuildDetails = true;
   private boolean allowMissingPackageInstallation = false;
   private List<SelectableService.BaseUrl> baseUrls;
 

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -29,10 +29,6 @@ igor:
 bakery:
   enabled: true
   baseUrl: ${services.rosco.baseUrl:http://localhost:8087}
-  # Rosco exposes more endpoints than Netflix's internal bakery. This disables
-  # the use of those endpoints.
-  roscoApisEnabled: true
-  allowMissingPackageInstallation: false
 kayenta:
   enabled: ${services.kayenta.enabled:false}
   baseUrl: ${services.kayenta.baseUrl:http://localhost:8090}

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -34,7 +34,7 @@ kayenta:
   baseUrl: ${services.kayenta.baseUrl:http://localhost:8090}
 
 redis:
-  connection: ${REDIS_URL:redis://localhost:6379}
+  connection: ${services.redis.baseUrl:redis://localhost:6379}
 
 keiko:
   queue:

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -1,5 +1,6 @@
 server:
-  port: 8083
+  port: ${services.orca.port:8083}
+  address: ${services.orca.host:localhost}
 
 default:
   bake:
@@ -10,30 +11,31 @@ default:
 
 front50:
   enabled: true
-  baseUrl: http://localhost:8080
+  baseUrl: ${services.front50.baseUrl:http://localhost:8080}
 tide:
   baseUrl: http://localhost:8090
 oort:
-  baseUrl: http://localhost:7002
+  baseUrl: ${services.clouddriver.baseUrl:http://localhost:7002}
 mort:
-  baseUrl: http://localhost:7002
+  baseUrl: ${services.clouddriver.baseUrl:http://localhost:7002}
 kato:
-  baseUrl: http://localhost:7002
+  baseUrl: ${services.clouddriver.baseUrl:http://localhost:7002}
 echo:
-  enabled: false
+  enabled: true
+  baseUrl: ${services.echo.baseUrl:http://localhost:8089}
 igor:
   enabled: true
-  baseUrl: http://localhost:8088
+  baseUrl: ${services.igor.baseUrl:http://localhost:8088}
 bakery:
   enabled: true
-  baseUrl: http://localhost:8087
+  baseUrl: ${services.rosco.baseUrl:http://localhost:8087}
   # Rosco exposes more endpoints than Netflix's internal bakery. This disables
   # the use of those endpoints.
   roscoApisEnabled: true
   allowMissingPackageInstallation: false
 kayenta:
-  enabled: false
-  baseUrl: http://localhost:8090
+  enabled: ${services.kayenta.enabled:false}
+  baseUrl: ${services.kayenta.baseUrl:http://localhost:8090}
 
 redis:
   connection: ${REDIS_URL:redis://localhost:6379}
@@ -47,6 +49,8 @@ keiko:
 
 tasks:
   useWaitForAllNetflixAWSInstancesDownTask: false
+  executionWindow:
+    timezone: ${global.spinnaker.timezone:America/Los_Angeles}
 
 logging:
   config: classpath:logback-defaults.xml


### PR DESCRIPTION
See spinnaker/clouddriver#4368 for more details; this is making the same changes to orca.  I'll hold off on doing more services until everyone has weighed in on these two PRs, but if all looks good I'll make the same changes to all other services.

* config(core): Push halyard config defaults down to base 

  This change pushes a number of config settings that were in the Halyard-specific config file down to the base config so they apply to all uesrs.

  The one potentially breaking change is that echo used to default to disabled but now defaults to enabled. Given that most users use Halyard and netflix uses echo, I suspect that nobody was relying on this to default to off. We can document this as a change in the release notes (as it's easy to override if desired).

* config(core): Update bakery defaults 

  Push the defaults for extractBuildDetails, roscoApisEnabled, and allowMissingPackageInstallation down to the properties class.
  (As defaults were there anyway, there is no need to specify them in clouddriver.yml.)

  This makes the following changes:
  * Removes references the services.rosco.* settings for two flags; only the Halyard config referenced them, but Halyard never wrote out those values.
  * Sets extractBuildDetails to default to true; this has always been the case for Halyard users.

* config(core): Update redis config setting 

  This change updates the core redis config setting to read from services.redis.baseUrl then default to localhost:6379.

  This does remove looking at the REDIS_URL environment variable. I strongly suspect this isn't being used by anyone (as definitely it is not set by Halyard users), though would like to confirm with Netflix before merging.
