### PR TITLE
fix(delete): Add index and chunk deletes of old executions

### DIFF
--- a/orca-sql/src/main/resources/db/changelog-master.yml
+++ b/orca-sql/src/main/resources/db/changelog-master.yml
@@ -47,3 +47,6 @@ databaseChangeLog:
 - include:
     file: changelog/20200327-deleted-executions-table.yml
     relativeToChangelogFile: true
+- include:
+    file: changelog/20200424-index-deleted-executions-table.yml
+    relativeToChangelogFile: true

--- a/orca-sql/src/main/resources/db/changelog/20200424-index-deleted-executions-table.yml
+++ b/orca-sql/src/main/resources/db/changelog/20200424-index-deleted-executions-table.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 20200424-index-deleted-executions-table
+      author: mvulfson
+      changes:
+        - createIndex:
+            indexName: deleted_at_idx
+            tableName: deleted_executions
+            columns:
+              - column:
+                  name: deleted_at
+    rollback:
+      - dropIndex:
+          indexName: deleted_at_idx
+          tableName: deleted_executions


### PR DESCRIPTION
In my prior change (https://github.com/spinnaker/orca/pull/3569) I introduced a concept of a `deleted_executions` table to keep track of ~1day worth of deletes so that peering has much easier time to peer deletes.
This change causes the deletion of executions to fail sometimes because of a SQL deadlock.

To fix it:
1. Add an index on `deleted_at` - this column is used to delete executions older than `x` time
2. Take the truncation of the `deleted_executions` table out of the big delete transaction
