### PR TITLE
fix(gremlin): Fix gremlin config

### DIFF
--- a/orca-integrations-gremlin/src/main/java/com/netflix/spinnaker/orca/config/GremlinConfiguration.kt
+++ b/orca-integrations-gremlin/src/main/java/com/netflix/spinnaker/orca/config/GremlinConfiguration.kt
@@ -25,7 +25,7 @@ class GremlinConfiguration {
 
   @Bean
   fun gremlinEndpoint(
-    @Value("\${integrations.gremlin.base-url}") gremlinBaseUrl: String
+    @Value("\${integrations.gremlin.base-url:https://api.gremlin.com/v1}") gremlinBaseUrl: String
   ): Endpoint {
     return Endpoints.newFixedEndpoint(gremlinBaseUrl)
   }

--- a/orca-integrations-gremlin/src/main/java/com/netflix/spinnaker/orca/config/GremlinConfiguration.kt
+++ b/orca-integrations-gremlin/src/main/java/com/netflix/spinnaker/orca/config/GremlinConfiguration.kt
@@ -7,7 +7,6 @@ import com.netflix.spinnaker.orca.gremlin.GremlinService
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.retrofit.logging.RetrofitSlf4jLog
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
@@ -18,7 +17,6 @@ import retrofit.RestAdapter
 import retrofit.client.Client
 
 @Configuration
-@ConditionalOnProperty("integrations.gremlin.enabled")
 @ComponentScan(
   "com.netflix.spinnaker.orca.gremlin.pipeline",
   "com.netflix.spinnaker.orca.gremlin.tasks"

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -65,7 +65,6 @@ resilience4j.retry:
 
 integrations:
   gremlin:
-    enabled: false
     baseUrl: https://api.gremlin.com/v1
 
 # This configuration lets you configure Webhook stages that will appear as native stages in the Deck UI.

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -63,10 +63,6 @@ resilience4j.retry:
       retryExceptions:
         - retrofit.RetrofitError
 
-integrations:
-  gremlin:
-    baseUrl: https://api.gremlin.com/v1
-
 # This configuration lets you configure Webhook stages that will appear as native stages in the Deck UI.
 # Properties that are set here will not be displayed in the GUI
 #webhook:


### PR DESCRIPTION
The feature flag for gremlin was removed from deck (along with a number of other feature flags) in 1.20 but we missed that this flag was also checked in orca. This change removes checking the flag in orca (and removes setting the flag in orca.yml).

As orca.yml already sets the base url, we don't need to default the Value using it (though in the future maybe it's better to push the defaulting to there rather than have it in the default config).
