### PR TITLE
fix(spel): Process all entries for evaluate variables with SPeLv4

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/EvaluateVariablesStage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/EvaluateVariablesStage.java
@@ -34,7 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class EvaluateVariablesStage implements ExpressionAwareStageDefinitionBuilder {
+public class EvaluateVariablesStage extends ExpressionAwareStageDefinitionBuilder {
   public static String STAGE_TYPE = "evaluateVariables";
 
   private ObjectMapper mapper;
@@ -55,6 +55,9 @@ public class EvaluateVariablesStage implements ExpressionAwareStageDefinitionBui
       @Nonnull ContextParameterProcessor contextParameterProcessor,
       @Nonnull ExpressionEvaluationSummary summary) {
 
+    processDefaultEntries(
+        stage, contextParameterProcessor, summary, Collections.singletonList("variables"));
+
     EvaluateVariablesStageContext context = stage.mapTo(EvaluateVariablesStageContext.class);
     StageContext augmentedContext = contextParameterProcessor.buildExecutionContext(stage);
     Map<String, Object> varSourceToEval = new HashMap<>();
@@ -73,10 +76,10 @@ public class EvaluateVariablesStage implements ExpressionAwareStageDefinitionBui
             contextParameterProcessor.process(varSourceToEval, augmentedContext, true, summary);
 
         // Since we process one variable at a time, the way we know if the current variable was
-        // evaluated properly is by
-        // checking if the total number of failures has changed since last evaluation. We can make
-        // this nicer, but that
-        // will involve a decent refactor of ExpressionEvaluationSummary
+        // evaluated properly is by checking if the total number of failures has changed since
+        // last evaluation.
+        // We can make this nicer, but that will involve a decent refactor of
+        // ExpressionEvaluationSummary
         boolean evaluationSucceeded = summary.getFailureCount() == lastFailedCount;
         if (evaluationSucceeded) {
           var.setValue(evaluatedVar.get("var"));

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExpressionAwareStageDefinitionBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExpressionAwareStageDefinitionBuilder.java
@@ -18,7 +18,11 @@ package com.netflix.spinnaker.orca.pipeline;
 import com.netflix.spinnaker.kork.expressions.ExpressionEvaluationSummary;
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.pipeline.model.StageContext;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nonnull;
 
 /**
@@ -26,17 +30,46 @@ import javax.annotation.Nonnull;
  *
  * <p>This is not available for the public Orca API.
  */
-public interface ExpressionAwareStageDefinitionBuilder extends StageDefinitionBuilder {
+public abstract class ExpressionAwareStageDefinitionBuilder implements StageDefinitionBuilder {
 
   /**
    * Allows the stage to process SpEL expression in its own context in a custom way
    *
    * @return true to continue processing, false to stop generic processing of expressions
    */
-  default boolean processExpressions(
+  public abstract boolean processExpressions(
       @Nonnull StageExecution stage,
       @Nonnull ContextParameterProcessor contextParameterProcessor,
-      @Nonnull ExpressionEvaluationSummary summary) {
-    return true;
+      @Nonnull ExpressionEvaluationSummary summary);
+
+  /**
+   * Processes all entries in the stage context that aren't handled in a special way by the stage
+   * itself (e.g. things like comments, notifications, etc)
+   *
+   * <p>This function should be called by the implementation of processExpressions, ideally, in the
+   * very beginning
+   *
+   * @param stage (should be same as passed into processExpressions)
+   * @param contextParameterProcessor (should be same as passed into processExpressions)
+   * @param summary (should be same as passed into processExpressions)
+   * @param excludedKeys keys to exclude from processing
+   */
+  final void processDefaultEntries(
+      @Nonnull StageExecution stage,
+      @Nonnull ContextParameterProcessor contextParameterProcessor,
+      @Nonnull ExpressionEvaluationSummary summary,
+      Collection<String> excludedKeys) {
+
+    StageContext augmentedContext = contextParameterProcessor.buildExecutionContext(stage);
+    Map<String, Object> stageContext = stage.getContext();
+
+    for (String key : stageContext.keySet()) {
+      if (!excludedKeys.contains(key)) {
+        Map<String, Object> temp = new HashMap<>();
+        temp.put(key, stageContext.get(key));
+        stageContext.put(
+            key, contextParameterProcessor.process(temp, augmentedContext, true, summary).get(key));
+      }
+    }
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesStageSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesStageSpec.groovy
@@ -61,4 +61,24 @@ class EvaluateVariablesStageSpec extends Specification {
     summary.totalEvaluated == 5
     summary.failureCount == 1
   }
+
+  void "Should eval non-variable part of context"() {
+    setup:
+    def summary = new ExpressionEvaluationSummary()
+
+    def stage = stage {
+      refId = "1"
+      type = "evaluateVariables"
+      context["notifications"] = [
+          [address: '${"someone" + "@somewhere.com"}']
+          ]
+    }
+
+    when:
+    def shouldContinue = evaluateVariablesStage.processExpressions(stage, contextParameterProcessor, summary)
+
+    then:
+    shouldContinue == false
+    stage.context.notifications[0].address == "someone@somewhere.com"
+  }
 }


### PR DESCRIPTION
When I implemented SPeLv4 (#3286) I introduced an issue where context keys that weren't part of `EvaluateVariableStage` didn't get processed.
This means that, for example, expressions in stage `notifications` wheren't processed an one could no longer specify an email as, say, `${parameters.email}`.

This change fixes the issue by introducing a helper method that runs all context values through the `ContextParameterProcessor` which aren't specially processed by the stage it self

This change correctly addresses https://github.com/spinnaker/spinnaker/issues/5697 and we will be able to revert https://github.com/spinnaker/echo/pull/869 which introduced a regression in RestEventListener
