### PR TITLE
feat(preconfiguredjob): Add 'ui' field to PreconfiguredJobStageProperties

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/preconfigured/jobs/PreconfiguredJobStageProperties.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/preconfigured/jobs/PreconfiguredJobStageProperties.java
@@ -58,13 +58,13 @@ public abstract class PreconfiguredJobStageProperties {
 
   private String propertyFile;
 
-  public enum PreconfiguredJobUI {
+  public enum PreconfiguredJobUIType {
     BASIC,
     CUSTOM
   };
 
   /** "BASIC" to auto-generate a UI. "CUSTOM" if a custom UI is provided for Deck */
-  private PreconfiguredJobUI ui = PreconfiguredJobUI.BASIC;
+  private PreconfiguredJobUIType uiType = PreconfiguredJobUIType.BASIC;
 
   /** Indicates whether this job produces any artifacts. */
   private boolean producesArtifacts = false;

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/preconfigured/jobs/PreconfiguredJobStageProperties.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/preconfigured/jobs/PreconfiguredJobStageProperties.java
@@ -58,6 +58,14 @@ public abstract class PreconfiguredJobStageProperties {
 
   private String propertyFile;
 
+  public enum PreconfiguredJobUI {
+    BASIC,
+    CUSTOM
+  };
+
+  /** "BASIC" to auto-generate a UI. "CUSTOM" if a custom UI is provided for Deck */
+  private PreconfiguredJobUI ui = PreconfiguredJobUI.BASIC;
+
   /** Indicates whether this job produces any artifacts. */
   private boolean producesArtifacts = false;
 

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -420,6 +420,7 @@ class OperationsController {
         noUserConfigurableFields: true,
         parameters: it.parameters,
         producesArtifacts: it.producesArtifacts,
+        ui: it.ui
       ]
     }
   }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -420,7 +420,7 @@ class OperationsController {
         noUserConfigurableFields: true,
         parameters: it.parameters,
         producesArtifacts: it.producesArtifacts,
-        ui: it.ui
+        ui: it.uiType
       ]
     }
   }


### PR DESCRIPTION
`basic` will cause Deck to register the default preconfigured job stage config UI (which renders inputs for each parameter).
