### PR TITLE
fix(cleanupagents): fix for issue #5583

### DIFF
--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgent.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgent.kt
@@ -49,7 +49,7 @@ class OldPipelineCleanupPollingNotificationAgent(
   @Value("\${pollers.old-pipeline-cleanup.threshold-days:30}") private val thresholdDays: Long,
   @Value("\${pollers.old-pipeline-cleanup.minimum-pipeline-executions:5}") private val minimumPipelineExecutions: Int,
   @Value("\${pollers.old-pipeline-cleanup.chunk-size:1}") private val chunkSize: Int,
-  @Value("\${sql.partition-name}") private val partitionName: String?
+  @Value("\${sql.partition-name:#{null}}") private val partitionName: String?
 ) : AbstractPollingNotificationAgent(clusterLock) {
 
   companion object {

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgent.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgent.kt
@@ -43,7 +43,7 @@ class TopApplicationExecutionCleanupPollingNotificationAgent(
   @Value("\${pollers.top-application-execution-cleanup.interval-ms:3600000}") private val pollingIntervalMs: Long,
   @Value("\${pollers.top-application-execution-cleanup.threshold:2000}") private val threshold: Int,
   @Value("\${pollers.top-application-execution-cleanup.chunk-size:1}") private val chunkSize: Int,
-  @Value("\${sql.partition-name}") private val partitionName: String?
+  @Value("\${sql.partition-name:#{null}}") private val partitionName: String?
 ) : AbstractPollingNotificationAgent(clusterLock) {
 
   private val log = LoggerFactory.getLogger(TopApplicationExecutionCleanupPollingNotificationAgent::class.java)


### PR DESCRIPTION
resolves https://github.com/spinnaker/spinnaker/issues/5583 which is a regression of https://github.com/spinnaker/orca/pull/3461/files
don't require partition names in cleanup agents
