### PR TITLE
fix(sqlrepo): Update execution partition

### DIFF
--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -764,6 +764,7 @@ class SqlExecutionRepository(
       val updatePairs = mapOf(
         field("status") to status,
         field("body") to body,
+        field(name("partition")) to partitionName,
         // won't have started on insert
         field("start_time") to execution.startTime,
         field("canceled") to execution.isCanceled,


### PR DESCRIPTION
During, say a failover, we need to be able to take over ownership of an execution previously owned by a different orca cluster.
This fix allows us to actually do that
