### PR TITLE
feat(pipeline executions/orca) : Added ability to add roles to manual judgment stage.

### DIFF
--- a/orca-echo/orca-echo.gradle
+++ b/orca-echo/orca-echo.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("javax.validation:validation-api")
   implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+  implementation("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
 
   testImplementation("com.squareup.retrofit:retrofit-mock")
 }

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.orca.echo.pipeline
 
+import com.netflix.spinnaker.fiat.model.Authorization
+import com.netflix.spinnaker.fiat.model.UserPermission
+import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
@@ -32,6 +35,7 @@ import com.netflix.spinnaker.security.User
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 
 @Component
 class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage {
@@ -72,18 +76,38 @@ class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage 
     @Autowired(required = false)
     EchoService echoService
 
+    @Autowired(required = false)
+    private FiatPermissionEvaluator fiatPermissionEvaluator
+
     @Override
     TaskResult execute(StageExecution stage) {
       StageData stageData = stage.mapTo(StageData)
+      def stageAuthorized = stage.context.get('isAuthorized')
+      def isTest = stage.context.get('isTest')
+      def stageRoles = stage.context.get('stageRoles')
+      def permissions = stage.context.get('permissions')
+      def username = stage.lastModified? stage.lastModified.user: ""
       String notificationState
       ExecutionStatus executionStatus
 
       switch (stageData.state) {
         case StageData.State.CONTINUE:
+          def flag = stageAuthorized || checkManualJudgmentAuthorizedGroups(stageRoles, permissions, username, isTest)
+          if(flag) {
+            stageAuthorized = true;
+          } else {
+            stageAuthorized = false;
+          }
           notificationState = "manualJudgmentContinue"
           executionStatus = ExecutionStatus.SUCCEEDED
           break
         case StageData.State.STOP:
+          def flag = stageAuthorized || checkManualJudgmentAuthorizedGroups(stageRoles, permissions, username, isTest)
+          if(flag) {
+            stageAuthorized = true;
+          } else {
+            stageAuthorized = false;
+          }
           notificationState = "manualJudgmentStop"
           executionStatus = ExecutionStatus.TERMINAL
           break
@@ -93,9 +117,64 @@ class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage 
           break
       }
 
+      if (!stageAuthorized) {
+        notificationState = "manualJudgment"
+        executionStatus = ExecutionStatus.RUNNING
+        stage.context.put("judgmentStatus", "")
+      }
       Map outputs = processNotifications(stage, stageData, notificationState)
 
       return TaskResult.builder(executionStatus).context(outputs).build()
+    }
+
+    boolean checkManualJudgmentAuthorizedGroups(def stageRoles, def permissions, def username, def isTest) {
+
+      if (isTest) {
+        return true
+      }
+      if (username) {
+        UserPermission.View permission = fiatPermissionEvaluator.getPermission(username);
+        if (permission == null) { // Should never happen?
+          return false;
+        }
+        // User has to have all the pipeline roles.
+        Set<Role.View> roleView = permission.getRoles()
+        def userRoles = []
+        roleView.each { it -> userRoles.add(it.getName().trim()) }
+        return checkAuthorizedGroups(userRoles, stageRoles, permissions)
+      } else {
+        return false
+      }
+    }
+
+    boolean checkAuthorizedGroups(def userRoles, def stageRoles, def permissions) {
+
+      def value = false
+      if (!stageRoles) {
+        return true
+      }
+      for (role in userRoles) {
+        if (stageRoles.contains(role)) {
+          for (perm in permissions) {
+            def permKey = perm.getKey()
+            List<String> strList = null
+            if (Authorization.CREATE.name().equals(permKey) ||
+                Authorization.EXECUTE.name().equals(permKey) ||
+                Authorization.WRITE.name().equals(permKey)) {
+              strList = perm.getValue()
+              if (strList && strList.contains(role)) {
+                return true
+              }
+            } else if (Authorization.READ.name().equals(permKey)) {
+              strList = perm.getValue()
+              if (strList && strList.contains(role)) {
+                value = false
+              }
+            }
+          }
+        }
+      }
+      return value
     }
 
     Map processNotifications(StageExecution stage, StageData stageData, String notificationState) {

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
@@ -42,10 +42,10 @@ class ManualJudgmentStageSpec extends Specification {
     where:
     context                      || expectedStatus
     [:]                          || ExecutionStatus.RUNNING
-    [judgmentStatus: "continue"] || ExecutionStatus.SUCCEEDED
-    [judgmentStatus: "Continue"] || ExecutionStatus.SUCCEEDED
-    [judgmentStatus: "stop"]     || ExecutionStatus.TERMINAL
-    [judgmentStatus: "STOP"]     || ExecutionStatus.TERMINAL
+    [judgmentStatus: "continue", isAuthorized: true, isTest: true] || ExecutionStatus.SUCCEEDED
+    [judgmentStatus: "Continue", isAuthorized: true, isTest: true] || ExecutionStatus.SUCCEEDED
+    [judgmentStatus: "stop", isAuthorized: true, isTest: true]     || ExecutionStatus.TERMINAL
+    [judgmentStatus: "STOP", isAuthorized: true, isTest: true]     || ExecutionStatus.TERMINAL
     [judgmentStatus: "unknown"]  || ExecutionStatus.RUNNING
   }
 
@@ -80,7 +80,9 @@ class ManualJudgmentStageSpec extends Specification {
       notifications: [
         new Notification(type: "email", address: "test@netflix.com", when: [ notificationState ])
       ],
-      judgmentStatus: judgmentStatus
+      judgmentStatus: judgmentStatus,
+      isAuthorized: true,
+      isTest: true
     ]))
 
     then:

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.orca.controllers
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.fiat.model.Authorization
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.shared.FiatService
@@ -30,6 +32,8 @@ import com.netflix.spinnaker.orca.exceptions.OperationFailedException
 import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.front50.PipelineModelMutator
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
+import com.netflix.spinnaker.orca.front50.model.Application
 import com.netflix.spinnaker.orca.igor.BuildService
 import com.netflix.spinnaker.orca.pipeline.ExecutionLauncher
 import com.netflix.spinnaker.orca.api.pipeline.models.Trigger
