### PR TITLE
fix(mine): Fix canary stage cancellation

### DIFF
--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/DeployCanaryStage.groovy
@@ -61,6 +61,9 @@ class DeployCanaryStage extends ParallelDeployStage implements CloudProviderAwar
   MineService mineService
 
   @Autowired
+  CanaryStage canaryStage
+
+  @Autowired
   MortService mortService
 
   @Nonnull
@@ -234,12 +237,12 @@ class DeployCanaryStage extends ParallelDeployStage implements CloudProviderAwar
   }
 
   @Override
-  @CompileDynamic
-  CancellableStage.Result cancel(StageExecution stage) {
-    def canary = stage.ancestors { StageExecution s, StageDefinitionBuilder stageBuilder ->
-      stageBuilder instanceof CanaryStage
-    } first()
-    return ((CanaryStage) canary.stageBuilder).cancel(canary.stage)
+  Result cancel(StageExecution stage) {
+    StageExecution canaryStageInstance = stage.directAncestors().find {
+      it.type == CanaryStage.PIPELINE_CONFIG_TYPE
+    }
+
+    return canaryStage.cancel(canaryStageInstance)
   }
 }
 

--- a/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/MonitorCanaryStage.groovy
+++ b/orca-mine/src/main/groovy/com/netflix/spinnaker/orca/mine/pipeline/MonitorCanaryStage.groovy
@@ -82,7 +82,7 @@ class MonitorCanaryStage implements StageDefinitionBuilder, CancellableStage {
       log.error("Unable to cancel canary '${canaryId}' in mine", e)
     }
 
-    StageExecution canaryStageInstance = stage.ancestors().find {
+    StageExecution canaryStageInstance = stage.directAncestors().find {
       it.type == CanaryStage.PIPELINE_CONFIG_TYPE
     }
 

--- a/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/MonitorCanaryStageSpec.groovy
+++ b/orca-mine/src/test/groovy/com/netflix/spinnaker/orca/mine/pipeline/MonitorCanaryStageSpec.groovy
@@ -58,6 +58,7 @@ class MonitorCanaryStageSpec extends Specification {
     def stage = new StageExecutionImpl(pipeline, "pipelineStage", [
       canary: [id: "canaryId"]
     ])
+    stage.setParentStageId(canaryStage.id)
     stage.setRequisiteStageRefIds(["1"])
 
     when:


### PR DESCRIPTION
Groovy... Canceling during [mine] canary deploys would cause an unhandled exception (`MissingMethod`) in the cancellation thread.
Because it's in a separate thread and uncaught we don't actually propagate the error in any way, but the side-effect is that if,
in a complex pipeline, some other stage fails and causes pipeline termination during a canary deploy, those deployed [canary and baseline]
clusters won't be cleaned up and still, potentially, taking traffic!

This fixes the cancelation code to correctly look up the top-level canary stage and cancel it.
