### PR TITLE
feat(peering): Pending Executions Agent

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
@@ -25,8 +25,8 @@ import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.time.Duration;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 import lombok.extern.slf4j.Slf4j;
@@ -61,8 +61,8 @@ public class CompoundExecutionOperator {
   }
 
   public void pause(
-      @NonNull ExecutionType executionType,
-      @NonNull String executionId,
+      @Nonnull ExecutionType executionType,
+      @Nonnull String executionId,
       @Nullable String pausedBy) {
     doInternal(
         runner::reschedule,
@@ -73,10 +73,10 @@ public class CompoundExecutionOperator {
   }
 
   public void resume(
-      @NonNull ExecutionType executionType,
-      @NonNull String executionId,
+      @Nonnull ExecutionType executionType,
+      @Nonnull String executionId,
       @Nullable String user,
-      @NonNull Boolean ignoreCurrentStatus) {
+      @Nonnull Boolean ignoreCurrentStatus) {
     doInternal(
         runner::unpause,
         () -> repository.resume(executionType, executionId, user, ignoreCurrentStatus),
@@ -86,10 +86,10 @@ public class CompoundExecutionOperator {
   }
 
   public PipelineExecution updateStage(
-      @NonNull ExecutionType executionType,
-      @NonNull String executionId,
-      @NonNull String stageId,
-      @NonNull Consumer<StageExecution> stageUpdater) {
+      @Nonnull ExecutionType executionType,
+      @Nonnull String executionId,
+      @Nonnull String stageId,
+      @Nonnull Consumer<StageExecution> stageUpdater) {
     return doInternal(
         runner::reschedule,
         () -> {

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/CancelInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/CancelInterlinkEvent.java
@@ -26,6 +26,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+/**
+ * This event is published on the interlink as a result of a user CANCELLING an execution on an orca
+ * instance that can't handle the partition for the given execution.
+ *
+ * <p>The event is then handled by an orca instance (listening on interlink) whose partition matches
+ * that of the execution. The resulting repository mutations of this event will then be peered by
+ * the PeeringAgent
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/DeleteInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/DeleteInterlinkEvent.java
@@ -26,6 +26,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+/**
+ * This event is published on the interlink as a result of a user DELETING an execution on an orca
+ * instance that can't handle the partition for the given execution.
+ *
+ * <p>The event is then handled by an orca instance (listening on interlink) whose partition matches
+ * that of the execution. The resulting repository mutations of this event will then be peered by
+ * the PeeringAgent
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
@@ -24,7 +24,19 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
 import javax.validation.constraints.NotNull;
 
-/** Common interface for all interlink event messages */
+/**
+ * Common interface for interlink events
+ *
+ * <p>Interlink events are published to communicate across orca peers. When an orca encounters an
+ * operation it can't handle due its partition not matching that of the execution/request it will
+ * generally broadcast an interlink event which will be handled by an orca instance (listening on
+ * interlink) whose partition matches that of the execution.
+ *
+ * <p>Interlink events don't have a delivery guarantee, since most such events are triggered by a
+ * user action this lack of guarantee is not a problem.
+ *
+ * <p>The resulting repository mutations of interlink events will then be peered by the PeeringAgent
+ */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "eventType")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = CancelInterlinkEvent.class, name = "CANCEL"),

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PatchStageInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PatchStageInterlinkEvent.java
@@ -33,6 +33,15 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * This event is published on the interlink as a result of a user "patching" a stage on an orca
+ * instance that can't handle the partition for the given execution. Patching a stage occurs when,
+ * for example, the user skips wait, skips execution window, passes manual judgement
+ *
+ * <p>The event is then handled by an orca instance (listening on interlink) whose partition matches
+ * that of the execution. The resulting repository mutations of this event will then be peered by
+ * the PeeringAgent
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PauseInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PauseInterlinkEvent.java
@@ -26,6 +26,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+/**
+ * This event is published on the interlink as a result of a user PAUSING an execution on an orca
+ * instance that can't handle the partition for the given execution.
+ *
+ * <p>The event is then handled by an orca instance (listening on interlink) whose partition matches
+ * that of the execution. The resulting repository mutations of this event will then be peered by
+ * the PeeringAgent
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/ResumeInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/ResumeInterlinkEvent.java
@@ -26,6 +26,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
+/**
+ * This event is published on the interlink as a result of a user RESUMING an execution on an orca
+ * instance that can't handle the partition for the given execution.
+ *
+ * <p>The event is then handled by an orca instance (listening on interlink) whose partition matches
+ * that of the execution. The resulting repository mutations of this event will then be peered by
+ * the PeeringAgent
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/pending/RedisPendingExecutionService.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/orca/q/redis/pending/RedisPendingExecutionService.kt
@@ -60,6 +60,9 @@ class RedisPendingExecutionService(
       redis.llen(listName(pipelineConfigId)).toInt()
     }
 
+  override fun pendingIds(): List<String> =
+    throw NotImplementedError("only implemented on SqlPendingExecutionService")
+
   private fun listName(pipelineConfigId: String) =
     "orca.pipeline.queue.$pipelineConfigId"
 }

--- a/orca-queue-sql/src/main/kotlin/com/netflix/spinnaker/orca/q/sql/pending/SqlPendingExecutionService.kt
+++ b/orca-queue-sql/src/main/kotlin/com/netflix/spinnaker/orca/q/sql/pending/SqlPendingExecutionService.kt
@@ -185,6 +185,17 @@ class SqlPendingExecutionService(
         .fetchOne(0, Int::class.java)
     }
 
+  override fun pendingIds(): List<String> {
+    return jooq
+      .select(configField)
+      .from(pendingTable)
+      .where(
+        shardCondition
+      )
+      .fetch(configField, String::class.java)
+      .distinct()
+  }
+
   private data class MessageContainer(
     val id: String,
     val message: String

--- a/orca-queue/orca-queue.gradle
+++ b/orca-queue/orca-queue.gradle
@@ -33,6 +33,7 @@ dependencies {
   implementation("com.github.ben-manes.caffeine:guava")
 
   testImplementation("com.netflix.spinnaker.kork:kork-jedis-test")
+  testImplementation(project(":orca-api-test"))
   testImplementation(project(":orca-test-kotlin"))
   testImplementation(project(":orca-queue-tck"))
   testImplementation(project(":orca-queue-redis"))

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/pending/DualPendingExecutionService.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/pending/DualPendingExecutionService.kt
@@ -97,4 +97,7 @@ class DualPendingExecutionService(
   override fun depth(pipelineConfigId: String): Int {
     return previous.depth(pipelineConfigId) + primary.depth(pipelineConfigId)
   }
+
+  override fun pendingIds(): List<String> =
+    throw NotImplementedError("only implemented on SqlPendingExecutionService")
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/pending/InMemoryPendingExecutionService.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/pending/InMemoryPendingExecutionService.kt
@@ -59,6 +59,8 @@ class InMemoryPendingExecutionService : PendingExecutionService {
     return pendingFor(pipelineConfigId).size
   }
 
+  override fun pendingIds(): List<String> = pending.keys.toList()
+
   private fun pendingFor(pipelineConfigId: String): Deque<Message> =
     pending.computeIfAbsent(pipelineConfigId) { LinkedList() }
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/pending/PendingExecutionAgent.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/pending/PendingExecutionAgent.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.q.pending
+
+import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import com.netflix.spinnaker.orca.notifications.AbstractPollingNotificationAgent
+import com.netflix.spinnaker.orca.notifications.NotificationClusterLock
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.q.StartWaitingExecutions
+import com.netflix.spinnaker.q.Queue
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnExpression("\${pollers.pending-execution-service-agent.enabled:false}")
+class PendingExecutionAgent(
+  clusterLock: NotificationClusterLock,
+  registry: Registry,
+  private val queue: Queue,
+  private val pendingExecutionService: PendingExecutionService,
+  private val executionRepository: ExecutionRepository,
+  @Value("\${pollers.pending-execution-service-agent.interval-ms:15000}") private val pollingIntervalMs: Long
+) : AbstractPollingNotificationAgent(clusterLock) {
+
+  private final val log = LoggerFactory.getLogger(PendingExecutionAgent::class.java)
+  private final val lastCompletedCriteria = ExecutionRepository.ExecutionCriteria()
+    .setPageSize(1)
+    .setStatuses(ExecutionStatus.COMPLETED.map { it.toString() })
+  private final val singleRunningCriteria = ExecutionRepository.ExecutionCriteria()
+    .setPageSize(1)
+    .setStatuses(ExecutionStatus.RUNNING)
+  private final val kickCounter: Counter = registry.counter("pollers.pendingExecutionAgent.kickedExecutions")
+
+  override fun getPollingInterval(): Long {
+    return pollingIntervalMs
+  }
+
+  override fun getNotificationType(): String {
+    return PendingExecutionAgent::class.java.simpleName
+  }
+
+  override fun tick() {
+    try {
+      val pendingConfigIds = pendingExecutionService.pendingIds()
+
+      for (configId in pendingConfigIds) {
+        val runningPipelines = executionRepository.retrievePipelinesForPipelineConfigId(configId, singleRunningCriteria)
+          .toList().toBlocking().single()
+
+        if (runningPipelines.isEmpty()) {
+          val lastCompletedPipeline = executionRepository.retrievePipelinesForPipelineConfigId(configId, lastCompletedCriteria)
+            .toList().toBlocking().single()
+
+          val purgeQueue = if (lastCompletedPipeline.any()) {
+            !(lastCompletedPipeline.first().isKeepWaitingPipelines)
+          } else {
+            false
+          }
+          queue.push(StartWaitingExecutions(configId, purgeQueue))
+
+          log.info("Found pending execution(s) for pipeline {} with no running pipelines, kick-starting it with purge = {}", configId, purgeQueue)
+          kickCounter.increment()
+        }
+      }
+    } catch (e: Exception) {
+      log.error("Agent {} failed to kick-start pending executions", javaClass, e)
+    }
+  }
+}

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/pending/PendingExecutionService.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/pending/PendingExecutionService.kt
@@ -28,4 +28,5 @@ interface PendingExecutionService {
   fun popNewest(pipelineConfigId: String): Message?
   fun purge(pipelineConfigId: String, callback: (Message) -> Unit)
   fun depth(pipelineConfigId: String): Int
+  fun pendingIds(): List<String>
 }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/pending/DualPendingExecutionServiceTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/pending/DualPendingExecutionServiceTest.kt
@@ -177,4 +177,7 @@ class RedisPendingExecutionServiceProxy(
 
   override fun depth(pipelineConfigId: String): Int =
     service.depth(pipelineConfigId)
+
+  override fun pendingIds(): List<String> =
+    service.pendingIds()
 }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/pending/PendingExecutionAgentTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/pending/PendingExecutionAgentTest.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.q.pending
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
+import com.netflix.spinnaker.orca.api.test.pipeline
+import com.netflix.spinnaker.orca.notifications.NotificationClusterLock
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.q.StartWaitingExecutions
+import com.netflix.spinnaker.q.Queue
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.reset
+import com.nhaarman.mockito_kotlin.times
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.jetbrains.spek.subject.SubjectSpek
+import rx.Observable
+
+internal object PendingExecutionAgentTest : SubjectSpek<PendingExecutionAgent>({
+  val clusterLock: NotificationClusterLock = mock()
+  val queue: Queue = mock()
+  val pendingExecutionService: PendingExecutionService = mock()
+  val executionRepository: ExecutionRepository = mock()
+
+  class PendingExecutionAgentProxy : PendingExecutionAgent(
+    clusterLock,
+    NoopRegistry(),
+    queue,
+    pendingExecutionService,
+    executionRepository,
+    10000
+  ) {
+    public override fun tick() {
+      super.tick()
+    }
+  }
+
+  afterEachTest {
+    reset(pendingExecutionService, executionRepository, queue)
+  }
+
+  describe("does nothing when there is nothing to do") {
+    given("there are no pending executions") {
+      beforeGroup {
+        whenever(pendingExecutionService.pendingIds()) doReturn emptyList<String>()
+      }
+      on("agent tick") {
+        PendingExecutionAgentProxy().tick()
+
+        it("does nothing") {
+          verify(queue, never()).push(any())
+          verify(executionRepository, never()).retrievePipelinesForPipelineConfigId(any(), any())
+        }
+      }
+    }
+  }
+
+  describe("does nothing when there is a running execution") {
+    given("there is a pending execution but another of the same id is still running") {
+      val runningPipeline = pipeline {
+        pipelineConfigId = "ID1"
+        status = ExecutionStatus.RUNNING
+      }
+
+      beforeGroup {
+        whenever(pendingExecutionService.pendingIds()) doReturn listOf(runningPipeline.pipelineConfigId)
+        whenever(executionRepository.retrievePipelinesForPipelineConfigId(
+          runningPipeline.pipelineConfigId,
+          ExecutionRepository.ExecutionCriteria().setPageSize(1).setStatuses(ExecutionStatus.RUNNING))) doReturn Observable.just(runningPipeline)
+      }
+
+      on("agent tick") {
+        PendingExecutionAgentProxy().tick()
+
+        it("does nothing") {
+          verify(queue, never()).push(any())
+        }
+      }
+    }
+  }
+
+  describe("pushes pending message when execution is pending") {
+    val completedPipeline = pipeline {
+      pipelineConfigId = "ID1"
+      isKeepWaitingPipelines = false
+      status = ExecutionStatus.SUCCEEDED
+    }
+    beforeGroup {
+      whenever(pendingExecutionService.pendingIds()) doReturn listOf(completedPipeline.pipelineConfigId)
+      whenever(executionRepository.retrievePipelinesForPipelineConfigId(
+        completedPipeline.pipelineConfigId,
+        ExecutionRepository.ExecutionCriteria().setPageSize(1).setStatuses(ExecutionStatus.RUNNING))) doReturn Observable.empty<PipelineExecution>()
+      whenever(executionRepository.retrievePipelinesForPipelineConfigId(
+        completedPipeline.pipelineConfigId,
+        ExecutionRepository.ExecutionCriteria().setPageSize(1).setStatuses(ExecutionStatus.COMPLETED.map { it.toString() }))) doReturn Observable.just(completedPipeline)
+    }
+
+    on("agent tick") {
+      PendingExecutionAgentProxy().tick()
+
+      it("pushes a pending message with purging") {
+        verify(queue, times(1)).push(StartWaitingExecutions(completedPipeline.pipelineConfigId, true))
+      }
+    }
+  }
+
+  describe("pushes pending message without purging when execution is pending") {
+    val completedPipeline = pipeline {
+      pipelineConfigId = "ID1"
+      isKeepWaitingPipelines = true
+      status = ExecutionStatus.SUCCEEDED
+    }
+    beforeGroup {
+      whenever(pendingExecutionService.pendingIds()) doReturn listOf(completedPipeline.pipelineConfigId)
+      whenever(executionRepository.retrievePipelinesForPipelineConfigId(
+        completedPipeline.pipelineConfigId,
+        ExecutionRepository.ExecutionCriteria().setPageSize(1).setStatuses(ExecutionStatus.RUNNING))) doReturn Observable.empty<PipelineExecution>()
+      whenever(executionRepository.retrievePipelinesForPipelineConfigId(
+        completedPipeline.pipelineConfigId,
+        ExecutionRepository.ExecutionCriteria().setPageSize(1).setStatuses(ExecutionStatus.COMPLETED.map { it.toString() }))) doReturn Observable.just(completedPipeline)
+    }
+
+    on("agent tick") {
+      PendingExecutionAgentProxy().tick()
+
+      it("pushes a pending message with purging") {
+        verify(queue, times(1)).push(StartWaitingExecutions(completedPipeline.pipelineConfigId, false))
+      }
+    }
+  }
+
+  describe("pushes pending message when execution is pending and no prior executions") {
+    beforeGroup {
+      whenever(pendingExecutionService.pendingIds()) doReturn listOf("ID1")
+      whenever(executionRepository.retrievePipelinesForPipelineConfigId(
+        "ID1",
+        ExecutionRepository.ExecutionCriteria().setPageSize(1).setStatuses(ExecutionStatus.RUNNING))) doReturn Observable.empty<PipelineExecution>()
+      whenever(executionRepository.retrievePipelinesForPipelineConfigId(
+        "ID1",
+        ExecutionRepository.ExecutionCriteria().setPageSize(1).setStatuses(ExecutionStatus.COMPLETED.map { it.toString() }))) doReturn Observable.empty<PipelineExecution>()
+    }
+
+    on("agent tick") {
+      PendingExecutionAgentProxy().tick()
+
+      it("pushes a pending message with purging") {
+        verify(queue, times(1)).push(StartWaitingExecutions("ID1", false))
+      }
+    }
+  }
+})


### PR DESCRIPTION
Introduces a pending execution agent which kicks off executions in the pending state.
Normally, such executions will be started by the act of completing a pipeline.
However, when there is a waiting execution in a different orca DB from where the current pipeline completed
it doesn't work.

With this change there is an agent that runs every ~15s (configurable) to see if there are any pending executions
which need to be kicked off and if so, kicks them off.

This is a continuation of failed attempt at implementing such functionality here:
https://github.com/spinnaker/orca/pull/3544
