### PR TITLE
fix(peering): minor perf improvement for peering

### DIFF
--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccess.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccess.kt
@@ -63,7 +63,7 @@ open class MySqlRawAccess(
       jooq
         .select(field("id"))
         .from(getExecutionTable(executionType))
-        .where(field("status").notIn(*completedStatuses.toTypedArray())
+        .where(field("status").`in`(*activeStatuses.toTypedArray())
           .and(partitionConstraint))
         .fetch(field("id"), String::class.java)
     }

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/SqlRawAccess.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/SqlRawAccess.kt
@@ -28,6 +28,7 @@ abstract class SqlRawAccess(
 ) {
   val log: Logger = LoggerFactory.getLogger(this.javaClass)
   val completedStatuses = ExecutionStatus.COMPLETED.map { it.toString() }
+  val activeStatuses = ExecutionStatus.values().map { it.toString() }.filter { !completedStatuses.contains(it) }
 
   /**
    *  Returns a list of execution IDs and their update_at times for completed executions


### PR DESCRIPTION
using `in` instead of `not in` is more performant and should shave ~15% of our running execution peering time
(ad hoc profiling showed the query going from 4s to about 1s)
