### PR TITLE
fix(kubernetes): Fix artifact binding in patch manifest stage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolvePatchSourceManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolvePatchSourceManifestTask.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.orca.api.pipeline.Task;
@@ -51,7 +52,12 @@ public final class ResolvePatchSourceManifestTask implements Task {
     return new ImmutableMap.Builder<String, Object>()
         .put("manifests", result.getManifests())
         .put("requiredArtifacts", result.getRequiredArtifacts())
-        .put("allArtifacts", result.getOptionalArtifacts())
+        .put(
+            "allArtifacts",
+            ImmutableList.builder()
+                .addAll(result.getRequiredArtifacts())
+                .addAll(result.getOptionalArtifacts())
+                .build())
         .build();
   }
 }


### PR DESCRIPTION
The patch manifest stage was incorrectly setting allArtifacts to just the required artifacts, which was breaking artifact resolution in clouddriver. Set this to all of the artifacts (both required and optional).