### PR TITLE
fix(aws): correctly find ancestor for restoring min capacity

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ApplySourceServerGroupCapacityTask.groovy
@@ -89,8 +89,8 @@ class ApplySourceServerGroupCapacityTask extends AbstractServerGroupTask {
       log.info("Restoring min capacity of ${context.region}/${targetServerGroup.name} to ${minCapacity} (currentMin: ${targetServerGroup.capacity.min}, snapshotMin: ${sourceServerGroupCapacitySnapshot.min})")
 
       return context
-    } catch (CannotFindAncestorStage e) {
-      log.warn("Unable to apply source server group capacity (executionId: ${stage.execution.id})")
+    } catch (CannotFindAncestorStage ignored) {
+      log.info("Not applying source server capacity because none was captured")
       return null
     } catch (Exception e) {
       log.error("Unable to apply source server group capacity (executionId: ${stage.execution.id})", e)
@@ -171,7 +171,7 @@ class ApplySourceServerGroupCapacityTask extends AbstractServerGroupTask {
    * Find an ancestor (or synthetic sibling) stage w/ `sourceServerGroupCapacitySnapshot` in it's context.
    */
   static StageExecution getAncestorSnapshotStage(StageExecution stage) {
-    def ancestors = stage.ancestors().findAll { ancestorStage ->
+    def ancestors = stage.directAncestors().findAll { ancestorStage ->
       ancestorStage.context.containsKey("sourceServerGroupCapacitySnapshot")
     }
 


### PR DESCRIPTION
If a user specified 'do not use source capacity' and has several deploy stages in a row (and at least one of the first stages does not have 'do not use source capacity' set)
When we restore capacity (which we shouldn't even need to do anyway) for one of the `do not use source capacity` ASGs we will look up the wrong ASG causing an erroneous error message to be logged.

This change only considers stages that are part of this deploy chain (as opposed to including all stages which are requisite to the current one).
Also, make the warn a info since it's expected when there is no snapshot capacity captured
