### PR TITLE
fix(build): Bump kotlin version to 1.3.71

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ buildscript {
 // this override is needed to omit compileOnly dependencies from generated pom.xml
       classpath "com.netflix.nebula:nebula-publishing-plugin:12.0.1"
     }
-    classpath "com.netflix.nebula:nebula-kotlin-plugin:1.3.31"
-    classpath "org.jetbrains.kotlin:kotlin-allopen:1.3.31"
+    classpath "com.netflix.nebula:nebula-kotlin-plugin:1.3.71"
+    classpath "org.jetbrains.kotlin:kotlin-allopen:1.3.71"
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
   }
 }

--- a/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca-clouddriver/orca-clouddriver.gradle
@@ -34,6 +34,7 @@ dependencies {
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   implementation("io.kubernetes:client-java:5.0.0")
   implementation("javax.validation:validation-api")
+  implementation("org.jetbrains:annotations")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava")
 
   api("com.netflix.spinnaker.kork:kork-web")

--- a/orca-front50/orca-front50.gradle
+++ b/orca-front50/orca-front50.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
   implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
   implementation("com.netflix.spectator:spectator-api")
+  implementation("org.jetbrains:annotations")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("org.springframework.security:spring-security-config")
   implementation("org.springframework.security:spring-security-core")

--- a/orca-integrations-cloudfoundry/orca-integrations-cloudfoundry.gradle
+++ b/orca-integrations-cloudfoundry/orca-integrations-cloudfoundry.gradle
@@ -11,6 +11,7 @@ dependencies {
   implementation(project(":orca-clouddriver"))
   implementation(project(":orca-core"))
 
+  implementation("org.jetbrains:annotations")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core:2.25.0")

--- a/orca-test-groovy/orca-test-groovy.gradle
+++ b/orca-test-groovy/orca-test-groovy.gradle
@@ -15,6 +15,7 @@
  */
 
 apply from: "$rootDir/gradle/groovy.gradle"
+apply from: "$rootDir/gradle/kotlin.gradle"
 
 dependencies {
   implementation(project(":orca-core"))


### PR DESCRIPTION
@rpalcolea

Kotlin version was bumped here -- https://github.com/robfletcher/strikt/compare/v0.24.0...master

Which also added a new module.  Current theory is that this new module comes in and tries to add kotlin `1.3.71` which results in a dependency conflict resolution error when the following task runs:

```
./gradlew -PenablePublishing=true :orca-api-test:generatePomFileForNebulaPublication
```

Anyways, this will resolve the branch build failure and also resolve the composite build failure we see in our `-nflx` builds.