### PR TITLE
fix(plugins): allow only enabled preconfigured jobs for configuration…

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -412,16 +412,17 @@ class OperationsController {
     if (!jobService) {
       return []
     }
-    return jobService?.getPreconfiguredStages().collect{
-      [ label: it.label,
-        description: it.description,
-        type: it.type,
-        waitForCompletion: it.waitForCompletion,
-        noUserConfigurableFields: true,
-        parameters: it.parameters,
-        producesArtifacts: it.producesArtifacts,
-        uiType: it.uiType
-      ]
+    // Only allow enabled jobs for configuration in pipelines.
+    return jobService.getPreconfiguredStages().findAll { it.enabled } .collect {
+        [label                   : it.label,
+         description             : it.description,
+         type                    : it.type,
+         waitForCompletion       : it.waitForCompletion,
+         noUserConfigurableFields: true,
+         parameters              : it.parameters,
+         producesArtifacts       : it.producesArtifacts,
+         uiType                  : it.uiType
+        ]
     }
   }
 


### PR DESCRIPTION
To rollout preconfigured jobs using plugins we need to turnoff the currently configured stages safely and for that we are going to make use of `enabled` property on job configuration to disable and load the job via plugin.  Also allow us to rollback the old config if needed.