### PR TITLE
fix(Authorization): allow users without `WRITE` permission to execute SavePipelineStage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 enablePublishing=false
-fiatVersion=1.18.4
+fiatVersion=1.18.5
 keikoVersion=3.6.2
 korkVersion=7.42.2
 kotlinVersion=1.3.71


### PR DESCRIPTION
The [SavePipelineStage](https://github.com/spinnaker/orca/blob/master/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/SavePipelineStage.java) is a pipeline stage that gets executed as part of a pipeline. This should mean that users with `EXECUTE` privilege should be able to execute it. However, they cannot, because the front50 save pipeline operation requires `WRITE` permission to the application.

This PR allows users to provide `asAnonymous` parameter, which will end up, executing the process anonymously, solving the problem.

If this is accepted, I would like to cherry-pick it into 1.20 as well please