### PR TITLE
perf(test): Speed up orca-sql tests

### DIFF
--- a/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/PipelineExecutionRepositoryTck.groovy
+++ b/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/PipelineExecutionRepositoryTck.groovy
@@ -49,8 +49,6 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
 
   abstract T repository()
 
-  abstract T previousRepository()
-
   def "can retrieve pipelines by status"() {
     given:
     def runningExecution = pipeline {

--- a/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/PipelineExecutionRepositoryTck.groovy
+++ b/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/PipelineExecutionRepositoryTck.groovy
@@ -45,23 +45,11 @@ import static java.time.temporal.ChronoUnit.HOURS
 @Subject(ExecutionRepository)
 @Unroll
 abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> extends Specification {
-
-  @Subject
-  ExecutionRepository repository
-
-  @Subject
-  ExecutionRepository previousRepository
-
   def clock = Clock.fixed(Instant.now(), UTC)
 
-  void setup() {
-    repository = createExecutionRepository()
-    previousRepository = createExecutionRepositoryPrevious()
-  }
+  abstract T repository()
 
-  abstract T createExecutionRepository()
-
-  abstract T createExecutionRepositoryPrevious()
+  abstract T previousRepository()
 
   def "can retrieve pipelines by status"() {
     given:
@@ -75,9 +63,9 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     }
 
     when:
-    repository.store(runningExecution)
-    repository.store(succeededExecution)
-    def pipelines = repository.retrievePipelinesForPipelineConfigId(
+    repository().store(runningExecution)
+    repository().store(succeededExecution)
+    def pipelines = repository().retrievePipelinesForPipelineConfigId(
       "pipeline-1", new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
@@ -85,7 +73,7 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     pipelines*.id.sort() == [runningExecution.id, succeededExecution.id].sort()
 
     when:
-    pipelines = repository.retrievePipelinesForPipelineConfigId(
+    pipelines = repository().retrievePipelinesForPipelineConfigId(
       "pipeline-1", new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
@@ -93,7 +81,7 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     pipelines*.id.sort() == [runningExecution.id].sort()
 
     when:
-    pipelines = repository.retrievePipelinesForPipelineConfigId(
+    pipelines = repository().retrievePipelinesForPipelineConfigId(
       "pipeline-1", new ExecutionCriteria(pageSize: 5, statuses: ["TERMINAL"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
@@ -116,9 +104,9 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     }
 
     when:
-    repository.store(runningExecution)
-    repository.store(succeededExecution)
-    def orchestrations = repository.retrieveOrchestrationsForApplication(
+    repository().store(runningExecution)
+    repository().store(succeededExecution)
+    def orchestrations = repository().retrieveOrchestrationsForApplication(
       runningExecution.application, new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
@@ -126,7 +114,7 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     orchestrations*.id.sort() == [runningExecution.id, succeededExecution.id].sort()
 
     when:
-    orchestrations = repository.retrieveOrchestrationsForApplication(
+    orchestrations = repository().retrieveOrchestrationsForApplication(
       runningExecution.application, new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
@@ -134,7 +122,7 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     orchestrations*.id.sort() == [runningExecution.id].sort()
 
     when:
-    orchestrations = repository.retrieveOrchestrationsForApplication(
+    orchestrations = repository().retrieveOrchestrationsForApplication(
       runningExecution.application, new ExecutionCriteria(pageSize: 5, statuses: ["TERMINAL"])
     ).subscribeOn(Schedulers.io()).toList().toBlocking().single()
 
@@ -158,9 +146,9 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     }
 
     when:
-    repository.store(runningExecution)
-    repository.store(succeededExecution)
-    def orchestrations = repository.retrieveOrchestrationsForApplication(
+    repository().store(runningExecution)
+    repository().store(succeededExecution)
+    def orchestrations = repository().retrieveOrchestrationsForApplication(
       runningExecution.application,
       new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING", "SUCCEEDED", "TERMINAL"]),
       NATURAL_ASC
@@ -172,7 +160,7 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     orchestrations*.id == [succeededExecution.id, runningExecution.id]
 
     when:
-    orchestrations = repository.retrieveOrchestrationsForApplication(
+    orchestrations = repository().retrieveOrchestrationsForApplication(
       runningExecution.application,
       new ExecutionCriteria(pageSize: 5, statuses: ["RUNNING"]),
       NATURAL_ASC
@@ -182,7 +170,7 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     orchestrations*.id == [runningExecution.id]
 
     when:
-    orchestrations = repository.retrieveOrchestrationsForApplication(
+    orchestrations = repository().retrieveOrchestrationsForApplication(
       runningExecution.application,
       new ExecutionCriteria(pageSize: 5, statuses: ["TERMINAL"]),
       NATURAL_ASC
@@ -208,11 +196,11 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
         startTime = config.startTime
       }
     }.forEach {
-      repository.store(it)
+      repository().store(it)
     }
 
     when:
-    def orchestrations = repository.retrieveOrchestrationsForApplication(
+    def orchestrations = repository().retrieveOrchestrationsForApplication(
       "covfefe",
       new ExecutionCriteria().with {
         startTimeCutoff = clock
@@ -255,12 +243,12 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
       }
     }
     def application = pipeline.application
-    repository.store(pipeline)
+    repository().store(pipeline)
 
     expect:
-    repository.retrieve(PIPELINE).toBlocking().first().id == pipeline.id
+    repository().retrieve(PIPELINE).toBlocking().first().id == pipeline.id
 
-    with(repository.retrieve(pipeline.type, pipeline.id)) {
+    with(repository().retrieve(pipeline.type, pipeline.id)) {
       id == pipeline.id
       application == pipeline.application
       name == pipeline.name
@@ -277,7 +265,7 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
 
   def "trying to retrieve an invalid #type.simpleName id throws an exception"() {
     when:
-    repository.retrieve(type, "invalid")
+    repository().retrieve(type, "invalid")
 
     then:
     thrown ExecutionNotFoundException
@@ -288,7 +276,7 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
 
   def "trying to delete a non-existent #type.simpleName id does not throw an exception"() {
     when:
-    repository.delete(type, "invalid")
+    repository().delete(type, "invalid")
 
     then:
     notThrown ExecutionNotFoundException
@@ -317,33 +305,33 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     }
 
     and:
-    repository.store(pipeline)
-    repository.delete(PIPELINE, pipeline.id)
+    repository().store(pipeline)
+    repository().delete(PIPELINE, pipeline.id)
 
     when:
-    repository.retrieve(PIPELINE, pipeline.id)
+    repository().retrieve(PIPELINE, pipeline.id)
 
     then:
     thrown ExecutionNotFoundException
 
     and:
-    repository.retrieve(PIPELINE).toList().toBlocking().first() == []
+    repository().retrieve(PIPELINE).toList().toBlocking().first() == []
   }
 
   def "updateStatus sets startTime to current time if new status is RUNNING"() {
     given:
-    repository.store(execution)
+    repository().store(execution)
 
     expect:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       startTime == null
     }
 
     when:
-    repository.updateStatus(execution.type, execution.id, RUNNING)
+    repository().updateStatus(execution.type, execution.id, RUNNING)
 
     then:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       status == RUNNING
       startTime != null
     }
@@ -359,19 +347,19 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
   def "updateStatus sets endTime to current time if new status is #status"() {
     given:
     execution.startTime = System.currentTimeMillis()
-    repository.store(execution)
+    repository().store(execution)
 
     expect:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       startTime != null
       endTime == null
     }
 
     when:
-    repository.updateStatus(execution.type, execution.id, status)
+    repository().updateStatus(execution.type, execution.id, status)
 
     then:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       status == status
       endTime != null
     }
@@ -385,19 +373,19 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
 
   def "updateStatus does not set endTime if a pipeline never started"() {
     given:
-    repository.store(execution)
+    repository().store(execution)
 
     expect:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       startTime == null
       endTime == null
     }
 
     when:
-    repository.updateStatus(execution.type, execution.id, status)
+    repository().updateStatus(execution.type, execution.id, status)
 
     then:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       status == status
       endTime == null
     }
@@ -410,19 +398,19 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
   def "cancelling a not-yet-started execution updates the status immediately"() {
     given:
     def execution = pipeline()
-    repository.store(execution)
+    repository().store(execution)
 
     expect:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       status == NOT_STARTED
     }
 
     when:
-    repository.cancel(execution.type, execution.id)
+    repository().cancel(execution.type, execution.id)
 
 
     then:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       canceled
       status == CANCELED
     }
@@ -431,20 +419,20 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
   def "cancelling a running execution does not update the status immediately"() {
     given:
     def execution = pipeline()
-    repository.store(execution)
-    repository.updateStatus(execution.type, execution.id, RUNNING)
+    repository().store(execution)
+    repository().updateStatus(execution.type, execution.id, RUNNING)
 
     expect:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       status == RUNNING
     }
 
     when:
-    repository.cancel(execution.type, execution.id)
+    repository().cancel(execution.type, execution.id)
 
 
     then:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       canceled
       status == RUNNING
     }
@@ -455,20 +443,20 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     given:
     def execution = pipeline()
     def user = "user@netflix.com"
-    repository.store(execution)
-    repository.updateStatus(execution.type, execution.id, RUNNING)
+    repository().store(execution)
+    repository().updateStatus(execution.type, execution.id, RUNNING)
 
     expect:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       status == RUNNING
     }
 
     when:
-    repository.cancel(execution.type, execution.id, user, reason)
+    repository().cancel(execution.type, execution.id, user, reason)
 
 
     then:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       canceled
       canceledBy == user
       status == RUNNING
@@ -485,14 +473,14 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
   def "pausing/resuming a running execution will set appropriate 'paused' details"() {
     given:
     def execution = pipeline()
-    repository.store(execution)
-    repository.updateStatus(execution.type, execution.id, RUNNING)
+    repository().store(execution)
+    repository().updateStatus(execution.type, execution.id, RUNNING)
 
     when:
-    repository.pause(execution.type, execution.id, "user@netflix.com")
+    repository().pause(execution.type, execution.id, "user@netflix.com")
 
     then:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       status == PAUSED
       paused.pauseTime != null
       paused.resumeTime == null
@@ -502,10 +490,10 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     }
 
     when:
-    repository.resume(execution.type, execution.id, "another@netflix.com")
+    repository().resume(execution.type, execution.id, "another@netflix.com")
 
     then:
-    with(repository.retrieve(execution.type, execution.id)) {
+    with(repository().retrieve(execution.type, execution.id)) {
       status == RUNNING
       paused.pauseTime != null
       paused.resumeTime != null
@@ -520,11 +508,11 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
   def "should only #method a #expectedStatus execution"() {
     given:
     def execution = pipeline()
-    repository.store(execution)
-    repository.updateStatus(execution.type, execution.id, status)
+    repository().store(execution)
+    repository().updateStatus(execution.type, execution.id, status)
 
     when:
-    repository."${method}"(execution.type, execution.id, "user@netflix.com")
+    repository()."${method}"(execution.type, execution.id, "user@netflix.com")
 
     then:
     def e = thrown(IllegalStateException)
@@ -542,20 +530,20 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
   def "should force resume an execution regardless of status"() {
     given:
     def execution = pipeline()
-    repository.store(execution)
-    repository.updateStatus(execution.type, execution.id, RUNNING)
+    repository().store(execution)
+    repository().updateStatus(execution.type, execution.id, RUNNING)
 
     when:
-    repository.pause(execution.type, execution.id, "user@netflix.com")
-    execution = repository.retrieve(execution.type, execution.id)
+    repository().pause(execution.type, execution.id, "user@netflix.com")
+    execution = repository().retrieve(execution.type, execution.id)
 
     then:
     execution.paused.isPaused()
 
     when:
-    repository.updateStatus(execution.type, execution.id, status)
-    repository.resume(execution.type, execution.id, "user@netflix.com", true)
-    execution = repository.retrieve(execution.type, execution.id)
+    repository().updateStatus(execution.type, execution.id, status)
+    repository().resume(execution.type, execution.id, "user@netflix.com", true)
+    execution = repository().retrieve(execution.type, execution.id)
 
     then:
     execution.status == RUNNING
@@ -570,18 +558,18 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     def execution = orchestration {
       trigger = new DefaultTrigger("manual", "covfefe")
     }
-    repository.store(execution)
-    repository.updateStatus(execution.type, execution.id, RUNNING)
+    repository().store(execution)
+    repository().updateStatus(execution.type, execution.id, RUNNING)
 
     when:
-    def result = repository.retrieveOrchestrationForCorrelationId('covfefe')
+    def result = repository().retrieveOrchestrationForCorrelationId('covfefe')
 
     then:
     result.id == execution.id
 
     when:
-    repository.updateStatus(execution.type, execution.id, SUCCEEDED)
-    repository.retrieveOrchestrationForCorrelationId('covfefe')
+    repository().updateStatus(execution.type, execution.id, SUCCEEDED)
+    repository().retrieveOrchestrationForCorrelationId('covfefe')
 
     then:
     thrown(ExecutionNotFoundException)
@@ -592,10 +580,10 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     def execution = pipeline {
       trigger = new PipelineTrigger(pipeline())
     }
-    repository.store(execution)
+    repository().store(execution)
 
     expect:
-    with(repository.retrieve(PIPELINE, execution.id)) {
+    with(repository().retrieve(PIPELINE, execution.id)) {
       trigger.parentExecution instanceof PipelineExecution
     }
   }
@@ -606,10 +594,10 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     for (status in ExecutionStatus.values()) {
       pipeline {
         setStatus(status)
-      }.with { execution -> repository.store(execution) }
+      }.with { execution -> repository().store(execution) }
       orchestration {
         setStatus(status)
-      }.with { execution -> repository.store(execution) }
+      }.with { execution -> repository().store(execution) }
     }
 
     and:
@@ -618,7 +606,7 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
       .setPageSize(limit)
 
     expect:
-    with(repository.retrieve(type, criteria).toList().toBlocking().single()) {
+    with(repository().retrieve(type, criteria).toList().toBlocking().single()) {
       size() == expectedResults
       type.every { it == type }
       if (statuses) {
@@ -654,11 +642,11 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     }
 
     when:
-    repository.store(execution1)
-    repository.store(execution2)
-    repository.store(execution3)
-    repository.store(execution4)
-    def apps = repository.retrieveAllApplicationNames(executionType, minExecutions)
+    repository().store(execution1)
+    repository().store(execution2)
+    repository().store(execution3)
+    repository().store(execution4)
+    def apps = repository().retrieveAllApplicationNames(executionType, minExecutions)
 
     then:
     apps.sort() == expectedApps.sort()

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisPipelineExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisPipelineExecutionRepositorySpec.groovy
@@ -56,6 +56,7 @@ class JedisPipelineExecutionRepositorySpec extends PipelineExecutionRepositoryTc
   @AutoCleanup("destroy")
   EmbeddedRedis embeddedRedisPrevious
 
+  @Shared
   @Subject
   RedisExecutionRepository repository
 
@@ -64,6 +65,7 @@ class JedisPipelineExecutionRepositorySpec extends PipelineExecutionRepositoryTc
     return repository
   }
 
+  @Shared
   @Subject
   RedisExecutionRepository previousRepository
 
@@ -94,9 +96,6 @@ class JedisPipelineExecutionRepositorySpec extends PipelineExecutionRepositoryTc
         new JedisClientDelegate("primaryDefault", jedisPool),
         new JedisClientDelegate("previousDefault", jedisPoolPrevious)
     ])
-  }
-
-  def setup() {
     repository = createExecutionRepository()
     previousRepository = createExecutionRepositoryPrevious()
   }

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisPipelineExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisPipelineExecutionRepositorySpec.groovy
@@ -69,7 +69,6 @@ class JedisPipelineExecutionRepositorySpec extends PipelineExecutionRepositoryTc
   @Subject
   RedisExecutionRepository previousRepository
 
-  @Override
   RedisExecutionRepository previousRepository() {
     return previousRepository
   }

--- a/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisPipelineExecutionRepositorySpec.groovy
+++ b/orca-redis/src/test/groovy/com/netflix/spinnaker/orca/pipeline/persistence/jedis/JedisPipelineExecutionRepositorySpec.groovy
@@ -19,7 +19,6 @@ import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
-import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.pipeline.StageExecutionFactory
@@ -31,6 +30,7 @@ import redis.clients.jedis.Jedis
 import redis.clients.jedis.util.Pool
 import spock.lang.AutoCleanup
 import spock.lang.Shared
+import spock.lang.Subject
 import spock.lang.Unroll
 
 import java.util.concurrent.CountDownLatch
@@ -56,9 +56,49 @@ class JedisPipelineExecutionRepositorySpec extends PipelineExecutionRepositoryTc
   @AutoCleanup("destroy")
   EmbeddedRedis embeddedRedisPrevious
 
+  @Subject
+  RedisExecutionRepository repository
+
+  @Override
+  RedisExecutionRepository repository() {
+    return repository
+  }
+
+  @Subject
+  RedisExecutionRepository previousRepository
+
+  @Override
+  RedisExecutionRepository previousRepository() {
+    return previousRepository
+  }
+
+  @Shared
+  Pool<Jedis> jedisPool
+
+  @Shared
+  Pool<Jedis> jedisPoolPrevious
+
+  @Shared
+  Jedis jedis
+
+  @Shared
+  RedisClientSelector redisClientSelector
+
   def setupSpec() {
     embeddedRedis = EmbeddedRedis.embed()
     embeddedRedisPrevious = EmbeddedRedis.embed()
+    jedisPool = embeddedRedis.pool
+    jedisPoolPrevious = embeddedRedisPrevious.pool
+    jedis = jedisPool.resource
+    redisClientSelector = new RedisClientSelector([
+        new JedisClientDelegate("primaryDefault", jedisPool),
+        new JedisClientDelegate("previousDefault", jedisPoolPrevious)
+    ])
+  }
+
+  def setup() {
+    repository = createExecutionRepository()
+    previousRepository = createExecutionRepositoryPrevious()
   }
 
   def cleanup() {
@@ -66,26 +106,12 @@ class JedisPipelineExecutionRepositorySpec extends PipelineExecutionRepositoryTc
     embeddedRedisPrevious.jedis.withCloseable { it.flushDB() }
   }
 
-  Pool<Jedis> jedisPool = embeddedRedis.pool
-  Pool<Jedis> jedisPoolPrevious = embeddedRedisPrevious.pool
-
-  RedisClientDelegate redisClientDelegate = new JedisClientDelegate("primaryDefault", jedisPool)
-  RedisClientDelegate previousRedisClientDelegate = new JedisClientDelegate("previousDefault", jedisPoolPrevious)
-  RedisClientSelector redisClientSelector = new RedisClientSelector([redisClientDelegate, previousRedisClientDelegate])
-
-  Registry registry = new NoopRegistry()
-
-  @AutoCleanup
-  def jedis = jedisPool.resource
-
-  @Override
   RedisExecutionRepository createExecutionRepository() {
-    return new RedisExecutionRepository(registry, redisClientSelector, 1, 50)
+    return new RedisExecutionRepository(new NoopRegistry(), redisClientSelector, 1, 50)
   }
 
-  @Override
   RedisExecutionRepository createExecutionRepositoryPrevious() {
-    return new RedisExecutionRepository(registry, new RedisClientSelector([new JedisClientDelegate("primaryDefault", jedisPoolPrevious)]), 1, 50)
+    return new RedisExecutionRepository(new NoopRegistry(), new RedisClientSelector([new JedisClientDelegate("primaryDefault", jedisPoolPrevious)]), 1, 50)
   }
 
 

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -43,12 +43,14 @@ import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPEL
 import static com.netflix.spinnaker.kork.sql.test.SqlTestUtil.initTcMysqlDatabase
 import static java.time.temporal.ChronoUnit.DAYS
 
-class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
+abstract class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
   @Shared
   ObjectMapper mapper = OrcaObjectMapper.newInstance().with {
     registerModule(new KotlinModule())
     it
   }
+
+  abstract SqlTestUtil.TestDatabase getDatabase()
 
   @Shared
   @AutoCleanup("close")
@@ -75,7 +77,7 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
   )
 
   def setupSpec() {
-    currentDatabase = initTcMysqlDatabase()
+    currentDatabase = getDatabase()
     executionRepository = new SqlExecutionRepository("test", currentDatabase.context, mapper, new RetryProperties(), 10, 100, "poolName", null)
   }
 
@@ -146,9 +148,16 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
   }
 }
 
+class MySqlOldPipelineCleanupPollingNotificationAgentSpec extends OldPipelineCleanupPollingNotificationAgentSpec {
+  @Override
+  SqlTestUtil.TestDatabase getDatabase() {
+    return initTcMysqlDatabase()
+  }
+}
+
 class PgOldPipelineCleanupPollingNotificationAgentSpec extends OldPipelineCleanupPollingNotificationAgentSpec {
-  def setupSpec() {
-    currentDatabase = initTcPostgresDatabase()
-    executionRepository = new SqlExecutionRepository("test", currentDatabase.context, mapper, new RetryProperties(), 10, 100, "poolName", null)
+  @Override
+  SqlTestUtil.TestDatabase getDatabase() {
+    return initTcPostgresDatabase()
   }
 }

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
@@ -61,6 +61,7 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
 
   def ulid = new ULID()
 
+  @Shared
   @Subject
   ExecutionRepository repository
 
@@ -69,6 +70,7 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
     return repository
   }
 
+  @Shared
   @Subject
   ExecutionRepository previousRepository
 
@@ -89,9 +91,6 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
 
   def setupSpec() {
     currentDatabase = getDatabase()
-  }
-
-  def setup() {
     repository = createExecutionRepository()
     previousRepository = createExecutionRepositoryPrevious()
   }

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
@@ -38,6 +38,7 @@ import rx.schedulers.Schedulers
 import de.huxhorn.sulky.ulid.ULID
 import spock.lang.AutoCleanup
 import spock.lang.Shared
+import spock.lang.Subject
 import spock.lang.Unroll
 
 import static com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
@@ -60,6 +61,22 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
 
   def ulid = new ULID()
 
+  @Subject
+  ExecutionRepository repository
+
+  @Override
+  ExecutionRepository repository() {
+    return repository
+  }
+
+  @Subject
+  ExecutionRepository previousRepository
+
+  @Override
+  ExecutionRepository previousRepository() {
+    return previousRepository
+  }
+
   @Shared
   @AutoCleanup("close")
   TestDatabase currentDatabase
@@ -74,17 +91,20 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
     currentDatabase = getDatabase()
   }
 
+  def setup() {
+    repository = createExecutionRepository()
+    previousRepository = createExecutionRepositoryPrevious()
+  }
+
   def cleanup() {
     cleanupDb(currentDatabase.context)
     cleanupDb(currentDatabase.previousContext)
   }
 
-  @Override
   ExecutionRepository createExecutionRepository() {
     return createExecutionRepository("test")
   }
 
-  @Override
   ExecutionRepository createExecutionRepositoryPrevious() {
     new SqlExecutionRepository("test", currentDatabase.previousContext, mapper, new RetryProperties(), 10, 100, "poolName", null)
   }

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
@@ -71,15 +71,6 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
   }
 
   @Shared
-  @Subject
-  ExecutionRepository previousRepository
-
-  @Override
-  ExecutionRepository previousRepository() {
-    return previousRepository
-  }
-
-  @Shared
   @AutoCleanup("close")
   TestDatabase currentDatabase
 
@@ -92,20 +83,14 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
   def setupSpec() {
     currentDatabase = getDatabase()
     repository = createExecutionRepository()
-    previousRepository = createExecutionRepositoryPrevious()
   }
 
   def cleanup() {
     cleanupDb(currentDatabase.context)
-    cleanupDb(currentDatabase.previousContext)
   }
 
   ExecutionRepository createExecutionRepository() {
     return createExecutionRepository("test")
-  }
-
-  ExecutionRepository createExecutionRepositoryPrevious() {
-    new SqlExecutionRepository("test", currentDatabase.previousContext, mapper, new RetryProperties(), 10, 100, "poolName", null)
   }
 
   ExecutionRepository createExecutionRepository(String partition, Interlink interlink = null) {

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
@@ -50,7 +50,7 @@ import static com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepositor
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.orchestration
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 
-class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepositoryTck<ExecutionRepository> {
+abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepositoryTck<ExecutionRepository> {
 
   @Shared
   ObjectMapper mapper = OrcaObjectMapper.newInstance().with {
@@ -68,8 +68,10 @@ class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepositoryTck<
   @AutoCleanup("close")
   TestDatabase previousDatabase
 
+  abstract TestDatabase getDatabase()
+
   def setupSpec() {
-    currentDatabase = initDualTcMysqlDatabases()
+    currentDatabase = getDatabase()
   }
 
   def cleanup() {
@@ -667,8 +669,16 @@ class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepositoryTck<
   }
 }
 
+class MySqlPipelineExecutionRepositorySpec extends SqlPipelineExecutionRepositorySpec {
+  @Override
+  TestDatabase getDatabase() {
+    return initDualTcMysqlDatabases()
+  }
+}
+
 class PgSqlPipelineExecutionRepositorySpec extends SqlPipelineExecutionRepositorySpec {
-  def setupSpec() {
-    currentDatabase = initDualTcPostgresDatabases()
+  @Override
+  TestDatabase getDatabase() {
+    return initDualTcPostgresDatabases()
   }
 }


### PR DESCRIPTION
Reduces the time to run `:orca-sql:test` from ~2m30s to ~1m40s.

* perf(test): Speed up PgSQL tests

  When overriding setupSpec, Spock runs both the parent (super.setupSpec) and the subclass setupSpec (in that order). This means that for the PgSQL tests, we're creating a MySQL database then immediately discarding it to replace it with a PgSQL database.

  As creating the database spins up a container and is resonably slow, lightly refactor this so that we don't do this extra work.

* refactor(test): Push some logic down from execution repository tests

  There's a lot of coupling between PipelineExecutionRepositoryTck and its subclasses that causes initialization order dependencies. In order to make it easier to make changes (such as changing what fields are updated in setup vs setupSpec), refactor this so that each subclass is fully responsible for initialization and we can control the order.

  The main issue here is that the super class was storing and initializing the ExecutionRepository, but we can't actually create the ExecutionRepository until we've created the persistence store, which is owned by the implementations. So we were subtly depending on each subclass having already initialized its persistence store before we create the ExecutionRepository.

  Now it's up to each subclass ot handle this order-dependence and expose a method to get the ExecutionRepository.

* perf(test): Share execution repository among tests

  Given that we share the actual persistence between tests, there's not much benefit to creating a new ExecutionRepository for each test. Speed the tests up by re-using it between tests.

* perf(test): Remove previous repository from base test

  The previous repository is only used in the Jedis tests; remove it from the base class so we can avoid creating it and cleaning it up after every test.