### PR TITLE
fix(log noise - mptv2): denoise some MPTv2 errors

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.front50.spring
 
 import com.netflix.spinnaker.fiat.shared.FiatStatus
+import com.netflix.spinnaker.kork.web.exceptions.ValidationException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
@@ -76,6 +77,10 @@ class DependentPipelineExecutionListener implements ExecutionListener {
        if (V2Util.isV2Pipeline(pipeline)) {
          try {
            return V2Util.planPipeline(contextParameterProcessor, executionPreprocessors, pipeline)
+         } catch (ValidationException ignored) {
+           // Really no point in logging this error out here - the user created a bad template, which has no relation
+           // to the currently executing pipeline
+           return null
          } catch (Exception e) {
            log.error("Failed to plan V2 templated pipeline {}", pipeline.getOrDefault("id", "<UNKNOWN ID>"), e)
            return null

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.PipelineMissingTemplateVariabledException
 import com.netflix.spinnaker.orca.pipelinetemplate.handler.DefaultHandlerChain
 import com.netflix.spinnaker.orca.pipelinetemplate.handler.GlobalPipelineTemplateContext
 import com.netflix.spinnaker.orca.pipelinetemplate.handler.PipelineTemplateContext
@@ -86,7 +87,11 @@ class PipelineTemplatePreprocessor
           throw IrrecoverableConditionException(t)
         }
 
-        log.error("Unexpected error occurred while processing template: ", context.getRequest().getId(), t)
+        // Missing variables is a very common error and not really an exception, just a user forgetting to specify all variables
+        // No point logging anything in this case - it's just noise
+        if (t !is PipelineMissingTemplateVariabledException) {
+          log.error("Unexpected error occurred while processing template: ", context.getRequest().getId(), t)
+        }
         context.getCaughtThrowables().add(t)
         chain.clear()
       }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/PipelineMissingTemplateVariabledException.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/exceptions/PipelineMissingTemplateVariabledException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.pipelinetemplate.exceptions;
+
+public class PipelineMissingTemplateVariabledException
+    extends IllegalTemplateConfigurationException {
+  public PipelineMissingTemplateVariabledException(String message) {
+    super(message);
+  }
+}

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/v2/transform/V2DefaultVariableAssignmentTransform.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/graph/v2/transform/V2DefaultVariableAssignmentTransform.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.v2.transform;
 
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.IllegalTemplateConfigurationException;
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.PipelineMissingTemplateVariabledException;
 import com.netflix.spinnaker.orca.pipelinetemplate.v2schema.V2PipelineTemplateVisitor;
 import com.netflix.spinnaker.orca.pipelinetemplate.v2schema.model.V2PipelineTemplate;
 import com.netflix.spinnaker.orca.pipelinetemplate.v2schema.model.V2TemplateConfiguration;
@@ -68,7 +69,7 @@ public class V2DefaultVariableAssignmentTransform implements V2PipelineTemplateV
             .collect(Collectors.toList());
 
     if (!missingVariables.isEmpty()) {
-      throw new IllegalTemplateConfigurationException(
+      throw new PipelineMissingTemplateVariabledException(
           "Missing variable values for: " + StringUtils.join(missingVariables, ", "));
     }
 


### PR DESCRIPTION
Currently, if there are any templated pipelines that are not fully specified (which is very common as users are iterating on pipeline design) planning those pipelines will generate lots of noise logs.
This is especially annoying when this is done as part of dependentpipeline starter and so it looks like an exception occurred during an execution when in fact it had nothing to do with this particular execution.

This change silences those logs for dependent pipeline starter, there will be a part 2 of this change where better logic is applied to `/v2/pipelineTemplates/plan` to not log exceptions for similar cases (this EP is called by echo alot)
