### PR TITLE
feat(bake): Toggleable pausing for bake stage

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -17,22 +17,20 @@
 package com.netflix.spinnaker.orca.bakery.pipeline
 
 import com.google.common.base.Joiner
-import com.netflix.spinnaker.kork.exceptions.ConstraintViolationException
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
-import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
-import com.netflix.spinnaker.orca.api.pipeline.graph.StageGraphBuilder
-import com.netflix.spinnaker.orca.pipeline.StageExecutionFactory
-
-import java.time.Clock
-import javax.annotation.Nonnull
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import com.netflix.spinnaker.kork.exceptions.ConstraintViolationException
 import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageGraphBuilder
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.bakery.tasks.CompletedBakeTask
 import com.netflix.spinnaker.orca.bakery.tasks.CreateBakeTask
 import com.netflix.spinnaker.orca.bakery.tasks.MonitorBakeTask
-import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
-import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
+import com.netflix.spinnaker.orca.pipeline.StageExecutionFactory
+import com.netflix.spinnaker.orca.pipeline.tasks.ToggleablePauseTask
 import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask
 import com.netflix.spinnaker.orca.pipeline.util.RegionCollector
 import groovy.transform.CompileDynamic
@@ -41,6 +39,8 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import javax.annotation.Nonnull
+import java.time.Clock
 import java.util.stream.Collectors
 
 import static com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner.STAGE_BEFORE
