### PR TITLE
Fixing mine canaries not waiting after disabling the canary clusters

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryDestroyClusterStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryDestroyClusterStage.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.mine.pipeline
+
+
+import com.netflix.spinnaker.orca.api.pipeline.CancellableStage
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
+import com.netflix.spinnaker.orca.mine.tasks.CleanupCanaryTask
+import com.netflix.spinnaker.orca.mine.tasks.CompleteCanaryTask
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import javax.annotation.Nonnull
+
+@Component
+class CanaryDestroyClusterStage implements StageDefinitionBuilder, CancellableStage {
+  public static final String STAGE_TYPE = "canaryDisableCluster"
+  @Autowired CanaryStage canaryStage
+
+  @Override
+  void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {
+    builder
+        .withTask("forceCacheRefresh", ServerGroupCacheForceRefreshTask)
+        .withTask("cleanupCanary", CleanupCanaryTask)
+        .withTask("monitorCleanup", MonitorKatoTask)
+        .withTask("completeCanary", CompleteCanaryTask)
+  }
+
+  @Override
+  Result cancel(StageExecution stage) {
+    StageExecution canaryStageInstance = stage.ancestors().find {
+      it.type == CanaryStage.PIPELINE_CONFIG_TYPE
+    }
+
+    if (!canaryStageInstance) {
+      throw new IllegalStateException("No upstream canary stage found (stageId: ${stage.id}, executionId: ${stage.execution.id})")
+    }
+
+    return canaryStage.cancel(canaryStageInstance)
+  }
+}

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryDisableClusterStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryDisableClusterStage.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.kayenta.pipeline
+
+import com.netflix.spinnaker.orca.api.pipeline.CancellableStage
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageGraphBuilder
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.mine.pipeline.CanaryDestroyClusterStage
+import com.netflix.spinnaker.orca.mine.pipeline.CanaryStage
+import com.netflix.spinnaker.orca.mine.tasks.DisableCanaryTask
+import com.netflix.spinnaker.orca.pipeline.WaitStage
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import javax.annotation.Nonnull
+
+import static com.netflix.spinnaker.orca.mine.pipeline.CanaryStage.DEFAULT_CLUSTER_DISABLE_WAIT_TIME
+
+@Component
+class CanaryDisableClusterStage implements StageDefinitionBuilder, CancellableStage {
+  public static final String STAGE_TYPE = "canaryDisableCluster"
+  @Autowired CanaryStage canaryStage
+  @Autowired WaitStage waitStage
+  @Autowired CanaryDestroyClusterStage canaryDestroyClusterStage
+
+  @Override
+  void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {
+    builder
+        .withTask("disableCanaryCluster", DisableCanaryTask)
+        .withTask("monitorDisable", MonitorKatoTask)
+        .withTask("disableBaselineCluster", DisableCanaryTask)
+        .withTask("monitorDisable", MonitorKatoTask)
+  }
+
+  @Override
+  void afterStages(StageExecution parent, StageGraphBuilder graph) {
+    Integer waitTime = parent.context.clusterDisableWaitTime != null ? stage.context.clusterDisableWaitTime : DEFAULT_CLUSTER_DISABLE_WAIT_TIME
+    graph.append {
+      it.type = waitStage.type
+      it.name = "Disable Canary and Baseline"
+      it.context = ["waitTime": waitTime]
+    }
+    graph.append {
+      it.type = canaryDestroyClusterStage.type
+      it.name = "Tear down Canary and Baseline"
+      it.context = parent.context
+    }
+  }
+
+  @Override
+  Result cancel(StageExecution stage) {
+    StageExecution canaryStageInstance = stage.ancestors().find {
+      it.type == CanaryStage.PIPELINE_CONFIG_TYPE
+    }
+
+    if (!canaryStageInstance) {
+      throw new IllegalStateException("No upstream canary stage found (stageId: ${stage.id}, executionId: ${stage.execution.id})")
+    }
+
+    return canaryStage.cancel(canaryStageInstance)
+  }
+}

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/DisableCanaryTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/DisableCanaryTask.groovy
@@ -30,8 +30,6 @@ import retrofit.RetrofitError
 
 import javax.annotation.Nonnull
 
