### PR TITLE
fix(exceptions): add exception handler for exceptional situations

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/RetryableIgorTask.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/RetryableIgorTask.java
@@ -89,10 +89,12 @@ public abstract class RetryableIgorTask<T extends RetryableStageDefinition>
       return true;
     }
 
-    int status = retrofitError.getResponse().getStatus();
-    if (status == 500 || status == 503) {
-      log.warn(String.format("Received HTTP %s response from igor, retrying...", status));
-      return true;
+    if (retrofitError.getResponse() != null) {
+      int status = retrofitError.getResponse().getStatus();
+      if (status == 500 || status == 503) {
+        log.warn(String.format("Received HTTP %s response from igor, retrying...", status));
+        return true;
+      }
     }
     return false;
   }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildPropertiesTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetBuildPropertiesTaskSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.igor.tasks
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.kork.exceptions.ConfigurationException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.igor.BuildService
@@ -141,7 +142,7 @@ class GetBuildPropertiesTaskSpec extends Specification {
     task.execute(stage)
 
     then:
-    IllegalStateException e = thrown IllegalStateException
+    ConfigurationException e = thrown ConfigurationException
     e.message == "Expected properties file $PROPERTY_FILE but it was either missing, empty or contained invalid syntax"
   }
 

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -23,8 +23,7 @@ import com.netflix.spinnaker.fiat.shared.FiatService
 import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.kork.exceptions.ConfigurationException
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException
-import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
-import com.netflix.spinnaker.kork.web.exceptions.ValidationException
+import com.netflix.spinnaker.kork.exceptions.UserException
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.clouddriver.service.JobService
 import com.netflix.spinnaker.orca.exceptions.OperationFailedException
@@ -330,7 +329,7 @@ class OperationsController {
         buildInfo = buildService.getBuild(trigger.buildNumber, trigger.master, trigger.job)
       } catch (RetrofitError e) {
         if (e.response?.status == 404) {
-          throw new IllegalStateException("Build ${trigger.buildNumber} of ${trigger.master}/${trigger.job} not found")
+          throw new ConfigurationException("Build ${trigger.buildNumber} of ${trigger.master}/${trigger.job} not found")
         } else {
           throw new OperationFailedException("Failed to get build ${trigger.buildNumber} of ${trigger.master}/${trigger.job}", e)
         }
@@ -351,7 +350,7 @@ class OperationsController {
           )
         } catch (RetrofitError e) {
           if (e.response?.status == 404) {
-            throw new IllegalStateException("Expected properties file " + trigger.propertyFile + " (configured on trigger), but it was missing")
+            throw new ConfigurationException("Expected properties file " + trigger.propertyFile + " (configured on trigger), but it was missing")
           } else {
             throw new OperationFailedException("Failed to get properties file ${trigger.propertyFile}", e)
           }

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/V2PipelineTemplateController.java
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/V2PipelineTemplateController.java
@@ -25,10 +25,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(value = "/v2/pipelineTemplates")

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/exceptions/OperationFailedException.java
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/exceptions/OperationFailedException.java
@@ -1,6 +1,8 @@
 package com.netflix.spinnaker.orca.exceptions;
 
-public class OperationFailedException extends RuntimeException {
+import com.netflix.spinnaker.kork.exceptions.IntegrationException;
+
+public class OperationFailedException extends IntegrationException {
   public OperationFailedException(String message) {
     super(message);
   }


### PR DESCRIPTION
When a user submits a bad pipeline e.g.
* with jenkins trigger that has an invalid properties file or job that doesn't exist)
* with a broken pipeline template

we don't want to 500 because:
a) the calling service (echo in most cases here) will keep retrying which makes no sense
b) it's an erroneous HTTP 500 metric that is noise

