### PR TITLE
fix(messageflagger): better thread safety

### DIFF
--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/MessageFlagger.kt
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/MessageFlagger.kt
@@ -17,14 +17,15 @@
 package com.netflix.spinnaker.orca.interlink
 
 import com.google.common.base.Preconditions
+import com.google.common.collect.EvictingQueue
 import com.google.common.hash.HashCode
 import com.google.common.hash.Hashing
 import com.netflix.spinnaker.config.InterlinkConfigurationProperties.FlaggerProperties
 import com.netflix.spinnaker.orca.interlink.events.InterlinkEvent
-import io.github.resilience4j.circularbuffer.ConcurrentEvictingQueue
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.locks.ReentrantLock
 
 /**
  * To avoid pathological cases where 2 orca clusters end up endlessly bouncing the same message back and forth across the
@@ -47,9 +48,10 @@ import java.time.Instant
  * @param lookback fingerprints older than the lookback duration will not count toward the threshold
  */
 class MessageFlagger(val clock: Clock, val props: FlaggerProperties) {
-  private val queue = ConcurrentEvictingQueue<TimestampedHash>(props.maxSize)
+  private val queue: EvictingQueue<TimestampedHash> = EvictingQueue.create(props.maxSize)
   private val hasher = Hashing.goodFastHash(64)
   private val lookback = Duration.ofSeconds(props.lookbackSeconds)
+  private val mutex = ReentrantLock()
 
   init {
     Preconditions.checkArgument(props.maxSize >= props.threshold, "maxSize (%s) has to be larger than threshold (%s)", props.maxSize, props.threshold)
@@ -61,16 +63,22 @@ class MessageFlagger(val clock: Clock, val props: FlaggerProperties) {
       return
     }
 
-    val hash = hasher.hashString(event.getFingerprint(), Charsets.UTF_8)
+    val hash = hasher.hashString(event.fingerprint, Charsets.UTF_8)
     val now = clock.instant()
     val timeCutoff = now.minus(lookback)
-    val matches = queue.filter { it.timestamp.isAfter(timeCutoff) && it.hash == hash }
-    if (matches.count() >= props.threshold) {
-      throw MessageFlaggedException("Event '$event' with fingerprint '${event.fingerprint}' has been encountered " +
-        "${matches.count()} times in the last ${props.lookbackSeconds}s")
-    }
 
-    queue.add(TimestampedHash(now, hash))
+    try {
+      mutex.lock()
+      val matches = queue.filter { it.timestamp.isAfter(timeCutoff) && it.hash == hash }
+      if (matches.count() >= props.threshold) {
+        throw MessageFlaggedException("Event '$event' with fingerprint '${event.fingerprint}' has been encountered " +
+          "${matches.count()} times in the last ${props.lookbackSeconds}s")
+      }
+
+      queue.add(TimestampedHash(now, hash))
+    } finally {
+        mutex.unlock()
+    }
   }
 
   private data class TimestampedHash(val timestamp: Instant, val hash: HashCode)


### PR DESCRIPTION
Follow up to my incorrect fix https://github.com/spinnaker/orca/pull/3537.
Since multiple threads run the `MessageFlagger::process` we need to make sure all `queue` is inside a lock of some sort.
