### PR TITLE
feat(peering): add ability to author custom peering agents

### DIFF
--- a/orca-peering/orca-peering.gradle
+++ b/orca-peering/orca-peering.gradle
@@ -18,6 +18,7 @@ apply from: "$rootDir/gradle/kotlin.gradle"
 apply from: "$rootDir/gradle/spock.gradle"
 
 dependencies {
+  api("com.netflix.spinnaker.keiko:keiko-core:$keikoVersion")
   implementation(project(":orca-core"))
 
   implementation("com.netflix.spinnaker.kork:kork-sql")

--- a/orca-peering/orca-peering.gradle
+++ b/orca-peering/orca-peering.gradle
@@ -18,7 +18,6 @@ apply from: "$rootDir/gradle/kotlin.gradle"
 apply from: "$rootDir/gradle/spock.gradle"
 
 dependencies {
-  api("com.netflix.spinnaker.keiko:keiko-core:$keikoVersion")
   implementation(project(":orca-core"))
 
   implementation("com.netflix.spinnaker.kork:kork-sql")

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/config/PeeringAgentConfiguration.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/config/PeeringAgentConfiguration.kt
@@ -49,7 +49,7 @@ class PeeringAgentConfiguration {
     dynamicConfigService: DynamicConfigService,
     registry: Registry,
     properties: PeeringAgentConfigurationProperties,
-    customPeerers: List<CustomPeerer>
+    customPeerer: CustomPeerer?
   ): PeeringAgent {
     if (properties.peerId == null || properties.poolName == null) {
       throw ConfigurationException("pollers.peering.id and pollers.peering.poolName must be specified for peering")
@@ -83,7 +83,7 @@ class PeeringAgentConfiguration {
       dynamicConfigService,
       metrics,
       copier,
-      customPeerers,
+      customPeerer,
       clusterLock)
   }
 }

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/config/PeeringAgentConfiguration.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/config/PeeringAgentConfiguration.kt
@@ -19,6 +19,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.orca.notifications.NotificationClusterLock
+import com.netflix.spinnaker.orca.peering.CustomPeerer
 import com.netflix.spinnaker.orca.peering.ExecutionCopier
 import com.netflix.spinnaker.orca.peering.MySqlRawAccess
 import com.netflix.spinnaker.orca.peering.PeeringAgent
@@ -47,7 +48,8 @@ class PeeringAgentConfiguration {
     clusterLock: NotificationClusterLock,
     dynamicConfigService: DynamicConfigService,
     registry: Registry,
-    properties: PeeringAgentConfigurationProperties
+    properties: PeeringAgentConfigurationProperties,
+    customPeerers: List<CustomPeerer>
   ): PeeringAgent {
     if (properties.peerId == null || properties.poolName == null) {
       throw ConfigurationException("pollers.peering.id and pollers.peering.poolName must be specified for peering")
@@ -81,6 +83,7 @@ class PeeringAgentConfiguration {
       dynamicConfigService,
       metrics,
       copier,
+      customPeerers,
       clusterLock)
   }
 }

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/CustomPeerer.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/CustomPeerer.kt
@@ -33,5 +33,5 @@ interface CustomPeerer {
    * doPeer function will be called AFTER all default peering actions are completed for this agent cycle
    *
    */
-  fun doPeer()
+  fun doPeer(): Boolean
 }

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/CustomPeerer.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/CustomPeerer.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.peering
+
+/**
+ * Interface that custom peerers should implement (and expose as a bean)
+ */
+interface CustomPeerer {
+  /**
+   * doPeer function will be called AFTER all default peering actions are completed for this agent cycle
+   *
+   * @param srcDb source/foreign (read-only) database, use srcDb.runQuery to get the jooq context to perform queries on
+   * @param destDb destination/local database
+   * @param peerId the id of the peer we are peering
+   */
+  fun doPeer(srcDb: SqlRawAccess, destDb: SqlRawAccess, peerId: String)
+}

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/CustomPeerer.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/CustomPeerer.kt
@@ -32,6 +32,7 @@ interface CustomPeerer {
   /**
    * doPeer function will be called AFTER all default peering actions are completed for this agent cycle
    *
+   * @return true if peering completed successfully, false otherwise
    */
   fun doPeer(): Boolean
 }

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/CustomPeerer.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/CustomPeerer.kt
@@ -21,11 +21,17 @@ package com.netflix.spinnaker.orca.peering
  */
 interface CustomPeerer {
   /**
-   * doPeer function will be called AFTER all default peering actions are completed for this agent cycle
+   * Let the custom peerer initialize itself
    *
    * @param srcDb source/foreign (read-only) database, use srcDb.runQuery to get the jooq context to perform queries on
    * @param destDb destination/local database
    * @param peerId the id of the peer we are peering
    */
-  fun doPeer(srcDb: SqlRawAccess, destDb: SqlRawAccess, peerId: String)
+  fun init(srcDb: SqlRawAccess, destDb: SqlRawAccess, peerId: String)
+
+  /**
+   * doPeer function will be called AFTER all default peering actions are completed for this agent cycle
+   *
+   */
+  fun doPeer()
 }

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccess.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccess.kt
@@ -179,7 +179,7 @@ open class MySqlRawAccess(
           }
 
           // Dump it to the DB
-          batchQuery
+          persisted += batchQuery
             .onDuplicateKeyUpdate()
             .set(updateSet)
             .execute()
@@ -194,13 +194,12 @@ open class MySqlRawAccess(
             .values(values)
         }
 
-        persisted++
         cumulativeSize += totalRecordSize
       }
 
       if (cumulativeSize > 0) {
         // Dump the last bit to the DB
-        batchQuery
+        persisted += batchQuery
           .onDuplicateKeyUpdate()
           .set(updateSet)
           .execute()

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccess.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccess.kt
@@ -16,13 +16,12 @@ import org.jooq.impl.DSL.table
 
 /**
  * Provides raw access to various tables in the orca SQL
- * TODO(mvulfson): Need an extension point to deal with cases such as OCA
  */
 open class MySqlRawAccess(
-  private val jooq: DSLContext,
-  private val poolName: String,
+  jooq: DSLContext,
+  poolName: String,
   chunkSize: Int
-) : SqlRawAccess(chunkSize) {
+) : SqlRawAccess(jooq, poolName, chunkSize) {
 
   private var maxPacketSize: Long = 0
 

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringMetrics.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringMetrics.kt
@@ -71,9 +71,9 @@ open class PeeringMetrics(
       .increment(count.toLong())
   }
 
-  open fun incrementCustomPeererError(peererName: String) {
+  open fun incrementCustomPeererError(peererName: String, exception: Exception) {
     registry
-      .counter(peeringCustomPeererNumErrorsId.withTag("peerer", peererName))
+      .counter(peeringCustomPeererNumErrorsId.withTags("peerer", peererName, "exception", exception.javaClass.simpleName))
       .increment()
   }
 }

--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringMetrics.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringMetrics.kt
@@ -31,6 +31,7 @@ open class PeeringMetrics(
   private val peeringNumDeletedId = registry.createId("pollers.peering.numDeleted").withTag("peerId", peeredId)
   private val peeringNumStagesDeletedId = registry.createId("pollers.peering.numStagesDeleted").withTag("peerId", peeredId)
   private val peeringNumErrorsId = registry.createId("pollers.peering.numErrors").withTag("peerId", peeredId)
+  private val peeringCustomPeererNumErrorsId = registry.createId("pollers.peering.customPeerer.numErrors").withTag("peerId", peeredId)
 
   open fun recordOverallLag(block: () -> Unit) {
     registry
@@ -68,6 +69,12 @@ open class PeeringMetrics(
     registry
       .counter(peeringNumStagesDeletedId.tag(executionType))
       .increment(count.toLong())
+  }
+
+  open fun incrementCustomPeererError(peererName: String) {
+    registry
+      .counter(peeringCustomPeererNumErrorsId.withTag("peerer", peererName))
+      .increment()
   }
 }
 


### PR DESCRIPTION
This change adds an extension point (in the form of beans injected into the `PeeringAgent`) to allow peering of custom data in the `orca` [SQL] DB.
Currently, the custom peering agents are called without much context as to what the main peering agent is doing (they are simply called at the end of every agent tick, after all main peering agent logic completes).
This can be changed later if needed but for now I wanted to keep the two as independant and simple as possible.