@@ -53,12 +53,18 @@ import static java.time.ZoneOffset.UTC
 class BakeStage implements StageDefinitionBuilder {
 
   public static final String PIPELINE_CONFIG_TYPE = "bake"
+  public static final String BAKE_PAUSE_TOGGLE = "stages.bake-stage.pause"
+
+  private RegionCollector regionCollector
+  private Clock clock
+  private DynamicConfigService dynamicConfigService
 
   @Autowired
-  RegionCollector regionCollector
-
-  @Autowired
-  Clock clock = systemUTC()
+  BakeStage(RegionCollector regionCollector, DynamicConfigService dynamicConfigService, Clock clock = systemUTC()) {
+    this.regionCollector = regionCollector
+    this.clock = clock
+    this.dynamicConfigService = dynamicConfigService
+  }
 
   @Override
   void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {
@@ -66,6 +72,18 @@ class BakeStage implements StageDefinitionBuilder {
       builder
         .withTask("completeParallel", CompleteParallelBakeTask)
     } else {
+      if (dynamicConfigService.isEnabled(BAKE_PAUSE_TOGGLE, false)) {
+        log.info("Baking is currently paused. Adding pause task to ${stage.name} stage.")
+        stage.context.put("pauseToggle", BAKE_PAUSE_TOGGLE)
+        builder.withTask("pauseBake", ToggleablePauseTask)
+
+        if (stage.context.containsKey("stageTimeoutMs")) {
+          log.warn("Baking paused indefinitely based on ${BAKE_PAUSE_TOGGLE} toggle, " +
+              "but stage has timeout defined (${stage.context.stageTimeoutMs}ms). " +
+              "This pipeline may fail as a result.")
+        }
+      }
+
       builder
         .withTask("createBake", CreateBakeTask)
         .withTask("monitorBake", MonitorBakeTask)

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -74,8 +74,8 @@ class BakeStage implements StageDefinitionBuilder {
     } else {
       if (dynamicConfigService.isEnabled(BAKE_PAUSE_TOGGLE, false)) {
         log.info("Baking is currently paused. Adding pause task to ${stage.name} stage.")
-        stage.context.put("pauseToggle", BAKE_PAUSE_TOGGLE)
-        builder.withTask("pauseBake", ToggleablePauseTask)
+        stage.context.put("pauseToggleKey", BAKE_PAUSE_TOGGLE)
+        builder.withTask("delayBake", ToggleablePauseTask)
 
         if (stage.context.containsKey("stageTimeoutMs")) {
           log.warn("Baking paused indefinitely based on ${BAKE_PAUSE_TOGGLE} toggle, " +

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -76,12 +76,6 @@ class BakeStage implements StageDefinitionBuilder {
         log.info("Baking is currently paused. Adding pause task to ${stage.name} stage.")
         stage.context.put("pauseToggleKey", BAKE_PAUSE_TOGGLE)
         builder.withTask("delayBake", ToggleablePauseTask)
-
-        if (stage.context.containsKey("stageTimeoutMs")) {
-          log.warn("Baking paused indefinitely based on ${BAKE_PAUSE_TOGGLE} toggle, " +
-              "but stage has timeout defined (${stage.context.stageTimeoutMs}ms). " +
-              "This pipeline may fail as a result.")
-        }
       }
 
       builder

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
@@ -39,7 +39,7 @@ import static java.time.temporal.ChronoUnit.SECONDS
 
 class BakeStageSpec extends Specification {
   def dynamicConfigService = Mock(DynamicConfigService)
-  def regionCollector = Mock(RegionCollector)
+  def regionCollector = new RegionCollector()
   def builder = Mock(TaskNode.Builder)
 
   @Unroll
@@ -59,9 +59,8 @@ class BakeStageSpec extends Specification {
 
     def bakeStage = new StageExecutionImpl(pipeline, "bake", "Bake!", bakeStageContext + [refId: "1"])
     def builder = new BakeStage(
-      clock: Clock.fixed(EPOCH.plus(1, HOURS).plus(15, MINUTES).plus(12, SECONDS), UTC),
-      regionCollector: new RegionCollector()
-    )
+        regionCollector, dynamicConfigService,
+        Clock.fixed(EPOCH.plus(1, HOURS).plus(15, MINUTES).plus(12, SECONDS), UTC))
 
     when:
     def parallelContexts = builder.parallelContexts(bakeStage)
@@ -116,7 +115,7 @@ class BakeStageSpec extends Specification {
 
     def bakeStage = pipeline.stageById("1")
     def graph = StageGraphBuilderImpl.beforeStages(bakeStage)
-    new BakeStage(regionCollector: new RegionCollector()).beforeStages(bakeStage, graph)
+    new BakeStage(regionCollector, dynamicConfigService).beforeStages(bakeStage, graph)
     def parallelStages = graph.build()
 
     parallelStages.eachWithIndex { it, idx -> it.context.ami = idx + 1 }
@@ -149,7 +148,7 @@ class BakeStageSpec extends Specification {
 
     def bakeStage = pipeline.stageById("1")
     def graph = StageGraphBuilderImpl.beforeStages(bakeStage)
-    new BakeStage(regionCollector: new RegionCollector()).beforeStages(bakeStage, graph)
+    new BakeStage(regionCollector, dynamicConfigService).beforeStages(bakeStage, graph)
     def parallelStages = graph.build()
 
     parallelStages.eachWithIndex { it, idx ->
@@ -194,7 +193,7 @@ class BakeStageSpec extends Specification {
     for (stageId in ["1", "2"]) {
       def bakeStage = pipeline.stageById(stageId)
       def graph = StageGraphBuilderImpl.beforeStages(bakeStage)
-      new BakeStage(regionCollector: new RegionCollector()).beforeStages(bakeStage, graph)
+      new BakeStage(regionCollector, dynamicConfigService).beforeStages(bakeStage, graph)
       def childBakeStages = graph.build()
       childBakeStages.eachWithIndex { it, idx ->
         it.context.ami = "${idx}"
@@ -229,7 +228,7 @@ class BakeStageSpec extends Specification {
 
     def bakeStage = pipeline.stageById("1")
     def graph = StageGraphBuilderImpl.beforeStages(bakeStage)
-    new BakeStage(regionCollector: new RegionCollector()).beforeStages(bakeStage, graph)
+    new BakeStage(regionCollector, dynamicConfigService).beforeStages(bakeStage, graph)
     def parallelStages = graph.build()
 
     parallelStages.eachWithIndex { it, idx ->

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
@@ -259,7 +259,7 @@ class BakeStageSpec extends Specification {
 
     then:
     1 * dynamicConfigService.isEnabled(BakeStage.BAKE_PAUSE_TOGGLE, false) >> bakePauseToggle
-    expectedPauseTaskCount * builder.withTask("pauseBake", ToggleablePauseTask)
+    expectedPauseTaskCount * builder.withTask("delayBake", ToggleablePauseTask)
     _ * builder.withTask(*_) >> builder
 
     where:

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStageSpec.groovy
@@ -18,22 +18,29 @@ package com.netflix.spinnaker.orca.bakery.pipeline
 
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.exceptions.ConstraintViolationException
-
-import java.time.Clock
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilderImpl
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
+import com.netflix.spinnaker.orca.pipeline.tasks.ToggleablePauseTask
 import com.netflix.spinnaker.orca.pipeline.util.RegionCollector
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import java.time.Clock
+
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 import static java.time.Instant.EPOCH
 import static java.time.ZoneOffset.UTC
-import static java.time.temporal.ChronoUnit.*
+import static java.time.temporal.ChronoUnit.HOURS
+import static java.time.temporal.ChronoUnit.MINUTES
+import static java.time.temporal.ChronoUnit.SECONDS
 
 class BakeStageSpec extends Specification {
   def dynamicConfigService = Mock(DynamicConfigService)
+  def regionCollector = Mock(RegionCollector)
+  def builder = Mock(TaskNode.Builder)
 
   @Unroll
   def "should build contexts corresponding to locally specified bake region and all target deploy regions"() {
@@ -237,6 +244,29 @@ class BakeStageSpec extends Specification {
     with(taskResult.outputs) {
       deploymentDetails[0].amiName == "iwantthisname"
     }
+  }
+
+  @Unroll
+  def "should include a pause task when the bake pause toggle is ON"() {
+    given:
+    def bakeStage = new BakeStage(regionCollector, dynamicConfigService)
+    def stageExecution = stage {
+      id = "1"
+      parentStageId = 0
+    }
+
+    when:
+    bakeStage.taskGraph(stageExecution, builder)
+
+    then:
+    1 * dynamicConfigService.isEnabled(BakeStage.BAKE_PAUSE_TOGGLE, false) >> bakePauseToggle
+    expectedPauseTaskCount * builder.withTask("pauseBake", ToggleablePauseTask)
+    _ * builder.withTask(*_) >> builder
+
+    where:
+   bakePauseToggle | expectedPauseTaskCount
+   false           | 0
+   true            | 1
   }
 
   private

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTask.java
@@ -35,17 +35,13 @@ public class ToggleablePauseTask implements RetryableTask {
 
     if (pauseToggle != null && dynamicConfigService.isEnabled(pauseToggle, false)) {
       log.debug(
-          stage.getName()
-              + " stage currently paused based on "
-              + pauseToggle
-              + " toggle. Waiting...");
+          "{} stage currently paused based on {} toggle. Waiting...", stage.getName(), pauseToggle);
       return TaskResult.RUNNING;
     } else {
       log.debug(
-          stage.getName()
-              + " stage currently unpaused based on "
-              + pauseToggle
-              + " toggle. Carrying on...");
+          "{} stage currently unpaused based on {} toggle. Carrying on...",
+          stage.getName(),
+          pauseToggle);
       return TaskResult.SUCCEEDED;
     }
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTask.java
@@ -13,8 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * A task that just waits indefinitely based on a feature toggle specified in the `pauseToggleKey`
- * property of the stage context. Useful for pausing stages as part of migrations, for instance.
+ * A task that waits based on a feature toggle specified in the `pauseToggleKey` property of the
+ * stage context. Useful for pausing stages as part of migrations, for instance.
  */
 @Component
 public class ToggleablePauseTask implements RetryableTask {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTask.java
@@ -1,0 +1,62 @@
+package com.netflix.spinnaker.orca.pipeline.tasks;
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.orca.api.pipeline.RetryableTask;
+import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import java.time.Duration;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * A task that just waits indefinitely based on a feature toggle specified in the `pauseToggle`
+ * property of the stage context. Useful for pausing stages as part of migrations, for instance.
+ */
+@Component
+public class ToggleablePauseTask implements RetryableTask {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+  private DynamicConfigService dynamicConfigService;
+
+  @Autowired
+  public ToggleablePauseTask(DynamicConfigService dynamicConfigService) {
+    this.dynamicConfigService = dynamicConfigService;
+  }
+
+  @Override
+  @Nonnull
+  public TaskResult execute(@Nonnull final StageExecution stage) {
+    final String pauseToggle =
+        stage.getContext().containsKey("pauseToggle")
+            ? stage.getContext().get("pauseToggle").toString()
+            : null;
+
+    if (pauseToggle != null && dynamicConfigService.isEnabled(pauseToggle, false)) {
+      log.debug(
+          stage.getName()
+              + " stage currently paused based on "
+              + pauseToggle
+              + " toggle. Waiting...");
+      return TaskResult.RUNNING;
+    } else {
+      log.debug(
+          stage.getName()
+              + " stage currently unpaused based on "
+              + pauseToggle
+              + " toggle. Carrying on...");
+      return TaskResult.SUCCEEDED;
+    }
+  }
+
+  @Override
+  public long getBackoffPeriod() {
+    return Duration.ofMinutes(1).toMillis();
+  }
+
+  @Override
+  public long getTimeout() {
+    return Long.MAX_VALUE;
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTaskSpec.groovy
@@ -14,7 +14,7 @@ class ToggleablePauseTaskSpec extends Specification {
 
   def stage = stage {
     context = [
-        pauseToggle: 'my.test.toggle'
+        pauseToggleKey: 'my.test.toggle'
     ]
   }
 
@@ -23,7 +23,7 @@ class ToggleablePauseTaskSpec extends Specification {
 
   def "should return SUCCEEDED when pause toggle is missing"() {
     given:
-    stage.context.remove("pauseToggle")
+    stage.context.remove("pauseToggleKey")
 
     when:
     def result = task.execute(stage)

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTaskSpec.groovy
@@ -1,0 +1,56 @@
+package com.netflix.spinnaker.orca.pipeline.tasks
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class ToggleablePauseTaskSpec extends Specification {
+  static final String TOGGLE_NAME = "my.test.toggle"
+
+  def dynamicConfigService = Mock(DynamicConfigService)
+
+  def stage = stage {
+    context = [
+        pauseToggle: 'my.test.toggle'
+    ]
+  }
+
+  @Subject
+  def task = new ToggleablePauseTask(dynamicConfigService)
+
+  def "should return SUCCEEDED when pause toggle is missing"() {
+    given:
+    stage.context.remove("pauseToggle")
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    0 * dynamicConfigService.isEnabled(TOGGLE_NAME, false)
+
+    result.status == ExecutionStatus.SUCCEEDED
+  }
+
+  def "should return SUCCEEDED when pause toggle is false"() {
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * dynamicConfigService.isEnabled(TOGGLE_NAME, false) >> { return false }
+
+    result.status == ExecutionStatus.SUCCEEDED
+  }
+
+  def "should return RUNNING when pause toggle is true"() {
+    when:
+    def result = task.execute(stage)
+
+    then:
+    1 * dynamicConfigService.isEnabled(TOGGLE_NAME, false) >> { return true }
+
+    result.status == ExecutionStatus.RUNNING
+  }
+}


### PR DESCRIPTION
Introduces the ability to "pause" bakes through a feature toggle.

Pausing is achieved by the insertion of a simple task at the top of the list which waits until the feature toggle has been cleared. Note that turning on the feature flag will not affect currently running bakes, only those that start after it's been set.

The immediate need for this is to support our migration of the Bakery to ElasticSearch 6.x. It will require temporary "downtime" as we finish migrating the data, deploy the new server groups, and verify everything is OK. During that period, the plan is to use this toggle to pause all new bakes, then allow running bakes to complete, before the deployment. Once the migration is completed, we will "unpause".