@@ -96,6 +100,9 @@ class OperationsController {
 
   @Autowired
   FiatStatus fiatStatus
+
+  @Autowired(required = false)
+  private FiatPermissionEvaluator fiatPermissionEvaluator
 
   @Autowired(required = false)
   FiatService fiatService
@@ -171,7 +178,7 @@ class OperationsController {
 
   private Map<String, Object> orchestratePipeline(Map pipeline) {
     def request = objectMapper.writeValueAsString(pipeline)
-
+    addStageAuthorizedRoles(request,pipeline)
     Exception pipelineError = null
     try {
       pipeline = parseAndValidatePipeline(pipeline)
@@ -195,6 +202,66 @@ class OperationsController {
       log.info("Failed to start pipeline {} based on request body {}", id, request)
       throw pipelineError
     }
+  }
+
+  private void addStageAuthorizedRoles(def request, Map pipeline) {
+
+    def applicationName = pipeline.application
+    if (applicationName) {
+      Application application = front50Service.get(applicationName)
+      if (application) {
+        def username = AuthenticatedRequest.getSpinnakerUser().orElse("")
+        def permissions = objectMapper.convertValue(application.getPermission().permissions.permissions,
+            new TypeReference<Map<String, Object>>() {})
+        UserPermission.View permission = fiatPermissionEvaluator.getPermission(username);
+        if (permission == null) { // Should never happen?
+          return;
+        }
+        // User has to have all the pipeline roles.
+        Set<Role.View> roleView = permission.getRoles()
+        def userRoles = []
+        roleView.each { it -> userRoles.add(it.getName().trim()) }
+        def stageList = pipeline.stages
+        def stageRoles = []
+        stageList.each { item ->
+          stageRoles = item.selectedStageRoles
+          item.isAuthorized = checkAuthorizedGroups(userRoles, stageRoles, permissions)
+          item.stageRoles = stageRoles
+          item.permissions = permissions
+        }
+      }
+    }
+  }
+
+  private boolean checkAuthorizedGroups(def userRoles, def stageRoles,
+                                        def permissions) {
+
+    def value = false
+    if (!stageRoles) {
+      return true
+    }
+    for (role in userRoles) {
+      if (stageRoles.contains(role)) {
+        for (perm in permissions) {
+          def permKey = perm.getKey()
+          List<String> strList = null
+          if (Authorization.CREATE.name().equals(permKey) ||
+              Authorization.EXECUTE.name().equals(permKey) ||
+              Authorization.WRITE.name().equals(permKey)) {
+            strList = perm.getValue()
+            if (strList && strList.contains(role)) {
+              return true
+            }
+          } else if (Authorization.READ.name().equals(permKey)) {
+            strList = perm.getValue()
+            if (strList && strList.contains(role)) {
+              value = false
+            }
+          }
+        }
+      }
+    }
+    return value
   }
 
   private void recordPipelineFailure(Map pipeline, String errorMessage) {


### PR DESCRIPTION
This is part of: spinnaker/spinnaker#4792.

Enhanced OperationsController.groovy to

Get the application roles, stage roles and the user roles.
Check each of the user roles whether they are contained in the stage and application roles.
Once the user role is contained in the manual judgment stage.
We check for whether the stage role has 'READ', 'WRITE', 'EXECUTE', 'CREATE' role in the application permissions,
if the role has application permission as 'READ', then the user will not be allowed to proceed further to subsequent(downstream) stages.
if the role has application permission as 'WRITE, EXECUTE,CREATE', then the user will be allowed to proceed further to subsequent stages.
If yes/no, set a isAuthorized flag to true/false in each of the stage. By default, all the stages except Manual Judgment are true.

Enhanced ManualJudgmentStage.groovy to

Check for the flag in ManualJudgmentStage.groovy whether to execute to the next stage or not.
If yes/no, continue with the next stages/continues running the same stage.

Enhanced ManualJudgmentStageSpec.groovy to

Modified the testcases as per the requirement.