### PR TITLE
fix(clouddriver): Retry submitting clouddriver operations

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component
 import rx.Observable
 
 import javax.annotation.Nonnull
+import java.time.Duration
 
 @Component
 class KatoService {
@@ -45,7 +46,7 @@ class KatoService {
   Observable<TaskId> requestOperations(Collection<? extends Map<String, Map>> operations) {
     TaskId taskId = retrySupport.retry({
       katoRestService.requestOperations(requestId(operations), operations)
-    }, 3, 500, false)
+    }, 3, Duration.ofSeconds(1), false)
 
     return Observable.from(taskId)
   }
@@ -53,7 +54,7 @@ class KatoService {
   Observable<TaskId> requestOperations(String cloudProvider, Collection<? extends Map<String, Map>> operations) {
     TaskId taskId = retrySupport.retry({
       katoRestService.requestOperations(requestId(operations), cloudProvider, operations)
-    }, 3, 500, false)
+    }, 3, Duration.ofSeconds(1), false)
 
     return Observable.from(taskId)
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/KatoService.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver
 
 import com.google.common.hash.Hashing
+import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.orca.ExecutionContext
 import com.netflix.spinnaker.orca.clouddriver.model.Task
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
@@ -32,19 +33,29 @@ class KatoService {
 
   private final KatoRestService katoRestService
   private final CloudDriverTaskStatusService cloudDriverTaskStatusService
+  private final RetrySupport retrySupport
 
   @Autowired
-  KatoService(KatoRestService katoRestService, CloudDriverTaskStatusService cloudDriverTaskStatusService) {
+  KatoService(KatoRestService katoRestService, CloudDriverTaskStatusService cloudDriverTaskStatusService, RetrySupport retrySupport) {
     this.katoRestService = katoRestService
     this.cloudDriverTaskStatusService = cloudDriverTaskStatusService
+    this.retrySupport = retrySupport
   }
 
   Observable<TaskId> requestOperations(Collection<? extends Map<String, Map>> operations) {
-    return Observable.from(katoRestService.requestOperations(requestId(operations), operations))
+    TaskId taskId = retrySupport.retry({
+      katoRestService.requestOperations(requestId(operations), operations)
+    }, 3, 500, false)
+
+    return Observable.from(taskId)
   }
 
   Observable<TaskId> requestOperations(String cloudProvider, Collection<? extends Map<String, Map>> operations) {
-    return Observable.from(katoRestService.requestOperations(requestId(operations), cloudProvider, operations))
+    TaskId taskId = retrySupport.retry({
+      katoRestService.requestOperations(requestId(operations), cloudProvider, operations)
+    }, 3, 500, false)
+
+    return Observable.from(taskId)
   }
 
   Task lookupTask(String id, boolean skipReplica = false) {


### PR DESCRIPTION
We see a few operations per day seemingly fail for network reasons but actually be submitted and executed successfully.
This change adds a retry around the operation submission - if a duplicate operation is submitted, clouddriver will just return the prior one so this is safe.
