### PR TITLE
fix(rollback): fix capacity casting

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
@@ -191,7 +191,7 @@ class ExplicitRollback implements Rollback {
     // let's directly produce a capacity with a pinned min instead of relying on the resize stage
     newRestoreCapacity.min = newRestoreCapacity.desired
 
-    ResizeStrategy.Capacity currentCapacity = restoreServerGroup.capacity
+    ResizeStrategy.Capacity currentCapacity = restoreServerGroup.getCapacity().asMap()
     if (currentCapacity == newRestoreCapacity) {
       log.info('Skipping resize stage because the current capacity of the restore server group {} would be unchanged ({})',
         restoreServerGroupName, newRestoreCapacity)


### PR DESCRIPTION
We were failing to rollback because Capacity also has an "isPinned" field ([here](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/Capacity.java#L20)). This fixes the casting so that it won't fail.