### PR TITLE
fix(execution promoter): Only enable execution promoter if enabled

### DIFF
--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionPromoter.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionPromoter.kt
@@ -27,6 +27,7 @@ import net.logstash.logback.argument.StructuredArguments.value
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.BeanInitializationException
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ApplicationListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -37,6 +38,7 @@ import org.springframework.stereotype.Component
 interface ExecutionPromoter
 
 @Component
+@ConditionalOnProperty("pollers.qos.enabled")
 class DefaultExecutionPromoter(
   private val executionLauncher: ExecutionLauncher,
   private val executionRepository: ExecutionRepository,


### PR DESCRIPTION
This way, if an orca cluster is not running the queue we don't enable the promoter
