### PR TITLE
feat(codebuild): Add exported environment variables in the stage context

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/AwsCodeBuildExecution.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/model/AwsCodeBuildExecution.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
+import java.util.List;
 import lombok.Data;
 import lombok.Getter;
 
@@ -30,16 +31,20 @@ public class AwsCodeBuildExecution {
   private final Status status;
   private final AwsCodeBuildLogs logs;
   private final String buildUrl;
+  private final List<AwsCodeBuildEnvironmentVariable> exportedEnvironmentVariables;
 
   @JsonCreator
   public AwsCodeBuildExecution(
       @JsonProperty("arn") String arn,
       @JsonProperty("buildStatus") String buildStatus,
-      @JsonProperty("logs") AwsCodeBuildLogs logs) {
+      @JsonProperty("logs") AwsCodeBuildLogs logs,
+      @JsonProperty("exportedEnvironmentVariables")
+          List<AwsCodeBuildEnvironmentVariable> exportedEnvironmentVariables) {
     this.arn = arn;
     this.status = Status.fromString(buildStatus);
     this.buildUrl = getBuildUrl(arn);
     this.logs = logs;
+    this.exportedEnvironmentVariables = exportedEnvironmentVariables;
   }
 
   private String getBuildUrl(String arn) {
@@ -56,6 +61,12 @@ public class AwsCodeBuildExecution {
   private static class AwsCodeBuildLogs {
     private String deepLink;
     private String s3DeepLink;
+  }
+
+  @Data
+  private static class AwsCodeBuildEnvironmentVariable {
+    private String name;
+    private String value;
   }
 
   public enum Status {

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorAwsCodeBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorAwsCodeBuildTaskSpec.groovy
@@ -41,7 +41,7 @@ class MonitorAwsCodeBuildTaskSpec extends Specification {
   @Unroll
   def "task returns #executionStatus when build returns #buildStatus"() {
     given:
-    def igorResponse = new AwsCodeBuildExecution(ARN, buildStatus, null)
+    def igorResponse = new AwsCodeBuildExecution(ARN, buildStatus, null, null)
     def stage = new StageExecutionImpl(execution, "awsCodeBuild", [
       account: ACCOUNT,
       buildInfo: [

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartAwsCodeBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartAwsCodeBuildTaskSpec.groovy
@@ -41,7 +41,7 @@ class StartAwsCodeBuildTaskSpec extends Specification {
 
   @Subject
   StartAwsCodeBuildTask task = new StartAwsCodeBuildTask(igorService, artifactUtils)
-  def igorResponse = new AwsCodeBuildExecution(ARN, null, null)
+  def igorResponse = new AwsCodeBuildExecution(ARN, null, null, null)
 
   def "should start a build"() {
     given:

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StopAwsCodeBuildTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StopAwsCodeBuildTaskSpec.groovy
@@ -38,7 +38,7 @@ class StopAwsCodeBuildTaskSpec extends Specification {
 
   def "should stop a build"() {
     given:
-    def igorResponse = new AwsCodeBuildExecution(ARN, null, null)
+    def igorResponse = new AwsCodeBuildExecution(ARN, null, null, null)
     def stage = new StageExecutionImpl(execution, "awsCodeBuild", [
         account: ACCOUNT,
         buildInfo: [
@@ -57,7 +57,7 @@ class StopAwsCodeBuildTaskSpec extends Specification {
 
   def "should do nothing if buildInfo doesn't exist"() {
     given:
-    def igorResponse = new AwsCodeBuildExecution(ARN, null, null)
+    def igorResponse = new AwsCodeBuildExecution(ARN, null, null, null)
     def stage = new StageExecutionImpl(execution, "awsCodeBuild", [account: ACCOUNT, projectName: PROJECT_NAME])
 
     when:


### PR DESCRIPTION
Adding exported environment variables in the stage context would allow end users to consume the environment variables exported from CodeBuild build stage by specifying a pipeline expression like `${#stage('AWS CodeBuild')['context']['buildInfo']['exportedEnvironmentVariables']}`.

This PR addressed feature request https://github.com/spinnaker/spinnaker/issues/5686