### PR TITLE
fix(plugins): allow more than one SimpleStage impl

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/TaskNode.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/TaskNode.java
@@ -110,6 +110,17 @@ public interface TaskNode {
     }
 
     /**
+     * Adds a task to the current graph.
+     *
+     * @param task the task node to add
+     * @return this builder with the new task appended.
+     */
+    public Builder withTask(TaskNode task) {
+      graph.add(task);
+      return this;
+    }
+
+    /**
      * Adds a sub-graph of tasks that may loop if any of them return {@link
      * ExecutionStatus#REDIRECT}. The sub-graph will run after any previously added tasks and before
      * any subsequently added ones. If the final task in the sub-graph returns {@link
@@ -162,8 +173,16 @@ public interface TaskNode {
     }
   }
 
+  interface DefinedTask {
+    @Nonnull
+    String getName();
+
+    @Nonnull
+    String getImplementingClassName();
+  }
+
   /** An individual task. */
-  class TaskDefinition implements TaskNode {
+  class TaskDefinition implements TaskNode, DefinedTask {
     private final String name;
     private final Class<? extends Task> implementingClass;
 
@@ -178,6 +197,11 @@ public interface TaskNode {
 
     public @Nonnull Class<? extends Task> getImplementingClass() {
       return implementingClass;
+    }
+
+    @Override
+    public @Nonnull String getImplementingClassName() {
+      return getImplementingClass().getCanonicalName();
     }
   }
 }

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/simplestage/SimpleTaskDefinition.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/simplestage/SimpleTaskDefinition.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.api.simplestage;
+
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.DefinedTask;
+import javax.annotation.Nonnull;
+
+public class SimpleTaskDefinition implements TaskNode, DefinedTask {
+  private final String name;
+  private final Class<? extends SimpleStage> implementingClass;
+
+  public SimpleTaskDefinition(
+      @Nonnull String name, @Nonnull Class<? extends SimpleStage> implementingClass) {
+    this.name = name;
+    this.implementingClass = implementingClass;
+  }
+
+  public @Nonnull String getName() {
+    return name;
+  }
+
+  public @Nonnull Class<? extends SimpleStage> getImplementingClass() {
+    return implementingClass;
+  }
+
+  @Override
+  public @Nonnull String getImplementingClassName() {
+    return getImplementingClass().getCanonicalName();
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -208,8 +208,10 @@ public class OrcaConfiguration {
   }
 
   @Bean
-  public TaskResolver taskResolver(Collection<Task> tasks) {
-    return new TaskResolver(tasks, true);
+  public TaskResolver taskResolver(
+      Collection<Task> tasks, Optional<List<SimpleStage>> simpleStages) {
+    List<SimpleStage> stages = simpleStages.orElseGet(ArrayList::new);
+    return new TaskResolver(tasks, stages, true);
   }
 
   @Bean

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleStageDefinitionBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleStageDefinitionBuilder.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.api.simplestage.SimpleStage;
+import com.netflix.spinnaker.orca.api.simplestage.SimpleTaskDefinition;
 import javax.annotation.Nonnull;
 
 public class SimpleStageDefinitionBuilder implements StageDefinitionBuilder {
@@ -30,7 +31,6 @@ public class SimpleStageDefinitionBuilder implements StageDefinitionBuilder {
   }
 
   public void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {
-    SimpleTask task = new SimpleTask(simpleStage);
-    builder.withTask(simpleStage.getName(), task.getClass());
+    builder.withTask(new SimpleTaskDefinition(simpleStage.getName(), simpleStage.getClass()));
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleTask.java
@@ -36,14 +36,12 @@ import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.ResolvableType;
-import org.springframework.stereotype.Component;
 
 @Slf4j
-@Component
 public class SimpleTask implements Task {
   private SimpleStage simpleStage;
 
-  SimpleTask(@Nullable SimpleStage simpleStage) {
+  public SimpleTask(@Nullable SimpleStage simpleStage) {
     this.simpleStage = simpleStage;
   }
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/StageDefinitionBuilders.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/StageDefinitionBuilders.kt
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWindow
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
-import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.TaskDefinition
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.DefinedTask
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.TaskGraph
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilderImpl
 import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner
@@ -52,11 +52,11 @@ private fun processTaskNode(
 ) {
   element.apply {
     when (value) {
-      is TaskDefinition -> {
+      is DefinedTask -> {
         val task = TaskExecutionImpl()
         task.id = (stage.tasks.size + 1).toString()
         task.name = value.name
-        task.implementingClass = value.implementingClass.name
+        task.implementingClass = value.implementingClassName
         if (isSubGraph) {
           task.isLoopStart = isFirst
           task.isLoopEnd = isLast

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -28,6 +28,8 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.SUCCEEDED
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.TERMINAL
 import com.netflix.spinnaker.orca.DefaultStageResolver
 import com.netflix.spinnaker.orca.TaskExecutionInterceptor
+import com.netflix.spinnaker.orca.TaskResolver
+import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.api.simplestage.SimpleStage
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
@@ -42,6 +44,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution.PausedDe
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl.STAGE_TIMEOUT_OVERRIDE_KEY
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
+import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.q.CompleteTask
@@ -67,7 +70,7 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
@@ -85,16 +88,19 @@ import kotlin.collections.listOf
 import kotlin.collections.mapOf
 import kotlin.collections.set
 import kotlin.collections.setOf
-import kotlin.reflect.jvm.jvmName
 
 object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
 
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
   val stageNavigator: StageNavigator = mock()
-  val task: DummyTask = mock()
+  val task: DummyTask = mock {
+    on { aliases() } doReturn emptyList<String>()
+  }
   val cloudProviderAwareTask: DummyCloudProviderAwareTask = mock()
-  val timeoutOverrideTask: DummyTimeoutOverrideTask = mock()
+  val timeoutOverrideTask: DummyTimeoutOverrideTask = mock() {
+    on { aliases() } doReturn emptyList<String>()
+  }
   val exceptionHandler: ExceptionHandler = mock()
   val clock = fixedClock()
   val contextParameterProcessor = ContextParameterProcessor()
@@ -109,7 +115,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       stageNavigator,
       DefaultStageDefinitionBuilderFactory(stageResolver),
       contextParameterProcessor,
-      listOf(task, timeoutOverrideTask, cloudProviderAwareTask),
+      TaskResolver(mutableListOf(task, timeoutOverrideTask, cloudProviderAwareTask) as Collection<Task>?),
       clock,
       listOf(exceptionHandler),
       taskExecutionInterceptors,
@@ -134,6 +140,129 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
       val stage = pipeline.stages.first()
       val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
+
+      and("has no context updates outputs") {
+        val taskResult = TaskResult.SUCCEEDED
+
+        beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
+          whenever(task.execute(any())) doReturn taskResult
+          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
+        }
+
+        afterGroup(::resetMocks)
+
+        action("the handler receives a message") {
+          subject.handle(message)
+        }
+
+        it("executes the task") {
+          verify(task).execute(pipeline.stages.first())
+        }
+
+        it("completes the task") {
+          verify(queue).push(check<CompleteTask> {
+            assertThat(it.status).isEqualTo(SUCCEEDED)
+          })
+        }
+
+        it("does not update the stage or global context") {
+          verify(repository, never()).storeStage(any())
+        }
+      }
+
+      and("has context updates") {
+        val stageOutputs = mapOf("foo" to "covfefe")
+        val taskResult = TaskResult.builder(SUCCEEDED).context(stageOutputs).build()
+
+        beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
+          whenever(task.execute(any())) doReturn taskResult
+          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
+        }
+
+        afterGroup(::resetMocks)
+
+        action("the handler receives a message") {
+          subject.handle(message)
+        }
+
+        it("updates the stage context") {
+          verify(repository).storeStage(check {
+            assertThat(stageOutputs).isEqualTo(it.context)
+          })
+        }
+      }
+
+      and("has outputs") {
+        val outputs = mapOf("foo" to "covfefe")
+        val taskResult = TaskResult.builder(SUCCEEDED).outputs(outputs).build()
+
+        beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
+          whenever(task.execute(any())) doReturn taskResult
+          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
+        }
+
+        afterGroup(::resetMocks)
+
+        action("the handler receives a message") {
+          subject.handle(message)
+        }
+
+        it("updates the stage outputs") {
+          verify(repository).storeStage(check {
+            assertThat(it.outputs).isEqualTo(outputs)
+          })
+        }
+      }
+
+      and("outputs a stageTimeoutMs value") {
+        val outputs = mapOf(
+          "foo" to "covfefe",
+          "stageTimeoutMs" to Long.MAX_VALUE
+        )
+        val taskResult = TaskResult.builder(SUCCEEDED).outputs(outputs).build()
+
+        beforeGroup {
+          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
+          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
+          whenever(task.execute(any())) doReturn taskResult
+          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
+        }
+
+        afterGroup(::resetMocks)
+
+        action("the handler receives a message") {
+          subject.handle(message)
+        }
+
+        it("does not write stageTimeoutMs to outputs") {
+          verify(repository).storeStage(check {
+            assertThat(it.outputs)
+              .containsKey("foo")
+              .doesNotContainKey("stageTimeoutMs")
+          })
+        }
+      }
+    }
+
+    describe("that completes successfully prefering specified TaskExecution implementingClass") {
+      val pipeline = pipeline {
+        stage {
+          type = "whatever"
+          task {
+            id = "1"
+            startTime = clock.instant().toEpochMilli()
+            implementingClass = task.javaClass.canonicalName
+          }
+        }
+      }
+      val stage = pipeline.stages.first()
+      val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", WaitTask::class.java)
 
       and("has no context updates outputs") {
         val taskResult = TaskResult.SUCCEEDED
@@ -544,7 +673,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
 
       it("does not execute the task") {
-        verifyZeroInteractions(task)
+        verify(task).aliases()
+        verifyNoMoreInteractions(task)
       }
     }
 
@@ -622,7 +752,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
 
       it("does not execute the task") {
-        verifyZeroInteractions(task)
+        verify(task).aliases()
+        verifyNoMoreInteractions(task)
       }
     }
 
@@ -1040,7 +1171,6 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
                 startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli()
                 task {
                   id = "1"
-
                   status = RUNNING
                   startTime = clock.instant().minusMillis(timeout.toMillis() - 1).toEpochMilli()
                 }
@@ -1077,7 +1207,6 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
                   startTime = clock.instant().minusMillis(timeoutOverride.toMillis() + 1).toEpochMilli()
                   task {
                     id = "1"
-
                     status = RUNNING
                     startTime = clock.instant().minusMillis(timeout.toMillis() - 1).toEpochMilli()
                   }
@@ -1513,7 +1642,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
     }
 
     it("does not run any tasks") {
-      verifyZeroInteractions(task)
+      verify(task).aliases()
+      verifyNoMoreInteractions(task)
     }
 
     it("emits an error event") {


### PR DESCRIPTION
Multiple SimpleStages keeps Orca from starting because SimpleTask had a Component annotation and took a SimpleStage in its constructor. Orca would try to construct all the Tasks for taskResolver and when it got to SimpleTask it wouldn't know which SimpleStage to inject. So SimpleTask obviously shouldn't be a Component. But once the Component annotation was removed SimpleStages would not execute.
The TaskResolver now needs to load all the SimpleStages and wrap each one in a SimpleTask. They need to be keyed by the SimpleStage impl class name, they can't all be keyed as a SimpleTask. But you could only use classes of type Task to refer to them in the task graph, even though it ultimately just gets turned into a String. I made some modification to stick the SimpleStage impl name in the task graph instead.
On the other side the RunTaskHandler looked up tasks based on a list of Task components and SimpleTask is no longer in that list now that it is not a Component. There would only be the one if it was anyway. Now RunTaskHandler looks up tasks using the TaskResolver. Doesn't it make more sense to use the TaskResolver to resolve tasks anyway? I also use the implementingClass on the TaskModel to look up the task rather than the RunTask.taskType because it would always be SimpleTask when someone is using SimpleStages. This seems cleaner but we still use RunTask.taskType and resolve the task based on type as a backup mainly for existing tests.
