### PR TITLE
fix(interlink): Add ability to skip flagging of certain interlink events

### DIFF
--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/MessageFlagger.kt
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/MessageFlagger.kt
@@ -59,7 +59,7 @@ class MessageFlagger(val clock: Clock, val props: FlaggerProperties) {
   }
 
   fun process(event: InterlinkEvent) {
-    if (!props.enabled) {
+    if (!props.enabled || !event.isFlaggable) {
       return
     }
 

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
@@ -72,6 +72,16 @@ public interface InterlinkEvent {
     return this;
   }
 
+  /**
+   * Should this event be subject to MessageFlagger validation
+   *
+   * @return true by default
+   */
+  @JsonIgnore
+  default boolean isFlaggable() {
+    return true;
+  }
+
   void applyTo(CompoundExecutionOperator executionOperator);
 
   @JsonIgnore

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/StartPendingInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/StartPendingInterlinkEvent.java
@@ -18,11 +18,9 @@ package com.netflix.spinnaker.orca.interlink.events;
 
 import static com.netflix.spinnaker.orca.interlink.events.InterlinkEvent.EventType.START_PENDING;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -66,10 +64,8 @@ public class StartPendingInterlinkEvent implements InterlinkEvent {
     executionOperator.startPending(pipelineConfigId, purgeQueue);
   }
 
-  @JsonIgnore
-  @NotNull
   @Override
-  public String getFingerprint() {
-    return getEventType() + ":" + getExecutionType() + ":" + pipelineConfigId;
+  public boolean isFlaggable() {
+    return false;
   }
 }

--- a/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/MessageFlaggerSpec.groovy
+++ b/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/MessageFlaggerSpec.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
 import com.netflix.spinnaker.orca.interlink.events.CancelInterlinkEvent
 import com.netflix.spinnaker.orca.interlink.events.DeleteInterlinkEvent
 import com.netflix.spinnaker.orca.interlink.events.PauseInterlinkEvent
+import com.netflix.spinnaker.orca.interlink.events.StartPendingInterlinkEvent
 import com.netflix.spinnaker.orca.time.MutableClock
 import spock.lang.Specification
 
@@ -29,10 +30,10 @@ import static com.netflix.spinnaker.config.InterlinkConfigurationProperties.Flag
 
 class MessageFlaggerSpec extends Specification {
   def cancel = new CancelInterlinkEvent(ExecutionType.ORCHESTRATION, "id", "user", "reason")
-  def cancelByOtherUser = new CancelInterlinkEvent(ExecutionType.ORCHESTRATION, "id", "otherUser", "reason")
   def pause = new PauseInterlinkEvent(ExecutionType.ORCHESTRATION, "id", "user")
   def delete = new DeleteInterlinkEvent(ExecutionType.ORCHESTRATION, "id")
   def deleteOtherId = new DeleteInterlinkEvent(ExecutionType.ORCHESTRATION, "otherId")
+  def startPending = new StartPendingInterlinkEvent(ExecutionType.PIPELINE, "id", false)
   MutableClock clock = new MutableClock()
 
   def 'flagger should flag repeated messages'() {
@@ -52,6 +53,19 @@ class MessageFlaggerSpec extends Specification {
 
     then:
     thrown(MessageFlaggedException)
+  }
+
+  def 'flagger skips non-flaggable events'() {
+    given:
+    def flagger = new MessageFlagger(clock, new FlaggerProperties(threshold: 2))
+
+    when:
+    flagger.process(startPending)
+    flagger.process(startPending)
+    flagger.process(startPending)
+
+    then:
+    noExceptionThrown()
   }
 
   def 'older events are evicted and not tripping the flagger'() {


### PR DESCRIPTION
Message flagging was designed to detect issues with events bouncing back and forth.
The StartPendingExecutions event is very voluminous and because it doesn't really have a unique and identifiable id it will
a) trip flagging all the time
b) will make flagging of all other events essentially impossible (since they are much much less frequent)

One solution is to fix the StartPendingExecutions event to be actually unique, but that requires a bit of surgery on the orca queue
Another solution is to skip flagging these events, I opted for skipping

