### PR TITLE
fix(java11): Fix some issues that occur when running under Java 11

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgent.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationExecutionCleanupPollingNotificationAgent.java
@@ -139,7 +139,8 @@ public class TopApplicationExecutionCleanupPollingNotificationAgent
   }
 
   private void cleanup(Observable<PipelineExecution> observable, String application, String type) {
-    List<Map> executions = observable.filter(filter).map(mapper).toList().toBlocking().single();
+    List<? extends Map> executions =
+        observable.filter(filter).map(mapper).toList().toBlocking().single();
     executions.sort(comparing(a -> (Long) Optional.ofNullable(a.get("startTime")).orElse(0L)));
     if (executions.size() > threshold) {
       executions

--- a/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
+++ b/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
@@ -38,6 +38,8 @@ import dev.minutest.rootContext
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.FORBIDDEN
 import retrofit.RetrofitError
@@ -120,13 +122,19 @@ internal class ImportDeliveryConfigTaskTests : JUnit5Minutests {
           )
         ),
         "pathExpression" to ".someField"
-      )
+      ),
+      // Jackson writes this as ms-since-epoch, so we need to strip off the nanoseconds, since we'll
+      // be round-tripping it through Jackson before testing for equality.
+      timestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS)
     )
 
     val accessDeniedError = SpringHttpError(
       status = FORBIDDEN.value(),
       error = FORBIDDEN.reasonPhrase,
-      message = "Access denied"
+      message = "Access denied",
+      // Jackson writes this as ms-since-epoch, so we need to strip off the nanoseconds, since we'll
+      // be round-tripping it through Jackson before testing for equality.
+      timestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS)
     )
   }
 


### PR DESCRIPTION
A few standard things I've seen other places:
1) Java 11 is stricter about type constraints
2) Java 11 returns `Instants` with nanoseconds when using `Instant.now()` and friends. 