### PR TITLE
chore(pollers): add configuration properties

### DIFF
--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/config/OldPipelineCleanupAgentConfigurationProperties.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/config/OldPipelineCleanupAgentConfigurationProperties.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("pollers.old-pipeline-cleanup")
+class OldPipelineCleanupAgentConfigurationProperties() {
+  /**
+   * How often the agent runs, in millis
+   */
+  var intervalMs: Long = 3600000
+
+  /**
+   * Maximum age of pipelines to keep (if more than minimumPipelineExecutions exist)
+   */
+  var thresholdDays: Long = 30
+
+  /**
+   * Always keep this number of pipelines regardless of age
+   */
+  var minimumPipelineExecutions: Int = 5
+
+  /**
+   * Chunk size for SQL operations
+   */
+  var chunkSize: Int = 1
+
+  constructor(intervalMs: Long, thresholdDays: Long, minimumPipelineExecutions: Int, chunkSize: Int) : this() {
+    this.intervalMs = intervalMs
+    this.thresholdDays = thresholdDays
+    this.minimumPipelineExecutions = minimumPipelineExecutions
+    this.chunkSize = chunkSize
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/config/TopApplicationExecutionCleanupAgentConfigurationProperties.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/config/TopApplicationExecutionCleanupAgentConfigurationProperties.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("pollers.top-application-execution-cleanup")
+class TopApplicationExecutionCleanupAgentConfigurationProperties {
+  /**
+   * How often the agent runs, in millis
+   */
+  var intervalMs: Long = 3600000
+
+  /**
+   * Maximum number of orchestrations to keep
+   */
+  var threshold: Int = 2000
+
+  /**
+   * Chunk size for SQL operations
+   */
+  var chunkSize: Int = 1
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgent.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgent.kt
@@ -17,30 +17,31 @@
 package com.netflix.spinnaker.orca.sql.cleanup
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.config.OrcaSqlProperties
+import com.netflix.spinnaker.config.TopApplicationExecutionCleanupAgentConfigurationProperties
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
 import com.netflix.spinnaker.orca.notifications.NotificationClusterLock
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import java.util.concurrent.atomic.AtomicInteger
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnExpression("\${pollers.top-application-execution-cleanup.enabled:false} && \${execution-repository.sql.enabled:false}")
+@EnableConfigurationProperties(TopApplicationExecutionCleanupAgentConfigurationProperties::class, OrcaSqlProperties::class)
 class TopApplicationExecutionCleanupPollingNotificationAgent(
   clusterLock: NotificationClusterLock,
   private val jooq: DSLContext,
   registry: Registry,
   private val executionRepository: ExecutionRepository,
-  @Value("\${pollers.top-application-execution-cleanup.interval-ms:3600000}") private val pollingIntervalMs: Long,
-  @Value("\${pollers.top-application-execution-cleanup.threshold:2000}") private val threshold: Int,
-  @Value("\${pollers.top-application-execution-cleanup.chunk-size:1}") private val chunkSize: Int,
-  @Value("\${sql.partition-name:#{null}}") private val partitionName: String?
+  private val configurationProperties: TopApplicationExecutionCleanupAgentConfigurationProperties,
+  private val orcaSqlProperties: OrcaSqlProperties
 ) : AbstractCleanupPollingAgent(
   clusterLock,
-  pollingIntervalMs,
+  configurationProperties.intervalMs,
   registry) {
 
   override fun performCleanup() {
@@ -49,15 +50,15 @@ class TopApplicationExecutionCleanupPollingNotificationAgent(
       .from(DSL.table("orchestrations"))
       .where(DSL.noCondition())
 
-    if (partitionName != null) {
+    if (orcaSqlProperties.partitionName != null) {
       queryBuilder = queryBuilder
         .and(
-          DSL.field("`partition`").eq(partitionName))
+          DSL.field("`partition`").eq(orcaSqlProperties.partitionName))
     }
 
     val applicationsWithOldOrchestrations = queryBuilder
       .groupBy(DSL.field("application"))
-      .having(DSL.count(DSL.field("id")).gt(threshold))
+      .having(DSL.count(DSL.field("id")).gt(configurationProperties.threshold))
       .fetch(DSL.field("application"), String::class.java)
 
     applicationsWithOldOrchestrations
@@ -95,12 +96,12 @@ class TopApplicationExecutionCleanupPollingNotificationAgent(
           .and(DSL.field("status").`in`(*completedStatuses.toTypedArray()))
       )
       .orderBy(DSL.field("build_time").desc())
-      .limit(threshold, Int.MAX_VALUE)
+      .limit(configurationProperties.threshold, Int.MAX_VALUE)
       .fetch(DSL.field("id"), String::class.java)
 
     log.debug("Found {} old orchestrations for {}", executionsToRemove.size, application)
 
-    executionsToRemove.chunked(chunkSize).forEach { ids ->
+    executionsToRemove.chunked(configurationProperties.chunkSize).forEach { ids ->
       deletedExecutionCount.addAndGet(ids.size)
 
       executionRepository.delete(ExecutionType.ORCHESTRATION, ids)

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.orca.sql.cleanup
 
+import com.netflix.spinnaker.config.OldPipelineCleanupAgentConfigurationProperties
+import com.netflix.spinnaker.config.OrcaSqlProperties
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 
@@ -58,11 +60,13 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
     Clock.systemDefaultZone(),
     new NoopRegistry(),
     executionRepository,
-    0,
-    10, // threshold days
-    5,  // minimum pipeline executions
-    1,
-    null
+    new OldPipelineCleanupAgentConfigurationProperties(
+        0L,
+        10L, // threshold days
+        5,  // minimum pipeline executions
+        1
+    ),
+    new OrcaSqlProperties()
   )
 
   def setupSpec() {


### PR DESCRIPTION
No functional change here, just move `@Value`s on the two cleanup agents to `ConfigurationProperties`

