### PR TITLE
fix(api): getType should use getExtensionClass to avoid getting type info from proxy

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/StageDefinitionBuilder.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/StageDefinitionBuilder.java
@@ -88,7 +88,7 @@ public interface StageDefinitionBuilder extends SpinnakerExtensionPoint {
 
   /** @return the stage type this builder handles. */
   default @Nonnull String getType() {
-    return getType(this.getClass());
+    return getType((Class<StageDefinitionBuilder>) this.getExtensionClass());
   }
 
   /**


### PR DESCRIPTION
Small fix while fixing other things.