### PR TITLE
fix(bakery): only conditionally override input artifact account in CreateBakeManifestTask

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.orca.bakery.tasks.manifests;
 
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask;
@@ -98,7 +99,9 @@ public class CreateBakeManifestTask implements RetryableTask {
                             "Input artifact (id: %s, account: %s) could not be found in execution (id: %s).",
                             p.getId(), p.getAccount(), stage.getExecution().getId()));
                   }
-                  a.setArtifactAccount(p.getAccount());
+                  if (!Strings.isNullOrEmpty(p.getAccount())) {
+                    a.setArtifactAccount(p.getAccount());
+                  }
                   return a;
                 })
             .collect(Collectors.toList());
@@ -107,7 +110,8 @@ public class CreateBakeManifestTask implements RetryableTask {
 
     if (expectedArtifacts.size() != 1) {
       throw new IllegalArgumentException(
-          "Exactly one expected artifact must be supplied. Please ensure that your Bake stage config's `expectedArtifacts` list contains exactly one artifact.");
+          "Exactly one expected artifact must be supplied. Please ensure that your Bake stage"
+              + " config's `expectedArtifacts` list contains exactly one artifact.");
     }
 
     String outputArtifactName = expectedArtifacts.get(0).getMatchArtifact().getName();


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4737, https://github.com/spinnaker/spinnaker/issues/5533

Helm `inputArtifacts` have unfortunately never worked with `artifactsRewrite` enabled: we are unconditionally overwriting the resolved artifact's account with the unresolved input artifact's account (which will always be empty if configured with `artifactsRewrite`). Let's only overwrite the resolved artifact's account when there is a non-empty account defined on the input artifact (in other words, when it was configured with `artifactsRewrite` disabled).

I think we should cherry-pick this back into each supported release given the number of users who have commented on the first issue linked above.