### PR TITLE
fix(provider/cf): fix form based manifest resolution in deploy stage (#3752)

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryServerGroupCreator.java
@@ -19,11 +19,13 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.providers.cf;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestContext;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ManifestEvaluator;
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCreator;
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils;
 import java.util.Collections;
 import java.util.List;
@@ -46,8 +48,7 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
   @Override
   public List<Map> getOperations(StageExecution stage) {
     Map<String, Object> context = stage.getContext();
-
-    Artifact manifestArtifact = resolveArtifact(stage, context.get("manifest"));
+    Artifact manifestArtifact = resolveManifestArtifact(stage, context.get("manifest"));
     CloudFoundryManifestContext manifestContext =
         CloudFoundryManifestContext.builder()
             .source(ManifestContext.Source.Artifact)
@@ -60,6 +61,8 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
             .build();
     ManifestEvaluator.Result evaluatedManifest = manifestEvaluator.evaluate(stage, manifestContext);
 
+    Moniker moniker = buildMoniker(context);
+
     final PipelineExecution execution = stage.getExecution();
     ImmutableMap.Builder<String, Object> operation =
         ImmutableMap.<String, Object>builder()
@@ -69,8 +72,11 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
             .put("region", context.get("region"))
             .put("executionId", execution.getId())
             .put("trigger", execution.getTrigger().getOther())
-            .put("applicationArtifact", resolveArtifact(stage, context.get("applicationArtifact")))
-            .put("manifest", evaluatedManifest.getManifests());
+            .put(
+                "applicationArtifact",
+                resolveApplicationArtifact(stage, context.get("applicationArtifact")))
+            .put("manifest", evaluatedManifest.getManifests())
+            .put("moniker", moniker);
 
     if (context.get("stack") != null) {
       operation.put("stack", context.get("stack"));
@@ -84,7 +90,7 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
         ImmutableMap.<String, Object>builder().put(OPERATION, operation.build()).build());
   }
 
-  private Artifact resolveArtifact(StageExecution stage, Object input) {
+  private Artifact resolveApplicationArtifact(StageExecution stage, Object input) {
     StageContextArtifactView stageContextArtifactView =
         mapper.convertValue(input, StageContextArtifactView.class);
     Artifact artifact =
@@ -93,10 +99,39 @@ class CloudFoundryServerGroupCreator implements ServerGroupCreator {
             stageContextArtifactView.getArtifactId(),
             stageContextArtifactView.getArtifact());
     if (artifact == null) {
-      throw new IllegalArgumentException("Unable to bind the application artifact");
+      throw new IllegalArgumentException(
+          "Unable to bind the application artifact. Either the application artifact doesn't exist or this stage doesn't have access to fetch it");
     }
 
     return artifact;
+  }
+
+  private Artifact resolveManifestArtifact(StageExecution stage, Object input) {
+    DeploymentManifest manifest = mapper.convertValue(input, DeploymentManifest.class);
+    Artifact artifact =
+        artifactUtils.getBoundArtifactForStage(
+            stage, manifest.getArtifactId(), manifest.getArtifact());
+    if (artifact == null) {
+      throw new IllegalArgumentException(
+          "Unable to bind the manifest artifact. Either the manifest artifact doesn't exist or this stage doesn't have access to fetch it");
+    }
+
+    return artifact;
+  }
+
+  private Moniker buildMoniker(Map<String, Object> context) {
+    String app = context.get("application").toString();
+    String stack = (String) context.getOrDefault("stack", "");
+    String detail = (String) context.getOrDefault("freeFormDetails", "");
+
+    String cluster = app;
+    if (!stack.isEmpty()) {
+      cluster = cluster + "-" + stack;
+    }
+    if (!detail.isEmpty()) {
+      cluster = cluster + "-" + detail;
+    }
+    return MonikerHelper.friggaToMoniker(cluster);
   }
 
   @Override

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryDeployServerGroupTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryDeployServerGroupTaskTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.cf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CloudFoundryDeployServerGroupTaskTest {
+
+  private ObjectMapper mapper =
+      new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+  @Test
+  void mapperShouldConvertFormBasedManifest() {
+    DeploymentManifest.Direct direct = new DeploymentManifest.Direct();
+    direct.setBuildpacks(Collections.emptyList());
+    direct.setEnv(Collections.emptyMap());
+    direct.setEnvironment(Collections.emptyList());
+    direct.setRoutes(Collections.emptyList());
+    direct.setDiskQuota("1024M");
+    direct.setMemory("1024M");
+
+    Map<String, DeploymentManifest.Direct> input = ImmutableMap.of("direct", direct);
+
+    String manifestYmlBytes = Base64.getEncoder().encodeToString(direct.toManifestYml().getBytes());
+    DeploymentManifest result = mapper.convertValue(input, DeploymentManifest.class);
+    assertThat(result.getArtifact()).isNotNull();
+    assertThat(result.getArtifact().getReference()).isEqualTo(manifestYmlBytes);
+  }
+}

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryDeployServerGroupTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryDeployServerGroupTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2020 Armory, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Please see https://github.com/spinnaker/orca/pull/3752. 

Here is the breaking [commit](https://github.com/spinnaker/orca/commit/98152c833631a84203f700099149c955e4e4cbb1#diff-9c8b0013a03ef69b40307d50445a4acd)

The object mapping on line 50 was expecting an Artifact or/and an ArtifactId. The original was an actual manifest so it didn't map correctly. This would work fine with any deployments that weren't form based but all form based broke after this change. The new change uses the original working mapper wrapped in a method to add some error handling and more specific throwables. 

Co-authored-by: Zach Smith
Co-authored-by: Zach Smith
Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>