### PR TITLE
chore(*): Cleanup Main Spring configuration

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/Main.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/Main.groovy
@@ -48,18 +48,10 @@ import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAuto
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
-import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.scheduling.annotation.EnableAsync
 
-@Configuration
 @EnableAsync
-@EnableAutoConfiguration(exclude = [
-  BatchAutoConfiguration,
-  GroovyTemplateAutoConfiguration,
-  DataSourceAutoConfiguration
-])
 @Import([
   PlatformComponents,
   WebConfiguration,
@@ -89,9 +81,9 @@ import org.springframework.scheduling.annotation.EnableAsync
 ])
 @SpringBootApplication(
     scanBasePackages = [
-        "com.netflix.spinnaker.config",
-        "com.netflix.spinnaker.plugin"
-    ]
+        "com.netflix.spinnaker.config"
+    ],
+    exclude = [BatchAutoConfiguration, GroovyTemplateAutoConfiguration, DataSourceAutoConfiguration]
 )
 class Main extends SpringBootServletInitializer {
   static final Map<String, String> DEFAULT_PROPS = [


### PR DESCRIPTION
Aligning usage of `@SpringBootApplication` with how I've been doing it in Echo and Gate.  Also, removes the deleted package `com.netflix.spinnaker.plugin`.