### PR TITLE
fix(google): Fix race condition in wait for up instances task

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
@@ -95,6 +95,10 @@ abstract class AbstractInstancesCheckTask extends AbstractCloudProviderAwareTask
     Map<String, List<String>> serverGroupsByRegion = getServerGroups(stage)
 
     if (!serverGroupsByRegion || !serverGroupsByRegion?.values()?.flatten()) {
+      log.warn(
+          String.format(
+              "No server groups found in stage context (stage.id: %s, execution.id: %s)",
+              stage.getId(), stage.getExecution()?.getId()));
       return TaskResult.ofStatus(ExecutionStatus.TERMINAL)
     }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleServerGroupCreator.groovy
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Component
 @Component
 class GoogleServerGroupCreator implements ServerGroupCreator, DeploymentDetailsAware {
 
-  boolean katoResultExpected = false
+  boolean katoResultExpected = true
   String cloudProvider = "gce"
 
   @Autowired

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTaskSpec.groovy
@@ -135,8 +135,8 @@ class CreateServerGroupTaskSpec extends Specification {
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | "image"           | false              || "some-ami-name"
-    "gce"                  | null              | "image"           | false              || "some-ami-name"
+    "gce"                  | "gce"             | "image"           | true               || "some-ami-name"
+    "gce"                  | null              | "image"           | true               || "some-ami-name"
     "aws"                  | "aws"             | "imageId"         | true               || "some-ami-name"
     "aws"                  | null              | "imageId"         | true               || "some-ami-name"
   }
@@ -194,8 +194,8 @@ class CreateServerGroupTaskSpec extends Specification {
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | "image"           | false              || "parent-ami"
-    "gce"                  | null              | "image"           | false              || "parent-ami"
+    "gce"                  | "gce"             | "image"           | true               || "parent-ami"
+    "gce"                  | null              | "image"           | true               || "parent-ami"
     "aws"                  | "aws"             | "imageId"         | true               || "parent-ami"
     "aws"                  | null              | "imageId"         | true               || "parent-ami"
   }
@@ -270,8 +270,8 @@ class CreateServerGroupTaskSpec extends Specification {
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | "image"           | false              || "grandparent-ami"
-    "gce"                  | null              | "image"           | false              || "grandparent-ami"
+    "gce"                  | "gce"             | "image"           | true               || "grandparent-ami"
+    "gce"                  | null              | "image"           | true               || "grandparent-ami"
     "aws"                  | "aws"             | "imageId"         | true               || "grandparent-ami"
     "aws"                  | null              | "imageId"         | true               || "grandparent-ami"
   }
@@ -327,8 +327,8 @@ class CreateServerGroupTaskSpec extends Specification {
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | "image"           | false              || "parent-name"
-    "gce"                  | null              | "image"           | false              || "parent-name"
+    "gce"                  | "gce"             | "image"           | true               || "parent-name"
+    "gce"                  | null              | "image"           | true               || "parent-name"
     "aws"                  | "aws"             | "imageId"         | true               || "parent-name"
     "aws"                  | null              | "imageId"         | true               || "parent-name"
   }
@@ -396,8 +396,8 @@ class CreateServerGroupTaskSpec extends Specification {
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | "image"           | false              || "grandparent-name"
-    "gce"                  | null              | "image"           | false              || "grandparent-name"
+    "gce"                  | "gce"             | "image"           | true               || "grandparent-name"
+    "gce"                  | null              | "image"           | true               || "grandparent-name"
     "aws"                  | "aws"             | "imageId"         | true               || "grandparent-name"
     "aws"                  | null              | "imageId"         | true               || "grandparent-name"
   }
@@ -462,8 +462,8 @@ class CreateServerGroupTaskSpec extends Specification {
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageId
-    "gce"                  | "gce"             | "image"           | false              || "parent-ami"
-    "gce"                  | null              | "image"           | false              || "parent-ami"
+    "gce"                  | "gce"             | "image"           | true               || "parent-ami"
+    "gce"                  | null              | "image"           | true               || "parent-ami"
     "aws"                  | "aws"             | "imageId"         | true               || "parent-ami"
     "aws"                  | null              | "imageId"         | true               || "parent-ami"
   }
@@ -571,8 +571,8 @@ class CreateServerGroupTaskSpec extends Specification {
 
     where:
     operationCloudProvider | bakeCloudProvider | imageAttributeKey | katoResultExpected || expectedImageIdBranchA | expectedImageIdBranchB
-    "gce"                  | "gce"             | "image"           | false              || "parent-name-branch-a" | "parent-name-branch-b"
-    "gce"                  | null              | "image"           | false              || "parent-name-branch-a" | "parent-name-branch-b"
+    "gce"                  | "gce"             | "image"           | true               || "parent-name-branch-a" | "parent-name-branch-b"
+    "gce"                  | null              | "image"           | true               || "parent-name-branch-a" | "parent-name-branch-b"
     "aws"                  | "aws"             | "imageId"         | true               || "parent-name-branch-a" | "parent-name-branch-b"
     "aws"                  | null              | "imageId"         | true               || "parent-name-branch-a" | "parent-name-branch-b"
   }


### PR DESCRIPTION
* fix(google): Fix race condition in wait for up instances task 

  There was a failure in the google_regional_server_group test this morning where the WaitForUpInstancesTask unexpectedly returned a status of TERMINAL.

  After digging into this, it appears that what happenned is the following:
  * The MonitorKatoTask earlier in the pipeline is supposed to wait for the deploy to finish, and the record certain details about the deployment in the stage context. In this case, the important field is the "deploy.server.groups" field, which should contain a list of server groups deployed.
  * In this particular case, the MonitorKatoTask found that the clouddriver task had completed, but looking in the stage context it was missing two entries from the task history (including the final "Orchestration Completed" entry) and had an empty set of results.
  * The WaitForUpInstancesTask immediately returns a TERMINAL status if tere are no instances to check, which is what caused this failure.

  After digging into this, there is actually a race condition in clouddriver as tasks are not fetched atomically from redis (as I don't believe it's possible for redis to do this). So if, during the request to "/tasks/taskId" we first grab the history and results of the task, then later grab the status, it's possible that we'll have stale results and history while still showing the status as complete.
  (The order is further complicated by the fact that these getters are actually called by the serialization logic directly, so we don't control the code where they are called; a task contains a reference to the redis repository and fetches information on demand in the accessors.)

  Likely as a workaround to this, there is a flag katoResultExpected that cloud providers can set for their deploy stages; in this case, the MonitorKatoTask will return status RUNNING if the task is completed but there are no results (and the next poll will likely return the results).  This flag is set in a number of other places, but not in GCE deploys. This appears safe as any GCE deploy that doesn't return a result will fail downstream anyway waiting for up instances. (The only place we set the flag for GCE is in the CreateServerGroupTask which always precedes a WaitForUpInstancesTask.)

  Also adding a log line to help with any other cases where we short-circuit WaitForUpInstancesTask due to a lack of instances.

* fix(google): Fix CreateServerGroupTaskSpec tests 

  These tests seem pretty over-specified; ideally we'd check the value of this key in a single test and have the other tests focus on just asserting the important keys of the output.  But I'll leave refactoring these to another day and will just update the relevant GCE field in each of the tests.
