### PR TITLE
fix(titus): Correctly detect image from prior stages

### DIFF
--- a/orca-clouddriver-provider-titus/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/titus/TitusServerGroupCreator.groovy
+++ b/orca-clouddriver-provider-titus/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/titus/TitusServerGroupCreator.groovy
@@ -25,19 +25,10 @@ import org.springframework.stereotype.Component
 
 @Slf4j
 @Component
-class TitusServerGroupCreator implements ServerGroupCreator, DeploymentDetailsAware {
-
-  /**
-   * Prefer composition over inheritance FTW!
-   */
-  @Delegate(excludes = ['getCloudProvider'])
-  @Autowired
-  AmazonServerGroupCreator delegate
-
-  final String cloudProvider = "titus"
-
+class TitusServerGroupCreator extends AmazonServerGroupCreator {
+  @Override
   String getCloudProvider() {
-    return cloudProvider
+    return "titus"
   }
 
   Optional<String> getHealthProviderName() {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonServerGroupCreator.groovy
@@ -45,7 +45,11 @@ class AmazonServerGroupCreator implements ServerGroupCreator, DeploymentDetailsA
   List<String> defaultSecurityGroups = DEFAULT_SECURITY_GROUPS
 
   boolean katoResultExpected = true
-  String cloudProvider = "aws"
+
+  @Override
+  String getCloudProvider() {
+    return "aws"
+  }
 
   @Override
   List<Map> getOperations(StageExecution stage) {


### PR DESCRIPTION
Because `TitusServerGroupCreator` was `@Delegating` work to `AmazonServerGroupCreator` when `AmazonServerGroupCreator::createServerGroupOperation` ran, it thought it was running in "AWS" mode.
The `cloudProvider` variable was set to `aws` (instead of `titus`) and so image lookup from prior stages would always fail to find the titus image to deploy if there was a AWS deploy ancestor stage.

This change ditches the `@Delegate` and uses inheritance as it's more appropriate (and correct) in this case, this way calls to `getCloudProvider` will return the correct cloudprovider

There have been a few attempts at fixing this:
* https://github.com/spinnaker/orca/pull/2960
* https://github.com/spinnaker/orca/pull/2980

Hopefully, this is the last one.
