### PR TITLE
refactor(core): Make task timeout methods return durations instead of longs

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/RetryableTask.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/RetryableTask.java
@@ -25,21 +25,31 @@ import java.time.Duration;
  */
 @Beta
 public interface RetryableTask extends Task {
-  /** TODO(rz): Use Duration. */
-  long getBackoffPeriod();
+  Duration getBackoffPeriod();
 
-  /** TODO(rz): Use Duration. */
-  long getTimeout();
+  Duration getTimeout();
 
-  default long getDynamicTimeout(StageExecution stage) {
+  default Duration getDynamicTimeout(StageExecution stage) {
     return getTimeout();
   }
 
-  default long getDynamicBackoffPeriod(Duration taskDuration) {
-    return getBackoffPeriod();
+  default Duration getDynamicBackoffPeriod(Duration taskDuration) {
+    Duration backoff = getBackoffPeriod();
+
+    if (backoff == null) {
+      backoff = Duration.ZERO;
+    }
+
+    return backoff;
   }
 
-  default long getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
-    return getDynamicBackoffPeriod(taskDuration);
+  default Duration getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
+    Duration result = getDynamicBackoffPeriod(taskDuration);
+
+    if (result == null) {
+      return Duration.ZERO;
+    }
+
+    return result;
   }
 }

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -41,14 +41,16 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 
+import java.time.Duration
+
 import static com.netflix.spinnaker.kork.web.selector.v2.SelectableService.*
 
 @Component
 @CompileStatic
 class CreateBakeTask implements RetryableTask {
 
-  long backoffPeriod = 30000
-  long timeout = 300000
+  Duration backoffPeriod = Duration.ofSeconds(30)
+  Duration timeout = Duration.ofMinutes(5)
 
   @Autowired
   ArtifactUtils artifactUtils

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -28,13 +28,15 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 
+import java.time.Duration
+
 @Slf4j
 @Component
 @CompileStatic
 class MonitorBakeTask implements OverridableTimeoutRetryableTask {
 
-  long backoffPeriod = 30000
-  long timeout = 3600000 // 1hr
+  Duration backoffPeriod = Duration.ofSeconds(30)
+  Duration timeout = Duration.ofHours(1)
 
   @Autowired(required = false)
   BakerySelector bakerySelector

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.orca.bakery.api.manifests.helm.HelmBakeManifestRequ
 import com.netflix.spinnaker.orca.bakery.api.manifests.kustomize.KustomizeBakeManifestRequest;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -46,13 +47,13 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class CreateBakeManifestTask implements RetryableTask {
   @Override
-  public long getBackoffPeriod() {
-    return 30000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(30);
   }
 
   @Override
-  public long getTimeout() {
-    return 300000;
+  public Duration getTimeout() {
+    return Duration.ofMinutes(5);
   }
 
   @Nullable private final BakeryService bakery;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
@@ -35,6 +35,8 @@ import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.time.Duration
+
 @Component
 @CompileStatic
 class ModifyAwsScalingProcessStage extends TargetServerGroupLinearStageSupport implements ForceCacheRefreshAware {
@@ -84,8 +86,8 @@ class ModifyAwsScalingProcessStage extends TargetServerGroupLinearStageSupport i
 
   @Component
   static class WaitForScalingProcess implements RetryableTask {
-    long timeout = 1200000
-    long backoffPeriod = 20000
+    Duration timeout = Duration.ofMinutes(20)
+    Duration backoffPeriod = Duration.ofSeconds(20)
 
     @Autowired
     OortHelper oortHelper

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/WaitForGceAutoscalingPolicyTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/gce/WaitForGceAutoscalingPolicyTask.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper;
+import java.time.Duration;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import lombok.Data;
@@ -32,13 +33,13 @@ public class WaitForGceAutoscalingPolicyTask implements RetryableTask {
   @Autowired private OortHelper oortHelper;
 
   @Override
-  public long getBackoffPeriod() {
-    return 20000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(20);
   }
 
   @Override
-  public long getTimeout() {
-    return 1200000;
+  public Duration getTimeout() {
+    return Duration.ofMinutes(20);
   }
 
   @Nonnull

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
@@ -28,13 +28,13 @@ import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
 import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.front50.model.Application;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,12 +148,12 @@ public class DetermineHealthProvidersTask implements RetryableTask, CloudProvide
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(5);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(5);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorCloudOperationTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorCloudOperationTask.java
@@ -33,12 +33,12 @@ public class MonitorCloudOperationTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return Duration.ofSeconds(5).toMillis();
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return Duration.ofHours(1).toMillis();
+  public Duration getTimeout() {
+    return Duration.ofHours(1);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
@@ -69,14 +69,14 @@ class MonitorKatoTask implements RetryableTask, CloudProviderAware {
     this.retrySupport = retrySupport
   }
 
-  long getBackoffPeriod() { 5000L }
+  Duration getBackoffPeriod() { return Duration.ofSeconds(5) }
 
-  long getTimeout() { 3600000L }
+  Duration getTimeout() { return Duration.ofHours(1) }
 
   @Override
-  long getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
+  Duration getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
     if ((stage.context."kato.task.lastStatus" as ExecutionStatus) == ExecutionStatus.TERMINAL) {
-      return Math.max(backoffPeriod, TimeUnit.MINUTES.toMillis(2))
+      return backoffPeriod > Duration.ofMinutes(2) ? backoffPeriod : Duration.ofMinutes(2)
     }
     return backoffPeriod
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/SubmitCloudOperationTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/SubmitCloudOperationTask.java
@@ -51,12 +51,12 @@ public class SubmitCloudOperationTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return Duration.ofSeconds(5).toMillis();
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return Duration.ofMinutes(1).toMillis();
+  public Duration getTimeout() {
+    return Duration.ofMinutes(1);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
@@ -34,6 +34,8 @@ import com.netflix.spinnaker.orca.kato.pipeline.CopyLastAsgStage
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
+import java.time.Duration
+
 /**
  * A task that operates on some subset of the ServerGroups in a cluster.
  */
@@ -41,13 +43,13 @@ import org.springframework.beans.factory.annotation.Autowired
 abstract class AbstractClusterWideClouddriverTask extends AbstractCloudProviderAwareTask implements RetryableTask {
 
   @Override
-  public long getBackoffPeriod() {
-    5000
+  Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5)
   }
 
   @Override
-  public long getTimeout() {
-    90000
+  Duration getTimeout() {
+    return Duration.ofSeconds(90)
   }
 
   abstract String getClouddriverOperation()

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
@@ -31,18 +31,20 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 
+import java.time.Duration
+
 abstract class AbstractWaitForClusterWideClouddriverTask extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
   private Logger log = LoggerFactory.getLogger(getClass())
 
   @Override
-  public long getBackoffPeriod() { 10000 }
+  public Duration getBackoffPeriod() { Duration.ofSeconds(10) }
 
   @Value('${tasks.wait-for-cluster-timeout-millis:1800000}')
   public long defaultTimeout
 
   @Override
-  public long getTimeout() {
-    return this.defaultTimeout
+  public Duration getTimeout() {
+    return Duration.ofMillis(this.defaultTimeout)
   }
 
   @Autowired

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTask.groovy
@@ -32,13 +32,15 @@ import retrofit.RetrofitError
 import retrofit.converter.ConversionException
 import retrofit.converter.JacksonConverter
 
+import java.time.Duration
+
 @Component
 class ClusterSizePreconditionTask extends AbstractCloudProviderAwareTask implements RetryableTask, PreconditionTask {
   public static final String PRECONDITION_TYPE = 'clusterSize'
 
   final String preconditionType = PRECONDITION_TYPE
-  final long backoffPeriod = 5000
-  final long timeout = 30000
+  final Duration backoffPeriod = Duration.ofSeconds(5)
+  final Duration timeout = Duration.ofSeconds(30)
 
   @Autowired
   OortService oortService

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
@@ -35,13 +35,13 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.RollbackServe
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.rollback.PreviousImageRollbackSupport;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -93,13 +93,13 @@ public class DetermineRollbackCandidatesTask extends AbstractCloudProviderAwareT
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(15);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(15);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(5);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(5);
   }
 
   @Nonnull

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -36,16 +36,23 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 
+import java.time.Duration
+
 @Component
 @Slf4j
 class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements RetryableTask {
 
   static String SUMMARY_TYPE = "Images"
 
-  final long backoffPeriod = 10000
+  final Duration backoffPeriod = Duration.ofSeconds(10)
 
   @Value('${tasks.find-image-from-cluster-timeout-millis:600000}')
-  long timeout
+  long configTimeout
+
+  @Override
+  Duration getTimeout() {
+    return Duration.ofMillis(configTimeout)
+  }
 
   static enum SelectionStrategy {
     /**

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/conditions/EvaluateConditionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/conditions/EvaluateConditionTask.java
@@ -31,7 +31,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -66,13 +65,13 @@ public class EvaluateConditionTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 3000L;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(3);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.SECONDS.toMillis(conditionsConfigurationProperties.getWaitTimeoutMs());
+  public Duration getTimeout() {
+    return Duration.ofMillis(conditionsConfigurationProperties.getWaitTimeoutMs());
   }
 
   @Nonnull

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/entitytags/BulkUpsertEntityTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/entitytags/BulkUpsertEntityTagsTask.java
@@ -22,10 +22,10 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -61,12 +61,12 @@ public class BulkUpsertEntityTagsTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(1);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(1);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/entitytags/DeleteEntityTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/entitytags/DeleteEntityTagsTask.java
@@ -23,10 +23,10 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -62,12 +62,12 @@ public class DeleteEntityTagsTask extends AbstractCloudProviderAwareTask impleme
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(1);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(1);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/entitytags/UpsertEntityTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/entitytags/UpsertEntityTagsTask.java
@@ -23,10 +23,10 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -62,12 +62,12 @@ public class UpsertEntityTagsTask extends AbstractCloudProviderAwareTask impleme
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(1);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(1);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/DeleteImageTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/DeleteImageTask.java
@@ -26,8 +26,8 @@ import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.image.DeleteImageStage;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.validation.ConstraintViolation;
@@ -90,12 +90,12 @@ public class DeleteImageTask extends AbstractCloudProviderAwareTask implements R
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(10);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(10);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(2);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(2);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/FindImageFromTagsTask.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -119,13 +120,13 @@ public class FindImageFromTagsTask extends AbstractCloudProviderAwareTask implem
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 10000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(10);
   }
 
   @Override
-  public long getTimeout() {
-    return this.findImageFromTagsTimeoutMillis;
+  public Duration getTimeout() {
+    return Duration.ofMillis(this.findImageFromTagsTimeoutMillis);
   }
 
   static class StageData {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/ImageForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/ImageForceCacheRefreshTask.java
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -52,12 +52,12 @@ public class ImageForceCacheRefreshTask extends AbstractCloudProviderAwareTask
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(5);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(5);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/MonitorDeleteImageTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/MonitorDeleteImageTask.java
@@ -24,8 +24,8 @@ import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.image.DeleteImageStage;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler;
+import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,12 +87,12 @@ public class MonitorDeleteImageTask extends AbstractCloudProviderAwareTask
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(5);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(5);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/UpsertImageTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/UpsertImageTagsTask.java
@@ -24,10 +24,10 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -97,12 +97,12 @@ public class UpsertImageTagsTask extends AbstractCloudProviderAwareTask implemen
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return upsertImageTagsTimeoutMillis;
+  public Duration getTimeout() {
+    return Duration.ofMillis(upsertImageTagsTimeoutMillis);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/WaitForUpsertedImageTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/image/WaitForUpsertedImageTagsTask.java
@@ -22,9 +22,9 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -57,13 +57,13 @@ public class WaitForUpsertedImageTagsTask implements RetryableTask, CloudProvide
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(30);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(30);
   }
 
   @Override
-  public long getTimeout() {
-    return this.waitForUpsertedImageTagsTimeoutMillis;
+  public Duration getTimeout() {
+    return Duration.ofMillis(this.waitForUpsertedImageTagsTimeoutMillis);
   }
 
   static class StageData {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTask.groovy
@@ -38,8 +38,8 @@ import retrofit.RetrofitError
 
 @Slf4j
 abstract class AbstractInstancesCheckTask extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
-  long backoffPeriod = TimeUnit.SECONDS.toMillis(10)
-  long timeout = TimeUnit.HOURS.toMillis(2)
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofHours(2)
   long serverGroupWaitTime = TimeUnit.MINUTES.toMillis(10)
 
   @Autowired
@@ -77,13 +77,13 @@ abstract class AbstractInstancesCheckTask extends AbstractCloudProviderAwareTask
   }
 
   @Override
-  long getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
+  Duration getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
     if (taskDuration.toMillis() > TimeUnit.MINUTES.toMillis(60)) {
       // task has been running > 60min, drop retry interval to every 2 minutes
-      return Math.max(backoffPeriod, TimeUnit.SECONDS.toMillis(120))
+      return (backoffPeriod.seconds > 120) ? backoffPeriod : Duration.ofSeconds(120)
     } else if (taskDuration.toMillis() > TimeUnit.MINUTES.toMillis(30)) {
       // task has been running > 30min, drop retry interval to every 60s
-      return Math.max(backoffPeriod, TimeUnit.SECONDS.toMillis(60))
+      return (backoffPeriod.seconds > 60) ? backoffPeriod : Duration.TimeUnit.SECONDS.toMillis(60)
     }
 
     return backoffPeriod

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractWaitForInstanceHealthChangeTask.groovy
@@ -24,9 +24,11 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import org.springframework.beans.factory.annotation.Autowired
 
+import java.time.Duration
+
 abstract class AbstractWaitForInstanceHealthChangeTask implements OverridableTimeoutRetryableTask {
-  long backoffPeriod = 5000
-  long timeout = 3600000
+  Duration backoffPeriod = Duration.ofSeconds(5)
+  Duration timeout = Duration.ofHours(1)
 
   @Autowired
   OortService oortService

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/CaptureInstanceUptimeTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/CaptureInstanceUptimeTask.groovy
@@ -29,11 +29,13 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.time.Duration
+
 @Slf4j
 @Component
 class CaptureInstanceUptimeTask extends AbstractCloudProviderAwareTask implements RetryableTask {
-  long backoffPeriod = 15000
-  long timeout = 300000
+  Duration backoffPeriod = Duration.ofSeconds(15)
+  Duration timeout = Duration.ofMinutes(5)
 
   @Autowired(required = false)
   InstanceUptimeCommand instanceUptimeCommand;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/VerifyInstanceUptimeTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/VerifyInstanceUptimeTask.groovy
@@ -29,11 +29,13 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.time.Duration
+
 @Slf4j
 @Component
 class VerifyInstanceUptimeTask extends AbstractCloudProviderAwareTask implements RetryableTask {
-  long backoffPeriod = 30000
-  long timeout = 600000
+  Duration backoffPeriod = Duration.ofSeconds(30)
+  Duration timeout = Duration.ofMinutes(10)
 
   @Autowired(required = false)
   InstanceUptimeCommand instanceUptimeCommand;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForTerminatedInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForTerminatedInstancesTask.groovy
@@ -27,12 +27,14 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.time.Duration
+
 @Slf4j
 @Component
 class WaitForTerminatedInstancesTask extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
 
-  long backoffPeriod = 10000
-  long timeout = 3600000
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofHours(1)
 
   @Autowired
   TerminatingInstanceSupport instanceSupport

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/RunJobTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/RunJobTask.groovy
@@ -43,8 +43,8 @@ class RunJobTask extends AbstractCloudProviderAwareTask implements RetryableTask
   @Autowired
   JobUtils jobUtils
 
-  long backoffPeriod = 2000
-  long timeout = 60000
+  Duration backoffPeriod = Duration.ofSeconds(2)
+  Duration timeout = Duration.ofMinutes(1)
 
   @Override
   @Nullable

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -42,8 +42,8 @@ import java.util.concurrent.TimeUnit
 public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
   private final Logger log = LoggerFactory.getLogger(getClass())
 
-  final long backoffPeriod = TimeUnit.SECONDS.toMillis(10)
-  final long timeout = TimeUnit.MINUTES.toMillis(120)
+  final Duration backoffPeriod = Duration.ofSeconds(10)
+  final Duration timeout = Duration.ofMinutes(120)
 
   @Autowired
   KatoRestService katoRestService
@@ -66,12 +66,12 @@ public class WaitOnJobCompletion extends AbstractCloudProviderAwareTask implemen
   static final Duration PROVIDER_PADDING = Duration.ofMinutes(5)
 
   @Override
-  long getDynamicTimeout(@Nonnull StageExecution stage) {
+  Duration getDynamicTimeout(@Nonnull StageExecution stage) {
     String jobTimeoutFromProvider = (stage.context.get("jobRuntimeLimit") as String)
 
     if (jobTimeoutFromProvider != null) {
       try {
-        return Duration.parse(jobTimeoutFromProvider).plus(PROVIDER_PADDING).toMillis()
+        return Duration.parse(jobTimeoutFromProvider).plus(PROVIDER_PADDING)
       } catch (DateTimeParseException e) {
         log.warn("Failed to parse job timeout specified by provider: '${jobTimeoutFromProvider}', using default", e)
       }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/launchconfigurations/DeleteLaunchConfigurationTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/launchconfigurations/DeleteLaunchConfigurationTask.java
@@ -26,11 +26,11 @@ import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.launchconfigurations.DeleteLaunchConfigurationStage.DeleteLaunchConfigurationRequest;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -77,12 +77,12 @@ public class DeleteLaunchConfigurationTask extends AbstractCloudProviderAwareTas
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(10);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(10);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(2);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(2);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTask.groovy
@@ -79,24 +79,24 @@ public class UpsertLoadBalancerForceRefreshTask extends AbstractCloudProviderAwa
   }
 
   @Override
-  long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(10)
+  Duration getTimeout() {
+    return Duration.ofMinutes(10)
   }
 
   @Override
-  long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5)
+  Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5)
   }
 
   @Override
-  long getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
+  Duration getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
     LBUpsertContext context = stage.mapTo(LBUpsertContext.class)
     if (context.refreshState.seenPendingCacheUpdates) {
       return getBackoffPeriod()
     } else {
       // Some LB types don't support onDemand updates and we'll never observe a pending update for their keys,
       // this ensures quicker short circuiting in that case.
-      return TimeUnit.SECONDS.toMillis(1)
+      return Duration.ofSeconds(1)
     }
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerTask.groovy
@@ -26,19 +26,21 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTa
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.time.Duration
+
 @Component
 class UpsertLoadBalancerTask extends AbstractCloudProviderAwareTask implements RetryableTask {
 
   static final String CLOUD_OPERATION_TYPE = "upsertLoadBalancer"
 
   @Override
-  long getBackoffPeriod() {
-    return 2000
+  Duration getBackoffPeriod() {
+    return Duration.ofSeconds(2)
   }
 
   @Override
-  long getTimeout() {
-    return 60000
+  Duration getTimeout() {
+    return Duration.ofMinutes(1)
   }
 
   @Autowired

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancersTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancersTask.groovy
@@ -26,6 +26,8 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTa
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.time.Duration
+
 /*
  * Task that can create multiple load balancers
  */
@@ -35,13 +37,13 @@ class UpsertLoadBalancersTask extends AbstractCloudProviderAwareTask implements 
   static final String CLOUD_OPERATION_TYPE = "upsertLoadBalancer"
 
   @Override
-  long getBackoffPeriod() {
-    return 2000
+  Duration getBackoffPeriod() {
+    return Duration.ofSeconds(2)
   }
 
   @Override
-  long getTimeout() {
-    return 300000
+  Duration getTimeout() {
+    return Duration.ofMinutes(5)
   }
 
   @Autowired

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestForceCacheRefreshTask.java
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheStatusService;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import java.io.IOException;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -56,8 +57,8 @@ public class ManifestForceCacheRefreshTask extends AbstractCloudProviderAwareTas
   private static final String REFRESH_TYPE = "manifest";
   public static final String TASK_NAME = "forceCacheRefresh";
 
-  @Getter private final long backoffPeriod = TimeUnit.SECONDS.toMillis(10);
-  @Getter private final long timeout = TimeUnit.MINUTES.toMillis(15);
+  @Getter private final Duration backoffPeriod = Duration.ofSeconds(10);
+  @Getter private final Duration timeout = Duration.ofMinutes(15);
 
   private final long autoSucceedAfterMs = TimeUnit.MINUTES.toMillis(12);
   private final Clock clock;

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTask.java
@@ -26,10 +26,10 @@ import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.clouddriver.model.Manifest;
 import com.netflix.spinnaker.orca.clouddriver.model.Manifest.Status;
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,13 +46,13 @@ public class WaitForManifestStableTask
   private final OortService oortService;
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(30);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(30);
   }
 
   @Nonnull

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/MonitoredDeployBaseTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/MonitoredDeployBaseTask.java
@@ -34,7 +34,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -74,31 +73,31 @@ public class MonitoredDeployBaseTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.MINUTES.toMillis(1);
+  public Duration getBackoffPeriod() {
+    return Duration.ofMinutes(1);
   }
 
   @Override
-  public long getTimeout() {
+  public Duration getTimeout() {
     // NOTE: This is not used since we override getDynamicTimeout
-    return 0;
+    return Duration.ZERO;
   }
 
   @Override
-  public long getDynamicTimeout(StageExecution stage) {
+  public Duration getDynamicTimeout(StageExecution stage) {
     MonitoredDeployInternalStageData stageData =
         stage.mapTo(MonitoredDeployInternalStageData.class);
 
     // If stage has an override, use that
     Integer stageOverride = stageData.getDeploymentMonitor().getMaxAnalysisMinutesOverride();
     if ((stageOverride != null) && (stageOverride > 0)) {
-      return Duration.ofMinutes(stageOverride).toMillis();
+      return Duration.ofMinutes(stageOverride);
     }
 
     DeploymentMonitorDefinition monitorDefinition = getDeploymentMonitorDefinition(stage);
 
     try {
-      return Duration.ofMinutes(monitorDefinition.getMaxAnalysisMinutes()).toMillis();
+      return Duration.ofMinutes(monitorDefinition.getMaxAnalysisMinutes());
     } catch (Exception e) {
       log.error(
           "Failed to compute timeout for {}, returning {} min",
@@ -106,8 +105,7 @@ public class MonitoredDeployBaseTask implements RetryableTask {
           DeploymentMonitorDefinition.DEFAULT_MAX_ANALYSIS_MINUTES,
           e);
 
-      return Duration.ofMinutes(DeploymentMonitorDefinition.DEFAULT_MAX_ANALYSIS_MINUTES)
-          .toMillis();
+      return Duration.ofMinutes(DeploymentMonitorDefinition.DEFAULT_MAX_ANALYSIS_MINUTES);
     }
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AbstractWaitForAppEngineServerGroupStopStartTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/AbstractWaitForAppEngineServerGroupStopStartTask.groovy
@@ -29,10 +29,12 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import retrofit.RetrofitError
 
+import java.time.Duration
+
 @Slf4j
 abstract class AbstractWaitForAppEngineServerGroupStopStartTask extends AbstractCloudProviderAwareTask implements RetryableTask {
-  long backoffPeriod = 10000
-  long timeout = 1800000
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofMinutes(30)
 
   @Autowired
   OortService oortService

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/UpsertAppEngineLoadBalancersTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/UpsertAppEngineLoadBalancersTask.groovy
@@ -29,19 +29,21 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTa
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.time.Duration
+
 @Component
 class UpsertAppEngineLoadBalancersTask extends AbstractCloudProviderAwareTask implements RetryableTask {
   static final String CLOUD_OPERATION_TYPE = "upsertLoadBalancer"
   static final String CLOUD_PROVIDER = "appengine"
 
   @Override
-  long getBackoffPeriod() {
-    return 2000
+  Duration getBackoffPeriod() {
+    return Duration.ofSeconds(2)
   }
 
   @Override
-  long getTimeout() {
-    return 300000
+  Duration getTimeout() {
+    return Duration.ofMinutes(5)
   }
 
   @Autowired

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/CloudFormationForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/CloudFormationForceCacheRefreshTask.java
@@ -21,10 +21,10 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -37,8 +37,8 @@ public class CloudFormationForceCacheRefreshTask extends AbstractCloudProviderAw
 
   @Autowired CloudDriverCacheService cacheService;
 
-  private final long backoffPeriod = TimeUnit.SECONDS.toMillis(10);
-  private final long timeout = TimeUnit.MINUTES.toMillis(5);
+  private final Duration backoffPeriod = Duration.ofSeconds(10);
+  private final Duration timeout = Duration.ofMinutes(5);
 
   @Override
   public TaskResult execute(@Nonnull StageExecution stage) {
@@ -70,12 +70,12 @@ public class CloudFormationForceCacheRefreshTask extends AbstractCloudProviderAw
   }
 
   @Override
-  public long getBackoffPeriod() {
+  public Duration getBackoffPeriod() {
     return backoffPeriod;
   }
 
   @Override
-  public long getTimeout() {
+  public Duration getTimeout() {
     return timeout;
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/EvaluateCloudFormationChangeSetExecutionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/EvaluateCloudFormationChangeSetExecutionTask.java
@@ -20,11 +20,11 @@ import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -67,13 +67,13 @@ public class EvaluateCloudFormationChangeSetExecutionTask
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 1_000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(1);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.DAYS.toMillis(3);
+  public Duration getTimeout() {
+    return Duration.ofDays(3);
   }
 
   private Optional getChangeSetExecutionChoice(StageExecution stage) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTask.java
@@ -20,12 +20,12 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,8 +38,8 @@ import retrofit.RetrofitError;
 public class WaitForCloudFormationCompletionTask implements OverridableTimeoutRetryableTask {
 
   public static final String TASK_NAME = "waitForCloudFormationCompletion";
-  private final long backoffPeriod = TimeUnit.SECONDS.toMillis(10);
-  private final long timeout = TimeUnit.HOURS.toMillis(2);
+  private final Duration backoffPeriod = Duration.ofSeconds(10);
+  private final Duration timeout = Duration.ofHours(2);
   @Autowired private OortService oortService;
 
   @Nonnull
@@ -106,12 +106,12 @@ public class WaitForCloudFormationCompletionTask implements OverridableTimeoutRe
   }
 
   @Override
-  public long getBackoffPeriod() {
+  public Duration getBackoffPeriod() {
     return backoffPeriod;
   }
 
   @Override
-  public long getTimeout() {
+  public Duration getTimeout() {
     return timeout;
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTask.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.orca.clouddriver.model.Task;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import groovy.transform.CompileStatic;
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -46,13 +47,13 @@ public class CloudFoundryMonitorKatoServicesTask extends AbstractCloudProviderAw
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 10 * 1000L;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(10);
   }
 
   @Override
-  public long getTimeout() {
-    return 30 * 60 * 1000L;
+  public Duration getTimeout() {
+    return Duration.ofMinutes(30);
   }
 
   @Nonnull

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/UpsertScalingPolicyTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/UpsertScalingPolicyTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.scalingpolicy
 
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask
@@ -35,8 +36,8 @@ class UpsertScalingPolicyTask extends AbstractCloudProviderAwareTask implements 
   @Autowired
   KatoService kato
 
-  long backoffPeriod = TimeUnit.SECONDS.toMillis(5)
-  long timeout = TimeUnit.SECONDS.toMillis(100)
+  Duration backoffPeriod = Duration.ofSeconds(5)
+  Duration timeout = Duration.ofSeconds(100)
 
   @Override
   TaskResult execute(StageExecution stage) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/WaitForUpsertedSecurityGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/WaitForUpsertedSecurityGroupTask.groovy
@@ -25,11 +25,13 @@ import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.time.Duration
+
 @Component
 class WaitForUpsertedSecurityGroupTask implements RetryableTask, CloudProviderAware {
 
-  long backoffPeriod = 1000
-  long timeout = 600000
+  Duration backoffPeriod = Duration.ofSeconds(1)
+  Duration timeout = Duration.ofMinutes(10)
 
   @Autowired
   List<SecurityGroupUpserter> securityGroupUpserters

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractBulkServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractBulkServerGroupTask.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Targe
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper;
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -49,13 +50,13 @@ public abstract class AbstractBulkServerGroupTask extends AbstractCloudProviderA
   abstract String getClouddriverOperation();
 
   @Override
-  public long getBackoffPeriod() {
-    return 10000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(10);
   }
 
   @Override
-  public long getTimeout() {
-    return 10000;
+  public Duration getTimeout() {
+    return Duration.ofSeconds(10);
   }
 
   @Override

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AbstractServerGroupTask.groovy
@@ -31,16 +31,18 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTa
 import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper
 import org.springframework.beans.factory.annotation.Autowired
 
+import java.time.Duration
+
 abstract class AbstractServerGroupTask extends AbstractCloudProviderAwareTask implements RetryableTask {
 
   @Override
-  long getBackoffPeriod() {
-    return 2000
+  Duration getBackoffPeriod() {
+    return Duration.ofSeconds(2)
   }
 
   @Override
-  long getTimeout() {
-    return 90000
+  Duration getTimeout() {
+    return Duration.ofSeconds(90)
   }
 
   @Autowired

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/AddServerGroupEntityTagsTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
@@ -33,8 +34,8 @@ import org.springframework.stereotype.Component
 @Component
 @Slf4j
 class AddServerGroupEntityTagsTask extends AbstractCloudProviderAwareTask implements RetryableTask {
-  long backoffPeriod = TimeUnit.SECONDS.toMillis(30)
-  long timeout = TimeUnit.MINUTES.toMillis(15)
+  Duration backoffPeriod = Duration.ofSeconds(30)
+  Duration timeout = Duration.ofMinutes(15)
 
   @Autowired
   KatoService kato

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkWaitForDestroyedServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/BulkWaitForDestroyedServerGroupTask.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTa
 import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
 import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -128,12 +129,12 @@ public class BulkWaitForDestroyedServerGroupTask extends AbstractCloudProviderAw
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 5000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return 10000;
+  public Duration getTimeout() {
+    return Duration.ofSeconds(10);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CreateServerGroupTask.groovy
@@ -27,6 +27,8 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.time.Duration
+
 @Slf4j
 @Component
 class CreateServerGroupTask extends AbstractCloudProviderAwareTask implements RetryableTask {
@@ -37,8 +39,8 @@ class CreateServerGroupTask extends AbstractCloudProviderAwareTask implements Re
   @Autowired
   List<ServerGroupCreator> serverGroupCreators
 
-  long backoffPeriod = 2000
-  long timeout = 60000
+  Duration backoffPeriod = Duration.ofSeconds(2)
+  Duration timeout = Duration.ofMinutes(1)
 
   @Override
   TaskResult execute(StageExecution stage) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
@@ -21,6 +21,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
 import java.time.Clock
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -47,8 +48,8 @@ class ServerGroupCacheForceRefreshTask extends AbstractCloudProviderAwareTask im
 
   private final Id cacheForceRefreshTaskId
 
-  long backoffPeriod = TimeUnit.SECONDS.toMillis(10)
-  long timeout = TimeUnit.MINUTES.toMillis(15)
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofMinutes(15)
 
   long autoSucceedAfterMs = TimeUnit.MINUTES.toMillis(12)
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDestroyedServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDestroyedServerGroupTask.groovy
@@ -30,11 +30,13 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 
+import java.time.Duration
+
 @Slf4j
 @Component
 class WaitForDestroyedServerGroupTask extends AbstractCloudProviderAwareTask implements RetryableTask {
-  long backoffPeriod = 10000
-  long timeout = 1800000
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofMinutes(30)
 
   @Autowired
   OortService oortService

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servicebroker/AbstractWaitForServiceTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servicebroker/AbstractWaitForServiceTask.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import java.time.Duration;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
@@ -34,13 +35,13 @@ public abstract class AbstractWaitForServiceTask extends AbstractCloudProviderAw
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 10 * 1000L;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(10);
   }
 
   @Override
-  public long getTimeout() {
-    return 30 * 60 * 1000L;
+  public Duration getTimeout() {
+    return Duration.ofMinutes(30);
   }
 
   @Nonnull

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/snapshot/DeleteSnapshotTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/snapshot/DeleteSnapshotTask.java
@@ -26,11 +26,11 @@ import com.netflix.spinnaker.orca.clouddriver.KatoService;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.snapshot.DeleteSnapshotStage;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -74,12 +74,12 @@ public class DeleteSnapshotTask extends AbstractCloudProviderAwareTask implement
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(10);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(10);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(2);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(2);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/strategy/DetermineSourceServerGroupTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.kato.pipeline.strategy
 
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask
@@ -39,10 +40,10 @@ class DetermineSourceServerGroupTask implements RetryableTask {
   static final int MAX_ATTEMPTS = 10
   static final int MIN_CONSECUTIVE_404 = 3
 
-  final long backoffPeriod = TimeUnit.SECONDS.toMillis(5)
+  final Duration backoffPeriod = Duration.ofSeconds(5)
 
   // not expecting to timeout, we will fail after MAX_ATTEMPTS:
-  final long timeout = TimeUnit.SECONDS.toMillis(300)
+  final Duration timeout = Duration.ofSeconds(300)
 
   @Autowired
   SourceResolver sourceResolver

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DetachInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/DetachInstancesTask.groovy
@@ -29,12 +29,14 @@ import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+import java.time.Duration
+
 @Component
 class DetachInstancesTask implements RetryableTask, CloudProviderAware {
 
-  final long backoffPeriod = 5000
+  final Duration backoffPeriod = Duration.ofSeconds(5)
 
-  final long timeout = 30000
+  final Duration timeout = Duration.ofSeconds(30)
 
   @Autowired
   KatoService kato

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.kato.tasks
 
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.regex.Matcher
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -50,8 +51,8 @@ class JarDiffsTask implements DiffTask {
 
   private static final int MAX_RETRIES = 10
 
-  long backoffPeriod = 10000
-  long timeout = TimeUnit.MINUTES.toMillis(5) // always set this higher than retries * backoffPeriod would take
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofMinutes(5) // always set this higher than retries * backoffPeriod would take
 
   @Autowired
   ComparableLooseVersion comparableLooseVersion

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/InstanceHealthCheckTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/InstanceHealthCheckTask.groovy
@@ -27,12 +27,14 @@ import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 import retrofit.client.Client
 
+import java.time.Duration
+
 @Component
 class InstanceHealthCheckTask extends AbstractQuipTask implements RetryableTask  {
   @Autowired ObjectMapper objectMapper
 
-  long backoffPeriod = 10000
-  long timeout = 3600000 // 60min
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofHours(1)
 
   @Autowired
   OortHelper oortHelper

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/MonitorQuipTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/MonitorQuipTask.groovy
@@ -26,14 +26,16 @@ import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 import retrofit.client.Client
 
+import java.time.Duration
+
 @Component
 class MonitorQuipTask extends AbstractQuipTask implements RetryableTask {
   @Autowired ObjectMapper objectMapper
 
   @Autowired Client retrofitClient
 
-  long backoffPeriod = 10000
-  long timeout = 1200000 // 20mins
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofMinutes(20)
 
   /**
    * TODO: make this more efficient by only polling the instances which are not done.

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/ResolveQuipVersionTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/ResolveQuipVersionTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.kato.tasks.quip
 
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
@@ -34,9 +35,9 @@ import org.springframework.stereotype.Component
 @Component
 class ResolveQuipVersionTask implements RetryableTask {
 
-  final long backoffPeriod = TimeUnit.SECONDS.toMillis(5)
+  final Duration backoffPeriod = Duration.ofSeconds(5)
 
-  final long timeout = TimeUnit.SECONDS.toMillis(30)
+  final Duration timeout = Duration.ofSeconds(30)
 
   @Autowired(required = false)
   BakeryService bakeryService

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTask.groovy
@@ -28,6 +28,8 @@ import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 import retrofit.client.Client
 
+import java.time.Duration
+
 @Component
 @Slf4j
 class TriggerQuipTask extends AbstractQuipTask implements RetryableTask {
@@ -41,8 +43,8 @@ class TriggerQuipTask extends AbstractQuipTask implements RetryableTask {
 
   long instanceVersionSleep = DEFAULT_INSTANCE_VERSION_SLEEP
 
-  long backoffPeriod = 10000
-  long timeout = 600000 // 10min
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofMinutes(10)
 
   @Override
   TaskResult execute(StageExecution stage) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/CleanUpTagsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/CleanUpTagsTask.java
@@ -29,8 +29,8 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTa
 import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
 import com.netflix.spinnaker.orca.kato.pipeline.support.SourceResolver;
 import com.netflix.spinnaker.orca.kato.pipeline.support.StageData;
+import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -144,12 +144,12 @@ public class CleanUpTagsTask extends AbstractCloudProviderAwareTask implements R
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(5);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(5);
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/WaitForNewUpInstancesLaunchTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/WaitForNewUpInstancesLaunchTask.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.utils.HealthHelper
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
@@ -36,9 +37,9 @@ class WaitForNewUpInstancesLaunchTask implements OverridableTimeoutRetryableTask
   @Autowired ObjectMapper objectMapper
   @Autowired(required = false) List<ServerGroupInstanceIdCollector> serverGroupInstanceIdCollectors = []
 
-  long getBackoffPeriod() { TimeUnit.SECONDS.toMillis(10) }
+  Duration getBackoffPeriod() { Duration.ofSeconds(10) }
 
-  long getTimeout() { TimeUnit.HOURS.toMillis(2) }
+  Duration getTimeout() { Duration.ofHours(2) }
 
   @Override
   TaskResult execute(StageExecution stage) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/EvaluateDeploymentHealthTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/monitoreddeploy/EvaluateDeploymentHealthTaskSpec.groovy
@@ -32,6 +32,7 @@ import spock.lang.Specification
 import com.netflix.spinnaker.orca.deploymentmonitor.DeploymentMonitorServiceProvider
 import spock.lang.Unroll
 
+import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
@@ -155,15 +156,15 @@ class EvaluateDeploymentHealthTaskSpec extends Specification {
     def stage = new StageExecutionImpl(pipe, "evaluateDeploymentHealth", stageData.toContextMap() + [application: pipe.application])
 
     then:
-    task.getTimeout() == 0
-    task.getDynamicTimeout(stage) == TimeUnit.MINUTES.toMillis(15)
+    task.getTimeout() == Duration.ZERO
+    task.getDynamicTimeout(stage) == Duration.ofMinutes(15)
 
     when: 'stage override is provided'
     stageData.deploymentMonitor.maxAnalysisMinutesOverride = new Integer(21)
     stage = new StageExecutionImpl(pipe, "evaluateDeploymentHealth", stageData.toContextMap() + [application: pipe.application])
 
     then:
-    task.getDynamicTimeout(stage) == TimeUnit.MINUTES.toMillis(21)
+    task.getDynamicTimeout(stage) == Duration.ofMinutes(21)
   }
 
   @Unroll

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletionTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletionTest.java
@@ -39,7 +39,7 @@ public final class WaitOnJobCompletionTest {
     StageExecutionImpl myStage =
         createStageWithContext(ImmutableMap.of("jobRuntimeLimit", duration.toString()));
     assertThat(task.getDynamicTimeout(myStage))
-        .isEqualTo((duration.plus(WaitOnJobCompletion.getPROVIDER_PADDING())).toMillis());
+        .isEqualTo((duration.plus(WaitOnJobCompletion.getPROVIDER_PADDING())));
 
     StageExecutionImpl myStageInvalid =
         createStageWithContext(ImmutableMap.of("jobRuntimeLimit", "garbage"));

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindow.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindow.java
@@ -29,12 +29,12 @@ import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,13 +122,13 @@ public class RestrictExecutionDuringTimeWindow implements StageDefinitionBuilder
   @VisibleForTesting
   private static class SuspendExecutionDuringTimeWindowTask implements RetryableTask {
     @Override
-    public long getBackoffPeriod() {
-      return TimeUnit.SECONDS.toMillis(30);
+    public Duration getBackoffPeriod() {
+      return Duration.ofSeconds(30);
     }
 
     @Override
-    public long getTimeout() {
-      return TimeUnit.DAYS.toMillis(7);
+    public Duration getTimeout() {
+      return Duration.ofDays(7);
     }
 
     private static final int DAY_START_HOUR = 0;

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/DependsOnExecutionTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/DependsOnExecutionTask.java
@@ -26,7 +26,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import javax.annotation.Nonnull;
 import javax.validation.constraints.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,13 +43,13 @@ public class DependsOnExecutionTask implements OverridableTimeoutRetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(10);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(10);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.HOURS.toMillis(2);
+  public Duration getTimeout() {
+    return Duration.ofHours(2);
   }
 
   @Nonnull

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/ToggleablePauseTask.java
@@ -59,13 +59,13 @@ public class ToggleablePauseTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return Duration.ofMinutes(1).toMillis();
+  public Duration getBackoffPeriod() {
+    return Duration.ofMinutes(1);
   }
 
   @Override
-  public long getTimeout() {
-    return Duration.ofHours(24).toMillis();
+  public Duration getTimeout() {
+    return Duration.ofHours(24);
   }
 
   @Nullable

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitUntilTask.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/WaitUntilTask.java
@@ -61,12 +61,12 @@ public class WaitUntilTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 1_000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(1);
   }
 
   @Override
-  public long getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
+  public Duration getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
     WaitUntilStage.WaitUntilStageContext context =
         stage.mapTo(WaitUntilStage.WaitUntilStageContext.class);
 
@@ -76,14 +76,14 @@ public class WaitUntilTask implements RetryableTask {
       Instant completion = Instant.ofEpochMilli(context.getEpochMillis());
 
       if (completion.isAfter(now)) {
-        return completion.toEpochMilli() - now.toEpochMilli();
+        return Duration.ofMillis(completion.toEpochMilli() - now.toEpochMilli());
       }
     }
     return getBackoffPeriod();
   }
 
   @Override
-  public long getTimeout() {
-    return Integer.MAX_VALUE;
+  public Duration getTimeout() {
+    return WaitTask.LOOONG_TIME;
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/WaitTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/WaitTaskSpec.groovy
@@ -21,8 +21,6 @@ import com.netflix.spinnaker.orca.time.MutableClock
 import spock.lang.Specification
 import spock.lang.Subject
 
-import java.util.concurrent.TimeUnit
-
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.RUNNING
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.SUCCEEDED
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
@@ -75,7 +73,7 @@ class WaitTaskSpec extends Specification {
 
     then:
     result.status == RUNNING
-    backOff == TimeUnit.SECONDS.toMillis(wait)
+    backOff == Duration.ofSeconds(wait)
   }
 
   void "should skip waiting when marked in context"() {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/WaitUntilTaskSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/WaitUntilTaskSpec.groovy
@@ -76,7 +76,7 @@ class WaitUntilTaskSpec extends Specification {
 
     then:
     result.status == RUNNING
-    backOff == waitTimeSeconds * 1000
+    backOff == Duration.ofSeconds(waitTimeSeconds)
   }
 
 }

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 
 import javax.annotation.Nonnull
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.google.common.annotations.VisibleForTesting
 import com.netflix.spinnaker.orca.*
@@ -66,8 +67,8 @@ class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage 
   @Component
   @VisibleForTesting
   public static class WaitForManualJudgmentTask implements OverridableTimeoutRetryableTask {
-    final long backoffPeriod = 15000
-    final long timeout = TimeUnit.DAYS.toMillis(3)
+    final Duration backoffPeriod = Duration.ofSeconds(15)
+    final Duration timeout = Duration.ofDays(3)
 
     @Autowired(required = false)
     EchoService echoService

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/tasks/CreateJiraIssueTask.java
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/tasks/CreateJiraIssueTask.java
@@ -24,8 +24,8 @@ import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.echo.JiraService;
 import com.netflix.spinnaker.orca.echo.JiraService.CreateJiraIssueResponse;
+import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -40,13 +40,13 @@ public class CreateJiraIssueTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(30);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(30);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(5);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(5);
   }
 
   @Nonnull

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/tasks/PageApplicationOwnerTask.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/tasks/PageApplicationOwnerTask.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.echo.tasks
 
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
@@ -34,8 +35,8 @@ import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.SUC
 @Component
 @CompileStatic
 class PageApplicationOwnerTask implements RetryableTask {
-  long backoffPeriod = 15000
-  long timeout = TimeUnit.MINUTES.toMillis(5)
+  Duration backoffPeriod = Duration.ofSeconds(15)
+  Duration timeout = Duration.ofMinutes(5)
 
   @Autowired
   EchoService echoService

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/LoadPluginReleaseTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/LoadPluginReleaseTask.java
@@ -66,12 +66,12 @@ public class LoadPluginReleaseTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return Duration.ofSeconds(10).toMillis();
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(10);
   }
 
   @Override
-  public long getTimeout() {
-    return Duration.ofMinutes(2).toMillis();
+  public Duration getTimeout() {
+    return Duration.ofMinutes(2);
   }
 }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorFront50Task.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorFront50Task.java
@@ -25,10 +25,10 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.front50.model.DeliveryConfig;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -65,13 +65,13 @@ public class MonitorFront50Task implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.SECONDS.toMillis(90);
+  public Duration getTimeout() {
+    return Duration.ofSeconds(90);
   }
 
   @Nonnull

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.front50.tasks
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask
@@ -36,8 +37,8 @@ class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
   @Autowired
   ExecutionRepository executionRepository
 
-  long backoffPeriod = TimeUnit.SECONDS.toMillis(15)
-  long timeout = TimeUnit.HOURS.toMillis(12)
+  Duration backoffPeriod = Duration.ofSeconds(15)
+  Duration timeout = Duration.ofHours(12)
 
   @Override
   TaskResult execute(StageExecution stage) {

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
@@ -22,8 +22,8 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.front50.PipelineModelMutator;
+import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -123,13 +123,13 @@ public class SavePipelineTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 1000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(1);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.SECONDS.toMillis(30);
+  public Duration getTimeout() {
+    return Duration.ofSeconds(30);
   }
 
   private void updateServiceAccount(Map<String, Object> pipeline, String serviceAccount) {

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTask.java
@@ -27,13 +27,13 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.front50.Front50Service;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
@@ -62,13 +62,13 @@ public class SaveServiceAccountTask implements RetryableTask {
   private FiatPermissionEvaluator fiatPermissionEvaluator;
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(1);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(1);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.SECONDS.toMillis(60);
+  public Duration getTimeout() {
+    return Duration.ofSeconds(60);
   }
 
   @Nonnull

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SetPreferredPluginReleaseTask.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/SetPreferredPluginReleaseTask.java
@@ -57,12 +57,12 @@ public class SetPreferredPluginReleaseTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return Duration.ofSeconds(10).toMillis();
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(10);
   }
 
   @Override
-  public long getTimeout() {
-    return Duration.ofMinutes(2).toMillis();
+  public Duration getTimeout() {
+    return Duration.ofMinutes(2);
   }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.igor.tasks
 
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -39,8 +40,8 @@ import retrofit.RetrofitError
 class GetCommitsTask implements DiffTask {
   private static final int MAX_RETRIES = 3
 
-  long backoffPeriod = 3000
-  long timeout = TimeUnit.MINUTES.toMillis(5)
+  Duration backoffPeriod = Duration.ofSeconds(3)
+  Duration timeout = Duration.ofMinutes(5)
   // always set this higher than retries * backoffPeriod would take
 
   @Autowired

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorAwsCodeBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorAwsCodeBuildTask.java
@@ -22,9 +22,9 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.igor.IgorService;
 import com.netflix.spinnaker.orca.igor.model.AwsCodeBuildExecution;
 import com.netflix.spinnaker.orca.igor.model.AwsCodeBuildStageDefinition;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -36,8 +36,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class MonitorAwsCodeBuildTask extends RetryableIgorTask<AwsCodeBuildStageDefinition>
     implements OverridableTimeoutRetryableTask {
-  @Getter protected long backoffPeriod = TimeUnit.SECONDS.toMillis(10);
-  @Getter protected long timeout = TimeUnit.HOURS.toMillis(8); // maximum build timeout
+  @Getter protected Duration backoffPeriod = Duration.ofSeconds(10);
+  @Getter protected Duration timeout = Duration.ofHours(8); // maximum build timeout
 
   private final IgorService igorService;
 

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorGoogleCloudBuildTask.java
@@ -22,9 +22,9 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.igor.IgorService;
 import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuild;
 import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildStageDefinition;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -36,8 +36,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class MonitorGoogleCloudBuildTask extends RetryableIgorTask<GoogleCloudBuildStageDefinition>
     implements OverridableTimeoutRetryableTask {
-  @Getter protected long backoffPeriod = 10000;
-  @Getter protected long timeout = TimeUnit.HOURS.toMillis(2);
+  @Getter protected Duration backoffPeriod = Duration.ofSeconds(10);
+  @Getter protected Duration timeout = Duration.ofHours(2);
 
   private final IgorService igorService;
 

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorJenkinsJobTask.groovy
@@ -27,14 +27,15 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 @Slf4j
 @Component
 class MonitorJenkinsJobTask implements OverridableTimeoutRetryableTask {
 
-  long backoffPeriod = 10000
-  long timeout = TimeUnit.HOURS.toMillis(2)
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofHours(2)
 
   @Autowired
   BuildService buildService

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorQueuedJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorQueuedJenkinsJobTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.igor.tasks
 
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask
@@ -32,8 +33,8 @@ import retrofit.RetrofitError
 @Component
 class MonitorQueuedJenkinsJobTask implements OverridableTimeoutRetryableTask {
 
-  long backoffPeriod = 10000
-  long timeout = TimeUnit.HOURS.toMillis(2)
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofHours(2)
 
   @Autowired
   BuildService buildService

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorWerckerJobStartedTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorWerckerJobStartedTask.groovy
@@ -19,13 +19,14 @@ import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 
 import javax.annotation.Nonnull
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 @Slf4j
 @Component
 class MonitorWerckerJobStartedTask implements OverridableTimeoutRetryableTask {
-  long backoffPeriod = 10000
-  long timeout = TimeUnit.HOURS.toMillis(2)
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofHours(2)
 
   @Autowired
   BuildService buildService

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/RetryableIgorTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/RetryableIgorTask.java
@@ -22,9 +22,9 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.igor.model.RetryableStageDefinition;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,12 +34,12 @@ import retrofit.RetrofitError;
 @Slf4j
 public abstract class RetryableIgorTask<T extends RetryableStageDefinition>
     implements RetryableTask {
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(5);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(5);
   }
 
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(1);
+  public Duration getTimeout() {
+    return Duration.ofSeconds(1);
   }
 
   protected int getMaxConsecutiveErrors() {

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/WaitForConcourseJobCompletionTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/WaitForConcourseJobCompletionTask.java
@@ -23,8 +23,8 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.igor.BuildService;
 import com.netflix.spinnaker.orca.igor.model.ConcourseStageDefinition;
 import com.netflix.spinnaker.orca.pipeline.model.ConcourseBuildInfo;
+import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -35,8 +35,8 @@ public class WaitForConcourseJobCompletionTask implements OverridableTimeoutRetr
   private final BuildService buildService;
   private final ObjectMapper mapper;
 
-  private final long backoffPeriod = 15000;
-  private final long timeout = TimeUnit.DAYS.toMillis(3);
+  private final Duration backoffPeriod = Duration.ofSeconds(15);
+  private final Duration timeout = Duration.ofDays(3);
 
   @Override
   @Nonnull
@@ -64,12 +64,12 @@ public class WaitForConcourseJobCompletionTask implements OverridableTimeoutRetr
   }
 
   @Override
-  public long getBackoffPeriod() {
+  public Duration getBackoffPeriod() {
     return backoffPeriod;
   }
 
   @Override
-  public long getTimeout() {
+  public Duration getTimeout() {
     return timeout;
   }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/WaitForConcourseJobStartTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/WaitForConcourseJobStartTask.java
@@ -22,9 +22,9 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.igor.ConcourseService;
 import com.netflix.spinnaker.orca.igor.model.ConcourseStageExecution;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -34,8 +34,8 @@ import org.springframework.stereotype.Component;
 public class WaitForConcourseJobStartTask implements OverridableTimeoutRetryableTask {
   private final ConcourseService concourseService;
 
-  private final long backoffPeriod = 15000;
-  private final long timeout = TimeUnit.HOURS.toMillis(1);
+  private final Duration backoffPeriod = Duration.ofSeconds(15);
+  private final Duration timeout = Duration.ofHours(1);
 
   @Nonnull
   @Override
@@ -51,12 +51,12 @@ public class WaitForConcourseJobStartTask implements OverridableTimeoutRetryable
   }
 
   @Override
-  public long getBackoffPeriod() {
+  public Duration getBackoffPeriod() {
     return backoffPeriod;
   }
 
   @Override
-  public long getTimeout() {
+  public Duration getTimeout() {
     return timeout;
   }
 }

--- a/orca-integrations-gremlin/src/main/java/com/netflix/spinnaker/orca/gremlin/tasks/MonitorGremlinAttackTask.java
+++ b/orca-integrations-gremlin/src/main/java/com/netflix/spinnaker/orca/gremlin/tasks/MonitorGremlinAttackTask.java
@@ -10,9 +10,9 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.gremlin.AttackStatus;
 import com.netflix.spinnaker.orca.gremlin.GremlinService;
 import com.netflix.spinnaker.orca.gremlin.pipeline.GremlinStage;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,13 +59,13 @@ public class MonitorGremlinAttackTask implements OverridableTimeoutRetryableTask
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return TimeUnit.SECONDS.toMillis(10);
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(10);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(15);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(15);
   }
 
   private boolean isFailure(final String gremlinStageName) {

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/MonitorKayentaCanaryTask.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/MonitorKayentaCanaryTask.kt
@@ -28,7 +28,7 @@ import com.netflix.spinnaker.orca.ext.mapTo
 import com.netflix.spinnaker.orca.kayenta.CanaryResults
 import com.netflix.spinnaker.orca.kayenta.KayentaService
 import com.netflix.spinnaker.orca.kayenta.Thresholds
-import java.util.concurrent.TimeUnit.HOURS
+import java.time.Duration
 import org.springframework.stereotype.Component
 
 @Component
@@ -36,9 +36,9 @@ class MonitorKayentaCanaryTask(
   private val kayentaService: KayentaService
 ) : OverridableTimeoutRetryableTask {
 
-  override fun getBackoffPeriod() = 1000L
+  override fun getBackoffPeriod() = Duration.ofSeconds(10)
 
-  override fun getTimeout() = HOURS.toMillis(12)
+  override fun getTimeout() = Duration.ofHours(12)
 
   data class MonitorKayentaCanaryContext(
     val canaryPipelineExecutionId: String,

--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
@@ -29,8 +29,8 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.Trigger
 import com.netflix.spinnaker.orca.igor.ScmService
 import java.net.URL
+import java.time.Duration
 import java.time.Instant
-import java.util.concurrent.TimeUnit
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
@@ -182,9 +182,9 @@ constructor(
     return TaskResult.builder(ExecutionStatus.TERMINAL).context(mapOf("error" to normalizedError)).build()
   }
 
-  override fun getBackoffPeriod() = TimeUnit.SECONDS.toMillis(30)
+  override fun getBackoffPeriod() = Duration.ofSeconds(30)
 
-  override fun getTimeout() = TimeUnit.SECONDS.toMillis(180)
+  override fun getTimeout() = Duration.ofSeconds(180)
 
   val RetrofitError.friendlyMessage: String
     get() = if (kind == RetrofitError.Kind.HTTP) {

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorAcaTaskTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorAcaTaskTask.groovy
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.orca.mine.tasks
 
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
+
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask
@@ -32,8 +34,8 @@ import retrofit.RetrofitError
 @Component
 @Slf4j
 class MonitorAcaTaskTask extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
-  long backoffPeriod = 10000
-  long timeout = TimeUnit.DAYS.toMillis(2)
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofDays(2)
 
   @Autowired
   MineService mineService

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorCanaryTask.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/tasks/MonitorCanaryTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.mine.tasks
 
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask
@@ -33,8 +34,8 @@ import retrofit.RetrofitError
 @Component
 @Slf4j
 class MonitorCanaryTask extends AbstractCloudProviderAwareTask implements OverridableTimeoutRetryableTask {
-  long backoffPeriod = TimeUnit.MINUTES.toMillis(1)
-  long timeout = TimeUnit.DAYS.toMillis(2)
+  Duration backoffPeriod = Duration.ofMinutes(1)
+  Duration timeout = Duration.ofDays(2)
 
   private long timeoutBuffer = TimeUnit.MINUTES.toMillis(15)
 
@@ -51,7 +52,7 @@ class MonitorCanaryTask extends AbstractCloudProviderAwareTask implements Overri
     Long canaryDurationMillis = TimeUnit.HOURS.toMillis(canaryDuration) + timeoutBuffer
     Map outputs = [
       canary : context.canary,
-      stageTimeoutMs: Math.max(canaryDurationMillis, timeout)
+      stageTimeoutMs: Math.max(canaryDurationMillis, timeout.toMillis())
     ]
 
     try {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/CreatePipelineTemplateTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/CreatePipelineTemplateTask.java
@@ -23,9 +23,9 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -82,12 +82,12 @@ public class CreatePipelineTemplateTask implements RetryableTask, SavePipelineTe
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 15000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(15);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(1);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(1);
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/DeletePipelineTemplateTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/DeletePipelineTemplateTask.java
@@ -21,9 +21,9 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.front50.Front50Service;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -63,12 +63,12 @@ public class DeletePipelineTemplateTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 15000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(15);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(1);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(1);
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/PlanTemplateDependentsTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/PlanTemplateDependentsTask.java
@@ -24,11 +24,11 @@ import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,12 +104,12 @@ public class PlanTemplateDependentsTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 15000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(15);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(10);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(10);
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/UpdatePipelineTemplateTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/UpdatePipelineTemplateTask.java
@@ -23,11 +23,11 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -97,12 +97,12 @@ public class UpdatePipelineTemplateTask implements RetryableTask, SavePipelineTe
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 15000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(15);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(1);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(1);
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/v2/CreateV2PipelineTemplateTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/v2/CreateV2PipelineTemplateTask.java
@@ -24,9 +24,9 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import com.netflix.spinnaker.orca.pipelinetemplate.v2schema.model.V2PipelineTemplate;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -92,12 +92,12 @@ public class CreateV2PipelineTemplateTask implements RetryableTask, SaveV2Pipeli
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 15000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(15);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(1);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(1);
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/v2/DeleteV2PipelineTemplateTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/v2/DeleteV2PipelineTemplateTask.java
@@ -21,9 +21,9 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.front50.Front50Service;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -58,12 +58,12 @@ public class DeleteV2PipelineTemplateTask implements RetryableTask {
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 15000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(15);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(1);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(1);
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/v2/UpdateV2PipelineTemplateTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/v2/UpdateV2PipelineTemplateTask.java
@@ -24,11 +24,11 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import com.netflix.spinnaker.orca.pipelinetemplate.v2schema.model.V2PipelineTemplate;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -111,12 +111,12 @@ public class UpdateV2PipelineTemplateTask implements RetryableTask, SaveV2Pipeli
   }
 
   @Override
-  public long getBackoffPeriod() {
-    return 15000;
+  public Duration getBackoffPeriod() {
+    return Duration.ofSeconds(15);
   }
 
   @Override
-  public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(1);
+  public Duration getTimeout() {
+    return Duration.ofMinutes(1);
   }
 }

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/ExecutionLatch.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/ExecutionLatch.kt
@@ -43,7 +43,7 @@ class ExecutionLatch(private val predicate: Predicate<ExecutionComplete>) :
     }
   }
 
-  fun await() = latch.await(10, TimeUnit.SECONDS)
+  fun await() = latch.await(100, TimeUnit.SECONDS)
 }
 
 fun ConfigurableApplicationContext.runToCompletion(execution: PipelineExecution, launcher: (PipelineExecution) -> Unit, repository: ExecutionRepository) {

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -140,7 +140,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -161,7 +161,8 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
+    whenever(dummyTask.getDynamicBackoffPeriod(any(), any())) doReturn Duration.ofMillis(100)
     whenever(dummyTask.execute(any())) doReturn TaskResult.RUNNING doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -197,7 +198,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -238,7 +239,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -333,7 +334,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(argThat { refId == "2a1" })) doReturn TaskResult.ofStatus(TERMINAL)
     whenever(dummyTask.execute(argThat { refId != "2a1" })) doReturn TaskResult.SUCCEEDED
 
@@ -382,7 +383,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(argThat { refId == "2a1" })) doReturn TaskResult.ofStatus(TERMINAL)
     whenever(dummyTask.execute(argThat { refId != "2a1" })) doReturn TaskResult.SUCCEEDED
 
@@ -438,7 +439,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(argThat { refId == "2a1" })) doReturn TaskResult.ofStatus(TERMINAL)
     whenever(dummyTask.execute(argThat { refId != "2a1" })) doReturn TaskResult.SUCCEEDED
 
@@ -577,7 +578,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -615,7 +616,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -654,7 +655,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(any())) doReturn TaskResult.builder(SUCCEEDED).context(mapOf("output" to "foo")).build()
 
     context.runToCompletion(pipeline, runner::start, repository)
@@ -704,7 +705,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(any())) doReturn TaskResult.SUCCEEDED // second run succeeds
 
     context.restartAndRunToCompletion(pipeline.stageByRef("1"), runner::restart, repository)
@@ -746,7 +747,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(any())) doAnswer {
       val stage = it.arguments.first() as StageExecution
       if (stage.refId == "1") {
@@ -804,7 +805,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(any())) doAnswer {
       val stage = it.arguments.first() as StageExecution
       if (stage.refId == "1") {
@@ -842,7 +843,7 @@ abstract class QueueIntegrationTest {
     repository.store(pipeline)
 
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java
-    whenever(dummyTask.getDynamicTimeout(any())) doReturn 2000L
+    whenever(dummyTask.getDynamicTimeout(any())) doReturn Duration.ofSeconds(2)
     whenever(dummyTask.execute(any())) doAnswer {
       val stage = it.arguments.first() as StageExecution
       if (stage.refId == "1") {
@@ -886,7 +887,7 @@ class TestConfig {
   @Bean
   fun dummyTask(): DummyTask = mock {
     on { extensionClass } doReturn DummyTask::class.java
-    on { getDynamicTimeout(any()) } doReturn Duration.ofMinutes(2).toMillis()
+    on { getDynamicTimeout(any()) } doReturn Duration.ofMinutes(2)
   }
 
   @Bean

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -239,7 +239,8 @@ class RunTaskHandler(
   ): Long {
     val dynamicBackOffPeriod = getDynamicBackoffPeriod(
       stage, Duration.ofMillis(System.currentTimeMillis() - (taskModel.startTime ?: 0))
-    )
+    ).toMillis()
+
     val backOffs: MutableList<Long> = mutableListOf(
       dynamicBackOffPeriod,
       dynamicConfigService.getConfig(
@@ -298,7 +299,7 @@ class RunTaskHandler(
           if (this is OverridableTimeoutRetryableTask && stage.parentWithTimeout.isPresent)
             stage.parentWithTimeout.get().timeout.get().toDuration()
           else
-            getDynamicTimeout(stage).toDuration()
+            getDynamicTimeout(stage) ?: ZERO
           )
         if (elapsedTime.minus(pausedDuration) > actualTimeout) {
           val durationString = formatTimeout(elapsedTime.toMillis())

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
@@ -37,6 +37,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
 import org.springframework.web.client.HttpStatusCodeException
 
+import java.time.Duration
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
@@ -46,8 +47,8 @@ class CreateWebhookTask implements RetryableTask {
 
   private static final Pattern URL_SCHEME = Pattern.compile("(.*)://(.*)")
 
-  long backoffPeriod = 10000
-  long timeout = 300000
+  Duration backoffPeriod = Duration.ofSeconds(10)
+  Duration timeout = Duration.ofMinutes(5)
 
   WebhookService webhookService
   WebhookProperties webhookProperties

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
@@ -41,8 +41,8 @@ import java.util.concurrent.TimeUnit
 @Component
 class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
 
-  long backoffPeriod = TimeUnit.SECONDS.toMillis(1)
-  long timeout = TimeUnit.HOURS.toMillis(1)
+  Duration backoffPeriod = Duration.ofSeconds(1)
+  Duration timeout = Duration.ofHours(1)
   private static final String JSON_PATH_NOT_FOUND_ERR_FMT = "Unable to parse %s: JSON property '%s' not found in response body"
 
   WebhookService webhookService
@@ -55,10 +55,10 @@ class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
   }
 
   @Override
-  long getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
+  Duration getDynamicBackoffPeriod(StageExecution stage, Duration taskDuration) {
     if (taskDuration.toMillis() > TimeUnit.MINUTES.toMillis(1)) {
       // task has been running > 1min, drop retry interval to every 15 sec
-      return Math.max(backoffPeriod, TimeUnit.SECONDS.toMillis(15))
+      return (backoffPeriod > Duration.ofSeconds(15)) ? backoffPeriod : Duration.ofSeconds(15)
     }
 
     return backoffPeriod


### PR DESCRIPTION
This is a breaking change (of questionable value... so maybe not worth doing at all) especially for plugins
