### PR TITLE
fix(stage): Handle SKIPPED tasks and synthetic stages

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -269,7 +269,7 @@ class CompleteStageHandler(
       allStatuses.contains(STOPPED) -> STOPPED
       allStatuses.contains(CANCELED) -> CANCELED
       allStatuses.contains(FAILED_CONTINUE) -> FAILED_CONTINUE
-      allStatuses.all { it == SUCCEEDED } -> SUCCEEDED
+      allStatuses.all { it == SUCCEEDED || it == SKIPPED } -> SUCCEEDED
       afterStageStatuses.contains(NOT_STARTED) -> RUNNING // after stages were planned but not run yet
       else -> {
         log.error("Unhandled condition for stage $id of ${execution.id}, marking as TERMINAL. syntheticStatuses=$syntheticStatuses, taskStatuses=$taskStatuses, planningStatus=$planningStatus, afterStageStatuses=$afterStageStatuses")

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
@@ -693,6 +693,75 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
       }
     }
 
+    describe("when a stage had skipped synthetics or tasks") {
+      given("some tasks were skipped") {
+        val pipeline = pipeline {
+          stage {
+            refId = "1"
+            type = multiTaskStage.type
+            multiTaskStage.plan(this)
+            tasks[0].status = SUCCEEDED
+            tasks[1].status = SKIPPED
+            tasks[2].status = SUCCEEDED
+            status = RUNNING
+          }
+        }
+        val message = CompleteStage(pipeline.stageByRef("1"))
+
+        beforeGroup {
+          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
+        }
+
+        afterGroup(::resetMocks)
+
+        on("receiving the message") {
+          subject.handle(message)
+        }
+
+        it("updates the stage state") {
+          verify(repository).storeStage(check {
+            assertThat(it.status).isEqualTo(SUCCEEDED)
+            assertThat(it.endTime).isEqualTo(clock.millis())
+          })
+        }
+      }
+
+      given("some synthetic stages were skipped") {
+        val pipeline = pipeline {
+          stage {
+            refId = "1"
+            type = stageWithSyntheticBefore.type
+            stageWithSyntheticBefore.buildBeforeStages(this)
+            stageWithSyntheticBefore.buildTasks(this)
+          }
+        }
+
+        val message = CompleteStage(pipeline.stageByRef("1"))
+
+        beforeGroup {
+          pipeline
+            .stages
+            .filter { it.syntheticStageOwner == STAGE_BEFORE }
+            .forEach { it.status = SKIPPED }
+          pipeline.stageById(message.stageId).tasks.forEach { it.status = SUCCEEDED }
+          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
+        }
+
+        afterGroup(::resetMocks)
+
+        on("receiving the message") {
+          subject.handle(message)
+        }
+
+        it("updates the stage state") {
+          verify(repository).storeStage(check {
+            assertThat(it.status).isEqualTo(SUCCEEDED)
+            assertThat(it.endTime).isEqualTo(clock.millis())
+          })
+        }
+      }
+    }
+
     given("a stage had no tasks or before stages") {
       but("does have after stages") {
         val pipeline = pipeline {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
@@ -741,10 +741,12 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
         }
 
         it("updates the stage state") {
-          verify(repository).storeStage(check {
-            assertThat(it.status).isEqualTo(SUCCEEDED)
-            assertThat(it.endTime).isEqualTo(clock.millis())
-          })
+          verify(repository).storeStage(
+            check {
+              assertThat(it.status).isEqualTo(SUCCEEDED)
+              assertThat(it.endTime).isEqualTo(clock.millis())
+            }
+          )
         }
       }
 
@@ -776,10 +778,12 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
         }
 
         it("updates the stage state") {
-          verify(repository).storeStage(check {
-            assertThat(it.status).isEqualTo(SUCCEEDED)
-            assertThat(it.endTime).isEqualTo(clock.millis())
-          })
+          verify(repository).storeStage(
+            check {
+              assertThat(it.status).isEqualTo(SUCCEEDED)
+              assertThat(it.endTime).isEqualTo(clock.millis())
+            }
+          )
         }
       }
     }


### PR DESCRIPTION
This PR is to fix https://github.com/spinnaker/spinnaker/issues/5936.

Before this PR, `CompleteStageHandler` treats `SKIPPED` tasks/synthetics as "unhandled condition".
As a result, `SKIPPED` tasks and synthetic stages will mark the (parent) stage as `TERMINAL`.
This is not desirable because:
- `SKIPPED` is benign
- a `SKIPPED` stage won't fail a pipeline and the behaviour is inconsistent
- `SKIPPED` has valid use cases, for example synthetic stages conditional on parent stage output

After this PR, `SKIPPED` task or synthetic stage won't fail (parent) stage.
A special case is where **all** the tasks are skipped. The stage status will be `SUCCEEDED` instead of `SKIPPED`, to differentiate from the case where the stage itself is conditional and skipped.
