### PR TITLE
fix(perf): retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBound…

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -352,18 +352,14 @@ class TaskController {
 
     List<PipelineExecution> matchingExecutions = new ArrayList<>()
 
+    int page = 1
     while (matchingExecutions.size() < size) {
-      int page = 1
       List<PipelineExecution> executions = executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
           pipelineConfigIds,
           triggerTimeStartBoundary,
           triggerTimeEndBoundary,
           executionCriteria.setPage(page)
       )
-
-      if (executions.size() == 0) {
-        break
-      }
 
       matchingExecutions.addAll(
           executions
@@ -382,6 +378,11 @@ class TaskController {
               })
               .collect(Collectors.toList())
       )
+
+      if (executions.size() < executionCriteria.pageSize) {
+        break
+      }
+
       page++
     }
 

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -370,7 +370,7 @@ class TaskControllerSpec extends Specification {
       ]
     ]
 
-    executionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _ ) >> pipelines.findAll {
+    executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _ ) >> pipelines.findAll {
         it.pipelineConfigId == "1"
       }.collect { config ->
         PipelineExecutionImpl pipeline = pipeline {
@@ -418,7 +418,7 @@ class TaskControllerSpec extends Specification {
       ]
     ]
 
-    executionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
+    executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
       it.pipelineConfigId == "1"
     }.collect { config ->
       PipelineExecutionImpl pipeline = pipeline {
@@ -467,7 +467,7 @@ class TaskControllerSpec extends Specification {
       ]
     ]
 
-    executionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
+    executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
       it.pipelineConfigId == "1"
     }.collect { config ->
       PipelineExecutionImpl pipeline = pipeline {
@@ -510,7 +510,7 @@ class TaskControllerSpec extends Specification {
       ]
     ]
 
-    executionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
+    executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
       it.pipelineConfigId == "1"
     }.collect { config ->
       PipelineExecutionImpl pipeline = pipeline {
@@ -549,7 +549,7 @@ class TaskControllerSpec extends Specification {
       ]
     ]
 
-    executionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["2"], _, _, _) >> pipelines.findAll {
+    executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["2"], _, _, _) >> pipelines.findAll {
       it.pipelineConfigId == "2"
     }.collect { config ->
       PipelineExecutionImpl pipeline = pipeline {
@@ -588,7 +588,7 @@ class TaskControllerSpec extends Specification {
       ]
     ]
 
-    executionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
+    executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
       it.pipelineConfigId == "1"
     }.collect { config ->
       PipelineExecutionImpl pipeline = pipeline {
@@ -626,7 +626,7 @@ class TaskControllerSpec extends Specification {
     pipelines[0].trigger.artifacts.addAll([Artifact.builder().name("a").version("1").build(), Artifact.builder().name("a").build()])
     pipelines[1].trigger.artifacts.addAll([Artifact.builder().name("a").build(), Artifact.builder().name("a").version("1").build()])
 
-    executionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
+    executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
       it.pipelineConfigId == "1"
     }.collect { config ->
       PipelineExecutionImpl pipeline = pipeline {
@@ -670,7 +670,7 @@ class TaskControllerSpec extends Specification {
       ]
     ]
 
-    executionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
+    executionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(["1"], _, _, _) >> pipelines.findAll {
       it.pipelineConfigId == "1"
     }.collect { config ->
       PipelineExecutionImpl pipeline = pipeline {


### PR DESCRIPTION
…ary shouldn't get all executions

Because of "elaborate" ability to filter in `searchForPipelinesByTrigger` it must combine the filtering capabilities of execution repository and plain code.
To do that, it would retrieve ALL executions first and then filter to the subset desired (default 10).

This change adds filter on a page-by-page execution retrieval, so only the minimum number of results are retrieved from the DB

Ideally, this endpoint just goes away. But this is the minimum change to make it palatable perf wise
