### PR TITLE
fix(peering): Trigger pending executions across orca peers

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.time.Duration;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 import lombok.Value;
@@ -61,8 +62,8 @@ public class CompoundExecutionOperator {
   }
 
   public void pause(
-      @NonNull ExecutionType executionType,
-      @NonNull String executionId,
+      @Nonnull ExecutionType executionType,
+      @Nonnull String executionId,
       @Nullable String pausedBy) {
     doInternal(
         runner::reschedule,
@@ -73,10 +74,10 @@ public class CompoundExecutionOperator {
   }
 
   public void resume(
-      @NonNull ExecutionType executionType,
-      @NonNull String executionId,
+      @Nonnull ExecutionType executionType,
+      @Nonnull String executionId,
       @Nullable String user,
-      @NonNull Boolean ignoreCurrentStatus) {
+      @Nonnull Boolean ignoreCurrentStatus) {
     doInternal(
         runner::unpause,
         () -> repository.resume(executionType, executionId, user, ignoreCurrentStatus),
@@ -104,6 +105,10 @@ public class CompoundExecutionOperator {
         "reschedule",
         executionType,
         executionId);
+  }
+
+  public void startPending(@Nonnull String pipelineConfigId, boolean purgeQueue) {
+    runner.startPending(pipelineConfigId, purgeQueue);
   }
 
   private PipelineExecution doInternal(

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionRunner.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionRunner.java
@@ -39,4 +39,8 @@ public interface ExecutionRunner {
       @Nonnull PipelineExecution execution, @Nonnull String user, @Nullable String reason) {
     throw new UnsupportedOperationException();
   }
+
+  default void startPending(@Nonnull String pipelineConfigId, boolean purgeQueue) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/CancelInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/CancelInterlinkEvent.java
@@ -26,6 +26,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+/**
+ * This event is published on the interlink as a result of a user CANCELLING an execution on an orca
+ * instance that can't handle the partition for the given execution.
+ *
+ * <p>The event is then handled by an orca instance (listening on interlink) whose partition matches
+ * that of the execution. The resulting repository mutations of this event will then be peered by
+ * the PeeringAgent
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/DeleteInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/DeleteInterlinkEvent.java
@@ -26,6 +26,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+/**
+ * This event is published on the interlink as a result of a user DELETING an execution on an orca
+ * instance that can't handle the partition for the given execution.
+ *
+ * <p>The event is then handled by an orca instance (listening on interlink) whose partition matches
+ * that of the execution. The resulting repository mutations of this event will then be peered by
+ * the PeeringAgent
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
@@ -24,14 +24,27 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import javax.validation.constraints.NotNull;
 
-/** Common interface for all interlink event messages */
+/**
+ * Common interface for interlink events
+ *
+ * <p>Interlink events are published to communicate across orca peers. When an orca encounters an
+ * operation it can't handle due its partition not matching that of the execution/request it will
+ * generally broadcast an interlink event which will be handled by an orca instance (listening on
+ * interlink) whose partition matches that of the execution.
+ *
+ * <p>Interlink events don't have a delivery guarantee, since most such events are triggered by a
+ * user action this lack of guarantee is not a problem.
+ *
+ * <p>The resulting repository mutations of interlink events will then be peered by the PeeringAgent
+ */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "eventType")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = CancelInterlinkEvent.class, name = "CANCEL"),
   @JsonSubTypes.Type(value = PauseInterlinkEvent.class, name = "PAUSE"),
   @JsonSubTypes.Type(value = ResumeInterlinkEvent.class, name = "RESUME"),
   @JsonSubTypes.Type(value = DeleteInterlinkEvent.class, name = "DELETE"),
-  @JsonSubTypes.Type(value = PatchStageInterlinkEvent.class, name = "PATCH")
+  @JsonSubTypes.Type(value = PatchStageInterlinkEvent.class, name = "PATCH"),
+  @JsonSubTypes.Type(value = StartPendingInterlinkEvent.class, name = "START_PENDING")
 })
 public interface InterlinkEvent {
   enum EventType {
@@ -39,7 +52,8 @@ public interface InterlinkEvent {
     PAUSE,
     DELETE,
     RESUME,
-    PATCH
+    PATCH,
+    START_PENDING,
   }
 
   @JsonIgnore

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PauseInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PauseInterlinkEvent.java
@@ -26,6 +26,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+/**
+ * This event is published on the interlink as a result of a user PAUSING an execution on an orca
+ * instance that can't handle the partition for the given execution.
+ *
+ * <p>The event is then handled by an orca instance (listening on interlink) whose partition matches
+ * that of the execution. The resulting repository mutations of this event will then be peered by
+ * the PeeringAgent
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/ResumeInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/ResumeInterlinkEvent.java
@@ -26,6 +26,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+/**
+ * This event is published on the interlink as a result of a user RESUMING an execution on an orca
+ * instance that can't handle the partition for the given execution.
+ *
+ * <p>The event is then handled by an orca instance (listening on interlink) whose partition matches
+ * that of the execution. The resulting repository mutations of this event will then be peered by
+ * the PeeringAgent
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/StartPendingInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/StartPendingInterlinkEvent.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.interlink.events;
+
+import static com.netflix.spinnaker.orca.interlink.events.InterlinkEvent.EventType.START_PENDING;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+/**
+ * This event is published on the interlink as a result of an orca instance completing an execution.
+ * NOTE: unlike other interlink events, this one is not published as a result of a user action.
+ *
+ * <p>When an execution completes, orca checks to see if there are any pending executions to be
+ * kicked off. However, the pending executions aren't peered and in a peered configuration a peer
+ * might have an execution pending that needs to be started. If, upon completion of an execution,
+ * current orca doesn't see any pending executions it will publish this event so that its peers can
+ * start any pending executions if they have any.
+ *
+ * <p>The event is then handled by an orca instance (listening on interlink) whose partition matches
+ * that of the execution. The resulting repository mutations of this event will then be peered by
+ * the PeeringAgent
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StartPendingInterlinkEvent implements InterlinkEvent {
+  final EventType eventType = START_PENDING;
+  @Nullable String partition;
+  @NonNull ExecutionType executionType;
+  @NonNull String executionId;
+  @NonNull String pipelineConfigId;
+  boolean purgeQueue;
+
+  public StartPendingInterlinkEvent(
+      @NonNull ExecutionType executionType, @NonNull String pipelineConfigId, boolean purgeQueue) {
+    this.executionType = executionType;
+    this.executionId = "NO_EXECUTION_ID";
+    this.pipelineConfigId = pipelineConfigId;
+    this.purgeQueue = purgeQueue;
+  }
+
+  @Override
+  public void applyTo(CompoundExecutionOperator executionOperator) {
+    executionOperator.startPending(pipelineConfigId, purgeQueue);
+  }
+
+  @JsonIgnore
+  @NotNull
+  @Override
+  public String getFingerprint() {
+    return getEventType() + ":" + getExecutionType() + ":" + pipelineConfigId;
+  }
+}

--- a/orca-queue/orca-queue.gradle
+++ b/orca-queue/orca-queue.gradle
@@ -21,6 +21,7 @@ dependencies {
   api(project(":orca-core"))
   api(project(":orca-api"))
   implementation(project(":orca-kotlin"))
+  implementation(project(":orca-interlink"))
   implementation("org.jetbrains.kotlin:kotlin-reflect")
   implementation("com.netflix.spinnaker.keiko:keiko-spring:$keikoVersion")
   implementation("com.netflix.spinnaker.keiko:keiko-core:$keikoVersion")

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueExecutionRunner.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueExecutionRunner.kt
@@ -45,4 +45,8 @@ class QueueExecutionRunner(
   override fun cancel(execution: PipelineExecution, user: String, reason: String?) {
     queue.push(CancelExecution(execution, user, reason))
   }
+
+  override fun startPending(pipelineConfigId: String, purge: Boolean) {
+    queue.push(StartWaitingExecutions(pipelineConfigId, purge))
+  }
 }


### PR DESCRIPTION
Imagine this scenario with peering:
* orca `peer A` is running execution `E1`
* a request (from `deck`) comes into orca `peer B` to start execution `E2`
  since an execution (`E1`) is already running, `peer B` queues `E2`
* `peer A` completes `E1` and checks if there are any pending executions
* since the pending table is not peered (that would be basically impossible to get right) `peer A` doesn't see any pending executions
* and so `E2` stays forever in a "pending" state

There were a few thoughts on how to fix this:
1. Pending execution agent
2. Use dual pending execution service
3. Peering pending executions table
4. Handle this in the peering agent when it peers completed executions
5. Use interlink

Basically, all of these approaches are flawed and interlink seems least problematic:
*Pending execution* has issues because:
* it feels disconnected from peering&interlink - it's another thing to configure and make sure it's on, etc
* the timing is non-deterministic
* due to current design, it doesn't know whether the queue should be purged or not (since this info is embedded in the prior execution)

*Dual pending execution service* breaks down when
* there are more than 2 peers (at least in current incarnation)
* it also adds the need for every peer to know every other peer which is not the case today and adds a ton of complexity to config/operation of orca

*Peering pending execution* table scared me!
* due to the inherent lag in peering the table could be horribly out of date
* to ensure we don't trigger something twice, we would also need to peer correlation ids (and again, the lag problem)

*Handing completions* in the peering agent, e.g. when we peer completed execution we see if we need to kick off something else:
* introduces requirements that peering agents run with queue (not the end of the world)
* adds this "weird" knowledge to peering agent

*Using Interlink* seemed like the least evil option:
* it fits in with the rest of implementation, nothing extra to configure
* fairly simple implementation

cons:
* it does add coupling between queue -> interlink (which is a bit gross)
* it has an issue in that interlink is not a guaranteed delivery, but I think it's ok/good enough

