### PR TITLE
fix(interlink): Don't rebroadcast StartPending interlink event

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
@@ -107,8 +107,9 @@ public class CompoundExecutionOperator {
         executionId);
   }
 
-  public void startPending(@Nonnull String pipelineConfigId, boolean purgeQueue) {
-    runner.startPending(pipelineConfigId, purgeQueue);
+  public void startPending(
+      @Nonnull String pipelineConfigId, boolean purgeQueue, boolean allowRebroadcast) {
+    runner.startPending(pipelineConfigId, purgeQueue, allowRebroadcast);
   }
 
   private PipelineExecution doInternal(

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionRunner.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionRunner.java
@@ -40,7 +40,8 @@ public interface ExecutionRunner {
     throw new UnsupportedOperationException();
   }
 
-  default void startPending(@Nonnull String pipelineConfigId, boolean purgeQueue) {
+  default void startPending(
+      @Nonnull String pipelineConfigId, boolean purgeQueue, boolean allowRebroadcast) {
     throw new UnsupportedOperationException();
   }
 }

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/StartPendingInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/StartPendingInterlinkEvent.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.interlink.events;
 
 import static com.netflix.spinnaker.orca.interlink.events.InterlinkEvent.EventType.START_PENDING;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import javax.annotation.Nullable;
@@ -63,13 +62,11 @@ public class StartPendingInterlinkEvent implements InterlinkEvent {
 
   @Override
   public void applyTo(CompoundExecutionOperator executionOperator) {
-    executionOperator.startPending(pipelineConfigId, purgeQueue);
+    executionOperator.startPending(pipelineConfigId, purgeQueue, false);
   }
 
-  @JsonIgnore
-  @NotNull
   @Override
-  public String getFingerprint() {
-    return getEventType() + ":" + getExecutionType() + ":" + pipelineConfigId;
+  public @NotNull String getFingerprint() {
+    return InterlinkEvent.super.getFingerprint() + ":" + pipelineConfigId + ":" + purgeQueue;
   }
 }

--- a/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/MessageFlaggerSpec.groovy
+++ b/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/MessageFlaggerSpec.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
 import com.netflix.spinnaker.orca.interlink.events.CancelInterlinkEvent
 import com.netflix.spinnaker.orca.interlink.events.DeleteInterlinkEvent
 import com.netflix.spinnaker.orca.interlink.events.PauseInterlinkEvent
+import com.netflix.spinnaker.orca.interlink.events.StartPendingInterlinkEvent
 import com.netflix.spinnaker.orca.time.MutableClock
 import spock.lang.Specification
 
@@ -29,10 +30,10 @@ import static com.netflix.spinnaker.config.InterlinkConfigurationProperties.Flag
 
 class MessageFlaggerSpec extends Specification {
   def cancel = new CancelInterlinkEvent(ExecutionType.ORCHESTRATION, "id", "user", "reason")
-  def cancelByOtherUser = new CancelInterlinkEvent(ExecutionType.ORCHESTRATION, "id", "otherUser", "reason")
   def pause = new PauseInterlinkEvent(ExecutionType.ORCHESTRATION, "id", "user")
   def delete = new DeleteInterlinkEvent(ExecutionType.ORCHESTRATION, "id")
   def deleteOtherId = new DeleteInterlinkEvent(ExecutionType.ORCHESTRATION, "otherId")
+  def startPending = new StartPendingInterlinkEvent(ExecutionType.PIPELINE, "id", false)
   MutableClock clock = new MutableClock()
 
   def 'flagger should flag repeated messages'() {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueExecutionRunner.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueExecutionRunner.kt
@@ -46,7 +46,7 @@ class QueueExecutionRunner(
     queue.push(CancelExecution(execution, user, reason))
   }
 
-  override fun startPending(pipelineConfigId: String, purge: Boolean) {
-    queue.push(StartWaitingExecutions(pipelineConfigId, purge))
+  override fun startPending(pipelineConfigId: String, purge: Boolean, allowRebroadcast: Boolean) {
+    queue.push(StartWaitingExecutions(pipelineConfigId, purge, allowRebroadcast))
   }
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartWaitingExecutionsHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartWaitingExecutionsHandler.kt
@@ -67,18 +67,22 @@ class StartWaitingExecutionsHandler(
     }
 
     if (pendingMessage != null) {
-
       // spoiler, it always is!
       if (pendingMessage is ExecutionLevel) {
         log.info("Starting queued pipeline {} {} {}", pendingMessage.application, pendingMessage.executionId)
       }
+
       queue.push(pendingMessage)
     } else {
-      interlink?.publish(
-        StartPendingInterlinkEvent(
-          ExecutionType.PIPELINE,
-          message.pipelineConfigId,
-          message.purgeQueue))
+      // If this message itself came from interlink and there are no pending executions we will rebroadcast it indefinitely
+      // So all pending kicks as a result of interlink messages are not rebroadcast on the interlink
+      if (message.allowRebroadcast) {
+        interlink?.publish(
+          StartPendingInterlinkEvent(
+            ExecutionType.PIPELINE,
+            message.pipelineConfigId,
+            message.purgeQueue))
+      }
     }
   }
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/messages.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/messages.kt
@@ -342,7 +342,8 @@ data class CancelExecution(
 @JsonTypeName("startWaitingExecutions")
 data class StartWaitingExecutions(
   val pipelineConfigId: String,
-  val purgeQueue: Boolean = false
+  val purgeQueue: Boolean = false,
+  val allowRebroadcast: Boolean = true
 ) : Message()
 
 /**


### PR DESCRIPTION
Previous implementation of triggering executions across peers (https://github.com/spinnaker/orca/pull/3519) had a flaw in that
the `StartPendingInterlinkEvent` would kept being rebroadcast if there are no pending executions causing an infinite stream of events until
`MessageFlagger` broke the chain.

This change makes it so that queue messages that result from processing the `StartPendingInterlinkEvent` are not rebroadcast if they aren't acted upon
