### PR TITLE
refactor(core): Clean up dependencies

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -55,6 +55,7 @@ dependencies {
   implementation("javax.servlet:javax.servlet-api:4.0.1")
   implementation("com.jayway.jsonpath:json-path:2.2.0")
   implementation("org.yaml:snakeyaml")
+  implementation("org.codehaus.groovy:groovy")
 
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")

--- a/orca-front50/orca-front50.gradle
+++ b/orca-front50/orca-front50.gradle
@@ -19,6 +19,9 @@ apply from: "$rootDir/gradle/groovy.gradle"
 dependencies {
   implementation(project(":orca-core"))
   implementation(project(":orca-retrofit"))
+
+  api("org.codehaus.groovy:groovy")
+
   implementation("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
   implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
   implementation("com.netflix.spectator:spectator-api")

--- a/orca-integrations-gremlin/orca-integrations-gremlin.gradle
+++ b/orca-integrations-gremlin/orca-integrations-gremlin.gradle
@@ -5,6 +5,7 @@ dependencies {
   implementation(project(":orca-kotlin"))
   implementation(project(":orca-retrofit"))
   implementation("org.springframework.boot:spring-boot-autoconfigure")
+  implementation("org.slf4j:slf4j-api")
 
   testImplementation(project(":orca-core-tck"))
 }

--- a/orca-retrofit/orca-retrofit.gradle
+++ b/orca-retrofit/orca-retrofit.gradle
@@ -19,6 +19,7 @@ apply from: "$rootDir/gradle/groovy.gradle"
 dependencies {
   api("com.squareup.retrofit:retrofit")
   api("com.squareup.retrofit:converter-jackson")
+  api("org.codehaus.groovy:groovy")
 
   implementation(project(":orca-core"))
   implementation("com.squareup.okhttp:okhttp")


### PR DESCRIPTION
An upcoming kork bump will remove some things that were api dependencies and make them implementation; update places that were relying on these to explicitly include them.

The places where groovy is added as an API dependency is because there are classes that due to groovy magic subclass a groovy type, so consumers need core groovy on the classpath.