### PR TITLE
fix(build): 2 minute Gradle HTTP client socket and connection timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx6g -Xms6g
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx6g -Xms6g -Dorg.gradle.internal.http.socketTimeout=120000 -Dorg.gradle.internal.http.connectionTimeout=120000
 
 jobs:
   release:


### PR DESCRIPTION
Release build has been failing with connection timeouts to bintray, let's see if this resolves that.