### PR TITLE
chore(bakeManifest): Update BakeManifest error when missing expectedArtifact

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
@@ -110,8 +110,8 @@ public class CreateBakeManifestTask implements RetryableTask {
 
     if (expectedArtifacts.size() != 1) {
       throw new IllegalArgumentException(
-          "Exactly one expected artifact must be supplied. Please ensure that your Bake stage"
-              + " config's `expectedArtifacts` list contains exactly one artifact.");
+          "The Bake (Manifest) stage produces one Base64 artifact.  Please ensure that your Bake stage config's"
+              + " `Produces Artifacts` section (`expectedArtifacts` field) contains exactly one artifact.");
     }
 
     String outputArtifactName = expectedArtifacts.get(0).getMatchArtifact().getName();

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
@@ -110,8 +110,8 @@ public class CreateBakeManifestTask implements RetryableTask {
 
     if (expectedArtifacts.size() != 1) {
       throw new IllegalArgumentException(
-          "The Bake (Manifest) stage produces one Base64 artifact.  Please ensure that your Bake stage config's"
-              + " `Produces Artifacts` section (`expectedArtifacts` field) contains exactly one artifact.");
+          "The Bake (Manifest) stage produces one embedded base64 artifact.  Please ensure that your Bake (Manifest) stage"
+              + " config's `Produces Artifacts` section (`expectedArtifacts` field) contains exactly one artifact.");
     }
 
     String outputArtifactName = expectedArtifacts.get(0).getMatchArtifact().getName();


### PR DESCRIPTION
The default error message here is confusing.  This is purely a clarification to the error message.