### PR TITLE
fix(redis): New a JedisPoolConfig instead of GenericObjectPoolConfig

### DIFF
--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/config/RedisConfiguration.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/config/RedisConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.*;
 import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.JedisPoolConfig;
 import rx.Scheduler;
 
 @Configuration
@@ -85,7 +86,7 @@ public class RedisConfiguration {
   @Bean
   @ConfigurationProperties("redis")
   public GenericObjectPoolConfig redisPoolConfig() {
-    GenericObjectPoolConfig config = new GenericObjectPoolConfig();
+    GenericObjectPoolConfig config = new JedisPoolConfig();
     config.setMaxTotal(100);
     config.setMaxIdle(100);
     config.setMinIdle(25);


### PR DESCRIPTION
Similarly to the change in Fiat (spinnaker/fiat#309) this switches us
over to using JedisPoolConfig. This, among other things, lowers the
minEvictableIdleTimeMillis to 60 sec from 30 min.
