### PR TITLE
fix(plugins): allow more than one SimpleStage impl

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/TaskNode.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/TaskNode.java
@@ -110,6 +110,17 @@ public interface TaskNode {
     }
 
     /**
+     * Adds a task to the current graph.
+     *
+     * @param task the task node to add
+     * @return this builder with the new task appended.
+     */
+    public Builder withTask(TaskNode task) {
+      graph.add(task);
+      return this;
+    }
+
+    /**
      * Adds a sub-graph of tasks that may loop if any of them return {@link
      * ExecutionStatus#REDIRECT}. The sub-graph will run after any previously added tasks and before
      * any subsequently added ones. If the final task in the sub-graph returns {@link
@@ -162,8 +173,23 @@ public interface TaskNode {
     }
   }
 
+  /**
+   * This is an abstraction above TaskDefinition that allows more flexibility for the implementing
+   * class name.
+   */
+  interface DefinedTask {
+
+    /** @return name of the task */
+    @Nonnull
+    String getName();
+
+    /** @return name of the class implementing the stage */
+    @Nonnull
+    String getImplementingClassName();
+  }
+
   /** An individual task. */
-  class TaskDefinition implements TaskNode {
+  class TaskDefinition implements TaskNode, DefinedTask {
     private final String name;
     private final Class<? extends Task> implementingClass;
 
@@ -178,6 +204,11 @@ public interface TaskNode {
 
     public @Nonnull Class<? extends Task> getImplementingClass() {
       return implementingClass;
+    }
+
+    @Override
+    public @Nonnull String getImplementingClassName() {
+      return getImplementingClass().getCanonicalName();
     }
   }
 }

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/simplestage/SimpleTaskDefinition.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/simplestage/SimpleTaskDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Armory, Inc.
+ * Copyright 2020 Armory, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,20 +20,31 @@ import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.DefinedTask;
 import javax.annotation.Nonnull;
 
+/**
+ * Provides a TaskDefinition for a SimpleStage which will be wrapped in a SimpleTask. SimpleTask
+ * alone is not enough information to disambiguate the implementing class.
+ */
 public class SimpleTaskDefinition implements TaskNode, DefinedTask {
   private final String name;
   private final Class<? extends SimpleStage> implementingClass;
 
+  /**
+   * @param name The name of the SimpleStage that gets executed
+   * @param implementingClass The SimpleStage class type that will be referenced by the task
+   *     resolver
+   */
   public SimpleTaskDefinition(
       @Nonnull String name, @Nonnull Class<? extends SimpleStage> implementingClass) {
     this.name = name;
     this.implementingClass = implementingClass;
   }
 
+  @Override
   public @Nonnull String getName() {
     return name;
   }
 
+  /** @return the SimpleStage class that will be executed by the task */
   public @Nonnull Class<? extends SimpleStage> getImplementingClass() {
     return implementingClass;
   }

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/simplestage/SimpleTaskDefinition.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/simplestage/SimpleTaskDefinition.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.api.simplestage;
+
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.DefinedTask;
+import javax.annotation.Nonnull;
+
+public class SimpleTaskDefinition implements TaskNode, DefinedTask {
+  private final String name;
+  private final Class<? extends SimpleStage> implementingClass;
+
+  public SimpleTaskDefinition(
+      @Nonnull String name, @Nonnull Class<? extends SimpleStage> implementingClass) {
+    this.name = name;
+    this.implementingClass = implementingClass;
+  }
+
+  public @Nonnull String getName() {
+    return name;
+  }
+
+  public @Nonnull Class<? extends SimpleStage> getImplementingClass() {
+    return implementingClass;
+  }
+
+  @Override
+  public @Nonnull String getImplementingClassName() {
+    return getImplementingClass().getCanonicalName();
+  }
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -208,8 +208,10 @@ public class OrcaConfiguration {
   }
 
   @Bean
-  public TaskResolver taskResolver(Collection<Task> tasks) {
-    return new TaskResolver(tasks, true);
+  public TaskResolver taskResolver(
+      Collection<Task> tasks, Optional<List<SimpleStage>> simpleStages) {
+    List<SimpleStage> stages = simpleStages.orElseGet(ArrayList::new);
+    return new TaskResolver(tasks, stages, true);
   }
 
   @Bean

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleStageDefinitionBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleStageDefinitionBuilder.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.api.simplestage.SimpleStage;
+import com.netflix.spinnaker.orca.api.simplestage.SimpleTaskDefinition;
 import javax.annotation.Nonnull;
 
 public class SimpleStageDefinitionBuilder implements StageDefinitionBuilder {
@@ -30,7 +31,6 @@ public class SimpleStageDefinitionBuilder implements StageDefinitionBuilder {
   }
 
   public void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {
-    SimpleTask task = new SimpleTask(simpleStage);
-    builder.withTask(simpleStage.getName(), task.getClass());
+    builder.withTask(new SimpleTaskDefinition(simpleStage.getName(), simpleStage.getClass()));
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/SimpleTask.java
@@ -36,14 +36,12 @@ import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.ResolvableType;
-import org.springframework.stereotype.Component;
 
 @Slf4j
-@Component
 public class SimpleTask implements Task {
   private SimpleStage simpleStage;
 
-  SimpleTask(@Nullable SimpleStage simpleStage) {
+  public SimpleTask(@Nullable SimpleStage simpleStage) {
     this.simpleStage = simpleStage;
   }
 

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/StageDefinitionBuilders.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/StageDefinitionBuilders.kt
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWindow
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
-import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.TaskDefinition
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.DefinedTask
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.TaskGraph
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilderImpl
 import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner
@@ -52,11 +52,11 @@ private fun processTaskNode(
 ) {
   element.apply {
     when (value) {
-      is TaskDefinition -> {
+      is DefinedTask -> {
         val task = TaskExecutionImpl()
         task.id = (stage.tasks.size + 1).toString()
         task.name = value.name
-        task.implementingClass = value.implementingClass.name
+        task.implementingClass = value.implementingClassName
         if (isSubGraph) {
           task.isLoopStart = isFirst
           task.isLoopEnd = isLast


### PR DESCRIPTION
Multiple SimpleStages keeps Orca from starting because SimpleTask had a Component annotation and took a SimpleStage in its constructor. Orca would try to construct all the Tasks for taskResolver and when it got to SimpleTask it wouldn't know which SimpleStage to inject. So SimpleTask obviously shouldn't be a Component. But once the Component annotation was removed SimpleStages would not execute.
The TaskResolver now needs to load all the SimpleStages and wrap each one in a SimpleTask. They need to be keyed by the SimpleStage impl class name, they can't all be keyed as a SimpleTask. But you could only use classes of type Task to refer to them in the task graph, even though it ultimately just gets turned into a String. I made some modification to stick the SimpleStage impl name in the task graph instead.
On the other side the RunTaskHandler looked up tasks based on a list of Task components and SimpleTask is no longer in that list now that it is not a Component. There would only be the one if it was anyway. Now RunTaskHandler looks up tasks using the TaskResolver. Doesn't it make more sense to use the TaskResolver to resolve tasks anyway? I also use the implementingClass on the TaskModel to look up the task rather than the RunTask.taskType because it would always be SimpleTask when someone is using SimpleStages. This seems cleaner but we still use RunTask.taskType and resolve the task based on type as a backup mainly for existing tests.