### PR TITLE
refactor(artifacts): Update call to getMetadata

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartAwsCodeBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartAwsCodeBuildTask.java
@@ -194,7 +194,7 @@ public class StartAwsCodeBuildTask implements Task {
       throw new IllegalArgumentException("No artifact account was specified.");
     }
 
-    if (matchArtifact.getMetadata() != null && matchArtifact.getMetadata().containsKey("subPath")) {
+    if (matchArtifact.getMetadata("subPath") != null) {
       throw new IllegalArgumentException("Subpath is not supported by AWS CodeBuild stage");
     }
     return matchArtifact;


### PR DESCRIPTION
I'm working on better encapuslating artifacts, and one change is removing direct access to the map of metadata via .getMetadata() in favor of having clients specifically ask for keys via getMetadata(String key). In addition to hiding the implementation from clients, this usually also simplifies client code as generally client code first checks that the metadata map is not null then checks a specific key.

This updates the one place in orca where we were fetching the full metadata map to instead look up the desired key.