### PR TITLE
feat(echo): Add stageId to Stage Event Details

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
@@ -118,6 +118,7 @@ class EchoNotifyingStageListener implements StageListener {
           endTime    : stage.endTime,
           execution  : stage.execution,
           executionId: stage.execution.id,
+          stageId    : stage.id,
           isSynthetic: stage.syntheticStageOwner != null,
           name: stage.name
         ]

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListenerSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListenerSpec.groovy
@@ -128,6 +128,7 @@ class EchoNotifyingStageListenerSpec extends Specification {
     message.content.standalone == standalone
     message.content.taskName == "${stage.type}.$taskName"
     message.content.taskName instanceof String
+    message.content.stageId == stage.id
 
     where:
     stage              | executionStatus | wasSuccessful | echoMessage | standalone


### PR DESCRIPTION
Simple PR to add `stage.id` to Echo event payload so that user can trace back which stage the event is coming from.

Closes https://github.com/spinnaker/spinnaker/issues/5660