### PR TITLE
fix(config): Clean up base config

### DIFF
--- a/halconfig/README.md
+++ b/halconfig/README.md
@@ -1,4 +1,4 @@
-This directory contains skeleton clouddriver configs to which Halyard concatenates
+This directory contains skeleton orca configs to which Halyard concatenates
 its generated deployment-specific config.
 
 These configs are **deprecated** and in general should not be further updated. To

--- a/halconfig/orca.yml
+++ b/halconfig/orca.yml
@@ -1,1 +1,5 @@
 # halconfig
+
+server:
+  port: ${services.orca.port:8083}
+  address: ${services.orca.host:localhost}

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -1,6 +1,5 @@
 server:
-  port: ${services.orca.port:8083}
-  address: ${services.orca.host:localhost}
+  port: 8083
 
 default:
   bake:


### PR DESCRIPTION
In #3482, I pushed some Halyard configs down to the base to prepare for kleat, which will not use the halconfig values.

As work on kleat has continued, I realize that we reading the port and bind address from spinnaker.yml is not a great idea and not something that I want to encourage in kleat. The decision of what port to listen on and what address to bind to is a decision that should be internal to that service and make in its config file; its externally visible URL is something external that other services should care about (and that should be in a common config file).

So let's revert the part of this that sets the port/address based on what's in the spinnaker.yml file; there is no real use case for overriding this in kleat so let's not over-complicate the base config without a clear use case.
