### PR TITLE
refactor(kubernetes): minimize getDynamicManifest contract

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.clouddriver;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.web.selector.SelectableService;
 import com.netflix.spinnaker.orca.clouddriver.model.Manifest;
+import com.netflix.spinnaker.orca.clouddriver.model.ManifestCoordinates;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
@@ -49,7 +50,7 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   }
 
   @Override
-  public Manifest getDynamicManifest(
+  public ManifestCoordinates getDynamicManifest(
       String account, String location, String kind, String app, String cluster, String criteria) {
     return getService().getDynamicManifest(account, location, kind, app, cluster, criteria);
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.clouddriver
 
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.orca.clouddriver.model.Manifest
+import com.netflix.spinnaker.orca.clouddriver.model.ManifestCoordinates
 import retrofit.client.Response
 import retrofit.http.Body
 import retrofit.http.GET
@@ -57,12 +58,12 @@ interface OortService {
                        @Query("includeEvents") boolean includeEvents)
 
   @GET("/manifests/{account}/{location}/{kind}/cluster/{app}/{clusterName}/dynamic/{criteria}")
-  Manifest getDynamicManifest(@Path("account") String account,
-                              @Path("location") String location,
-                              @Path("kind") String kind,
-                              @Path("app") String app,
-                              @Path("clusterName") String clusterName,
-                              @Path("criteria") String criteria)
+  ManifestCoordinates getDynamicManifest(@Path("account") String account,
+                                         @Path("location") String location,
+                                         @Path("kind") String kind,
+                                         @Path("app") String app,
+                                         @Path("clusterName") String clusterName,
+                                         @Path("criteria") String criteria)
 
   @Deprecated
   @GET("/applications/{app}/serverGroups/{account}/{region}/{serverGroup}")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/model/ManifestCoordinates.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/model/ManifestCoordinates.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import lombok.Builder;
+import lombok.Value;
+
+@JsonDeserialize(builder = ManifestCoordinates.ManifestCoordinatesBuilder.class)
+@NonnullByDefault
+@Value
+public class ManifestCoordinates {
+  String kind;
+  String namespace;
+  String name;
+
+  @Builder(toBuilder = true)
+  private ManifestCoordinates(String kind, String namespace, String name) {
+    this.kind = kind;
+    this.namespace = namespace;
+    this.name = name;
+  }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static final class ManifestCoordinatesBuilder {}
+
+  @JsonIgnore
+  public String getFullResourceName() {
+    return String.join(" ", this.kind, this.name);
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolveTargetManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolveTargetManifestTask.java
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
-import com.netflix.spinnaker.orca.clouddriver.model.Manifest;
+import com.netflix.spinnaker.orca.clouddriver.model.ManifestCoordinates;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
 import java.io.IOException;
 import java.util.Map;
@@ -56,7 +56,7 @@ public class ResolveTargetManifestTask extends AbstractCloudProviderAwareTask im
       return TaskResult.SUCCEEDED;
     }
 
-    Manifest target =
+    ManifestCoordinates target =
         retrySupport.retry(
             () ->
                 oortService.getDynamicManifest(
@@ -75,7 +75,9 @@ public class ResolveTargetManifestTask extends AbstractCloudProviderAwareTask im
     }
 
     Map<String, Object> outputs =
-        new ImmutableMap.Builder<String, Object>().put("manifestName", target.getName()).build();
+        new ImmutableMap.Builder<String, Object>()
+            .put("manifestName", target.getFullResourceName())
+            .build();
 
     return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).outputs(outputs).build();
   }


### PR DESCRIPTION
* refactor(kubernetes): minimize getDynamicManifest contract 

  The only client of Clouddriver's dynamic manifest endpoint is Orca's ResolveDynamicManifestTask, which immediately discards the entire Manifest except for its name.

  Adds a ManifestCoordinates model, whose analog ezimanyi recently added to Clouddriver. As we continue to stop passing entire Kubernetes manifests among Orca tasks and stages and between Orca tasks and Clouddriver, we will likely re-use this soon.
