### PR TITLE
fix(kubernetes): correctly write Patch Manifest patchBody (#3602)

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PatchManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/PatchManifestTask.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
@@ -26,9 +28,9 @@ import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.PatchManifestContext.MergeStrategy;
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
 import com.netflix.spinnaker.orca.pipeline.model.Stage;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +40,7 @@ import org.springframework.stereotype.Component;
 @NonnullByDefault
 public final class PatchManifestTask extends AbstractCloudProviderAwareTask implements Task {
   public static final String TASK_NAME = "patchManifest";
+  private static final ObjectMapper objectMapper = OrcaObjectMapper.getInstance();
 
   private final KatoService katoService;
 
@@ -57,7 +60,10 @@ public final class PatchManifestTask extends AbstractCloudProviderAwareTask impl
   private ImmutableMap<String, Map> getOperation(Stage stage) {
     PatchManifestContext context = stage.mapTo(PatchManifestContext.class);
     MergeStrategy mergeStrategy = context.getOptions().getMergeStrategy();
-    List<Map<Object, Object>> patchBody = context.getManifests();
+    ImmutableList<Map<String, Object>> patchBody =
+        objectMapper.convertValue(
+            stage.getContext().get("manifests"),
+            new TypeReference<ImmutableList<Map<String, Object>>>() {});
 
     if (patchBody.isEmpty()) {
       throw new IllegalArgumentException(


### PR DESCRIPTION
Prior to [this refactor](https://github.com/spinnaker/orca/pull/3402), PatchManifestTask read patchBody directly from the ManifestEvaluator's result. Now, we are attempting to read it off the stage's context, but we deserialized the context with the same model, PatchManifestContext, that we used to deserialize the initial stage inputs, which tries to read manifests from patchBody (at this point, we should be reading manifests from the manifests key instead). This is intended to be a cherry-pickable fix, but a better more invasive fix would define different models for the inputs and outputs of each task and assert that the context had required values before beginning the task.