### PR TITLE
fix(evaluate variables): handle null/empty variable keys

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTask.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.pipeline.tasks;
 
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.orca.api.pipeline.Task;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
@@ -46,7 +47,9 @@ public class EvaluateVariablesTask implements Task {
 
     Map<String, Object> outputs = new HashMap<>();
     for (EvaluateVariablesStage.Variable v : context.getVariables()) {
-      outputs.put(v.getKey(), v.getValue());
+      if (!Strings.isNullOrEmpty(v.getKey())) {
+        outputs.put(v.getKey(), v.getValue());
+      }
     }
 
     return TaskResult.builder(ExecutionStatus.SUCCEEDED)

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesTaskSpec.groovy
@@ -45,6 +45,27 @@ class EvaluateVariablesTaskSpec extends Specification {
     result.outputs.get("myKey2") == "myMy"
   }
 
+  void "Removes null&empty keys"() {
+    setup:
+    def stage = stage {
+      refId = "1"
+      type = "evaluateVariables"
+      context["variables"] = [
+          ["key": null, "value": null],
+          ["key": null, "value": 1],
+          ["key": "", "value": 1],
+          ["key": "validKey", "value": "validValue"]
+      ]
+    }
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.outputs.size() == 1
+    result.outputs.get("validKey") == "validValue"
+  }
+
   void "Supports values that are complex objects"() {
     setup:
     def simpleValue = "A simple string";


### PR DESCRIPTION
it's possible to consruct a pipeline with bad eval vars stage context as follows (both in UI and by hand):
```
  "type": "evaluateVariables",
  "variables": [
  {
    "key": "a",
    "value": 1
  },
  {
    "key": null,
    "value": null
  }
]
```

This causes an exception inside the exception handler of `RunTaskHandler`.
This fix strips out invalid variable keys
