### PR TITLE
chore(dependencies): replace kork dependencies with kork-runtime

### DIFF
--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -63,12 +63,13 @@ dependencies {
   implementation(project(":orca-sql"))
   implementation(project(":orca-webhook"))
   implementation("com.netflix.spinnaker.kork:kork-exceptions")
-  implementation("com.netflix.spinnaker.kork:kork-stackdriver")
   implementation("com.netflix.spinnaker.kork:kork-web")
   implementation("com.netflix.spinnaker.kork:kork-plugins")
   implementation("net.logstash.logback:logstash-logback-encoder")
   implementation("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
   implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+
+  runtimeOnly("com.netflix.spinnaker.kork:kork-runtime")
 
   if (!rootProject.hasProperty("excludeSqlDrivers")) {
     runtimeOnly(project(":orca-sql-mysql"))
@@ -77,9 +78,6 @@ dependencies {
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")
 
-  runtimeOnly("com.netflix.spinnaker.kork:kork-core")
-  runtimeOnly("com.netflix.spinnaker.kork:kork-secrets-aws")
-  runtimeOnly("com.netflix.spinnaker.kork:kork-secrets-gcp")
   //this brings in the jetty GzipFilter which boot will autoconfigure
   runtimeOnly("org.eclipse.jetty:jetty-servlets:9.2.11.v20150529")
 

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/Main.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/Main.groovy
@@ -16,12 +16,6 @@
 
 package com.netflix.spinnaker.orca
 
-import com.netflix.spinnaker.config.ErrorConfiguration
-import com.netflix.spinnaker.config.InterlinkConfiguration
-import com.netflix.spinnaker.config.QosConfiguration
-import com.netflix.spinnaker.config.StackdriverConfig
-import com.netflix.spinnaker.config.TomcatConfiguration
-import com.netflix.spinnaker.kork.PlatformComponents
 import com.netflix.spinnaker.orca.applications.config.ApplicationConfig
 import com.netflix.spinnaker.orca.bakery.config.BakeryConfiguration
 import com.netflix.spinnaker.orca.clouddriver.config.CloudDriverConfiguration
@@ -53,9 +47,7 @@ import org.springframework.scheduling.annotation.EnableAsync
 
 @EnableAsync
 @Import([
-  PlatformComponents,
   WebConfiguration,
-  ErrorConfiguration,
   OrcaConfiguration,
   RedisConfiguration,
   BakeryConfiguration,
@@ -66,18 +58,14 @@ import org.springframework.scheduling.annotation.EnableAsync
   ClouddriverJobConfiguration,
   IgorConfiguration,
   DiscoveryPollingConfiguration,
-  TomcatConfiguration,
   MineConfiguration,
   ApplicationConfig,
-  StackdriverConfig,
   PipelineTemplateConfiguration,
   KayentaConfiguration,
   WebhookConfiguration,
   KeelConfiguration,
-  QosConfiguration,
   CloudFoundryConfiguration,
   GremlinConfiguration,
-  InterlinkConfiguration
 ])
 @SpringBootApplication(
     scanBasePackages = [


### PR DESCRIPTION
cleans up some configuration imports in Main that get discovered via auto configuration or
component scanning as well