### PR TITLE
fix(monitored-deploy): roll back to original server group

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategy.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategy.groovy
@@ -393,7 +393,7 @@ class MonitoredDeployStrategy implements Strategy {
       return stages
     }
 
-    stages.addAll(composeRollbackStages(parent))
+    stages.addAll(composeRollbackStages(parent, source))
 
     def cleanupConfig = AbstractDeployStrategyStage.CleanupConfig.fromStage(parent)
 
@@ -451,7 +451,7 @@ class MonitoredDeployStrategy implements Strategy {
     return stages
   }
 
-  List<StageExecution> composeRollbackStages(StageExecution parent) {
+  List<StageExecution> composeRollbackStages(StageExecution parent, ResizeStrategy.Source source) {
     CreateServerGroupStage.StageData stageData = parent.mapTo(CreateServerGroupStage.StageData)
     MonitoredDeployStageData monitoredDeployStageData = parent.mapTo(MonitoredDeployStageData)
     String deployedServerGroupName = stageData.getServerGroup()
@@ -480,6 +480,7 @@ class MonitoredDeployStrategy implements Strategy {
         cloudProvider            : stageData.cloudProvider,
         regions                  : [stageData.region],
         serverGroup              : stageData.serverGroup,
+        originalServerGroup      : source.serverGroupName,
         stageTimeoutMs           : MINUTES.toMillis(30), // timebox a rollback to 30 minutes
         additionalRollbackContext: [
           enableAndDisableOnly: true,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.FeaturesService;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.CreateServerGroupStage;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.RollbackServerGroupStage;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.rollback.PreviousImageRollbackSupport;
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask;
@@ -220,7 +221,8 @@ public class DetermineRollbackCandidatesTask extends AbstractCloudProviderAwareT
 
   /** Return the name of the original server group we should roll back to */
   private Optional<String> getOriginalServerGroup(StageExecution stage) {
-    return Optional.ofNullable(stage.findAncestor(isType("createServerGroup")))
+    return Optional.ofNullable(
+            stage.findAncestor(isType(CreateServerGroupStage.PIPELINE_CONFIG_TYPE)))
         .map(StageExecution::getContext)
         .map(this::getSourceServerGroup);
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
@@ -239,6 +239,7 @@ public class DetermineRollbackCandidatesTask extends AbstractCloudProviderAwareT
         return serverGroupName.toString();
       }
     }
+    logger.error("Failed to get source server group from createServerGroup context");
     return null;
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
@@ -57,8 +57,11 @@ import retrofit.client.Response;
  * The {@code DetermineRollbackCandidatesTask} task determines how one or more regions of a cluster
  * should be rolled back.
  *
- * <p>The determination is based on inspecting the most recently deployed (and enabled!) server
- * group in each region.
+ * <p>If the stage's context contains an `originalServerGroup` key, then this value is used as the
+ * server group to roll back to.
+ *
+ * <p>If the `originalServerGroup` is not specified in the stage context, the determination is based
+ * on inspecting the most recently deployed (and enabled!) server group in each region.
  *
  * <p>If this server group has the `spinnaker:metadata` entity tag: - rollback to a previous server
  * group (if exists!) with the `spinnaker:metadata` image id - if no such server group exists, clone

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
@@ -534,11 +534,6 @@ public class DetermineRollbackCandidatesTask extends AbstractCloudProviderAwareT
     return 95;
   }
 
-  /** Helper function for finding an ancestor stage */
-  private static Predicate<StageExecution> isType(String stageType) {
-    return s -> s.getType().equals(stageType);
-  }
-
   /** Helper function useful for filtering streams */
   private static Predicate<ServerGroup> exclude(ServerGroup group) {
     return s -> !(s.name.equalsIgnoreCase(group.name));

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategySpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/MonitoredDeployStrategySpec.groovy
@@ -195,6 +195,7 @@ class MonitoredDeployStrategySpec extends Specification {
     def pipeline = configureBasicPipeline()
     def strategy = createStrategy()
     def deployedServerGroupMoniker = "test-dev"
+    def originalServerGroupName = "${deployedServerGroupMoniker}-v005".toString()
     def deployedServerGroupName = "${deployedServerGroupMoniker}-v006".toString()
 
     when: 'no target server group is created (yet)'
@@ -231,6 +232,7 @@ class MonitoredDeployStrategySpec extends Specification {
     then: 'should rollback, unpin source, and then notify monitor of completion'
     failureStages.size() == 4
     failureStages[0].type == RollbackClusterStage.PIPELINE_CONFIG_TYPE
+    failureStages[0].context.originalServerGroup == originalServerGroupName
     failureStages[1].type == DestroyServerGroupStage.PIPELINE_CONFIG_TYPE
     failureStages[1].name == "Destroy ${deployedServerGroupName} due to rollback"
     failureStages[1].context.serverGroupName == deployedServerGroupName

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
@@ -27,7 +27,7 @@ import spock.lang.Subject
 import spock.lang.Unroll
 
 import static DetermineRollbackCandidatesTask.determineTargetHealthyRollbackPercentage
-
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage;
 
 class DetermineRollbackCandidatesTaskSpec extends Specification {
@@ -52,6 +52,71 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
         app    : "app",
         cluster: "app-stack-details"
       ]
+    ]
+  }
+
+  def "should EXPLICIT-ly roll back to original ASG when parent createServerGroup has source info"() {
+
+    given: "a parent create server group stage in the pipeline"
+    pipeline {
+      stage {
+        type = "createServerGroup"
+        context = [
+            source: [serverGroupName: "servergroup-v001"]
+        ]
+
+        stage = stage {
+          type = "rollbackCluster"
+          context = [
+              credentials  : "test",
+              cloudProvider: "aws",
+              regions      : ["us-west-2"],
+              moniker      : [
+                  app    : "app",
+                  cluster: "app-stack-details"
+              ]
+          ]
+        }
+      }
+    }
+
+    and: "entity tags contain metadata with the image id of the previous server group"
+    featuresService.areEntityTagsAvailable() >> { return true }
+    oortService.getEntityTags(*_) >> {
+      return [buildSpinnakerMetadata("my_image-0", "ami-xxxxx0", "5")]
+    }
+
+    and: "there are at least two server groups"
+    oortService.getCluster("app", "test", "app-stack-details", "aws") >> {
+      return buildResponse([
+          serverGroups: [
+              buildServerGroup("servergroup-v001", "us-west-2",  100, true, [:], [:], 5),
+              buildServerGroup("servergroup-v002", "us-west-2" , 150, false, [:], [:], 5)
+          ]
+      ])
+    }
+
+    when: "the task is executed"
+    def result = task.execute(stage)
+
+    then: "it uses the EXPLICIT strategy to roll back to the original server group"
+    result.context == [
+        imagesToRestore: [
+            [region: "us-west-2", image: "my_image-0", buildNumber: "5", rollbackMethod: "EXPLICIT"]
+        ]
+    ]
+
+    result.outputs == [
+        rollbackTypes   : [
+            "us-west-2": "EXPLICIT"
+        ],
+        rollbackContexts: [
+            "us-west-2": [
+                rollbackServerGroupName        : "servergroup-v002",
+                restoreServerGroupName         : "servergroup-v001",
+                targetHealthyRollbackPercentage: 100
+            ]
+        ]
     ]
   }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
@@ -57,7 +57,7 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
 
   def "should EXPLICIT-ly roll back to original ASG when parent createServerGroup has source info"() {
 
-    given: "a parent create server group stage in the pipeline"
+    given: "an ancestor create server group stage in the pipeline"
     pipeline {
       stage {
         type = "createServerGroup"

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
@@ -55,6 +55,50 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
     ]
   }
 
+  def "should EXPLICIT-ly roll back to original ASG when original cluster is in context"() {
+    given: "the name of the original server group is present in the context"
+    stage.context["originalServerGroup"] = "servergroup-v001"
+
+    and: "entity tags contain metadata with the image id of the original server group"
+    featuresService.areEntityTagsAvailable() >> { return true }
+    oortService.getEntityTags(*_) >> {
+      return [buildSpinnakerMetadata("my_image-0", "ami-xxxxx0", "5")]
+    }
+
+    and: "there are at least two server groups"
+    oortService.getCluster("app", "test", "app-stack-details", "aws") >> {
+      return buildResponse([
+          serverGroups: [
+              buildServerGroup("servergroup-v001", "us-west-2",  100, true, [:], [:], 5),
+              buildServerGroup("servergroup-v002", "us-west-2" , 150, false, [:], [:], 5)
+          ]
+      ])
+    }
+
+    when: "the task is executed"
+    def result = task.execute(stage)
+
+    then: "it uses the EXPLICIT strategy to roll back to the original server group"
+    result.context == [
+        imagesToRestore: [
+            [region: "us-west-2", image: "my_image-0", buildNumber: "5", rollbackMethod: "EXPLICIT"]
+        ]
+    ]
+
+    result.outputs == [
+        rollbackTypes   : [
+            "us-west-2": "EXPLICIT"
+        ],
+        rollbackContexts: [
+            "us-west-2": [
+                rollbackServerGroupName        : "servergroup-v002",
+                restoreServerGroupName         : "servergroup-v001",
+                targetHealthyRollbackPercentage: 100
+            ]
+        ]
+    ]
+  }
+
   def "should EXPLICIT-ly roll back to original ASG when parent createServerGroup has source info"() {
 
     given: "an ancestor create server group stage in the pipeline"

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
@@ -27,7 +27,6 @@ import spock.lang.Subject
 import spock.lang.Unroll
 
 import static DetermineRollbackCandidatesTask.determineTargetHealthyRollbackPercentage
-import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage;
 
 class DetermineRollbackCandidatesTaskSpec extends Specification {
@@ -60,71 +59,6 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
     stage.context["originalServerGroup"] = "servergroup-v001"
 
     and: "entity tags contain metadata with the image id of the original server group"
-    featuresService.areEntityTagsAvailable() >> { return true }
-    oortService.getEntityTags(*_) >> {
-      return [buildSpinnakerMetadata("my_image-0", "ami-xxxxx0", "5")]
-    }
-
-    and: "there are at least two server groups"
-    oortService.getCluster("app", "test", "app-stack-details", "aws") >> {
-      return buildResponse([
-          serverGroups: [
-              buildServerGroup("servergroup-v001", "us-west-2",  100, true, [:], [:], 5),
-              buildServerGroup("servergroup-v002", "us-west-2" , 150, false, [:], [:], 5)
-          ]
-      ])
-    }
-
-    when: "the task is executed"
-    def result = task.execute(stage)
-
-    then: "it uses the EXPLICIT strategy to roll back to the original server group"
-    result.context == [
-        imagesToRestore: [
-            [region: "us-west-2", image: "my_image-0", buildNumber: "5", rollbackMethod: "EXPLICIT"]
-        ]
-    ]
-
-    result.outputs == [
-        rollbackTypes   : [
-            "us-west-2": "EXPLICIT"
-        ],
-        rollbackContexts: [
-            "us-west-2": [
-                rollbackServerGroupName        : "servergroup-v002",
-                restoreServerGroupName         : "servergroup-v001",
-                targetHealthyRollbackPercentage: 100
-            ]
-        ]
-    ]
-  }
-
-  def "should EXPLICIT-ly roll back to original ASG when parent createServerGroup has source info"() {
-
-    given: "an ancestor create server group stage in the pipeline"
-    pipeline {
-      stage {
-        type = "createServerGroup"
-        context = [
-            source: [serverGroupName: "servergroup-v001"]
-        ]
-
-        stage = stage {
-          type = "rollbackCluster"
-          context = [
-              credentials  : "test",
-              cloudProvider: "aws",
-              regions      : ["us-west-2"],
-              moniker      : [
-                  app    : "app",
-                  cluster: "app-stack-details"
-              ]
-          ]
-        }
-      }
-    }
-
-    and: "entity tags contain metadata with the image id of the previous server group"
     featuresService.areEntityTagsAvailable() >> { return true }
     oortService.getEntityTags(*_) >> {
       return [buildSpinnakerMetadata("my_image-0", "ami-xxxxx0", "5")]


### PR DESCRIPTION
## Problem

In some cases, when a stage in a monitored deploy pipeline execution fails and attempts to automatically
roll back, the rollback stage fails. The associated error reported by the rollback stage is that Spinnaker cannot find a valid server group to roll back to. However, the original server group still exists.

## Solution requirements

If the original server group still exists, a rollback triggered by a monitored deployment should roll back to the original server group.

## Implemented solution

The *MonitoredDeployStrategy* class has been modified to add the name of the original server group to the context of the *RollbackClusterStage* in the pipeline.

The *DetermineRollbackCandidatesTask* class, which executes inside of a *RollbackClusterStage*, now determines which server group to roll back to by retrieving the original server group from its stage's context.  If the task fails to retrieve this information, it falls back to the previously implemented behavior.
