### PR TITLE
chore(java11): Compile with Java 11 (but targeting Java 8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle
@@ -26,4 +31,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Build
-        run: ./gradlew build --stacktrace
+        run: ./gradlew -PenableCrossCompilerPlugin=true build --stacktrace

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,9 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    # Install Java 8 for cross-compilation support. Setting it up before
+    # Java 11 means it comes later in $PATH (because of how setup-java works)
     - uses: actions/setup-java@v1
       with:
         java-version: 8
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.gradle
@@ -20,4 +25,4 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
     - name: Build
-      run: ./gradlew build
+      run: ./gradlew -PenableCrossCompilerPlugin=true build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,53 +13,56 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: git fetch --prune --unshallow
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - uses: actions/cache@v1
-      with:
-        path: ~/.gradle
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    - name: Assemble release info
-      id: release_info
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        . .github/workflows/release_info.sh ${{ github.event.repository.full_name }}
-        echo ::set-output name=CHANGELOG::$(echo -e "${CHANGELOG}")
-        echo ::set-output name=SKIP_RELEASE::${SKIP_RELEASE}
-        echo ::set-output name=IS_CANDIDATE::${IS_CANDIDATE}
-        echo ::set-output name=RELEASE_VERSION::${RELEASE_VERSION}
-    - name: Release build
-      env:
-        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-        BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
-        RELEASE_VERSION: ${{ steps.release_info.outputs.RELEASE_VERSION }}
-      run: |
-        ./gradlew --info -Pversion="${RELEASE_VERSION}" -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" publish
-    - name: Create release
-      if: steps.release_info.outputs.SKIP_RELEASE == 'false'
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.event.repository.name }} ${{ github.ref }}
-        body: |
-          ${{ steps.release_info.outputs.CHANGELOG }}
-        draft: false
-        prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
-    - name: Pause before dependency bump
-      if: steps.release_info.outputs.IS_CANDIDATE == 'false'
-      run: sleep 90
-    - name: Trigger dependency bump workflow
-      if: steps.release_info.outputs.IS_CANDIDATE == 'false'
-      uses: peter-evans/repository-dispatch@v1
-      with:
-        token: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}
-        event-type: bump-dependencies
-        client-payload: '{"ref": "${{ github.ref }}"}'
+      - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Assemble release info
+        id: release_info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          . .github/workflows/release_info.sh ${{ github.event.repository.full_name }}
+          echo ::set-output name=CHANGELOG::$(echo -e "${CHANGELOG}")
+          echo ::set-output name=SKIP_RELEASE::${SKIP_RELEASE}
+          echo ::set-output name=IS_CANDIDATE::${IS_CANDIDATE}
+          echo ::set-output name=RELEASE_VERSION::${RELEASE_VERSION}
+      - name: Release build
+        env:
+          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+          RELEASE_VERSION: ${{ steps.release_info.outputs.RELEASE_VERSION }}
+        run: |
+          ./gradlew -PenableCrossCompilerPlugin=true --info -Pversion="${RELEASE_VERSION}" -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" publish
+      - name: Create release
+        if: steps.release_info.outputs.SKIP_RELEASE == 'false'
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+           tag_name: ${{ github.ref }}
+           release_name: ${{ github.event.repository.name }} ${{ github.ref }}
+           body: |
+            ${{ steps.release_info.outputs.CHANGELOG }}
+           draft: false
+           prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
+      - name: Pause before dependency bump
+        run: sleep 90
+      - name: Trigger dependency bump workflow
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}
+          event-type: bump-dependencies
+          client-payload: '{"ref": "${{ github.ref }}"}'

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,5 +1,11 @@
-FROM openjdk:8
+FROM ubuntu:bionic
+RUN apt-get update && apt-get install -y \
+    openjdk-8-jdk \
+    openjdk-11-jdk \
+ && rm -rf /var/lib/apt/lists/*
 MAINTAINER sig-platform@spinnaker.io
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
+ENV JDK_18 /usr/lib/jvm/java-8-openjdk-amd64
 ENV GRADLE_USER_HOME /workspace/.gradle
-ENV GRADLE_OPTS -Xmx2048m
-CMD ./gradlew --no-daemon orca-web:installDist -x test
+ENV GRADLE_OPTS -Xmx6g
+CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true orca-web:installDist -x test

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/StageDefinitionBuilder.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/StageDefinitionBuilder.java
@@ -16,11 +16,9 @@
 
 package com.netflix.spinnaker.orca.api.pipeline.graph;
 
-import static com.google.common.base.Preconditions.checkState;
 import static com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.Builder;
 import static com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.GraphType.FULL;
 
-import com.google.common.base.Strings;
 import com.netflix.spinnaker.kork.annotations.Beta;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.TaskGraph;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
@@ -110,9 +108,10 @@ public interface StageDefinitionBuilder extends ExtensionPoint {
    */
   static String getType(Class<? extends StageDefinitionBuilder> clazz) {
     String className = clazz.getSimpleName();
-    checkState(
-        !Strings.isNullOrEmpty(className),
-        "StageDefinitionBuilder.getType() cannot be called on an anonymous type");
+    if (className.equals("")) {
+      throw new IllegalStateException(
+          "StageDefinitionBuilder.getType() cannot be called on an anonymous type");
+    }
     return className.substring(0, 1).toLowerCase()
         + className
             .substring(1)

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/StageDefinitionBuilder.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/StageDefinitionBuilder.java
@@ -16,9 +16,11 @@
 
 package com.netflix.spinnaker.orca.api.pipeline.graph;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.Builder;
 import static com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.GraphType.FULL;
 
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.kork.annotations.Beta;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.TaskGraph;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
@@ -108,6 +110,9 @@ public interface StageDefinitionBuilder extends ExtensionPoint {
    */
   static String getType(Class<? extends StageDefinitionBuilder> clazz) {
     String className = clazz.getSimpleName();
+    checkState(
+        !Strings.isNullOrEmpty(className),
+        "StageDefinitionBuilder.getType() cannot be called on an anonymous type");
     return className.substring(0, 1).toLowerCase()
         + className
             .substring(1)

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
@@ -156,6 +156,7 @@ val stageWithNestedSynthetics = object : StageDefinitionBuilder {
 }
 
 val stageWithParallelBranches = object : StageDefinitionBuilder {
+  override fun getType() = "stageWithParallelBranches"
   override fun beforeStages(parent: StageExecution, graph: StageGraphBuilder) {
     listOf("us-east-1", "us-west-2", "eu-west-1")
       .map { region ->

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/AbortStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/AbortStageHandlerTest.kt
@@ -29,7 +29,6 @@ import com.netflix.spinnaker.orca.q.AbortStage
 import com.netflix.spinnaker.orca.q.CancelStage
 import com.netflix.spinnaker.orca.q.CompleteExecution
 import com.netflix.spinnaker.orca.q.CompleteStage
-import com.netflix.spinnaker.orca.time.toInstant
 import com.netflix.spinnaker.q.Queue
 import com.netflix.spinnaker.time.fixedClock
 import com.nhaarman.mockito_kotlin.any
@@ -120,7 +119,7 @@ object AbortStageHandlerTest : SubjectSpek<AbortStageHandler>({
       it("marks the stage as TERMINAL") {
         verify(repository).storeStage(check {
           assertThat(it.status).isEqualTo(TERMINAL)
-          assertThat(it.endTime.toInstant()).isEqualTo(clock.instant())
+          assertThat(it.endTime).isEqualTo(clock.instant().toEpochMilli())
         })
       }
 
@@ -170,7 +169,7 @@ object AbortStageHandlerTest : SubjectSpek<AbortStageHandler>({
       it("marks the stage as TERMINAL") {
         verify(repository).storeStage(check {
           assertThat(it.status).isEqualTo(TERMINAL)
-          assertThat(it.endTime.toInstant()).isEqualTo(clock.instant())
+          assertThat(it.endTime).isEqualTo(clock.instant().toEpochMilli())
         })
       }
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
@@ -106,7 +106,9 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
   val registry = NoopRegistry()
   val contextParameterProcessor: ContextParameterProcessor = mock()
 
-  val emptyStage = object : StageDefinitionBuilder {}
+  val emptyStage = object : StageDefinitionBuilder {
+    override fun getType() = "emptyStage"
+  }
 
   val stageWithTaskAndAfterStages = object : StageDefinitionBuilder {
     override fun getType() = "stageWithTaskAndAfterStages"

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -58,7 +58,6 @@ import com.netflix.spinnaker.orca.q.RunTask
 import com.netflix.spinnaker.orca.q.singleTaskStage
 import com.netflix.spinnaker.q.Queue
 import com.netflix.spinnaker.spek.and
-import com.netflix.spinnaker.time.fixedClock
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.anyOrNull
 import com.nhaarman.mockito_kotlin.check
@@ -72,14 +71,12 @@ import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
+import java.time.Clock
 import java.time.Duration
-import kotlin.collections.first
-import kotlin.collections.forEach
-import kotlin.collections.hashMapOf
-import kotlin.collections.listOf
-import kotlin.collections.mapOf
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import kotlin.collections.set
-import kotlin.collections.setOf
 import kotlin.reflect.jvm.jvmName
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
@@ -103,7 +100,10 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
     on { aliases() } doReturn emptyList<String>()
   }
   val exceptionHandler: ExceptionHandler = mock()
-  val clock = fixedClock()
+  // Stages store times as ms-since-epoch, and we do a lot of tests to make sure things run at the
+  // appropriate time, so we need to make sure
+  // clock.instant() == Instant.ofEpochMilli(clock.instant())
+  val clock = Clock.fixed(Instant.now().truncatedTo(ChronoUnit.MILLIS), ZoneId.systemDefault())
   val contextParameterProcessor = ContextParameterProcessor()
   val dynamicConfigService: DynamicConfigService = mock()
   val taskExecutionInterceptors: List<TaskExecutionInterceptor> = listOf(mock())


### PR DESCRIPTION
* chore(java11): Compile with Java 11 (but targeting Java 8)

release.yml looks scary in the GitHub diff view, but it's mostly indentation changes, and one other unrelated changes (removing two redundant If conditions) that already exist in every other repository. It's just copied from clouddriver.

* fix(java11): don't compare times with nanoseconds to those with millis

* fix(java11): Define getType for all anonymous StageDefinitionBuilders

Under Java 11, Class#getSimpleName() returns the empty string for an anonymous object literal. I verified that these are the only places in the entire codebase where we have an anonymous definition of StageDefinitionBuilder that doesn't override getType().