### PR TITLE
chore(plugins): Enable v2 framework in orca-plugins-test

### DIFF
--- a/orca-plugins-test/src/main/kotlin/com/netflix/spinnaker/orca/plugins/PreconfiguredJobConfigurationProviderExtension.kt
+++ b/orca-plugins-test/src/main/kotlin/com/netflix/spinnaker/orca/plugins/PreconfiguredJobConfigurationProviderExtension.kt
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.orca.plugins
 
-import com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration
+import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
 import com.netflix.spinnaker.kork.plugins.api.PluginSdks
 import com.netflix.spinnaker.orca.api.preconfigured.jobs.PreconfiguredJobConfigurationProvider
 import com.netflix.spinnaker.orca.api.preconfigured.jobs.PreconfiguredJobStageProperties
@@ -41,7 +41,7 @@ class PreconfiguredJobConfigurationProviderExtension(
   }
 }
 
-@ExtensionConfiguration("preconfigured-job-config")
+@PluginConfiguration("preconfigured-job-config")
 class PreconfiguredJobConfigProperties {
   var enabled = true
 }

--- a/orca-plugins-test/src/test/resources/orca-plugins-test.yml
+++ b/orca-plugins-test/src/test/resources/orca-plugins-test.yml
@@ -24,6 +24,8 @@ spring:
 
 spinnaker:
   extensibility:
+    framework:
+      version: v2
     plugins-root-path: build/plugins
     plugins:
       com.netflix.orca.enabled.plugin:


### PR DESCRIPTION
The tests will fail until the framework bug is resolved, but this is a good thing to do.