### PR TITLE
chore(bumpdeps): increase the pause before running bumpdeps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
     - name: Pause before dependency bump
       if: steps.release_info.outputs.IS_CANDIDATE == 'false'
-      run: sleep 90
+      run: sleep 300
     - name: Trigger dependency bump workflow
       if: steps.release_info.outputs.IS_CANDIDATE == 'false'
       uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
90 seconds isn't long enough; often the artifacts don't show up in bintray yet. I had made this change previously, but I think it got accidentally overwritten in the migration to the new plugin.