### PR TITLE
feat(plugins): Add plugin description and provider to PluginTrigger

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PluginTrigger.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PluginTrigger.kt
@@ -31,6 +31,8 @@ data class PluginTrigger
   private var isDryRun: Boolean = false,
   private var isStrategy: Boolean = false,
   val pluginId: String,
+  val description: String,
+  val provider: String,
   val version: String,
   val releaseDate: String,
   val requires: List<Map<String, String>>,

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/support/TriggerDeserializer.kt
@@ -153,6 +153,8 @@ class TriggerDeserializer :
           get("dryRun")?.booleanValue() == true,
           get("strategy")?.booleanValue() == true,
           get("pluginId").textValue(),
+          get("description").textValue(),
+          get("provider").textValue(),
           get("version").textValue(),
           get("releaseDate").textValue(),
           get("requires").listValue(parser),


### PR DESCRIPTION
It will be useful to have this data on the plugin trigger.

Related to:

https://github.com/spinnaker/igor/pull/793
https://github.com/spinnaker/echo/pull/949