### PR TITLE
refactor(artifacts): Update places that mutate artifacts

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.orca.bakery.tasks.manifests;
 
-import com.google.common.base.Strings;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask;
@@ -99,10 +98,7 @@ public class CreateBakeManifestTask implements RetryableTask {
                             "Input artifact (id: %s, account: %s) could not be found in execution (id: %s).",
                             p.getId(), p.getAccount(), stage.getExecution().getId()));
                   }
-                  if (!Strings.isNullOrEmpty(p.getAccount())) {
-                    a.setArtifactAccount(p.getAccount());
-                  }
-                  return a;
+                  return ArtifactUtils.withAccount(a, p.getAccount());
                 })
             .collect(Collectors.toList());
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluator.java
@@ -171,13 +171,12 @@ public class ManifestEvaluator implements CloudProviderAware {
         Optional.ofNullable(
                 artifactUtils.getBoundArtifactForStage(
                     stage, context.getManifestArtifactId(), context.getManifestArtifact()))
+            // Once the legacy artifacts feature is removed, all trigger expected artifacts will be
+            // required to define an account up front.
+            .map(
+                artifact ->
+                    ArtifactUtils.withAccount(artifact, context.getManifestArtifactAccount()))
             .orElseThrow(() -> new IllegalArgumentException("No manifest artifact was specified."));
-
-    // Once the legacy artifacts feature is removed, all trigger expected artifacts will be
-    // required to define an account up front.
-    if (context.getManifestArtifactAccount() != null) {
-      manifestArtifact.setArtifactAccount(context.getManifestArtifactAccount());
-    }
 
     checkArgument(
         manifestArtifact.getArtifactAccount() != null,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineServerGroupCreator.groovy
@@ -76,8 +76,7 @@ class AppEngineServerGroupCreator implements ServerGroupCreator {
       if (configArtifacts != null && configArtifacts.size() > 0) {
         operation.configArtifacts = configArtifacts.collect { artifactAccountPair ->
           def artifact = artifactUtils.getBoundArtifactForStage(stage, artifactAccountPair.id, artifactAccountPair.artifact)
-          artifact.artifactAccount = artifactAccountPair.account
-          return artifact
+          return ArtifactUtils.withAccount(artifact, artifactAccountPair.account)
         }
       }
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTask.java
@@ -89,9 +89,11 @@ public class DeployCloudFormationTask extends AbstractCloudProviderAwareTask imp
               .map(m -> objectMapper.convertValue(m, Artifact.class))
               .orElse(null);
       Artifact artifact =
-          artifactUtils.getBoundArtifactForStage(stage, stackArtifactId, stackArtifact);
-      Optional.ofNullable(task.get("stackArtifactAccount"))
-          .ifPresent(account -> artifact.setArtifactAccount(account.toString()));
+          ArtifactUtils.withAccount(
+              artifactUtils.getBoundArtifactForStage(stage, stackArtifactId, stackArtifact),
+              Optional.ofNullable(task.get("stackArtifactAccount"))
+                  .map(Object::toString)
+                  .orElse(null));
       Response response = oortService.fetchArtifact(artifact);
       try {
         String template = CharStreams.toString(new InputStreamReader(response.getBody().in()));

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtilsTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtilsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.util;
+
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPELINE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.persistence.InMemoryExecutionRepository;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class ArtifactUtilsTest {
+  @Test
+  void withAccountNonNullAccount() {
+    Artifact artifact = Artifact.builder().artifactAccount("old-account").build();
+    Artifact newArtifact = ArtifactUtils.withAccount(artifact, "new-account");
+    assertThat(newArtifact.getArtifactAccount()).isEqualTo("new-account");
+  }
+
+  @Test
+  void withAccountDoesNotMutate() {
+    Artifact artifact = Artifact.builder().artifactAccount("old-account").build();
+    Artifact newArtifact = ArtifactUtils.withAccount(artifact, "new-account");
+    assertThat(artifact.getArtifactAccount()).isEqualTo("old-account");
+  }
+
+  @Test
+  void withAccountEmptyAccount() {
+    Artifact artifact = Artifact.builder().artifactAccount("old-account").build();
+    Artifact newArtifact = ArtifactUtils.withAccount(artifact, "");
+    assertThat(newArtifact.getArtifactAccount()).isEqualTo("old-account");
+  }
+
+  @Test
+  void withAccountNullAccount() {
+    Artifact artifact = Artifact.builder().artifactAccount("old-account").build();
+    Artifact newArtifact = ArtifactUtils.withAccount(artifact, null);
+    assertThat(newArtifact.getArtifactAccount()).isEqualTo("old-account");
+  }
+
+  @Test
+  void getBoundArtifactForIdPreservesAccount() {
+    ArtifactUtils artifactUtils = createArtifactUtils();
+    String id = "my-artifact-id";
+    StageExecution execution =
+        executionWithArtifacts(
+            ImmutableList.of(
+                ExpectedArtifact.builder()
+                    .id(id)
+                    .matchArtifact(Artifact.builder().artifactAccount("match-account").build())
+                    .boundArtifact(Artifact.builder().artifactAccount("bound-account").build())
+                    .build()));
+    Artifact result = artifactUtils.getBoundArtifactForId(execution, id);
+    assertThat(result.getArtifactAccount()).isEqualTo("bound-account");
+  }
+
+  @Test
+  void getBoundArtifactForIdDefaultsToMatchAccount() {
+    ArtifactUtils artifactUtils = createArtifactUtils();
+    String id = "my-artifact-id";
+    StageExecution execution =
+        executionWithArtifacts(
+            ImmutableList.of(
+                ExpectedArtifact.builder()
+                    .id(id)
+                    .matchArtifact(Artifact.builder().artifactAccount("match-account").build())
+                    .boundArtifact(Artifact.builder().build())
+                    .build()));
+    Artifact result = artifactUtils.getBoundArtifactForId(execution, id);
+    assertThat(result.getArtifactAccount()).isEqualTo("match-account");
+  }
+
+  @Test
+  void getBoundArtifactForIdReturnsNull() {
+    ArtifactUtils artifactUtils = createArtifactUtils();
+    String id = "my-artifact-id";
+    StageExecution execution = executionWithArtifacts(ImmutableList.of());
+    Artifact result = artifactUtils.getBoundArtifactForId(execution, id);
+    assertThat(result).isNull();
+  }
+
+  private StageExecution executionWithArtifacts(Iterable<ExpectedArtifact> expectedArtifacts) {
+    Map<String, Object> context = new HashMap<>();
+    context.put("resolvedExpectedArtifacts", ImmutableList.copyOf(expectedArtifacts));
+    return createExecution(context);
+  }
+
+  private StageExecution createExecution(Map<String, Object> context) {
+    PipelineExecution pipeline = new PipelineExecutionImpl(PIPELINE, "3", "foo");
+    return new StageExecutionImpl(pipeline, "test", context);
+  }
+
+  private ArtifactUtils createArtifactUtils() {
+    return new ArtifactUtils(
+        new ObjectMapper(), new InMemoryExecutionRepository(), new ContextParameterProcessor());
+  }
+}

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartGoogleCloudBuildTask.java
@@ -81,7 +81,7 @@ public class StartGoogleCloudBuildTask implements Task {
     return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(context).build();
   }
 
-  private Map<String, Object> getBuildDefinitionFromArtifact(
+  private Artifact getBuildDefinitionArtifact(
       @Nonnull StageExecution stage, GoogleCloudBuildStageDefinition stageDefinition) {
     Artifact buildDefinitionArtifact =
         artifactUtils.getBoundArtifactForStage(
@@ -93,15 +93,19 @@ public class StartGoogleCloudBuildTask implements Task {
       throw new IllegalArgumentException("No manifest artifact was specified.");
     }
 
-    if (stageDefinition.getBuildDefinitionArtifact().getArtifactAccount() != null) {
-      buildDefinitionArtifact.setArtifactAccount(
-          stageDefinition.getBuildDefinitionArtifact().getArtifactAccount());
-    }
-
+    buildDefinitionArtifact =
+        ArtifactUtils.withAccount(
+            buildDefinitionArtifact,
+            stageDefinition.getBuildDefinitionArtifact().getArtifactAccount());
     if (buildDefinitionArtifact.getArtifactAccount() == null) {
       throw new IllegalArgumentException("No manifest artifact account was specified.");
     }
+    return buildDefinitionArtifact;
+  }
 
+  private Map<String, Object> getBuildDefinitionFromArtifact(
+      @Nonnull StageExecution stage, GoogleCloudBuildStageDefinition stageDefinition) {
+    final Artifact buildDefinitionArtifact = getBuildDefinitionArtifact(stage, stageDefinition);
     Map<String, Object> buildDefinition =
         retrySupport.retry(
             () -> {


### PR DESCRIPTION
Artifacts will soon become immutable to eliminate the confusion about whether mutating an artifact is actually updating the artifact on the pipeline. This is confusing because we very often use objectMapper.convertValue() on artifacts to convert back and forth between maps. It is thus far from clear whether a mutation at any given point is acting on a copy of the pipeline artifact or the artifact itself.

This commit updates places that mutated artifacts to instead return a copy. In all cases this is setting the account for legacy workflows that have this specified separately from the artifact itself. We should not be adding more of these, and ideally these would at some point be migrated to use the new workflow of having the account specified on the artifact.

In all cases updated here were were either always or sometimes operating on a copy of the artifact anyway because of the frequent Map <-> Artifact conversion we do (mostly to evaluate SpEL). This will make things a lot clearer by having these mutations always return a mutated copy to avoid depending on the fragile behavior of mutating a sometimes-copy.

(At one point a Spring Boot upgrade which upgraded Jackson broke artifact workflows because it changed whether objectMapper.convertValue short-circuited in the event of no conversion being necessary, for an example of the fragility of mutating artifacts.)