### PR TITLE
fix(sql): Fix migrations for users who do not run MySQL

### DIFF
--- a/orca-sql/src/main/resources/db/changelog-master.yml
+++ b/orca-sql/src/main/resources/db/changelog-master.yml
@@ -50,3 +50,6 @@ databaseChangeLog:
 - include:
     file: changelog/20200424-index-deleted-executions-table.yml
     relativeToChangelogFile: true
+- include:
+    file: changelog/20200603-deleted-executions-table-not-mysql.yml
+    relativeToChangelogFile: true

--- a/orca-sql/src/main/resources/db/changelog/20200424-index-deleted-executions-table.yml
+++ b/orca-sql/src/main/resources/db/changelog/20200424-index-deleted-executions-table.yml
@@ -4,6 +4,7 @@ databaseChangeLog:
       author: mvulfson
       changes:
         - createIndex:
+            dbms: mysql
             indexName: deleted_at_idx
             tableName: deleted_executions
             columns:

--- a/orca-sql/src/main/resources/db/changelog/20200603-deleted-executions-table-not-mysql.yml
+++ b/orca-sql/src/main/resources/db/changelog/20200603-deleted-executions-table-not-mysql.yml
@@ -1,0 +1,61 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-deleted-executions-table-for-not-mysql
+      author: robzienert
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          tableExists:
+            tableName: deleted_executions
+      changes:
+        - createTable:
+            tableName: deleted_executions
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: execution_id
+                  type: char(26)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: execution_type
+                  type: varchar(15)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: deleted_at
+                  type: datetime
+                  constraints:
+                    nullable: false
+        - addAutoIncrement:
+            tableName: deleted_executions
+            columnName: id
+            columnDataType: int
+
+      rollback:
+        - dropTable:
+            tableName: deleted_executions
+  - changeSet:
+      id: create-deleted-executions-index-for-not-mysql
+      author: robzienert
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          indexExists:
+            indexName: deleted_at_idx
+      changes:
+        - createIndex:
+            indexName: deleted_at_idx
+            tableName: deleted_executions
+            columns:
+              - column:
+                  name: deleted_at
+    rollback:
+      - dropIndex:
+          indexName: deleted_at_idx
+          tableName: deleted_executions


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5788

I had to change `20200424-index-deleted-executions-table.yml` which I thought would break MySQL users due to checksum issues, but running locally I didn't encounter any problems. Maybe it's fine?

Anyway, this change will get non-MySQL users a working Orca, and MySQL users will be unaffected:

```
2020-06-03 15:37:11.999  INFO 99068 --- [           main] liquibase.changelog.ChangeSet            : [] Marking ChangeSet: classpath:db/changelog/20200603-deleted-executions-table-not-mysql.yml::create-deleted-executions-table-for-not-mysql::robzienert ran despite precondition failure due to onFail='MARK_RAN': 
          classpath:db/changelog-master.yml : Not precondition failed

2020-06-03 15:37:12.000  INFO 99068 --- [           main] liquibase.executor.jvm.JdbcExecutor      : [] SELECT MAX(ORDEREXECUTED) FROM orca.DATABASECHANGELOG
2020-06-03 15:37:12.002  INFO 99068 --- [           main] liquibase.executor.jvm.JdbcExecutor      : [] INSERT INTO orca.DATABASECHANGELOG (ID, AUTHOR, FILENAME, DATEEXECUTED, ORDEREXECUTED, MD5SUM, `DESCRIPTION`, COMMENTS, EXECTYPE, CONTEXTS, LABELS, LIQUIBASE, DEPLOYMENT_ID) VALUES ('create-deleted-executions-table-for-not-mysql', 'robzienert', 'classpath:db/changelog/20200603-deleted-executions-table-not-mysql.yml', NOW(), 39, '8:b333e8c8b075804f1c71fc60cd9d916b', 'createTable tableName=deleted_executions', '', 'MARK_RAN', NULL, NULL, '3.8.7', '1223831944')
2020-06-03 15:37:12.080  INFO 99068 --- [           main] liquibase.changelog.ChangeSet            : [] Marking ChangeSet: classpath:db/changelog/20200603-deleted-executions-table-not-mysql.yml::create-deleted-executions-index-for-not-mysql::robzienert ran despite precondition failure due to onFail='MARK_RAN': 
          classpath:db/changelog-master.yml : Not precondition failed

2020-06-03 15:37:12.081  INFO 99068 --- [           main] liquibase.executor.jvm.JdbcExecutor      : [] INSERT INTO orca.DATABASECHANGELOG (ID, AUTHOR, FILENAME, DATEEXECUTED, ORDEREXECUTED, MD5SUM, `DESCRIPTION`, COMMENTS, EXECTYPE, CONTEXTS, LABELS, LIQUIBASE, DEPLOYMENT_ID) VALUES ('create-deleted-executions-index-for-not-mysql', 'robzienert', 'classpath:db/changelog/20200603-deleted-executions-table-not-mysql.yml', NOW(), 40, '8:6df5b6d9c3df28ec52de2d40a8dfb491', 'createIndex indexName=deleted_at_idx, tableName=deleted_executions', '', 'MARK_RAN', NULL, NULL, '3.8.7', '1223831944')
```