### PR TITLE
fix(execution): Persist `Execution.spelEvaluator` in Redis

### DIFF
--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -866,6 +866,9 @@ public class RedisExecutionRepository implements ExecutionRepository {
         execution.setPaused(mapper.readValue(map.get("paused"), PausedDetails.class));
       }
       execution.setKeepWaitingPipelines(Boolean.parseBoolean(map.get("keepWaitingPipelines")));
+      if (map.get("spelEvaluator") != null) {
+        execution.setSpelEvaluator(map.get("spelEvaluator"));
+      }
       execution.setOrigin(map.get("origin"));
       if (map.get("source") != null) {
         execution.setSource(
@@ -995,6 +998,7 @@ public class RedisExecutionRepository implements ExecutionRepository {
       map.put("authentication", mapper.writeValueAsString(execution.getAuthentication()));
       map.put("paused", mapper.writeValueAsString(execution.getPaused()));
       map.put("keepWaitingPipelines", String.valueOf(execution.isKeepWaitingPipelines()));
+      map.put("spelEvaluator", execution.getSpelEvaluator());
       map.put("origin", execution.getOrigin());
       map.put("source", mapper.writeValueAsString(execution.getSource()));
       map.put("trigger", mapper.writeValueAsString(execution.getTrigger()));


### PR DESCRIPTION
When using Redis as the execution repository, the spelEvaluator field of
the Execution object was not serialized or deserialized.
This change adds the field to the object stored in Redis, and reads it
back out when deserializing an Execution object.