### PR TITLE
perf(peering): improve peering perf

### DIFF
--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccess.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccess.kt
@@ -69,13 +69,13 @@ open class MySqlRawAccess(
     }
   }
 
-  override fun getStageIdsForExecutions(executionType: ExecutionType, executionIds: List<String>): List<String> {
+  override fun getStageIdsForExecutions(executionType: ExecutionType, executionIds: List<String>): List<ExecutionDiffKey> {
     return withPool(poolName) {
       jooq
-        .select(field("id"))
+        .select(field("id"), field("updated_at"))
         .from(getStagesTable(executionType))
         .where(field("execution_id").`in`(*executionIds.toTypedArray()))
-        .fetch(field("id"), String::class.java)
+        .fetchInto(ExecutionDiffKey::class.java)
     }
   }
 

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
@@ -165,12 +165,10 @@ class PeeringAgent(
     val pipelineIdsToMigrate = completedPipelineKeys
       .filter { key -> migratedPipelineKeysMap[key.id]?.updated_at ?: 0 < key.updated_at }
       .map { it.id }
-      .toList()
 
     val pipelineIdsToDelete = migratedPipelineKeys
       .filter { key -> !completedPipelineKeysMap.containsKey(key.id) }
       .map { it.id }
-      .toList()
 
     fun getLatestCompletedUpdatedTime() =
       (completedPipelineKeys.map { it.updated_at }.max() ?: 0)

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/SqlRawAccess.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/SqlRawAccess.kt
@@ -43,7 +43,7 @@ abstract class SqlRawAccess(
   /**
    * Returns a list of stage IDs that belong to the given executions
    */
-  abstract fun getStageIdsForExecutions(executionType: ExecutionType, executionIds: List<String>): List<String>
+  abstract fun getStageIdsForExecutions(executionType: ExecutionType, executionIds: List<String>): List<ExecutionDiffKey>
 
   /**
    * Returns (a list of) full execution DB records with given execution IDs


### PR DESCRIPTION
A big chunk of time was spent storing all stages of running executions.
This is not necessary because most of those stages don't change (only about 8% change with ~30s agent interval)
Only store stages that have a different `updated_at` timestamp (or those that don't exist).
This improves peering performance by about 25%
