### PR TITLE
fix(orca-validation): Update json-schema-validator to 2.2.12.

### DIFF
--- a/orca-validation/orca-validation.gradle
+++ b/orca-validation/orca-validation.gradle
@@ -4,5 +4,5 @@ dependencies {
   implementation(project(":orca-core"))
   implementation("org.springframework:spring-context")
   implementation("com.fasterxml.jackson.core:jackson-core")
-  implementation("com.github.fge:json-schema-validator:2.2.6")
+  implementation("com.github.java-json-tools:json-schema-validator:2.2.12")
 }


### PR DESCRIPTION
This also changes the organization from [fge](https://github.com/fge) to [java-json-tools](https://github.com/java-json-tools), as the former is retired. Avoids v2.2.6's references to Guava versions with known CVEs. Addresses https://github.com/spinnaker/spinnaker/issues/5523