### PR TITLE
fix(misc): newer version of fiat api client requires url to wire up c…

### DIFF
--- a/orca-api-tck/src/test/resources/orca-test-app.yml
+++ b/orca-api-tck/src/test/resources/orca-test-app.yml
@@ -29,3 +29,7 @@ redis:
 spring:
   application:
     name: orca
+
+services:
+  fiat:
+    baseUrl: https://fiat.net

--- a/orca-plugins-test/src/test/resources/orca-plugins-test.yml
+++ b/orca-plugins-test/src/test/resources/orca-plugins-test.yml
@@ -32,3 +32,7 @@ spinnaker:
         enabled: false
       com.netflix.orca.version.not.supported.plugin:
         enabled: true
+
+services:
+  fiat:
+    baseUrl: https://fiat.net

--- a/orca-web/src/test/resources/orca-test.yml
+++ b/orca-web/src/test/resources/orca-test.yml
@@ -21,3 +21,7 @@ executionRepository:
 spring:
   application:
     name: orcaTest
+
+services:
+  fiat:
+    baseUrl: https://fiat.net


### PR DESCRIPTION
- Newer version of fiat api client requires  url and performs non null check and this change is to satisfy that constraint by supplying the necessary config while building the application contexts in unit tests. There is failing build of [autobump PR ](https://github.com/spinnaker/orca/pull/3684)due to this.
