### PR TITLE
feat(destroy): Add a flag to be able to skip the disable of destroy stage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -25,11 +25,15 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.DestroyServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForDestroyedServerGroupTask
 import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilderImpl
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
 class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport implements ForceCacheRefreshAware {
+  private static final Logger log = LoggerFactory.getLogger(DestroyServerGroupStage.class)
+  
   static final String PIPELINE_CONFIG_TYPE = "destroyServerGroup"
 
   private final DynamicConfigService dynamicConfigService
@@ -48,6 +52,8 @@ class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport implem
         it.type = getType(DisableServerGroupStage)
         it.context.putAll(context)
       }
+    } else {
+      log.info("DisableServerGroupStage has been skipped (skipDisableBeforeDestroy: true)")
     }
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -47,6 +47,8 @@ class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport implem
     boolean skipDisable = (boolean)context.getOrDefault("skipDisableBeforeDestroy", false)
 
     if (!skipDisable) {
+      // conditional opt-out for server groups where an explicit disable is unnecessary 
+      // (ie. they do not register in service discovery or a load balancer)
       graph.add {
         it.name = "disableServerGroup"
         it.type = getType(DisableServerGroupStage)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -40,10 +40,14 @@ class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport implem
   }
 
   private static void addDisableStage(Map<String, Object> context, StageGraphBuilderImpl graph) {
-    graph.add {
-      it.name = "disableServerGroup"
-      it.type = getType(DisableServerGroupStage)
-      it.context.putAll(context)
+    boolean skipDisable = (boolean)context.getOrDefault("forceSkipDisable", false)
+
+    if (!skipDisable ) {
+      graph.add {
+        it.name = "disableServerGroup"
+        it.type = getType(DisableServerGroupStage)
+        it.context.putAll(context)
+      }
     }
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -40,9 +40,9 @@ class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport implem
   }
 
   private static void addDisableStage(Map<String, Object> context, StageGraphBuilderImpl graph) {
-    boolean skipDisable = (boolean)context.getOrDefault("forceSkipDisable", false)
+    boolean skipDisable = (boolean)context.getOrDefault("skipDisableBeforeDestroy", false)
 
-    if (!skipDisable ) {
+    if (!skipDisable) {
       graph.add {
         it.name = "disableServerGroup"
         it.type = getType(DisableServerGroupStage)


### PR DESCRIPTION
Add an experimental flag `forceSkipDisable` to the `DestroyServerGroupStage` so that applications that don't participate in discovery can skip disable step which should speed up their destruction operation.

