### PR TITLE
docs(api): Initial samples and some more api docs

### DIFF
--- a/orca-api/api.md
+++ b/orca-api/api.md
@@ -1,3 +1,17 @@
 # Module orca-api
 
-I need to say something about things here.
+Contains all public Java APIs for Orca.
+
+## Package com.netflix.spinnaker.orca.api.simplestage
+
+The `SimpleStage` extension point is useful for the most basic custom stages that do not need to interact with separate systems.
+
+## Package com.netflix.spinnaker.orca.api.pipeline.graph
+
+The `StageDefinitionBuilder` extension point provides absolute low-level access to building a stage within Spinnaker.
+It offers the ability to create arbitrarily complex stage definitions of any number of Tasks or the composition of other stages.
+
+## Package com.netflix.spinnaker.orca.api.preconfigured.jobs
+
+The `PreconfiguredJobConfigurationProvider` extension point provides a simple API for providing one or more preconfigured job stages.
+A preconfigured job is a container that is executed as a stage and can be configured with a custom UI.

--- a/orca-api/orca-api.gradle
+++ b/orca-api/orca-api.gradle
@@ -18,6 +18,10 @@ apply from: "$rootDir/gradle/kotlin.gradle"
 apply from: "$rootDir/gradle/dokka.gradle"
 apply from: "$rootDir/gradle/spock.gradle"
 
