### PR TITLE
fix(queue): avoid pushing message for foreign execution

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
@@ -99,7 +99,7 @@ public class CompoundExecutionOperator {
             if (repository.handlesPartition(execution.getPartition())) {
               runnerAction.accept(execution);
             } else {
-              log.warn(
+              log.info(
                   "Not pushing queue message action='{}' for execution with foreign partition='{}'",
                   action,
                   execution.getPartition());

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
@@ -17,10 +17,12 @@
 package com.netflix.spinnaker.orca.pipeline;
 
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.orca.pipeline.model.Execution;
 import com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.time.Duration;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -48,7 +50,7 @@ public class CompoundExecutionOperator {
 
   public void cancel(ExecutionType executionType, String executionId, String user, String reason) {
     doInternal(
-        () -> runner.cancel(repository.retrieve(executionType, executionId), user, reason),
+        (Execution execution) -> runner.cancel(execution, user, reason),
         () -> repository.cancel(executionType, executionId, user, reason),
         "cancel",
         executionType,
@@ -64,7 +66,7 @@ public class CompoundExecutionOperator {
       @NonNull String executionId,
       @Nullable String pausedBy) {
     doInternal(
-        () -> runner.reschedule(repository.retrieve(executionType, executionId)),
+        (Execution execution) -> runner.reschedule(execution),
         () -> repository.pause(executionType, executionId, pausedBy),
         "pause",
         executionType,
@@ -77,7 +79,7 @@ public class CompoundExecutionOperator {
       @Nullable String user,
       @NonNull Boolean ignoreCurrentStatus) {
     doInternal(
-        () -> runner.unpause(repository.retrieve(executionType, executionId)),
+        (Execution execution) -> runner.unpause(execution),
         () -> repository.resume(executionType, executionId, user, ignoreCurrentStatus),
         "resume",
         executionType,
@@ -85,13 +87,24 @@ public class CompoundExecutionOperator {
   }
 
   private void doInternal(
-      Runnable runnerAction,
+      Consumer<Execution> runnerAction,
       Runnable repositoryAction,
       String action,
       ExecutionType executionType,
       String executionId) {
     try {
-      runWithRetries(runnerAction);
+      runWithRetries(
+          () -> {
+            Execution execution = repository.retrieve(executionType, executionId);
+            if (repository.handlesPartition(execution.getPartition())) {
+              runnerAction.accept(execution);
+            } else {
+              log.warn(
+                  "Not pushing queue message action='{}' for execution with foreign partition='{}'",
+                  action,
+                  execution.getPartition());
+            }
+          });
       runWithRetries(repositoryAction);
     } catch (Exception e) {
       log.error(

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.pipeline
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.orca.pipeline.model.Execution
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import org.slf4j.MDC
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -28,6 +29,10 @@ class CompoundExecutionOperatorSpec extends Specification {
   ExecutionRepository repository = Mock(ExecutionRepository)
   ExecutionRunner runner = Mock(ExecutionRunner)
   def execution = Mock(Execution)
+
+  def setupSpec() {
+    MDC.clear()
+  }
 
   @Subject
   CompoundExecutionOperator operator = new CompoundExecutionOperator(repository, runner, new RetrySupport())

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorSpec.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline
+
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.orca.pipeline.model.Execution
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
+
+class CompoundExecutionOperatorSpec extends Specification {
+  ExecutionRepository repository = Mock(ExecutionRepository)
+  ExecutionRunner runner = Mock(ExecutionRunner)
+  def execution = Mock(Execution)
+
+  @Subject
+  CompoundExecutionOperator operator = new CompoundExecutionOperator(repository, runner, new RetrySupport())
+
+  def 'should not push messages on the queue for foreign executions'() {
+    when:
+    operator.cancel(PIPELINE, "id")
+
+    then: 'we never call runner.cancel(), only repository.cancel()'
+    1 * repository.retrieve(PIPELINE, "id") >> execution
+    _ * execution.getPartition() >> "foreign"
+    1 * repository.handlesPartition("foreign") >> false
+    1 * repository.cancel(PIPELINE, "id", "anonymous", null)
+    0 * _
+  }
+
+  def 'should handle both the queue and the execution repository for local executions'() {
+    when:
+    operator.cancel(PIPELINE, "id")
+
+    then: 'we call both runner.cancel() and repository.cancel()'
+    1 * repository.retrieve(PIPELINE, "id") >> execution
+    _ * execution.getPartition() >> "local"
+    1 * repository.handlesPartition("local") >> true
+    1 * repository.cancel(PIPELINE, "id", "anonymous", null)
+    1 * runner.cancel(execution, "anonymous", null)
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/ExecutionSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/ExecutionSpec.groovy
@@ -31,17 +31,21 @@ class ExecutionSpec extends Specification {
     }
   }
 
-  def "should return Optional.empty if no authenticated details available"() {
-    given:
+  def setup() {
     MDC.clear()
+  }
 
+  def cleanup() {
+    MDC.clear()
+  }
+
+  def "should return Optional.empty if no authenticated details available"() {
     expect:
     !Execution.AuthenticationDetails.build().present
   }
 
   def "should build AuthenticationDetails containing authenticated details"() {
     given:
-    MDC.clear()
     MDC.put(Header.USER.header, "SpinnakerUser")
     MDC.put(Header.ACCOUNTS.header, "Account1,Account2")
 


### PR DESCRIPTION
When manually cancelling an execution handled by a different orca cluster, we want to let the execution repo handle it. Also pushing messages on the queue for that foreign execution was an oversight, and it led to duplicate interlink messages getting published.