### PR TITLE
fix(config): Fix accidentally changed bakery config

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfigurationProperties.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfigurationProperties.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "bakery")
 public class BakeryConfigurationProperties {
   private String baseUrl;
-  private boolean roscoApisEnabled = false;
+  private boolean roscoApisEnabled = true;
   private boolean extractBuildDetails = true;
   private boolean allowMissingPackageInstallation = false;
   private List<SelectableService.BaseUrl> baseUrls;


### PR DESCRIPTION
The commit to clean up the config file by pushing some config down to code accidentally changed the default value of roscoApisEnabled. This was set as true in orca.yml, but I forgot to flip the default to true in code when removing the value in orca.yml, which ended up being a breaking change.

This change flips the default value of the boolean to true in code, restoring the deafult to what it was prior to the earlier change.