### PR TITLE
fix(provider/appengine): groovy.lang.MissingMethodException when referencing github config artifact for GAE deploy - spinnaker/spinnaker#5836

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineServerGroupCreator.groovy
@@ -25,9 +25,7 @@ import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import static com.netflix.spinnaker.orca.pipeline.model.Execution.ExecutionType.PIPELINE
-import groovy.util.logging.Slf4j
 
-@Slf4j
 @Component
 class AppEngineServerGroupCreator implements ServerGroupCreator {
   boolean katoResultExpected = false

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineServerGroupCreator.groovy
@@ -77,16 +77,7 @@ class AppEngineServerGroupCreator implements ServerGroupCreator {
       List<ArtifactAccountPair> configArtifacts = operation.configArtifacts
       if (configArtifacts != null && configArtifacts.size() > 0) {
         operation.configArtifacts = configArtifacts.collect { artifactAccountPair ->
-          log.debug ("appendArtifactData: artifactAccountPair.id="+artifactAccountPair.id+" artifactAccountPair.artifact="+artifactAccountPair.artifact+" className="+artifactAccountPair.artifact.getClass().getName()+" account="+artifactAccountPair.account)
-          String c_id = artifactAccountPair.id
-          def Artifact c_artifact
-          if (artifactAccountPair.artifact instanceof Map){
-            def map = artifactAccountPair.artifact
-            c_artifact = Artifact.builder().reference(map.get("reference")).metadata(map.get("metadata")).artifactAccount(map.get("artifactAccount")).uuid(map.get("id")).type(map.get("type")).build()
-          } else if (artifactAccountPair.artifact instanceof Artifact){
-            c_artifact = artifactAccountPair.artifact
-          }
-          def artifact = artifactUtils.getBoundArtifactForStage(stage, c_id, c_artifact)
+          def artifact = artifactUtils.getBoundArtifactForStage(stage, artifactAccountPair.id, objectMapper.convertValue(artifactAccountPair.artifact, Artifact.class))
           if (artifactAccountPair.account != null){
             artifact.artifactAccount = artifactAccountPair.account
           }


### PR DESCRIPTION
**Bug description:**
groovy.lang.MissingMethodException thrown when referencing github config artifact for GAE deploy. (see spinnaker/spinnaker#5836 for more details)

**Fix:**
The config artifacts  were of instance of HashMap not an Artifact object. Added logic to translate HashMap to Artifact.

