### PR TITLE
fix(disable): enforce serverGroup.disabled is true

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTaskSpec.groovy
@@ -31,7 +31,7 @@ class WaitForClusterDisableTaskSpec extends Specification {
   @Subject def task = new WaitForClusterDisableTask([serverGroupCreator])
 
   @Unroll
-  def "status=#status when oldSGDisabled=#oldSGDisabled, desiredPercentage=#desiredPct, interestingHealthProviderNames=#interestingHealthProviderNames"() {
+  def "status=#status when desiredPercentage=#desiredPct, interestingHealthProviderNames=#interestingHealthProviderNames"() {
     given:
     def stage = stage {
       context = [
@@ -53,7 +53,7 @@ class WaitForClusterDisableTaskSpec extends Specification {
         serverGroup("$clusterName-v051".toString(), "us-west-1", [:]),
         serverGroup("$clusterName-$newServerGroup".toString(), region, [:]),
         serverGroup("$clusterName-$oldServerGroup".toString(), region, [
-          disabled: oldSGDisabled,
+          disabled: disabled,
           capacity: [desired: desired],
           instances: [
             instance('i-1', platformHealthState, extraHealths),
@@ -75,36 +75,37 @@ class WaitForClusterDisableTaskSpec extends Specification {
     result.getStatus() == status
 
     where:
-    dsgregion | minWaitTime | oldSGDisabled | desired | desiredPct | interestingHealthProviderNames | extraHealths                  | platformHealthState || status
-    "other"   | 0           | false         | 3       | null       | ['platformHealthType']         | []                            | 'Unknown'           || SUCCEEDED  // exercises if (!remainingDeployServerGroups)...
-    "other"   | 90          | false         | 3       | null       | ['platformHealthType']         | []                            | 'Unknown'           || RUNNING    // keeps running if duration < minWaitTime
+    dsgregion | minWaitTime | disabled | desired | desiredPct | interestingHealthProviderNames | extraHealths                  | platformHealthState || status
+    "other"   | 0           | false    | 3       | null       | ['platformHealthType']         | []                            | 'Unknown'           || SUCCEEDED  // exercises if (!remainingDeployServerGroups)...
+    "other"   | 90          | false    | 3       | null       | ['platformHealthType']         | []                            | 'Unknown'           || RUNNING    // keeps running if duration < minWaitTime
+    region    | 0           | false    | 3       | null       | null                           | []                            | 'Unknown'           || RUNNING    // keeps running if disabled is false
 
     // tests for isDisabled==true
-    region    | 0           | true          | 3       | null       | ['platformHealthType']         | []                            | 'Unknown'           || SUCCEEDED
-    region    | 0           | true          | 3       | null       | ['platformHealthType']         | []                            | 'NotUnknown'        || RUNNING    // wait for instances down even if cluster is disabled
-    region    | 0           | true          | 3       | 100        | ['platformHealthType']         | []                            | 'NotUnknown'        || RUNNING    // also wait for instances down with a desiredPct
-    region    | 0           | true          | 4       | 50         | ['platformHealthType']         | []                            | 'Unknown'           || SUCCEEDED
-    region    | 0           | true          | 3       | null       | ['strangeType']                | []                            | 'Unknown'           || SUCCEEDED  // intersection of interesting and provided healths is empty, so we're done
-    region    | 0           | true          | 3       | null       | ['strangeType']                | health('strange', 'Down')     | 'Unknown'           || SUCCEEDED  // also done if we provide it and are down...
-    region    | 0           | true          | 3       | null       | ['strangeType']                | health('strange', 'Up')       | 'Unknown'           || RUNNING    // ...but not if that extra health is up
+    region    | 0           | true     | 3       | null       | ['platformHealthType']         | []                            | 'Unknown'           || SUCCEEDED
+    region    | 0           | true     | 3       | null       | ['platformHealthType']         | []                            | 'NotUnknown'        || RUNNING    // wait for instances down even if cluster is disabled
+    region    | 0           | true     | 3       | 100        | ['platformHealthType']         | []                            | 'NotUnknown'        || RUNNING    // also wait for instances down with a desiredPct
+    region    | 0           | true     | 4       | 50         | ['platformHealthType']         | []                            | 'Unknown'           || SUCCEEDED
+    region    | 0           | true     | 3       | null       | ['strangeType']                | []                            | 'Unknown'           || SUCCEEDED  // intersection of interesting and provided healths is empty, so we're done
+    region    | 0           | true     | 3       | null       | ['strangeType']                | health('strange', 'Down')     | 'Unknown'           || SUCCEEDED  // also done if we provide it and are down...
+    region    | 0           | true     | 3       | null       | ['strangeType']                | health('strange', 'Up')       | 'Unknown'           || RUNNING    // ...but not if that extra health is up
 
-    // tests for isDisabled==false, no desiredPct
-    region    | 0           | false         | 3       | null       | []                             | []                            | 'Unknown'           || SUCCEEDED  // no health providers to check so short-circuits early
-    region    | 0           | false         | 3       | null       | null                           | []                            | 'Unknown'           || RUNNING    // exercises null vs empty behavior of interestingHealthProviderNames
-    region    | 0           | false         | 3       | null       | ['platformHealthType']         | []                            | 'Unknown'           || SUCCEEDED  // considered complete because only considers the platform health
-    region    | 0           | false         | 3       | null       | ['platformHealthType']         | []                            | 'Up'                || SUCCEEDED  // considered complete because only considers the platform health, despite platform health being Up
-    region    | 0           | false         | 3       | null       | ['strangeType']                | []                            | 'Unknown'           || RUNNING    // can't complete if we need to monitor an unknown health provider...
-    region    | 0           | false         | 3       | null       | ['strangeType']                | health('strange', 'Down')     | 'Unknown'           || RUNNING    // ...regardless of down status
+    // tests for no desiredPct
+    region    | 0           | true     | 3       | null       | []                             | []                            | 'Unknown'           || SUCCEEDED  // no health providers to check so short-circuits early
+    region    | 0           | true     | 3       | null       | null                           | []                            | 'Unknown'           || SUCCEEDED  // exercises null vs empty behavior of interestingHealthProviderNames
+    region    | 0           | true     | 3       | null       | ['platformHealthType']         | []                            | 'Unknown'           || SUCCEEDED  // considered complete because only considers the platform health
+    region    | 0           | true     | 3       | null       | ['platformHealthType']         | health('eureka', 'Up')        | 'Unknown'           || SUCCEEDED  // up health is filtered out so we're done
+    region    | 0           | true     | 3       | null       | ['strangeType']                | []                            | 'Unknown'           || SUCCEEDED  // missing health is filtered out so we're done
+    region    | 0           | true     | 3       | null       | ['strangeType']                | health('strange', 'Down')     | 'Unknown'           || SUCCEEDED  // extra health is down so we're done
 
-    // tests for waitForRequiredInstancesDownTask.hasSucceeded
-    region    | 0           | false         | 3       | 100        | null                           | []                            | 'Unknown'           || SUCCEEDED  // no other health providers than platform, and it looks down
-    region    | 0           | false         | 3       | 100        | null                           | []                            | 'NotUnknown'        || RUNNING    // no other health providers than platform, and it looks NOT down
-    region    | 0           | false         | 4       | 100        | ['platformHealthType']         | []                            | 'Unknown'           || RUNNING    // can't reach count(someAreDownAndNoneAreUp) >= targetDesiredSize
-    region    | 0           | false         | 4       | 50         | ['platformHealthType']         | []                            | 'Unknown'           || SUCCEEDED  // all look down, and we want at least 2 down so we're done
-    region    | 0           | false         | 3       | 100        | ['strangeType']                | []                            | 'Unknown'           || SUCCEEDED  // intersection of interesting and provided healths is empty, so we're done
-    region    | 0           | false         | 3       | 100        | ['strangeType']                | health('strange', 'Down')     | 'Unknown'           || SUCCEEDED  // ...unless we have data for that health provider
-    region    | 0           | false         | 3       | 100        | ['strangeType']                | health('strange', 'Up')       | 'Unknown'           || RUNNING    // ...unless we have data for that health provider
-    region    | 0           | false         | 3       | 100        | ['strangeType']                | health('strange', 'Starting') | 'Unknown'           || SUCCEEDED  // Starting is considered down
+    // tests with desiredPct
+    region    | 0           | true     | 3       | 100        | null                           | []                            | 'Unknown'           || SUCCEEDED  // no other health providers than platform
+    region    | 0           | true     | 3       | 100        | null                           | []                            | 'NotUnknown'        || RUNNING    // no other health providers than platform
+    region    | 0           | true     | 4       | 100        | ['platformHealthType']         | []                            | 'Unknown'           || RUNNING    // can't reach count(someAreDownAndNoneAreUp) >= targetDesiredSize
+    region    | 0           | true     | 4       | 50         | ['platformHealthType']         | []                            | 'Unknown'           || SUCCEEDED  // all look down, and we want at least 2 down so we're done
+    region    | 0           | true     | 3       | 100        | ['strangeType']                | []                            | 'Unknown'           || SUCCEEDED  // intersection of interesting and provided healths is empty, so we're done
+    region    | 0           | true     | 3       | 100        | ['strangeType']                | health('strange', 'Down')     | 'Unknown'           || SUCCEEDED  // extra health is down so we're done
+    region    | 0           | true     | 3       | 100        | ['strangeType']                | health('strange', 'Up')       | 'Unknown'           || RUNNING    // extra health is up so we're not done
+    region    | 0           | true     | 3       | 100        | ['strangeType']                | health('strange', 'Starting') | 'Unknown'           || SUCCEEDED  // Starting is considered down
 
     oldServerGroup = "v167"
     newServerGroup = "v168"


### PR DESCRIPTION
Let's simplify the logic in WaitForClusterDisableTask:
1. first make sure that the server group disabled flag is set
2. then delegate to waitForRequiredInstancesDownTask to check the various healths and the more subtle points like whether interestingHealthProviderNames are set or not

Motivation: it was possible to get out of WaitForClusterDisableTask with a server group that had Down instances but `disabled: false`, therefore it would still count as an active server group and would be filtered out by downstream stages like scaleDownServerGroup.
