### PR TITLE
fix(leak): fix metaspace leak form preconfigured jobs

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStage.groovy
@@ -76,14 +76,14 @@ class PreconfiguredJobStage extends RunJobStage {
     }
     preconfiguredJob.parameters.each { defaults ->
       if (defaults.defaultValue != null) {
-        Eval.xy(context, defaults.defaultValue, "x.${defaults.mapping} = y.toString()")
+        context[defaults.mapping] = defaults.defaultValue
       }
     }
     if (context.parameters) {
       context.parameters.each { k, v ->
         def parameterDefinition = preconfiguredJob.parameters.find { it.name == k }
         if (parameterDefinition) {
-          Eval.xy(context, v, "x.${parameterDefinition.mapping} = y.toString()")
+          context[parameterDefinition.mapping] = v.toString()
         }
       }
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStage.groovy
@@ -76,19 +76,32 @@ class PreconfiguredJobStage extends RunJobStage {
     }
     preconfiguredJob.parameters.each { defaults ->
       if (defaults.defaultValue != null) {
-        context[defaults.mapping] = defaults.defaultValue
+        setNestedValue(context, defaults.mapping, defaults.defaultValue)
       }
     }
     if (context.parameters) {
       context.parameters.each { k, v ->
         def parameterDefinition = preconfiguredJob.parameters.find { it.name == k }
         if (parameterDefinition) {
-          context[parameterDefinition.mapping] = v.toString()
+          setNestedValue(context, parameterDefinition.mapping, v.toString())
         }
       }
     }
     context.preconfiguredJobParameters = preconfiguredJob.parameters
     return context
+  }
+
+  private static void setNestedValue(Object root, String mapping, Object value) {
+    String[] props = mapping.split(/\./)
+    Object current = root
+    for (int i = 0; i < props.length - 1; i++) {
+      Object next = current[props[i]]
+      if (next == null) {
+        throw new IllegalArgumentException("no property ${props[i]} on $current")
+      }
+      current = next
+    }
+    current[props.last()] = value
   }
 
 }


### PR DESCRIPTION
Every execution of preconfigured job would run groovy.eval which in turn generates a script whose Klass stuffs is never released from metaspace
(similar issues: https://github.com/elastic/elasticsearch/issues/18572 and https://hoangx281283.wordpress.com/2014/07/24/unload-groovy-classes/)

Unclear why there is a need to run `eval` here anyway, so removing it all-together

