### PR TITLE
fix(provider/appengine): Fix for issue https://github.com/spinnaker/spinnaker/issues/5836 (Master branch)

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineServerGroupCreator.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AppEngineServerGroupCreator.groovy
@@ -75,7 +75,7 @@ class AppEngineServerGroupCreator implements ServerGroupCreator {
       List<ArtifactAccountPair> configArtifacts = operation.configArtifacts
       if (configArtifacts != null && configArtifacts.size() > 0) {
         operation.configArtifacts = configArtifacts.collect { artifactAccountPair ->
-          def artifact = artifactUtils.getBoundArtifactForStage(stage, artifactAccountPair.id, artifactAccountPair.artifact)
+          def artifact = artifactUtils.getBoundArtifactForStage(stage, artifactAccountPair.id, objectMapper.convertValue(artifactAccountPair.artifact, Artifact.class))
           return ArtifactUtils.withAccount(artifact, artifactAccountPair.account)
         }
       }


### PR DESCRIPTION
groovy.lang.MissingMethodException when referencing github config artifact for GAE deploy. The config artifacts  were of instance of HashMap not an Artifact object. Added logic to translate HashMap to Artifact.
