### PR TITLE
fix(provider/cf): use moniker objects for task operations to support future non-frigga names

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/AbstractLoadBalancerRegistrationTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/AbstractLoadBalancerRegistrationTask.java
@@ -37,7 +37,11 @@ abstract class AbstractLoadBalancerRegistrationTask
     List<TargetServerGroup> tsgList = tsgResolver.resolve(stage);
     if (!tsgList.isEmpty()) {
       Optional.ofNullable(tsgList.get(0))
-          .ifPresent(tsg -> stage.getContext().put("serverGroupName", tsg.getName()));
+          .ifPresent(
+              tsg -> {
+                stage.getContext().put("serverGroupName", tsg.getName());
+                stage.getContext().put("moniker", tsg.getMoniker());
+              });
     }
 
     return super.execute(stage);

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryJobRunner.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryJobRunner.java
@@ -19,13 +19,13 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.providers.cf;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver;
 import com.netflix.spinnaker.orca.clouddriver.tasks.job.JobRunner;
 import groovy.util.logging.Slf4j;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.Data;
@@ -62,14 +62,17 @@ public class CloudFoundryJobRunner implements JobRunner {
 
     TargetServerGroup serverGroup = resolvedServerGroups.get(0);
 
-    Map<String, String> operationContext = new HashMap<>();
-    operationContext.put("region", region);
-    operationContext.put("credentials", accountName);
-    operationContext.put("jobName", (String) stageContext.get("jobName"));
-    operationContext.put("serverGroupName", serverGroup.getName());
-    operationContext.put("command", (String) stageContext.get("command"));
+    ImmutableMap.Builder<String, Object> operationContext =
+        ImmutableMap.<String, Object>builder()
+            .put("region", region)
+            .put("credentials", accountName)
+            .put("jobName", stageContext.get("jobName"))
+            .put("serverGroupName", serverGroup.getName())
+            .put("command", stageContext.get("command"))
+            .put("moniker", serverGroup.getMoniker());
 
-    return Collections.singletonList(Collections.singletonMap(OPERATION, operationContext));
+    return Collections.singletonList(
+        ImmutableMap.<String, Object>builder().put(OPERATION, operationContext.build()).build());
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
@@ -74,7 +74,8 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
             .put("executionId", execution.getId())
             .put("trigger", execution.getTrigger().getOther())
             .put("applicationArtifact", resolveArtifact(stage, context.get("applicationArtifact")))
-            .put("manifest", evaluatedManifest.getManifests());
+            .put("manifest", evaluatedManifest.getManifests())
+            .put("moniker", moniker);
 
     if (context.get("stack") != null) {
       operation.put("stack", context.get("stack"));


### PR DESCRIPTION
In the future we will be using Moniker to support non-frigga based naming conventions. This change ensures that the cloudfoundry tasks which use application name are sending the moniker object, as well as the old. The old will be removed once all clouddriver operations have been changed as well. 