-import static com.netflix.spinnaker.orca.mine.pipeline.CanaryStage.DEFAULT_CLUSTER_DISABLE_WAIT_TIME
-
 @Component
 @Slf4j
 class DisableCanaryTask extends AbstractCloudProviderAwareTask implements Task {
@@ -42,9 +40,6 @@ class DisableCanaryTask extends AbstractCloudProviderAwareTask implements Task {
   @Nonnull
   @Override
   TaskResult execute(@Nonnull StageExecution stage) {
-
-    Integer waitTime = stage.context.clusterDisableWaitTime != null ? stage.context.clusterDisableWaitTime : DEFAULT_CLUSTER_DISABLE_WAIT_TIME
-
     try {
       def canary = mineService.getCanary(stage.context.canary.id)
       if (canary.health?.health == 'UNHEALTHY' || stage.context.unhealthy != null) {
@@ -70,8 +65,7 @@ class DisableCanaryTask extends AbstractCloudProviderAwareTask implements Task {
     return TaskResult.builder(ExecutionStatus.SUCCEEDED).context([
       'kato.last.task.id'    : taskId,
       'deploy.server.groups' : dSG,
-      disabledCluster        : selector,
-      waitTime               : waitTime
+      disabledCluster        : selector
     ]).build()
   }
 }

--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryDestroyClusterStageSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryDestroyClusterStageSpec.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.mine.pipeline
+
+import com.netflix.spinnaker.orca.api.pipeline.CancellableStage
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
+import spock.lang.Specification
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class CanaryDestroyClusterStageSpec extends Specification {
+
+  def "should propagate cancel upstream if canary registered and execution explicitly canceled"() {
+    given:
+    def pipeline = pipeline {
+      stage {
+        refId = "1"
+        type = CanaryStage.PIPELINE_CONFIG_TYPE
+      }
+    }
+    def canaryStage = pipeline.stageByRef("1")
+    def canaryStageBuilder = Mock(CanaryStage)
+    def destroyCanaryClusterStage = new CanaryDestroyClusterStage(canaryStage: canaryStageBuilder)
+    def stage = new StageExecutionImpl(pipeline, "pipelineStage", [
+        canary: [id: "canaryId"]
+    ])
+    stage.setRequisiteStageRefIds(["1"])
+
+    when:
+    stage.execution.canceled = true
+    def result = destroyCanaryClusterStage.cancel(stage)
+
+    then:
+    result.details == [:]
+    1 * canaryStageBuilder.cancel(canaryStage) >> {
+      new CancellableStage.Result(stage, [:])
+    }
+  }
+
+  def "should raise exception if no upstream canary stage found"() {
+    def destroyClusterStage = new CanaryDestroyClusterStage()
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "pipelineStage", [
+        canary: [id: "canaryId"]
+    ])
+
+    when:
+    stage.execution.canceled = true
+    destroyClusterStage.cancel(stage)
+
+    then:
+    thrown(IllegalStateException)
+  }
+}

--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryDisableClusterStageSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/CanaryDisableClusterStageSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.mine.pipeline
+
+import com.netflix.spinnaker.orca.api.pipeline.CancellableStage
+import com.netflix.spinnaker.orca.kayenta.pipeline.CanaryDisableClusterStage
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
+import spock.lang.Specification
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class CanaryDisableClusterStageSpec extends Specification {
+
+  def "should propagate cancel upstream if canary registered and execution explicitly canceled"() {
+    given:
+    def pipeline = pipeline {
+      stage {
+        refId = "1"
+        type = CanaryStage.PIPELINE_CONFIG_TYPE
+      }
+    }
+    def canaryStage = pipeline.stageByRef("1")
+    def canaryStageBuilder = Mock(CanaryStage)
+    def destroyCanaryClusterStage = new CanaryDisableClusterStage(canaryStage: canaryStageBuilder)
+    def stage = new StageExecutionImpl(pipeline, "pipelineStage", [
+        canary: [id: "canaryId"]
+    ])
+    stage.setRequisiteStageRefIds(["1"])
+
+    when:
+    stage.execution.canceled = true
+    def result = destroyCanaryClusterStage.cancel(stage)
+
+    then:
+    result.details == [:]
+    1 * canaryStageBuilder.cancel(canaryStage) >> {
+      new CancellableStage.Result(stage, [:])
+    }
+  }
+
+  def "should raise exception if no upstream canary stage found"() {
+    def destroyClusterStage = new CanaryDisableClusterStage()
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "pipelineStage", [
+        canary: [id: "canaryId"]
+    ])
+
+    when:
+    stage.execution.canceled = true
+    destroyClusterStage.cancel(stage)
+
+    then:
+    thrown(IllegalStateException)
+  }
+}


### PR DESCRIPTION
This is to address RSLNC-365 and, in particular, mine canaries failing to wait after disabling the baseline and canary cluster. Ideally this would use the disableCluster stage. However it looked like that might require a larger refactor since Mine doesn't deploy things in a normal fashion and the disableCluster stage was silently filtering out the cluster I gave it.  
