### PR TITLE
fix(manualJudgment): Retain all fields in notification context

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.orca.echo.pipeline
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
@@ -155,6 +158,19 @@ class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage 
 
     Map<String, Date> lastNotifiedByNotificationState = [:]
     Long notifyEveryMs = -1
+
+    @JsonIgnore
+    Map<String, Object> other = new HashMap<>()
+
+    @JsonAnyGetter
+    public Map<String, Object> other() {
+      return other
+    }
+
+    @JsonAnySetter
+    public void set(String name, Object value) {
+      other.put(name, value)
+    }
 
     boolean shouldNotify(String notificationState, Date now = new Date()) {
       // The new scheme for configuring notifications requires the use of the when list (just like the other stages).

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
@@ -151,6 +151,26 @@ class ManualJudgmentStageSpec extends Specification {
   }
 
   @Unroll
+  void "should retain unknown fields in the notification context"() {
+    given:
+    def task = new WaitForManualJudgmentTask(echoService: Mock(EchoService))
+
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        notifications: [
+            new Notification(type: "slack", customMessage: "hello slack"),
+            new Notification(type: "email", customSubject: "hello email")
+        ]
+    ])
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.context.notifications?.get(0)?.other?.customMessage == "hello slack"
+    result.context.notifications?.get(1)?.other?.customSubject == "hello email"
+  }
+
+  @Unroll
   void "should return modified authentication context"() {
     given:
     def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [


### PR DESCRIPTION
This PR is to fix https://github.com/spinnaker/spinnaker/issues/5976.

Though `ManualJudgment` stage has its own logic to send custom notifications, it should still be compatible with the standard notification events on stage starting/completion/failure.

Before this PR, the notification configurations under `context.notifications` will be trimmed due to the deserialization. Some fields will be missing after stage execution, for example, `customSubject` supported by `email` provider and `customMessage` supported by `slack` provider.

After this PR, all the configured fields will be kept even if it's unknown to `ManualJudgment` stage.