### PR TITLE
feat(kubernetes): DeployManifestStage makes live calls to determine cluster members for rollout strategies 

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -56,6 +56,12 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   }
 
   @Override
+  public List<ManifestCoordinates> getClusterManifests(
+      String account, String location, String kind, String app, String cluster) {
+    return getService().getClusterManifests(account, location, kind, app, cluster);
+  }
+
+  @Override
   public Response getServerGroupFromCluster(
       String app,
       String account,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/OortService.groovy
@@ -65,6 +65,13 @@ interface OortService {
                                          @Path("clusterName") String clusterName,
                                          @Path("criteria") String criteria)
 
+  @GET("/manifests/{account}/{location}/{kind}/cluster/{app}/{clusterName}")
+  List<ManifestCoordinates> getClusterManifests(@Path("account") String account,
+                                                @Path("location") String location,
+                                                @Path("kind") String kind,
+                                                @Path("app") String app,
+                                                @Path("clusterName") String clusterName)
+
   @Deprecated
   @GET("/applications/{app}/serverGroups/{account}/{region}/{serverGroup}")
   Response getServerGroup(@Path("app") String app,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
@@ -84,16 +84,16 @@ public class DeployManifestStage implements StageDefinitionBuilder {
     }
   }
 
-  private void disableOldManifests(Map parentContext, StageGraphBuilder graph) {
+  private void disableOldManifests(Map<String, Object> parentContext, StageGraphBuilder graph) {
     addStagesForOldManifests(parentContext, graph, DisableManifestStage.PIPELINE_CONFIG_TYPE);
   }
 
-  private void deleteOldManifests(Map parentContext, StageGraphBuilder graph) {
+  private void deleteOldManifests(Map<String, Object> parentContext, StageGraphBuilder graph) {
     addStagesForOldManifests(parentContext, graph, DeleteManifestStage.PIPELINE_CONFIG_TYPE);
   }
 
   private void addStagesForOldManifests(
-      Map parentContext, StageGraphBuilder graph, String stageType) {
+      Map<String, Object> parentContext, StageGraphBuilder graph, String stageType) {
     List<Map<String, ?>> deployedManifests = getNewManifests(parentContext);
     String account = (String) parentContext.get("account");
     Map manifestMoniker = (Map) parentContext.get("moniker");
@@ -127,7 +127,7 @@ public class DeployManifestStage implements StageDefinitionBuilder {
         });
   }
 
-  private List<Map<String, ?>> getNewManifests(Map parentContext) {
+  private List<Map<String, ?>> getNewManifests(Map<String, Object> parentContext) {
     List<Map<String, ?>> manifests = (List<Map<String, ?>>) parentContext.get("outputs.manifests");
     return manifests.stream()
         .filter(manifest -> manifest.get("kind").equals("ReplicaSet"))

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
@@ -17,32 +17,38 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.manifest;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageGraphBuilder;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.model.ManifestCoordinates;
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.artifacts.CleanupArtifactsTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.*;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestContext.TrafficManagement;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ResolveDeploySourceManifestTask;
-import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper;
 import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class DeployManifestStage implements StageDefinitionBuilder {
   public static final String PIPELINE_CONFIG_TYPE = "deployManifest";
 
-  private final OortHelper oortHelper;
+  private final OortService oortService;
+
+  @Autowired
+  public DeployManifestStage(OortService oortService) {
+    this.oortService = oortService;
+  }
 
   @Override
   public void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {
@@ -103,7 +109,7 @@ public class DeployManifestStage implements StageDefinitionBuilder {
           String clusterName = (String) annotations.get("moniker.spinnaker.io/cluster");
           String cloudProvider = "kubernetes";
 
-          List<String> previousManifestNames =
+          ImmutableList<String> previousManifestNames =
               getOldManifestNames(application, account, clusterName, namespace, manifestName);
           previousManifestNames.forEach(
               name -> {
@@ -128,32 +134,17 @@ public class DeployManifestStage implements StageDefinitionBuilder {
         .collect(Collectors.toList());
   }
 
-  private List<String> getOldManifestNames(
+  private ImmutableList<String> getOldManifestNames(
       String application,
       String account,
       String clusterName,
       String namespace,
       String newManifestName) {
-    Map cluster =
-        oortHelper
-            .getCluster(application, account, clusterName, "kubernetes")
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        String.format(
-                            "Error fetching cluster %s in account %s and namespace %s",
-                            clusterName, account, namespace)));
-
-    List<Map> serverGroups =
-        Optional.ofNullable((List<Map>) cluster.get("serverGroups")).orElse(null);
-
-    if (serverGroups == null) {
-      return new ArrayList<>();
-    }
-
-    return serverGroups.stream()
-        .filter(s -> s.get("region").equals(namespace) && !s.get("name").equals(newManifestName))
-        .map(s -> (String) s.get("name"))
-        .collect(Collectors.toList());
+    return oortService
+        .getClusterManifests(account, namespace, "replicaSet", application, clusterName)
+        .stream()
+        .filter(m -> !m.getFullResourceName().equals(newManifestName))
+        .map(ManifestCoordinates::getFullResourceName)
+        .collect(toImmutableList());
   }
 }

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStageTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStageTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.model.ManifestCoordinates;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestContext;
+import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestContext.TrafficManagement.ManifestStrategyType;
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
+import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilderImpl;
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class DeployManifestStageTest {
+  private static final ObjectMapper objectMapper = OrcaObjectMapper.getInstance();
+  private static final String ACCOUNT = "my-acct";
+  private static final String APPLICATION = "my-app";
+  private static final String CLUSTER = "replicaSet my-rs";
+  private static final String NAMESAPCE = "my-ns";
+
+  @Mock private OortService oortService;
+  private DeployManifestStage deployManifestStage;
+
+  @BeforeEach
+  void setUp() {
+    deployManifestStage = new DeployManifestStage(oortService);
+  }
+
+  @Test
+  void rolloutStrategyDisabled() {
+    StageExecutionImpl stage = new StageExecutionImpl();
+    stage.setContext(
+        getContext(
+            DeployManifestContext.builder()
+                .trafficManagement(
+                    DeployManifestContext.TrafficManagement.builder().enabled(false).build())
+                .build()));
+    assertThat(getAfterStages(stage)).isEmpty();
+  }
+
+  @Test
+  void rolloutStrategyRedBlack() {
+    when(oortService.getClusterManifests(ACCOUNT, NAMESAPCE, "replicaSet", APPLICATION, CLUSTER))
+        .thenReturn(
+            ImmutableList.of(
+                ManifestCoordinates.builder()
+                    .name("my-rs-v000")
+                    .kind("replicaSet")
+                    .namespace(NAMESAPCE)
+                    .build()));
+    Map<String, Object> context =
+        getContext(
+            DeployManifestContext.builder()
+                .trafficManagement(
+                    DeployManifestContext.TrafficManagement.builder()
+                        .enabled(true)
+                        .options(
+                            DeployManifestContext.TrafficManagement.Options.builder()
+                                .strategy(ManifestStrategyType.RED_BLACK)
+                                .build())
+                        .build())
+                .build());
+    StageExecutionImpl stage =
+        new StageExecutionImpl(
+            new PipelineExecutionImpl(ExecutionType.PIPELINE, APPLICATION),
+            DeployManifestStage.PIPELINE_CONFIG_TYPE,
+            context);
+    assertThat(getAfterStages(stage))
+        .extracting(StageExecution::getType)
+        .containsExactly(DisableManifestStage.PIPELINE_CONFIG_TYPE);
+    assertThat(getAfterStages(stage))
+        .extracting(s -> s.getContext().get("account"))
+        .containsExactly(ACCOUNT);
+    assertThat(getAfterStages(stage))
+        .extracting(s -> s.getContext().get("app"))
+        .containsExactly(APPLICATION);
+    assertThat(getAfterStages(stage))
+        .extracting(s -> s.getContext().get("location"))
+        .containsExactly(NAMESAPCE);
+    assertThat(getAfterStages(stage))
+        .extracting(s -> s.getContext().get("manifestName"))
+        .containsExactly("replicaSet my-rs-v000");
+  }
+
+  @Test
+  void rolloutStrategyHighlander() {
+    when(oortService.getClusterManifests(ACCOUNT, NAMESAPCE, "replicaSet", APPLICATION, CLUSTER))
+        .thenReturn(
+            ImmutableList.of(
+                ManifestCoordinates.builder()
+                    .name("my-rs-v000")
+                    .kind("replicaSet")
+                    .namespace(NAMESAPCE)
+                    .build()));
+    Map<String, Object> context =
+        getContext(
+            DeployManifestContext.builder()
+                .trafficManagement(
+                    DeployManifestContext.TrafficManagement.builder()
+                        .enabled(true)
+                        .options(
+                            DeployManifestContext.TrafficManagement.Options.builder()
+                                .strategy(ManifestStrategyType.HIGHLANDER)
+                                .build())
+                        .build())
+                .build());
+    StageExecutionImpl stage =
+        new StageExecutionImpl(
+            new PipelineExecutionImpl(ExecutionType.PIPELINE, APPLICATION),
+            DeployManifestStage.PIPELINE_CONFIG_TYPE,
+            context);
+    assertThat(getAfterStages(stage))
+        .extracting(StageExecution::getType)
+        .containsExactly(
+            DisableManifestStage.PIPELINE_CONFIG_TYPE, DeleteManifestStage.PIPELINE_CONFIG_TYPE);
+    assertThat(getAfterStages(stage))
+        .extracting(s -> s.getContext().get("account"))
+        .containsExactly(ACCOUNT, ACCOUNT);
+    assertThat(getAfterStages(stage))
+        .extracting(s -> s.getContext().get("app"))
+        .containsExactly(APPLICATION, APPLICATION);
+    assertThat(getAfterStages(stage))
+        .extracting(s -> s.getContext().get("location"))
+        .containsExactly(NAMESAPCE, NAMESAPCE);
+    assertThat(getAfterStages(stage))
+        .extracting(s -> s.getContext().get("manifestName"))
+        .containsExactly("replicaSet my-rs-v000", "replicaSet my-rs-v000");
+  }
+
+  @Test
+  void rolloutStrategyEmptyCluster() {
+    when(oortService.getClusterManifests(ACCOUNT, NAMESAPCE, "replicaSet", APPLICATION, CLUSTER))
+        .thenReturn(ImmutableList.of());
+    Map<String, Object> context =
+        getContext(
+            DeployManifestContext.builder()
+                .trafficManagement(
+                    DeployManifestContext.TrafficManagement.builder()
+                        .enabled(true)
+                        .options(
+                            DeployManifestContext.TrafficManagement.Options.builder()
+                                .strategy(ManifestStrategyType.RED_BLACK)
+                                .build())
+                        .build())
+                .build());
+    StageExecutionImpl stage =
+        new StageExecutionImpl(
+            new PipelineExecutionImpl(ExecutionType.PIPELINE, APPLICATION),
+            DeployManifestStage.PIPELINE_CONFIG_TYPE,
+            context);
+    assertThat(getAfterStages(stage)).isEmpty();
+  }
+
+  private Iterable<StageExecution> getAfterStages(StageExecutionImpl stage) {
+    StageGraphBuilderImpl graph = StageGraphBuilderImpl.afterStages(stage);
+    deployManifestStage.afterStages(stage, graph);
+    return graph.build();
+  }
+
+  private static Map<String, Object> getContext(DeployManifestContext deployManifestContext) {
+    Map<String, Object> context =
+        objectMapper.convertValue(
+            deployManifestContext, new TypeReference<Map<String, Object>>() {});
+    context.put("moniker", ImmutableMap.of("app", APPLICATION));
+    context.put("account", ACCOUNT);
+    context.put(
+        "outputs.manifests",
+        ImmutableList.of(
+            ImmutableMap.of(
+                "kind",
+                "ReplicaSet",
+                "metadata",
+                ImmutableMap.of(
+                    "name",
+                    "my-rs-v001",
+                    "namespace",
+                    NAMESAPCE,
+                    "annotations",
+                    ImmutableMap.of("moniker.spinnaker.io/cluster", CLUSTER)))));
+    return context;
+  }
+}

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStageTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStageTest.java
@@ -77,6 +77,11 @@ final class DeployManifestStageTest {
                     .name("my-rs-v000")
                     .kind("replicaSet")
                     .namespace(NAMESAPCE)
+                    .build(),
+                ManifestCoordinates.builder()
+                    .name("my-rs-v001")
+                    .kind("replicaSet")
+                    .namespace(NAMESAPCE)
                     .build()));
     Map<String, Object> context =
         getContext(
@@ -121,6 +126,11 @@ final class DeployManifestStageTest {
                     .name("my-rs-v000")
                     .kind("replicaSet")
                     .namespace(NAMESAPCE)
+                    .build(),
+                ManifestCoordinates.builder()
+                    .name("my-rs-v001")
+                    .kind("replicaSet")
+                    .namespace(NAMESAPCE)
                     .build()));
     Map<String, Object> context =
         getContext(
@@ -158,9 +168,15 @@ final class DeployManifestStageTest {
   }
 
   @Test
-  void rolloutStrategyEmptyCluster() {
+  void rolloutStrategyNoClusterSiblings() {
     when(oortService.getClusterManifests(ACCOUNT, NAMESAPCE, "replicaSet", APPLICATION, CLUSTER))
-        .thenReturn(ImmutableList.of());
+        .thenReturn(
+            ImmutableList.of(
+                ManifestCoordinates.builder()
+                    .name("my-rs-v001")
+                    .kind("replicaSet")
+                    .namespace(NAMESAPCE)
+                    .build()));
     Map<String, Object> context =
         getContext(
             DeployManifestContext.builder()


### PR DESCRIPTION
Groundwork for: https://github.com/spinnaker/spinnaker/issues/5906
Requires: https://github.com/spinnaker/clouddriver/pull/4841

* feat(kubernetes): DeployManifestStage makes live calls to determine cluster members for rollout strategies 

  In order to make the `liveManifestCalls` behavior the default for all users, we must change all pipeline operations that rely on cache consistency to instead call Clouddriver endpoints that make live queries against the Kubernetes cluster.

  This commit replaces the existing `getClusters` call in the DeployManifestStage, used to hydrate the context of any Disable and Delete stages necessary in order to enact a Red/Black or Highlander rollout strategy, with a new `getClusterManifests` call, which returns a list of ManifestCoordinates for members of a given cluster. Also adds tests asserting on the basic correctness of the stage graph when using rollout strategies.

* refactor(kubernetes): remove raw context Maps in DeployManifestStage 

  Leaving the other non-context raw Maps as-is because those are all a result of deeply inspecting the list of full manifests currently present in the stage context as raw Maps, which we'll replace in an upcoming PR with a list of ManifestCoordinates.
