### PR TITLE
fix(peering): Improve peering of deletes

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
@@ -164,6 +164,14 @@ class DualExecutionRepository(
     return select(type, id).delete(type, id)
   }
 
+  override fun delete(type: ExecutionType, idsToDelete: MutableList<String>) {
+    // NOTE: Not a great implementation, but this method right now is only used on SqlExecutionRepository which has
+    // a performant implementation
+    idsToDelete.forEach { id ->
+      delete(type, id)
+    }
+  }
+
   override fun retrieve(type: ExecutionType): Observable<PipelineExecution> {
     return Observable.merge(
       primary.retrieve(type),

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -70,6 +70,8 @@ public interface ExecutionRepository {
 
   void delete(@Nonnull ExecutionType type, @Nonnull String id);
 
+  void delete(@Nonnull ExecutionType type, @Nonnull List<String> idsToDelete);
+
   @Nonnull
   @Instrumented(metricName = "retrieveByType")
   Observable<PipelineExecution> retrieve(@Nonnull ExecutionType type);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/InMemoryExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/InMemoryExecutionRepository.kt
@@ -123,6 +123,11 @@ class InMemoryExecutionRepository : ExecutionRepository {
     storageFor(type).remove(id)
   }
 
+  override fun delete(type: ExecutionType, idsToDelete: MutableList<String>) {
+    val storage = storageFor(type)
+    idsToDelete.forEach { id -> storage.remove(id) }
+  }
+
   override fun hasExecution(type: ExecutionType, id: String): Boolean {
     return storageFor(type).containsKey(id)
   }

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringMetrics.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringMetrics.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.peering
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
+import java.time.Duration
 
 open class PeeringMetrics(
   peeredId: String,
@@ -31,12 +32,18 @@ open class PeeringMetrics(
   private val peeringNumStagesDeletedId = registry.createId("pollers.peering.numStagesDeleted").withTag("peerId", peeredId)
   private val peeringNumErrorsId = registry.createId("pollers.peering.numErrors").withTag("peerId", peeredId)
 
-  open fun recordLag(executionType: ExecutionType, block: () -> Unit) {
+  open fun recordOverallLag(block: () -> Unit) {
     registry
-      .timer(peeringLagTimerId.tag(executionType))
+      .timer(peeringLagTimerId.withTag("executionType", "OVER_ALL"))
       .record {
         block()
       }
+  }
+
+  open fun recordLag(executionType: ExecutionType, duration: Duration) {
+    registry
+      .timer(peeringLagTimerId.tag(executionType))
+      .record(duration)
   }
 
   open fun incrementNumPeered(executionType: ExecutionType, state: ExecutionState, count: Int) {

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/SqlRawAccess.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/SqlRawAccess.kt
@@ -41,6 +41,11 @@ abstract class SqlRawAccess(
   abstract fun getActiveExecutionIds(executionType: ExecutionType, partitionName: String?): List<String>
 
   /**
+   * Returns a list of execution IDs that have been deleted since the specified "cursor" (0 means give me all known deletions)
+   */
+  abstract fun getDeletedExecutions(sinceCursor: Int): List<DeletedExecution>
+
+  /**
    * Returns a list of stage IDs that belong to the given executions
    */
   abstract fun getStageIdsForExecutions(executionType: ExecutionType, executionIds: List<String>): List<ExecutionDiffKey>
@@ -61,9 +66,9 @@ abstract class SqlRawAccess(
   abstract fun deleteStages(executionType: ExecutionType, stageIdsToDelete: List<String>)
 
   /**
-   * Delete specified executions
+   * Delete specified executions, returns count deleted
    */
-  abstract fun deleteExecutions(executionType: ExecutionType, pipelineIdsToDelete: List<String>)
+  abstract fun deleteExecutions(executionType: ExecutionType, pipelineIdsToDelete: List<String>): Int
 
   /**
    * Load given records into the specified table using jooq loader api
@@ -73,5 +78,11 @@ abstract class SqlRawAccess(
   data class ExecutionDiffKey(
     val id: String,
     val updated_at: Long
+  )
+
+  data class DeletedExecution(
+    val id: Int,
+    val execution_id: String,
+    val execution_type: String
   )
 }

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -366,6 +366,14 @@ public class RedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
+  public void delete(@Nonnull ExecutionType type, @Nonnull List<String> idsToDelete) {
+    // NOTE: Not a great implementation, but this method right now is only used on
+    // SqlExecutionRepository which has
+    // a performant implementation
+    idsToDelete.forEach(id -> delete(type, id));
+  }
+
+  @Override
   public @Nonnull Observable<PipelineExecution> retrievePipelinesForApplication(
       @Nonnull String application) {
     List<Observable<PipelineExecution>> observables =

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/telemetry/RedisInstrumentedExecutionRepository.kt
@@ -138,6 +138,12 @@ class RedisInstrumentedExecutionRepository(
     }
   }
 
+  override fun delete(type: ExecutionType, idsToDelete: List<String>) {
+    withMetrics("delete") {
+      executionRepository.delete(type, idsToDelete)
+    }
+  }
+
   override fun retrieve(type: ExecutionType, id: String): PipelineExecution {
     return withMetrics("retrieve2") {
       executionRepository.retrieve(type, id)

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -55,7 +55,8 @@ class SqlConfiguration {
     SpringLiquibaseProxy(properties)
 
   @ConditionalOnProperty("execution-repository.sql.enabled")
-  @Bean fun sqlExecutionRepository(
+  @Bean
+  fun sqlExecutionRepository(
     dsl: DSLContext,
     mapper: ObjectMapper,
     registry: Registry,
@@ -76,7 +77,8 @@ class SqlConfiguration {
     }
 
   @ConditionalOnProperty("execution-repository.sql.enabled", "execution-repository.sql.secondary.enabled")
-  @Bean fun secondarySqlExecutionRepository(
+  @Bean
+  fun secondarySqlExecutionRepository(
     dsl: DSLContext,
     mapper: ObjectMapper,
     registry: Registry,
@@ -96,10 +98,12 @@ class SqlConfiguration {
       InstrumentedProxy.proxy(registry, it, "sql.executions", mapOf(Pair("repository", "secondary"))) as ExecutionRepository
     }
 
-  @Bean fun sqlHealthcheckActivator(dsl: DSLContext, registry: Registry) =
+  @Bean
+  fun sqlHealthcheckActivator(dsl: DSLContext, registry: Registry) =
     SqlHealthcheckActivator(dsl, registry)
 
-  @Bean("dbHealthIndicator") fun dbHealthIndicator(
+  @Bean("dbHealthIndicator")
+  fun dbHealthIndicator(
     sqlHealthcheckActivator: SqlHealthcheckActivator,
     sqlProperties: SqlProperties,
     dynamicConfigService: DynamicConfigService

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/AbstractCleanupPollingAgent.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/AbstractCleanupPollingAgent.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.sql.cleanup
+
+import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.patterns.LongTaskTimer
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import com.netflix.spinnaker.orca.notifications.AbstractPollingNotificationAgent
+import com.netflix.spinnaker.orca.notifications.NotificationClusterLock
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+abstract class AbstractCleanupPollingAgent(
+  clusterLock: NotificationClusterLock,
+  private val pollingIntervalMs: Long,
+  val registry: Registry
+) : AbstractPollingNotificationAgent(clusterLock) {
+
+  val log: Logger = LoggerFactory.getLogger(javaClass)
+  val completedStatuses = ExecutionStatus.COMPLETED.map { it.toString() }
+
+  val deletedId: Id = registry.createId("pollers.$notificationType.deleted")
+  val errorsCounter: Counter = registry.counter("pollers.$notificationType.errors")
+  val invocationTimer: LongTaskTimer = LongTaskTimer.get(registry, registry.createId("pollers.$notificationType.timing"))
+
+  abstract fun performCleanup()
+
+  override fun tick() {
+    val timerId = invocationTimer.start()
+    val startTime = System.currentTimeMillis()
+
+    try {
+      log.info("Agent $notificationType started")
+      performCleanup()
+    } catch (e: Exception) {
+      log.error("Agent $notificationType failed to perform cleanup", e)
+    } finally {
+      log.info("Agent $notificationType completed in ${System.currentTimeMillis() - startTime}ms")
+      invocationTimer.stop(timerId)
+    }
+  }
+
+  override fun getPollingInterval(): Long {
+    return pollingIntervalMs
+  }
+
+  override fun getNotificationType(): String {
+    return javaClass.simpleName
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgent.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgent.kt
@@ -16,20 +16,14 @@
 
 package com.netflix.spinnaker.orca.sql.cleanup
 
-import com.netflix.spectator.api.Counter
-import com.netflix.spectator.api.Id
-import com.netflix.spectator.api.LongTaskTimer
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.kork.core.RetrySupport
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
-import com.netflix.spinnaker.orca.notifications.AbstractPollingNotificationAgent
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
 import com.netflix.spinnaker.orca.notifications.NotificationClusterLock
-import com.netflix.spinnaker.orca.sql.pipeline.persistence.transactional
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import org.jooq.DSLContext
 import org.jooq.impl.DSL.count
 import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.table
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.stereotype.Component
@@ -39,64 +33,24 @@ import java.time.temporal.ChronoUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 @Component
-@ConditionalOnExpression("\${pollers.old-pipeline-cleanup.enabled:false} && !\${execution-repository.redis.enabled:false}")
+@ConditionalOnExpression("\${pollers.old-pipeline-cleanup.enabled:false} && \${execution-repository.sql.enabled:false}")
 class OldPipelineCleanupPollingNotificationAgent(
   clusterLock: NotificationClusterLock,
   private val jooq: DSLContext,
   private val clock: Clock,
-  private val registry: Registry,
+  registry: Registry,
+  private val executionRepository: ExecutionRepository,
   @Value("\${pollers.old-pipeline-cleanup.interval-ms:3600000}") private val pollingIntervalMs: Long,
   @Value("\${pollers.old-pipeline-cleanup.threshold-days:30}") private val thresholdDays: Long,
   @Value("\${pollers.old-pipeline-cleanup.minimum-pipeline-executions:5}") private val minimumPipelineExecutions: Int,
   @Value("\${pollers.old-pipeline-cleanup.chunk-size:1}") private val chunkSize: Int,
   @Value("\${sql.partition-name:#{null}}") private val partitionName: String?
-) : AbstractPollingNotificationAgent(clusterLock) {
+) : AbstractCleanupPollingAgent(
+  clusterLock,
+  pollingIntervalMs,
+  registry) {
 
-  companion object {
-    internal val retrySupport = RetrySupport()
-  }
-
-  private val log = LoggerFactory.getLogger(OldPipelineCleanupPollingNotificationAgent::class.java)
-
-  private val deletedId: Id
-  private val errorsCounter: Counter
-  private val invocationTimer: LongTaskTimer
-
-  private val completedStatuses = ExecutionStatus.COMPLETED.map { it.toString() }
-
-  init {
-    deletedId = registry.createId("pollers.oldPipelineCleanup.deleted")
-    errorsCounter = registry.counter("pollers.oldPipelineCleanup.errors")
-
-    invocationTimer = com.netflix.spectator.api.patterns.LongTaskTimer.get(
-      registry, registry.createId("pollers.oldPipelineCleanup.timing")
-    )
-  }
-
-  override fun getPollingInterval(): Long {
-    return pollingIntervalMs
-  }
-
-  override fun getNotificationType(): String {
-    return OldPipelineCleanupPollingNotificationAgent::class.java.simpleName
-  }
-
-  override fun tick() {
-    val timerId = invocationTimer.start()
-    val startTime = System.currentTimeMillis()
-
-    try {
-      log.info("Agent {} started", notificationType)
-      performCleanup()
-    } catch (e: Exception) {
-      log.error("Agent {} failed to perform cleanup", javaClass, e)
-    } finally {
-      log.info("Agent {} completed in {}ms", notificationType, System.currentTimeMillis() - startTime)
-      invocationTimer.stop(timerId)
-    }
-  }
-
-  private fun performCleanup() {
+  override fun performCleanup() {
     val thresholdMillis = Instant.ofEpochMilli(clock.millis()).minus(thresholdDays, ChronoUnit.DAYS).toEpochMilli()
 
     val candidateApplications = jooq
@@ -171,14 +125,10 @@ class OldPipelineCleanupPollingNotificationAgent(
     var queryBuilder = jooq
       .select(field("id"))
       .from(table("pipelines"))
-      .where(
-        field("build_time").le(thresholdMillis).and(
-          "status IN (${completedStatuses.joinToString(",") { "'$it'" }})"
-        ).and(
-          field("application").eq(application)
-        ).and(
-          field("config_id").eq(pipelineConfigId)
-        )
+      .where(field("build_time").le(thresholdMillis)
+        .and(field("status").`in`(*completedStatuses.toTypedArray()))
+        .and(field("application").eq(application))
+        .and(field("config_id").eq(pipelineConfigId))
       )
 
     if (partitionName != null) {
@@ -190,22 +140,11 @@ class OldPipelineCleanupPollingNotificationAgent(
     val executionsToRemove = queryBuilder
       .orderBy(field("build_time").desc())
       .limit(minimumPipelineExecutions, Int.MAX_VALUE)
-      .fetch()
-      .map { it.getValue(field("id")) }
+      .fetch(field("id"), String::class.java)
 
     executionsToRemove.chunked(chunkSize).forEach { ids ->
       deletedExecutionCount.addAndGet(ids.size)
-      jooq.transactional(retrySupport) {
-        it.delete(table("correlation_ids")).where(
-          "pipeline_id IN (${ids.joinToString(",") { "'$it'" }})"
-        ).execute()
-        it.delete(table("pipeline_stages")).where(
-          "execution_id IN (${ids.joinToString(",") { "'$it'" }})"
-        ).execute()
-        it.delete(table("pipelines")).where(
-          "id IN (${ids.joinToString(",") { "'$it'" }})"
-        ).execute()
-      }
+      executionRepository.delete(ExecutionType.PIPELINE, ids)
 
       registry.counter(deletedId.withTag("application", application)).add(ids.size.toDouble())
     }

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.routing.withPool
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.BUFFERED
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.CANCELED
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.RUNNING
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.NOT_STARTED
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.PAUSED
@@ -50,6 +49,7 @@ import com.netflix.spinnaker.orca.pipeline.persistence.UnpausablePipelineExcepti
 import com.netflix.spinnaker.orca.pipeline.persistence.UnresumablePipelineException
 import de.huxhorn.sulky.ulid.SpinULID
 import org.jooq.DSLContext
+import org.jooq.DatePart
 import org.jooq.Field
 import org.jooq.Record
 import org.jooq.SelectConditionStep
@@ -63,7 +63,9 @@ import org.jooq.impl.DSL
 import org.jooq.impl.DSL.count
 import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.name
+import org.jooq.impl.DSL.now
 import org.jooq.impl.DSL.table
+import org.jooq.impl.DSL.timestampSub
 import org.jooq.impl.DSL.value
 import org.slf4j.LoggerFactory
 import rx.Observable
@@ -267,28 +269,57 @@ class SqlExecutionRepository(
 
   override fun delete(type: ExecutionType, id: String) {
     doForeignAware(DeleteInterlinkEvent(type, id)) {
-      execution, dslContext ->
-      val correlationField = if (type == PIPELINE) "pipeline_id" else "orchestration_id"
-      val (ulid, _) = mapLegacyId(jooq, type.tableName, id)
+      _, dslContext ->
+      val (ulid, _) = mapLegacyId(dslContext, type.tableName, id)
 
-      val correlationId = jooq.select(field("id")).from("correlation_ids")
-        .where(field(correlationField).eq(ulid))
-        .limit(1)
-        .fetchOne()
-        ?.into(String::class.java)
-      val stageIds = jooq.select(field("id")).from(type.stagesTableName)
-        .where(field("execution_id").eq(ulid))
-        .fetch()
-        ?.into(String::class.java)?.toTypedArray()
-
-      if (correlationId != null) {
-        dslContext.delete(table("correlation_ids")).where(field("id").eq(correlationId)).execute()
-      }
-      if (stageIds != null) {
-        dslContext.delete(type.stagesTableName).where(field("id").`in`(*stageIds)).execute()
-      }
-      dslContext.delete(type.tableName).where(field("id").eq(ulid)).execute()
+      deleteInternal(dslContext, type, listOf(ulid))
     }
+  }
+
+  /**
+   * Deletes given executions
+   * NOTE: this method explicitly does not check if the execution is foreign or not.
+   */
+  override fun delete(type: ExecutionType, idsToDelete: List<String>) {
+    jooq.transactional { tx ->
+      deleteInternal(tx, type, idsToDelete)
+    }
+  }
+
+  private fun deleteInternal(dslContext: DSLContext, type: ExecutionType, idsToDelete: List<String>) {
+    val correlationField = if (type == PIPELINE) "pipeline_id" else "orchestration_id"
+
+    dslContext
+      .delete(table("correlation_ids"))
+      .where(field(correlationField).`in`(*idsToDelete.toTypedArray()))
+      .execute()
+
+    dslContext
+      .delete(type.stagesTableName)
+      .where(field("execution_id").`in`(*idsToDelete.toTypedArray()))
+      .execute()
+
+    dslContext
+      .delete(type.tableName)
+      .where(field("id").`in`(*idsToDelete.toTypedArray()))
+      .execute()
+
+    var insertQueryBuilder = dslContext
+      .insertInto(table("deleted_executions"))
+      .columns(field("execution_id"), field("execution_type"), field("deleted_at"))
+
+    idsToDelete.forEach { id ->
+      insertQueryBuilder = insertQueryBuilder
+        .values(id, type.toString(), now())
+    }
+
+    insertQueryBuilder
+      .execute()
+
+    dslContext
+      .deleteFrom(table("deleted_executions"))
+      .where(field("deleted_at").lt(timestampSub(now(), 2, DatePart.DAY)))
+      .execute()
   }
 
   // TODO rz - Refactor to not use exceptions. So weird.
@@ -970,7 +1001,7 @@ class SqlExecutionRepository(
 
     return try {
       val execution = retrieve(executionType, id)
-      isForeign(execution)
+      isForeign(execution, shouldThrow)
     } catch (_: ExecutionNotFoundException) {
       // Execution not found, we can proceed since the rest is likely a noop anyway
       false

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -287,7 +287,11 @@ class SqlExecutionRepository(
   }
 
   private fun deleteInternal(dslContext: DSLContext, type: ExecutionType, idsToDelete: List<String>) {
-    val correlationField = if (type == PIPELINE) "pipeline_id" else "orchestration_id"
+    val correlationField = when (type) {
+      PIPELINE -> "pipeline_id"
+      ORCHESTRATION -> "orchestration_id"
+      else -> throw IllegalStateException("Unexpected field $type")
+    }
 
     dslContext
       .delete(table("correlation_ids"))
@@ -318,7 +322,7 @@ class SqlExecutionRepository(
 
     dslContext
       .deleteFrom(table("deleted_executions"))
-      .where(field("deleted_at").lt(timestampSub(now(), 2, DatePart.DAY)))
+      .where(field("deleted_at").lt(timestampSub(now(), 1, DatePart.DAY)))
       .execute()
   }
 

--- a/orca-sql/src/main/resources/db/changelog-master.yml
+++ b/orca-sql/src/main/resources/db/changelog-master.yml
@@ -44,3 +44,6 @@ databaseChangeLog:
 - include:
     file: changelog/20200221-partition-name-table.yml
     relativeToChangelogFile: true
+- include:
+    file: changelog/20200327-deleted-executions-table.yml
+    relativeToChangelogFile: true

--- a/orca-sql/src/main/resources/db/changelog/20200327-deleted-executions-table.yml
+++ b/orca-sql/src/main/resources/db/changelog/20200327-deleted-executions-table.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-deleted-executions-table
+      author: mvulfson
+      changes:
+        - sql:
+            dbms: mysql
+            sql: CREATE TABLE `deleted_executions` (id INT AUTO_INCREMENT, execution_id char(26) NOT NULL, execution_type ENUM("pipeline", "orchestration") NOT NULL, deleted_at DATETIME NOT NULL, CONSTRAINT deleted_executions_pk PRIMARY KEY (id))
+    rollback:
+      - dropTable:
+          tableName: deleted_executions

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -57,6 +57,7 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
     currentDatabase.context,
     Clock.systemDefaultZone(),
     new NoopRegistry(),
+    executionRepository,
     0,
     10, // threshold days
     5,  // minimum pipeline executions


### PR DESCRIPTION
Currently, in order to detect deletes, we need to perform a period FULL diff of the DB. This is EXTREMELY expensive and causes peering delay to be inconsistent.
This change adds what is essentially a log of all "recent" deletes into the new `deleted_executions` table.
The peering agent can then scan that table (remembering the last known "deletion" id) and delete all executions listed in the table.
Deletes older than some time (e.g. 2days) are cleaned up from the table during a delete.

Because execution deletes are now more complicated (need to add a row into the `deleted_executions` table) I had to change how cleanup agents work (in order not to duplicate the deletion code).
While there, I refactored them a little to extract [some] of the common functionality.
