### PR TITLE
feature(Pipeline Expressions): add pipelineIdOrNull SpEl helper function

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineExpressionFunctionProvider.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineExpressionFunctionProvider.java
@@ -58,6 +58,15 @@ public class PipelineExpressionFunctionProvider implements ExpressionFunctionPro
                 "execution",
                 "The execution containing the currently executing stage"),
             new FunctionParameter(
+                String.class, "pipelineName", "A valid stage reference identifier")),
+        new FunctionDefinition(
+            "pipelineIdOrNull",
+            "Lookup pipeline ID given the name of the pipeline in the current application",
+            new FunctionParameter(
+                PipelineExecution.class,
+                "execution",
+                "The execution containing the currently executing stage"),
+            new FunctionParameter(
                 String.class, "pipelineName", "A valid stage reference identifier")));
   }
 
@@ -66,7 +75,7 @@ public class PipelineExpressionFunctionProvider implements ExpressionFunctionPro
    *
    * @param execution the current execution
    * @param pipelineName name of the pipeline to lookup
-   * @return the id of the pipeline or null if pipeline not found
+   * @return the id of the pipeline or exception if pipeline not found
    */
   public static String pipelineId(PipelineExecution execution, String pipelineName) {
     if (Strings.isNullOrEmpty(pipelineName)) {
@@ -106,6 +115,25 @@ public class PipelineExpressionFunctionProvider implements ExpressionFunctionPro
       throw e;
     } catch (Exception e) {
       throw new SpelHelperFunctionException("Failed to evaluate #pipelineId function", e);
+    }
+  }
+
+  /**
+   * Function to convert pipeline name to pipeline ID (within current application), will return Null
+   * if pipeline ID not found
+   *
+   * @param execution the current execution
+   * @param pipelineName name of the pipeline to lookup
+   * @return the id of the pipeline or null if pipeline not found
+   */
+  public static String pipelineIdOrNull(PipelineExecution execution, String pipelineName) {
+    try {
+      return pipelineId(execution, pipelineName);
+    } catch (SpelHelperFunctionException e) {
+      if (e.getMessage().startsWith("Pipeline with name ")) {
+        return null;
+      }
+      throw e;
     }
   }
 }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineExpressionFunctionProvider.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineExpressionFunctionProvider.java
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.orca.front50.pipeline;
 
-import static java.lang.String.format;
-
 import com.google.common.base.Strings;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.expressions.ExpressionFunctionProvider;
@@ -95,10 +93,7 @@ public class PipelineExpressionFunctionProvider implements ExpressionFunctionPro
               true);
 
       if (pipeline == null) {
-        throw new SpelHelperFunctionException(
-            format(
-                "Pipeline with name '%s' could not be found on application %s",
-                pipelineName, currentApplication));
+        return null;
       }
 
       return (String) pipeline.get("id");

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineExpressionFunctionProvider.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineExpressionFunctionProvider.java
@@ -61,7 +61,7 @@ public class PipelineExpressionFunctionProvider implements ExpressionFunctionPro
                 String.class, "pipelineName", "A valid stage reference identifier")),
         new FunctionDefinition(
             "pipelineIdOrNull",
-            "Lookup pipeline ID given the name of the pipeline in the current application",
+            "Lookup pipeline ID (or null if not found) given the name of the pipeline in the current application",
             new FunctionParameter(
                 PipelineExecution.class,
                 "execution",

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineExpressionFunctionProvider.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineExpressionFunctionProvider.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.orca.front50.pipeline;
 
+import static java.lang.String.format;
+
 import com.google.common.base.Strings;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.expressions.ExpressionFunctionProvider;
@@ -93,7 +95,10 @@ public class PipelineExpressionFunctionProvider implements ExpressionFunctionPro
               true);
 
       if (pipeline == null) {
-        return null;
+        throw new SpelHelperFunctionException(
+            format(
+                "Pipeline with name '%s' could not be found on application %s",
+                pipelineName, currentApplication));
       }
 
       return (String) pipeline.get("id");


### PR DESCRIPTION
I don't think it's a good idea to throw an exception when a pipeline does not exist, because exceptions cannot be handled in Spinnaker Expressions.

We should just return `null`, and let the user decide what to do with that