### PR TITLE
feat(interlink): patch stage support for foreign executions

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.EqualsAndHashCode;
 
 /** The runtime execution state of a stage. */
 @Beta
@@ -183,6 +184,7 @@ public interface StageExecution {
   @Nonnull
   List<StageExecution> downstreamStages();
 
+  @EqualsAndHashCode
   class LastModifiedDetails implements Serializable {
 
     private String user;

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
@@ -28,7 +28,9 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import lombok.EqualsAndHashCode;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 /** The runtime execution state of a stage. */
 @Beta
@@ -184,22 +186,15 @@ public interface StageExecution {
   @Nonnull
   List<StageExecution> downstreamStages();
 
-  @EqualsAndHashCode
+  @Data
+  @NoArgsConstructor
   class LastModifiedDetails implements Serializable {
+    @NonNull private String user;
 
-    private String user;
-    private Collection<String> allowedAccounts = emptySet();
+    @NonNull private Collection<String> allowedAccounts = emptySet();
 
     /** TODO(rz): Convert to Instant */
-    private Long lastModifiedTime;
-
-    public @Nonnull String getUser() {
-      return user;
-    }
-
-    public void setUser(@Nonnull String user) {
-      this.user = user;
-    }
+    @NonNull private Long lastModifiedTime;
 
     public @Nonnull Collection<String> getAllowedAccounts() {
       return ImmutableSet.copyOf(allowedAccounts);
@@ -207,14 +202,6 @@ public interface StageExecution {
 
     public void setAllowedAccounts(@Nonnull Collection<String> allowedAccounts) {
       this.allowedAccounts = ImmutableSet.copyOf(allowedAccounts);
-    }
-
-    public @Nonnull Long getLastModifiedTime() {
-      return lastModifiedTime;
-    }
-
-    public void setLastModifiedTime(@Nonnull Long lastModifiedTime) {
-      this.lastModifiedTime = lastModifiedTime;
     }
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
@@ -17,28 +17,28 @@
 package com.netflix.spinnaker.orca.pipeline;
 
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.time.Duration;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import lombok.NonNull;
+import lombok.Value;
+import lombok.experimental.NonFinal;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Value
+@NonFinal
 public class CompoundExecutionOperator {
-  private ExecutionRepository repository;
-  private ExecutionRunner runner;
-  private RetrySupport retrySupport;
-
-  public CompoundExecutionOperator(
-      ExecutionRepository repository, ExecutionRunner runner, RetrySupport retrySupport) {
-    this.repository = repository;
-    this.runner = runner;
-    this.retrySupport = retrySupport;
-  }
+  ExecutionRepository repository;
+  ExecutionRunner runner;
+  RetrySupport retrySupport;
 
   public void cancel(ExecutionType executionType, String executionId) {
     cancel(
@@ -66,7 +66,7 @@ public class CompoundExecutionOperator {
       @NonNull String executionId,
       @Nullable String pausedBy) {
     doInternal(
-        (PipelineExecution execution) -> runner.reschedule(execution),
+        runner::reschedule,
         () -> repository.pause(executionType, executionId, pausedBy),
         "pause",
         executionType,
@@ -79,32 +79,67 @@ public class CompoundExecutionOperator {
       @Nullable String user,
       @NonNull Boolean ignoreCurrentStatus) {
     doInternal(
-        (PipelineExecution execution) -> runner.unpause(execution),
+        runner::unpause,
         () -> repository.resume(executionType, executionId, user, ignoreCurrentStatus),
         "resume",
         executionType,
         executionId);
   }
 
-  private void doInternal(
+  public PipelineExecution updateStage(
+      @NonNull ExecutionType executionType,
+      @NonNull String executionId,
+      @NonNull String stageId,
+      @NonNull Consumer<StageExecution> stageUpdater) {
+    return doInternal(
+        runner::reschedule,
+        () -> {
+          PipelineExecution execution = repository.retrieve(executionType, executionId);
+
+          StageExecution stage =
+              execution.getStages().stream()
+                  .filter(s -> s.getId().equals(stageId))
+                  .findFirst()
+                  .orElseThrow(
+                      () ->
+                          new NotFoundException(
+                              "Could not find stage with id "
+                                  + stageId
+                                  + " in execution "
+                                  + executionId));
+
+          // mutates stage in place
+          stageUpdater.accept(stage);
+
+          repository.storeStage(stage);
+        },
+        "reschedule",
+        executionType,
+        executionId);
+  }
+
+  private PipelineExecution doInternal(
       Consumer<PipelineExecution> runnerAction,
       Runnable repositoryAction,
       String action,
       ExecutionType executionType,
       String executionId) {
+    PipelineExecution toReturn = null;
     try {
-      runWithRetries(
-          () -> {
-            PipelineExecution execution = repository.retrieve(executionType, executionId);
-            if (repository.handlesPartition(execution.getPartition())) {
-              runnerAction.accept(execution);
-            } else {
-              log.info(
-                  "Not pushing queue message action='{}' for execution with foreign partition='{}'",
-                  action,
-                  execution.getPartition());
-            }
-          });
+      toReturn =
+          runWithRetries(
+              () -> {
+                PipelineExecution execution = repository.retrieve(executionType, executionId);
+                if (repository.handlesPartition(execution.getPartition())) {
+                  runnerAction.accept(execution);
+                } else {
+                  log.info(
+                      "Not pushing queue message action='{}' for execution with foreign partition='{}'",
+                      action,
+                      execution.getPartition());
+                }
+                return execution;
+              });
       runWithRetries(repositoryAction);
     } catch (Exception e) {
       log.error(
@@ -114,6 +149,11 @@ public class CompoundExecutionOperator {
           executionId,
           e);
     }
+    return toReturn;
+  }
+
+  private <T> T runWithRetries(Supplier<T> action) {
+    return retrySupport.retry(action, 5, Duration.ofMillis(100), false);
   }
 
   private void runWithRetries(Runnable action) {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
@@ -114,6 +114,8 @@ public class CompoundExecutionOperator {
       String executionId) {
     PipelineExecution toReturn = null;
     try {
+      runWithRetries(repositoryAction);
+
       toReturn =
           runWithRetries(
               () -> {
@@ -128,7 +130,6 @@ public class CompoundExecutionOperator {
                 }
                 return execution;
               });
-      runWithRetries(repositoryAction);
     } catch (Exception e) {
       log.error(
           "Failed to {} execution with executionType={} and executionId={}",

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.orca.pipeline;
 
 import com.netflix.spinnaker.kork.core.RetrySupport;
-import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
@@ -95,18 +94,7 @@ public class CompoundExecutionOperator {
         runner::reschedule,
         () -> {
           PipelineExecution execution = repository.retrieve(executionType, executionId);
-
-          StageExecution stage =
-              execution.getStages().stream()
-                  .filter(s -> s.getId().equals(stageId))
-                  .findFirst()
-                  .orElseThrow(
-                      () ->
-                          new NotFoundException(
-                              "Could not find stage with id "
-                                  + stageId
-                                  + " in execution "
-                                  + executionId));
+          StageExecution stage = execution.stageById(stageId);
 
           // mutates stage in place
           stageUpdater.accept(stage);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
@@ -49,7 +49,9 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class StageExecutionImpl implements StageExecution, Serializable {
 
@@ -329,6 +331,15 @@ public class StageExecutionImpl implements StageExecution, Serializable {
   }
 
   public void setLastModified(@Nullable LastModifiedDetails lastModified) {
+    if (lastModified != null
+        && this.lastModified != null
+        && lastModified.getLastModifiedTime() < this.lastModified.getLastModifiedTime()) {
+      log.warn(
+          "Setting lastModified to a value with an older timestamp, current={}, new={}",
+          this.lastModified,
+          lastModified);
+    }
+
     this.lastModified = lastModified;
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
@@ -20,10 +20,7 @@ import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPEL
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
-import static java.util.Collections.singletonList;
+import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
@@ -47,17 +44,7 @@ import com.netflix.spinnaker.orca.pipeline.model.support.RequisiteStageRefIdDese
 import de.huxhorn.sulky.ulid.ULID;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -335,7 +322,9 @@ public class StageExecutionImpl implements StageExecution, Serializable {
 
   private LastModifiedDetails lastModified;
 
-  public @Nullable LastModifiedDetails getLastModified() {
+  @Nullable
+  @Override
+  public StageExecution.LastModifiedDetails getLastModified() {
     return lastModified;
   }
 

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorSpec.groovy
@@ -17,18 +17,23 @@
 package com.netflix.spinnaker.orca.pipeline
 
 import com.netflix.spinnaker.kork.core.RetrySupport
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import org.slf4j.MDC
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
+
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPELINE
 
 
 class CompoundExecutionOperatorSpec extends Specification {
   ExecutionRepository repository = Mock(ExecutionRepository)
   ExecutionRunner runner = Mock(ExecutionRunner)
   def execution = Mock(PipelineExecution)
+  def stage = Mock(StageExecution)
 
   def setupSpec() {
     MDC.clear()
@@ -37,27 +42,60 @@ class CompoundExecutionOperatorSpec extends Specification {
   @Subject
   CompoundExecutionOperator operator = new CompoundExecutionOperator(repository, runner, new RetrySupport())
 
-  def 'should not push messages on the queue for foreign executions'() {
+  @Unroll
+  def '#method call should not push messages on the queue for foreign executions'() {
     when:
-    operator.cancel(ExecutionType.PIPELINE, "id")
+    operator."$method"(*args)
 
-    then: 'we never call runner.cancel(), only repository.cancel()'
-    1 * repository.retrieve(ExecutionType.PIPELINE, "id") >> execution
+    then: 'we never call runner.$method(), only repository.$method()'
     _ * execution.getPartition() >> "foreign"
+    _ * execution.getStages() >> [stage]
+    _ * stage.getId() >> "stageId"
+
+    _ * repository.retrieve(PIPELINE, "id") >> execution
     1 * repository.handlesPartition("foreign") >> false
-    1 * repository.cancel(ExecutionType.PIPELINE, "id", "anonymous", null)
-    0 * _
+    1 * repository."$repoMethod"(*_)
+    0 * runner._(*_)
+
+    where:
+    method        | repoMethod   | args
+    'cancel'      | 'cancel'     | [PIPELINE, "id"]
+    'pause'       | 'pause'      | [PIPELINE, "id", "user"]
+    'resume'      | 'resume'     | [PIPELINE, "id", "user", false]
+    'updateStage' | 'storeStage' | [PIPELINE, "id", "stageId", {} ]
   }
 
-  def 'should handle both the queue and the execution repository for local executions'() {
+  @Unroll
+  def '#method call should handle both the queue and the execution repository for local executions'() {
     when:
-    operator.cancel(ExecutionType.PIPELINE, "id")
+    operator."$method"(*args)
 
     then: 'we call both runner.cancel() and repository.cancel()'
-    1 * repository.retrieve(ExecutionType.PIPELINE, "id") >> execution
+    1 * repository.retrieve(PIPELINE, "id") >> execution
     _ * execution.getPartition() >> "local"
     1 * repository.handlesPartition("local") >> true
-    1 * repository.cancel(ExecutionType.PIPELINE, "id", "anonymous", null)
-    1 * runner.cancel(execution, "anonymous", null)
+    1 * repository."$method"(*_)
+    1 * runner."$runnerMethod"(*_)
+
+    where:
+    method   | runnerMethod | args
+    'cancel' | 'cancel'     | [PIPELINE, "id"]
+    'pause'  | 'reschedule' | [PIPELINE, "id", "user"]
+    'resume' | 'unpause'    | [PIPELINE, "id", "user", false]
+  }
+
+  def 'updateStage() updates the stage'() {
+    given:
+    StageExecutionImpl stage = new StageExecutionImpl(id: 'stageId')
+
+    when:
+    operator.updateStage(PIPELINE, 'id', 'stageId',
+        { it.setLastModified(new StageExecution.LastModifiedDetails(user: 'user')) })
+
+    then:
+    _ * repository.retrieve(PIPELINE, 'id') >> execution
+    1 * execution.getStages() >> [stage]
+    1 * repository.storeStage(stage)
+    stage.getLastModified().getUser() == 'user'
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorSpec.groovy
@@ -49,7 +49,7 @@ class CompoundExecutionOperatorSpec extends Specification {
 
     then: 'we never call runner.$method(), only repository.$method()'
     _ * execution.getPartition() >> "foreign"
-    _ * execution.getStages() >> [stage]
+    _ * execution.stageById('stageId') >> stage
     _ * stage.getId() >> "stageId"
 
     _ * repository.retrieve(PIPELINE, "id") >> execution
@@ -94,7 +94,7 @@ class CompoundExecutionOperatorSpec extends Specification {
 
     then:
     _ * repository.retrieve(PIPELINE, 'id') >> execution
-    1 * execution.getStages() >> [stage]
+    1 * execution.stageById('stageId') >> stage
     1 * repository.storeStage(stage)
     stage.getLastModified().getUser() == 'user'
   }

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/aws/InterlinkAmazonMessageHandler.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/aws/InterlinkAmazonMessageHandler.java
@@ -65,7 +65,7 @@ public class InterlinkAmazonMessageHandler implements AmazonPubsubMessageHandler
       MDC.put(Header.EXECUTION_ID.getHeader(), event.getExecutionId());
 
       if (executionRepository.handlesPartition(event.getPartition())) {
-        event.applyTo(executionOperator);
+        event.withObjectMapper(objectMapper).applyTo(executionOperator);
       } else {
         log.debug(
             "Execution repository with local partition {} can't handle this event {} so it will not be applied",

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.interlink.events;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import javax.validation.constraints.NotNull;
@@ -29,7 +30,8 @@ import javax.validation.constraints.NotNull;
   @JsonSubTypes.Type(value = CancelInterlinkEvent.class, name = "CANCEL"),
   @JsonSubTypes.Type(value = PauseInterlinkEvent.class, name = "PAUSE"),
   @JsonSubTypes.Type(value = ResumeInterlinkEvent.class, name = "RESUME"),
-  @JsonSubTypes.Type(value = DeleteInterlinkEvent.class, name = "DELETE")
+  @JsonSubTypes.Type(value = DeleteInterlinkEvent.class, name = "DELETE"),
+  @JsonSubTypes.Type(value = PatchStageInterlinkEvent.class, name = "PATCH")
 })
 public interface InterlinkEvent {
   enum EventType {
@@ -37,6 +39,7 @@ public interface InterlinkEvent {
     PAUSE,
     DELETE,
     RESUME,
+    PATCH
   }
 
   @JsonIgnore
@@ -61,5 +64,9 @@ public interface InterlinkEvent {
   @NotNull
   default String getFingerprint() {
     return getEventType() + ":" + getExecutionType() + ":" + getExecutionId();
+  }
+
+  default InterlinkEvent withObjectMapper(ObjectMapper objectMapper) {
+    return this;
   }
 }

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PatchStageInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PatchStageInterlinkEvent.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.interlink.events;
+
+import static com.netflix.spinnaker.orca.interlink.events.InterlinkEvent.EventType.PATCH;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Slf4j
+public class PatchStageInterlinkEvent implements InterlinkEvent {
+  final EventType eventType = PATCH;
+  @Nullable String partition;
+  @NonNull ExecutionType executionType;
+  @NonNull String executionId;
+  @NonNull String stageId;
+  @NonNull String stageBody;
+
+  @JsonIgnore @Nullable ObjectMapper mapper;
+
+  public PatchStageInterlinkEvent(
+      @NonNull ExecutionType executionType,
+      @NonNull String executionId,
+      @NonNull String stageId,
+      @NonNull String stageBody) {
+    this.executionType = executionType;
+    this.executionId = executionId;
+    this.stageId = stageId;
+    this.stageBody = stageBody;
+  }
+
+  @Override
+  public void applyTo(CompoundExecutionOperator executionOperator) {
+    Preconditions.checkNotNull(mapper, "applyTo requires an ObjectMapper");
+
+    try {
+      StageExecution stageFromMessage = mapper.readValue(stageBody, StageExecutionImpl.class);
+
+      executionOperator.updateStage(
+          executionType,
+          executionId,
+          stageId,
+          stage -> {
+            stage.getContext().putAll(stageFromMessage.getContext());
+
+            if (stageFromMessage.getLastModified() != null) {
+              if (isMoreRecent(stageFromMessage.getLastModified(), stage.getLastModified())) {
+                stage.setLastModified(stageFromMessage.getLastModified());
+              } else {
+                log.warn(
+                    "Not propagating patch stage interlink event's lastModified details as they are older than "
+                        + "the ones in the stage: event.lastModified={}, stage.lastModified={}",
+                    stageFromMessage.getLastModified(),
+                    stage.getLastModified());
+              }
+            }
+          });
+    } catch (JsonProcessingException e) {
+      log.error("failed to parse stageBody {}", stageBody, e);
+    }
+  }
+
+  private boolean isMoreRecent(
+      StageExecution.LastModifiedDetails lhs, StageExecution.LastModifiedDetails rhs) {
+    return rhs == null || lhs.getLastModifiedTime() > rhs.getLastModifiedTime();
+  }
+
+  @Override
+  public InterlinkEvent withObjectMapper(ObjectMapper mapper) {
+    this.mapper = mapper;
+    return this;
+  }
+}

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PatchStageInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PatchStageInterlinkEvent.java
@@ -69,29 +69,20 @@ public class PatchStageInterlinkEvent implements InterlinkEvent {
           executionType,
           executionId,
           stageId,
-          stage -> {
-            stage.getContext().putAll(stageFromMessage.getContext());
+          stageFromRepo -> {
+            stageFromRepo.getContext().putAll(stageFromMessage.getContext());
 
             if (stageFromMessage.getLastModified() != null) {
-              if (isMoreRecent(stageFromMessage.getLastModified(), stage.getLastModified())) {
-                stage.setLastModified(stageFromMessage.getLastModified());
-              } else {
-                log.warn(
-                    "Not propagating patch stage interlink event's lastModified details as they are older than "
-                        + "the ones in the stage: event.lastModified={}, stage.lastModified={}",
-                    stageFromMessage.getLastModified(),
-                    stage.getLastModified());
-              }
+              stageFromRepo.setLastModified(stageFromMessage.getLastModified());
+            } else {
+              log.warn(
+                  "Unexpected state: stageFromMessage.getLastModified() is null, stageFromMessage={}",
+                  stageFromMessage);
             }
           });
     } catch (JsonProcessingException e) {
       log.error("failed to parse stageBody {}", stageBody, e);
     }
-  }
-
-  private boolean isMoreRecent(
-      StageExecution.LastModifiedDetails lhs, StageExecution.LastModifiedDetails rhs) {
-    return rhs == null || lhs.getLastModifiedTime() > rhs.getLastModifiedTime();
   }
 
   @Override

--- a/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/InterlinkSpec.groovy
+++ b/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/InterlinkSpec.groovy
@@ -17,20 +17,32 @@
 package com.netflix.spinnaker.orca.interlink
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.interlink.events.*
 import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator
+import com.netflix.spinnaker.orca.pipeline.ExecutionRunner
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.time.Duration
+import java.time.Instant
+
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.ORCHESTRATION
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPELINE
+
 class InterlinkSpec extends Specification {
   ObjectMapper objectMapper = new ObjectMapper()
-  @Shared def cancel = new CancelInterlinkEvent(ExecutionType.ORCHESTRATION, "execId", "user", "reason")
-  @Shared def pause = new PauseInterlinkEvent(ExecutionType.PIPELINE, "execId", "user")
-  @Shared def resume = new ResumeInterlinkEvent(ExecutionType.PIPELINE, "execId", "user", false).withPartition("partition")
-  @Shared def delete = new DeleteInterlinkEvent(ExecutionType.ORCHESTRATION, "execId").withPartition("partition")
+  @Shared def cancel = new CancelInterlinkEvent(ORCHESTRATION, "execId", "user", "reason")
+  @Shared def pause = new PauseInterlinkEvent(PIPELINE, "execId", "user")
+  @Shared def resume = new ResumeInterlinkEvent(PIPELINE, "execId", "user", false).withPartition("partition")
+  @Shared def delete = new DeleteInterlinkEvent(ORCHESTRATION, "execId").withPartition("partition")
+  @Shared def patch = new PatchStageInterlinkEvent(ORCHESTRATION, "execId", "stageId",
+      '{"id": "someId", "context": {"value": 42}}').withPartition("partition")
 
   @Unroll
   def "can parse execution event type #event.getEventType()"() {
@@ -46,7 +58,8 @@ class InterlinkSpec extends Specification {
         cancel,
         pause,
         resume,
-        delete
+        delete,
+        patch
     ]
   }
 
@@ -56,7 +69,7 @@ class InterlinkSpec extends Specification {
     def executionOperator = Mock(CompoundExecutionOperator)
 
     when:
-    event.applyTo(executionOperator)
+    event.withObjectMapper(new ObjectMapper()).applyTo(executionOperator)
 
     then:
     1 * executionOperator."$methodName"(*_)
@@ -67,5 +80,63 @@ class InterlinkSpec extends Specification {
     pause  | "pause"
     resume | "resume"
     delete | "delete"
+    patch  | "updateStage"
+  }
+
+  @Unroll
+  def "applying a patch stage event patches the stage"() {
+    given:
+    def stage = new StageExecutionImpl(
+        id: 'stageId',
+        context: [untouched: 'untouched indeed', overridden: 'override me'],
+        lastModified: stageLastModified)
+    def execution = Mock(PipelineExecution)
+    def repository = Mock(ExecutionRepository)
+    def executionOperator = new CompoundExecutionOperator(
+        repository,
+        Mock(ExecutionRunner),
+        new RetrySupport())
+    def mapper = new ObjectMapper()
+
+    and:
+    def event = new PatchStageInterlinkEvent(ORCHESTRATION, "execId", "stageId",
+      mapper.writeValueAsString(
+          new StageExecutionImpl(id: 'stageId', context: [overridden: true, new_value: 42], lastModified: eventLastModified)
+      )).withObjectMapper(mapper)
+
+    when:
+    event.applyTo(executionOperator)
+
+    then:
+    _ * repository.retrieve(event.executionType, event.executionId) >> execution
+    1 * execution.getStages() >> [stage]
+    1 * repository.storeStage(stage)
+
+    // we apply values from the event's context map on top of the stage's context map
+    stage.context.untouched == 'untouched indeed'
+    stage.context.overridden == true
+    stage.context.new_value == 42
+
+    // and we propagate auth information when appropriate
+    stage.lastModified == expectedLastModified
+
+    where:
+    stageLastModified          | eventLastModified                       || expectedLastModified
+    null                       | null                                    || null
+    lastModified('user')       | null                                    || stageLastModified
+
+    // the lastModified details from the event get persisted if they are newer than the ones from the retrieved stage
+    lastModified('new')        | lastModified('old', 5)                  || stageLastModified
+    null                       | lastModified('user')                    || eventLastModified
+    lastModified('old', 5)     | lastModified('new', 2)                  || eventLastModified
+    lastModified('old', 5, []) | lastModified('new', 2, ['someaccount']) || eventLastModified
+  }
+
+  private static StageExecution.LastModifiedDetails lastModified(String user, int minutesAgo = 0, Collection<String> allowedAccounts = []) {
+    return new StageExecution.LastModifiedDetails(
+        user: user,
+        allowedAccounts: allowedAccounts,
+        lastModifiedTime: Instant.now().minus(Duration.ofMinutes(minutesAgo)).toEpochMilli()
+    )
   }
 }

--- a/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/InterlinkSpec.groovy
+++ b/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/InterlinkSpec.groovy
@@ -109,7 +109,7 @@ class InterlinkSpec extends Specification {
 
     then:
     _ * repository.retrieve(event.executionType, event.executionId) >> execution
-    1 * execution.getStages() >> [stage]
+    1 * execution.stageById('stageId') >> stage
     1 * repository.storeStage(stage)
 
     // we apply values from the event's context map on top of the stage's context map
@@ -124,9 +124,7 @@ class InterlinkSpec extends Specification {
     stageLastModified          | eventLastModified                       || expectedLastModified
     null                       | null                                    || null
     lastModified('user')       | null                                    || stageLastModified
-
-    // the lastModified details from the event get persisted if they are newer than the ones from the retrieved stage
-    lastModified('new')        | lastModified('old', 5)                  || stageLastModified
+    lastModified('new')        | lastModified('old', 5)                  || eventLastModified // should warn about timestamp but still override
     null                       | lastModified('user')                    || eventLastModified
     lastModified('old', 5)     | lastModified('new', 2)                  || eventLastModified
     lastModified('old', 5, []) | lastModified('new', 2, ['someaccount']) || eventLastModified

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -471,7 +471,7 @@ class TaskController {
           )
 
           // `lastModifiedBy` is deprecated (pending a update to deck)
-          stage.context["lastModifiedBy"] = AuthenticatedRequest.getSpinnakerUser().orElse("anonymous")
+          stage.context["lastModifiedBy"] = stage.lastModified.user
         })
   }
 

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -460,7 +460,7 @@ class TaskController {
   PipelineExecution updatePipelineStage(
     @PathVariable String id,
     @PathVariable String stageId, @RequestBody Map context) {
-    executionOperator.updateStage(PIPELINE, id, stageId,
+    return executionOperator.updateStage(PIPELINE, id, stageId,
         { stage ->
           stage.context.putAll(context)
           validateStageUpdate(stage)

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -20,18 +20,13 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.annotations.VisibleForTesting
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
-import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
-import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.api.pipeline.models.*
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.model.OrchestrationViewModel
 import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator
-import com.netflix.spinnaker.orca.pipeline.EvaluateVariablesStage
 import com.netflix.spinnaker.orca.pipeline.ExecutionRunner
-import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
-import com.netflix.spinnaker.orca.api.pipeline.models.Trigger
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
@@ -465,26 +460,19 @@ class TaskController {
   PipelineExecution updatePipelineStage(
     @PathVariable String id,
     @PathVariable String stageId, @RequestBody Map context) {
-    def pipeline = executionRepository.retrieve(PIPELINE, id)
-    def stage = pipeline.stages.find { it.id == stageId }
-    if (stage) {
-      stage.context.putAll(context)
-      validateStageUpdate(stage)
+    executionOperator.updateStage(PIPELINE, id, stageId,
+        { stage ->
+          stage.context.putAll(context)
+          validateStageUpdate(stage)
+          stage.lastModified = new StageExecution.LastModifiedDetails(
+              user: AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"),
+              allowedAccounts: AuthenticatedRequest.getSpinnakerAccounts().orElse(null)?.split(",") ?: [],
+              lastModifiedTime: System.currentTimeMillis()
+          )
 
-      stage.lastModified = new StageExecution.LastModifiedDetails(
-        user: AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"),
-        allowedAccounts: AuthenticatedRequest.getSpinnakerAccounts().orElse(null)?.split(",") ?: [],
-        lastModifiedTime: System.currentTimeMillis()
-      )
-
-      // `lastModifiedBy` is deprecated (pending a update to deck)
-      stage.context["lastModifiedBy"] = AuthenticatedRequest.getSpinnakerUser().orElse("anonymous")
-
-      executionRepository.storeStage(stage)
-
-      executionRunner.reschedule(pipeline)
-    }
-    pipeline
+          // `lastModifiedBy` is deprecated (pending a update to deck)
+          stage.context["lastModifiedBy"] = AuthenticatedRequest.getSpinnakerUser().orElse("anonymous")
+        })
   }
 
   // If other execution mutations need validation, factor this out.


### PR DESCRIPTION
Some operations like skip wait or manual approvals result in calls to

    PATCH /pipelines/pipelineId/stages/stageId

with a context map values used to augment the designated stage context. The TaskController also updates the stage's `lastModified` field with user and account information, so that manual approval stages can be used to propagate auth info. This is all great as long as we operate on local executions, but for foreign executions (owned by a different orca cluster), we can't just patch read-only stages.

To support this, we:
- make `ExecutionRepository::storeStage` foreign-aware
- for foreign executions, we create a `PatchStageInterlinkEvent` (if supported) that contains the body of the stage
- the stage body includes the updated context map values and `lastModified` information
- we add an `updateStage` method in `CompoundExecutionOperator` and update the `TaskController` to call it
- we also call it from the event's `applyTo` method
