### PR TITLE
fix(peering): don't reset lastUpdated time if there is nothing to copy

### DIFF
--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
@@ -203,7 +203,7 @@ class PeeringAgent(
       .map { it.id }
 
     fun getLatestCompletedUpdatedTime() =
-      (completedPipelineKeys.map { it.updated_at }.max() ?: 0)
+      (completedPipelineKeys.map { it.updated_at }.max() ?: updatedAfter)
 
     if (pipelineIdsToDelete.isEmpty() && pipelineIdsToMigrate.isEmpty()) {
       log.debug("No completed $executionType executions to copy for peering")


### PR DESCRIPTION
This fixes an issue where when there are no [new] completed executions to copy to the peer the peer would reset its "lastUpdated" timestamp causing a full diff on the DB next peering cycle.
Instead, we should just leave the "lastUpdated" timestamp unchanged. Also, fixed the test that didn't but should've exposed this issue (the test was incorrect)