+sourceSets {
+  sample
+}
+
 dependencies {
   api("com.netflix.spinnaker.kork:kork-plugins-api")
   api("com.netflix.spinnaker.kork:kork-artifacts")
@@ -27,6 +31,8 @@ dependencies {
 
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
   testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
+
+  sampleImplementation(sourceSets.main.runtimeClasspath)
 }
 
 test {

--- a/orca-api/src/sample/java/preconfiguredjob/PreconfiguredJobStageSample.java
+++ b/orca-api/src/sample/java/preconfiguredjob/PreconfiguredJobStageSample.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package preconfiguredjob;
+
+import com.netflix.spinnaker.kork.plugins.api.PluginSdks;
+import com.netflix.spinnaker.kork.plugins.api.yaml.YamlResourceLoader;
+import com.netflix.spinnaker.orca.api.preconfigured.jobs.PreconfiguredJobConfigurationProvider;
+import com.netflix.spinnaker.orca.api.preconfigured.jobs.PreconfiguredJobStageProperties;
+import com.netflix.spinnaker.orca.api.preconfigured.jobs.TitusPreconfiguredJobProperties;
+import java.util.ArrayList;
+import java.util.List;
+import org.pf4j.Extension;
+
+/**
+ * A (real life) example of a preconfigured job stage.
+ *
+ * <p>This stage is used within Netflix and runs on Titus. Treasure is a service for deploying and
+ * serving static websites either internally or externally complying with Netflix security and
+ * infrastructure paved road practices.
+ *
+ * <p>This example also exhibits usage of the Config SDK to load standard configuration through a
+ * YAML file packaged with the plugin itself.
+ */
+@Extension
+public class PreconfiguredJobStageSample implements PreconfiguredJobConfigurationProvider {
+  private final PluginSdks pluginSdks;
+
+  public PreconfiguredJobStageSample(PluginSdks pluginSdks) {
+    this.pluginSdks = pluginSdks;
+  }
+
+  @Override
+  public List<? extends PreconfiguredJobStageProperties> getJobConfigurations() {
+    List<TitusPreconfiguredJobProperties> preconfiguredJobProperties = new ArrayList<>();
+
+    YamlResourceLoader yamlResourceLoader = pluginSdks.yamlResourceLoader();
+    TitusPreconfiguredJobProperties titusRunJobConfigProps =
+        yamlResourceLoader.loadResource("treasure.yml", TitusPreconfiguredJobProperties.class);
+    preconfiguredJobProperties.add(titusRunJobConfigProps);
+
+    return preconfiguredJobProperties;
+  }
+}

--- a/orca-api/src/sample/java/simplestage/SimpleStageSample.java
+++ b/orca-api/src/sample/java/simplestage/SimpleStageSample.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package simplestage;
+
+import static java.lang.String.format;
+
+import com.netflix.spinnaker.orca.api.simplestage.SimpleStage;
+import com.netflix.spinnaker.orca.api.simplestage.SimpleStageInput;
+import com.netflix.spinnaker.orca.api.simplestage.SimpleStageOutput;
+import com.netflix.spinnaker.orca.api.simplestage.SimpleStageStatus;
+import java.util.Collections;
+import org.pf4j.Extension;
+
+/**
+ * A plain example of the {@link SimpleStage} extension point.
+ *
+ * <p>This stage takes two optional input fields and emits a message.
+ *
+ * <pre>{@code
+ * {
+ *   "type": "simple",
+ *   "recipient": "Programmer person",
+ *   "message": "This message is from the simple stage. Wow!"
+ * }
+ * }</pre>
+ */
+@Extension
+public class SimpleStageSample implements SimpleStage<SimpleStageSample.Input> {
+
+  @Override
+  public SimpleStageOutput execute(SimpleStageInput<Input> simpleStageInput) {
+    final Output output = new Output();
+
+    output.setOutput(
+        format(
+            "recipient=%s message=%s",
+            simpleStageInput.getValue().recipient, simpleStageInput.getValue().message));
+    output.setContext(Collections.emptyMap());
+    output.setStatus(SimpleStageStatus.SUCCEEDED);
+
+    return output;
+  }
+
+  @Override
+  public String getName() {
+    return "simple";
+  }
+
+  public static class Input {
+    public String recipient;
+    public String message;
+  }
+
+  public static class Output extends SimpleStageOutput<String, Object> {}
+}

--- a/orca-api/src/sample/resources/preconfiguredjob/treasure.yml
+++ b/orca-api/src/sample/resources/preconfiguredjob/treasure.yml
@@ -1,0 +1,65 @@
+label: Treasure Deploy
+description: Publishes static assets to Treasure
+type: treasureDeploy
+waitForCompletion: true
+uiType: CUSTOM
+parameters:
+  - name: buildFolder
+    mapping: cluster.env.BUILD_FOLDER
+    defaultValue: build
+    description: The folder to deploy (from the Jenkins Job)
+    label: Build Folder
+    order: 0
+  - name: rootFolder
+    mapping: cluster.env.ROOT_FOLDER
+    defaultValue: private
+    description: Determines if the root folder will be private (protected by Meechum)
+    label: Root Folder (private or public)
+    order: 1
+  - name: environment
+    mapping: cluster.env.ENV
+    defaultValue: test
+    label: Environment
+    order: 2
+  - name: region
+    mapping: cluster.env.DESTINATION_REGION
+    defaultValue: us-east-1
+    label: Destination Region
+    order: 3
+  - name: hostname
+    mapping: cluster.env.HOST_NAME
+    label: Hostname
+    order: 4
+    description: The hostname that will be used to access this content
+  - name: account
+    mapping: credentials
+    label: Titus Account
+    defaultValue: titustestvpc
+    order: 5
+  - name: buildUrl
+    mapping: cluster.env.BUILD_URL
+    label: url of your build
+    defaultValue: "${dollarSign}{(execution.stages.$[type=='jenkins' && hasSucceeded]?.context?.buildInfo?.url ?: trigger?.buildInfo?.url) ?: 'unknown'}"
+    order: 6
+cloudProvider: titus
+credentials: titustestvpc
+region: us-east-1
+cluster:
+  imageId: edge/treasure-deploy:latest
+  application: treasure
+  stack: ${execution.application}
+  region: us-east-1
+  capacity:
+    desired: 1
+    max: 1
+    min: 1
+  env:
+    SOURCE_APP: ${execution.application}
+  runtimeLimitSecs: 3600
+  resources:
+    cpu: 1
+    disk: 10000
+    gpu: 0
+    memory: 512
+    networkMbps: 128
+  retries: 2


### PR DESCRIPTION
Working through getting docs and examples in place. Nice thing about this strategy of putting samples in the service repos themselves is that we'll be able to ensure they continue to compile and (eventually) continue to pass unit tests. My intention is that these samples will function as both examples of basic usage as well as functional contract tests for every extension point exposed.

The docs are generated through Dokka. I'll be working on emitting the Jekyll format so we can export these artifacts into the spinnaker.io website every release.

<img width="1507" alt="Screen Shot 2020-03-17 at 11 19 05 AM" src="https://user-images.githubusercontent.com/108741/76889109-3e441180-6842-11ea-986c-d3d2e59524ab.png">
