### PR TITLE
Revert "fix(FindImageFromCluster): update context with inferred regio…

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -294,16 +294,11 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
       return artifact
     }.flatten()
 
-    // When additional regions are inferred for downstream deploy stages, adding them back
-    // to Stage.context.regions enables direct use via DeploymentDetailsAware.withImageFromPrecedingStage()
-    // instead of via a subsequent code path that may exhibit different behavior.
-    Map<String, Object> context = [amiDetails: deploymentDetails, artifacts: artifacts]
-    context.put("regions", config.regions + inferredRegions)
-    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(
-      context
-    ).outputs([
-      deploymentDetails: deploymentDetails,
-      inferredRegions: inferredRegions
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context([
+      amiDetails: deploymentDetails,
+      artifacts: artifacts
+    ]).outputs([
+      deploymentDetails: deploymentDetails
     ]).build()
   }
 


### PR DESCRIPTION
…ns (#3508)"

This reverts commit 96384a32c80f77169488d0228ecab7cd3414e2b8.

The end to end tests are failing with an NPE for the [`kube_smoke_tests`](https://builds.spinnaker.io/job/Validate_BomMultiPlatform/4370/CLOUD_PLATFORM=gce/artifact/logs/citest_logs/kube_smoke_test.html): `java.lang.NullPointerException: Cannot execute null+[]` from line 301 of `FindImageFromClusterTask` . I'm guessing this is because `config.regions` is null for non-AWS providers. I don't have enough context around this change to determine whether the correct solution is to only execute the new logic if the provider is AWS, or if this change was intended to apply to other non-AWS providers and we should default `config.regions` to an empty set. Going to revert this change for now so that we can get the builds back in a healthy state.