### PR TITLE
fix(provider/cf): fix form based manifest resolution in deploy stage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
@@ -100,7 +100,8 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
             stageContextArtifactView.getArtifactId(),
             stageContextArtifactView.getArtifact());
     if (artifact == null) {
-      throw new IllegalArgumentException("Unable to bind the application artifact");
+      throw new IllegalArgumentException(
+          "Unable to bind the application artifact. Either the application artifact doesn't exist or this stage doesn't have access to fetch it");
     }
 
     return artifact;
@@ -112,7 +113,8 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
         artifactUtils.getBoundArtifactForStage(
             stage, manifest.getArtifactId(), manifest.getArtifact());
     if (artifact == null) {
-      throw new IllegalArgumentException("Unable to bind the manifest artifact");
+      throw new IllegalArgumentException(
+          "Unable to bind the manifest artifact. Either the manifest artifact doesn't exist or this stage doesn't have access to fetch it");
     }
 
     return artifact;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
@@ -49,7 +49,7 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
   public List<Map> getOperations(StageExecution stage) {
     Map<String, Object> context = stage.getContext();
 
-    Artifact manifestArtifact = resolveArtifact(stage, context.get("manifest"));
+    Artifact manifestArtifact = resolveManifestArtifact(stage, context.get("manifest"));
     CloudFoundryManifestContext manifestContext =
         CloudFoundryManifestContext.builder()
             .source(ManifestContext.Source.Artifact)
@@ -73,7 +73,9 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
             .put("region", context.get("region"))
             .put("executionId", execution.getId())
             .put("trigger", execution.getTrigger().getOther())
-            .put("applicationArtifact", resolveArtifact(stage, context.get("applicationArtifact")))
+            .put(
+                "applicationArtifact",
+                resolveApplicationArtifact(stage, context.get("applicationArtifact")))
             .put("manifest", evaluatedManifest.getManifests())
             .put("moniker", moniker);
 
@@ -89,7 +91,7 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
         ImmutableMap.<String, Object>builder().put(OPERATION, operation.build()).build());
   }
 
-  private Artifact resolveArtifact(StageExecution stage, Object input) {
+  private Artifact resolveApplicationArtifact(StageExecution stage, Object input) {
     StageContextArtifactView stageContextArtifactView =
         mapper.convertValue(input, StageContextArtifactView.class);
     Artifact artifact =
@@ -99,6 +101,18 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
             stageContextArtifactView.getArtifact());
     if (artifact == null) {
       throw new IllegalArgumentException("Unable to bind the application artifact");
+    }
+
+    return artifact;
+  }
+
+  private Artifact resolveManifestArtifact(StageExecution stage, Object input) {
+    DeploymentManifest manifest = mapper.convertValue(input, DeploymentManifest.class);
+    Artifact artifact =
+        artifactUtils.getBoundArtifactForStage(
+            stage, manifest.getArtifactId(), manifest.getArtifact());
+    if (artifact == null) {
+      throw new IllegalArgumentException("Unable to bind the manifest artifact");
     }
 
     return artifact;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
@@ -48,7 +48,6 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
   @Override
   public List<Map> getOperations(StageExecution stage) {
     Map<String, Object> context = stage.getContext();
-
     Artifact manifestArtifact = resolveManifestArtifact(stage, context.get("manifest"));
     CloudFoundryManifestContext manifestContext =
         CloudFoundryManifestContext.builder()


### PR DESCRIPTION
Originally, when doing a CloudFoundry form-based manifest deployment, the form-based manifest would be set in the context under "manifest". This manifest object contains the actual details that are presented in the form. When this was passed to the resolveManifest method, it would try to map it to a StageContextArtifactView which contains an artifactId and an Artifact. This is then passed to artifactUtils.getBoundArtifactForStage(*) so that we can correctly resolve the manifest if its from a prior stage, statically typed in the stage, etc, etc. The problem was that when we tried to map a direct manifest (form-based) to the StageContextArtifactView, it would result in all its field being null, hence breaking. 

The fix is to use the pre-existing DeploymentManifest object and map the direct manifest to it. This will give us either the artifactId or the resolved artifact. The DeploymentManifest has logic to handle it out of the box. We then pass this object to the new resolverUtil that will allow the stage to resolve the manifest if its from a previous stage, etc. Also, rather than sharing the logic for the resolve method and mapping each artifact before-hand, I kept them separate so that we could throw an error thats specific to the artifact being resolved. 