### PR TITLE
feat(plugins): Orca v2 framework compatibility

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/DefaultStageResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/DefaultStageResolver.java
@@ -19,10 +19,15 @@ package com.netflix.spinnaker.orca;
 import static java.lang.String.format;
 
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 
 /**
  * {@code StageResolver} allows for {@code StageDefinitionBuilder} retrieval via bean name or alias.
@@ -30,24 +35,49 @@ import javax.annotation.Nonnull;
  * <p>Aliases represent the previous bean names that a {@code StageDefinitionBuilder} registered as.
  */
 public class DefaultStageResolver implements StageResolver {
-  private final Map<String, StageDefinitionBuilder> stageDefinitionBuilderByAlias = new HashMap<>();
+  private final ConcurrentHashMap<String, StageDefinitionBuilder> stageDefinitionBuilderByAlias =
+      new ConcurrentHashMap<>();
+  private final ObjectProvider<Collection<StageDefinitionBuilder>> stageDefinitionBuildersProvider;
 
-  public DefaultStageResolver(Collection<StageDefinitionBuilder> stageDefinitionBuilders) {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  public DefaultStageResolver(
+      ObjectProvider<Collection<StageDefinitionBuilder>> stageDefinitionBuildersProvider) {
+    this.stageDefinitionBuildersProvider = stageDefinitionBuildersProvider;
+    computeStageDefinitionBuilders();
+  }
+
+  /**
+   * Compute a cache of stage definition builders. A local map is first built and validated for
+   * duplicate stages and then copied to the thread safe cache.
+   *
+   * <p>This allows us to re-compute the stage definition builder cache if necessary (on a cache
+   * miss for example) and ensures the validation always runs correctly against the latest set of
+   * {@link StageDefinitionBuilder} classes.
+   */
+  private void computeStageDefinitionBuilders() {
+    Collection<StageDefinitionBuilder> stageDefinitionBuilders =
+        stageDefinitionBuildersProvider.getIfAvailable(ArrayList::new);
+    Map<String, StageDefinitionBuilder> localStageDefinitionBuildersByAlias = new HashMap<>();
+
     for (StageDefinitionBuilder stageDefinitionBuilder : stageDefinitionBuilders) {
-      stageDefinitionBuilderByAlias.put(stageDefinitionBuilder.getType(), stageDefinitionBuilder);
+      localStageDefinitionBuildersByAlias.put(
+          stageDefinitionBuilder.getType(), stageDefinitionBuilder);
       for (String alias : stageDefinitionBuilder.aliases()) {
-        if (stageDefinitionBuilderByAlias.containsKey(alias)) {
+        if (localStageDefinitionBuildersByAlias.containsKey(alias)) {
           throw new DuplicateStageAliasException(
               format(
                   "Duplicate stage alias detected (alias: %s, previous: %s, current: %s)",
                   alias,
-                  stageDefinitionBuilderByAlias.get(alias).getClass().getCanonicalName(),
+                  localStageDefinitionBuildersByAlias.get(alias).getClass().getCanonicalName(),
                   stageDefinitionBuilder.getClass().getCanonicalName()));
         }
 
-        stageDefinitionBuilderByAlias.put(alias, stageDefinitionBuilder);
+        localStageDefinitionBuildersByAlias.put(alias, stageDefinitionBuilder);
       }
     }
+
+    stageDefinitionBuilderByAlias.putAll(localStageDefinitionBuildersByAlias);
   }
 
   /**
@@ -61,15 +91,32 @@ public class DefaultStageResolver implements StageResolver {
   @Override
   @Nonnull
   public StageDefinitionBuilder getStageDefinitionBuilder(@Nonnull String type, String typeAlias) {
-    StageDefinitionBuilder stageDefinitionBuilder =
-        stageDefinitionBuilderByAlias.getOrDefault(
-            type, stageDefinitionBuilderByAlias.get(typeAlias));
+    StageDefinitionBuilder stageDefinitionBuilder = getOrDefault(type, typeAlias);
 
     if (stageDefinitionBuilder == null) {
-      throw new NoSuchStageDefinitionBuilderException(
-          type, typeAlias, stageDefinitionBuilderByAlias.keySet());
+      log.debug(
+          "Stage definition builder for '{}' not found in initial stage definition builder cache, re-computing...",
+          type);
+      computeStageDefinitionBuilders();
+      stageDefinitionBuilder = getOrDefault(type, typeAlias);
+
+      if (stageDefinitionBuilder == null) {
+        throw new NoSuchStageDefinitionBuilderException(
+            type, typeAlias, stageDefinitionBuilderByAlias.keySet());
+      }
     }
 
     return stageDefinitionBuilder;
+  }
+
+  /**
+   * {@link ConcurrentHashMap#get)} throws an NPE if the parameter is null, so first ensure
+   * typeAlias is not null and then perform the necessary get.
+   */
+  private StageDefinitionBuilder getOrDefault(@Nonnull String type, String typeAlias) {
+    return typeAlias != null
+        ? stageDefinitionBuilderByAlias.getOrDefault(
+            type, stageDefinitionBuilderByAlias.get(typeAlias))
+        : stageDefinitionBuilderByAlias.get(type);
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -49,6 +49,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import org.pf4j.PluginManager;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -205,7 +206,7 @@ public class OrcaConfiguration {
   }
 
   @Bean
-  public TaskResolver taskResolver(Collection<Task> tasks) {
+  public TaskResolver taskResolver(ObjectProvider<Collection<Task>> tasks) {
     return new TaskResolver(tasks, true);
   }
 
@@ -213,14 +214,14 @@ public class OrcaConfiguration {
   @ConditionalOnProperty("dynamic-stage-resolver.enabled")
   public DynamicStageResolver dynamicStageResolver(
       DynamicConfigService dynamicConfigService,
-      Collection<StageDefinitionBuilder> stageDefinitionBuilders) {
+      ObjectProvider<Collection<StageDefinitionBuilder>> stageDefinitionBuilders) {
     return new DynamicStageResolver(dynamicConfigService, stageDefinitionBuilders);
   }
 
   @Bean
   @ConditionalOnMissingBean(StageResolver.class)
   public DefaultStageResolver defaultStageResolver(
-      Collection<StageDefinitionBuilder> stageDefinitionBuilders) {
+      ObjectProvider<Collection<StageDefinitionBuilder>> stageDefinitionBuilders) {
     return new DefaultStageResolver(stageDefinitionBuilders);
   }
 

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/DefaultStageResolverSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/DefaultStageResolverSpec.groovy
@@ -24,10 +24,10 @@ import spock.lang.Unroll
 
 class DefaultStageResolverSpec extends Specification {
   @Subject
-  def stageResolver = new DefaultStageResolver([
+  def stageResolver = new DefaultStageResolver(new StageDefinitionBuildersProvider([
     new WaitStage(),
     new AliasedStageDefinitionBuilder()
-  ])
+  ]))
 
   @Unroll
   def "should lookup stage by name or alias"() {
@@ -43,10 +43,10 @@ class DefaultStageResolverSpec extends Specification {
 
   def "should raise exception on duplicate alias"() {
     when:
-    new DefaultStageResolver([
+    new DefaultStageResolver(new StageDefinitionBuildersProvider([
       new AliasedStageDefinitionBuilder(),
       new AliasedStageDefinitionBuilder()
-    ])
+    ]))
 
     then:
     thrown(StageResolver.DuplicateStageAliasException)

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/StageDefinitionBuildersProvider.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/StageDefinitionBuildersProvider.groovy
@@ -1,0 +1,34 @@
+package com.netflix.spinnaker.orca
+
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
+import org.springframework.beans.BeansException
+import org.springframework.beans.factory.ObjectProvider
+
+class StageDefinitionBuildersProvider implements ObjectProvider<Collection<StageDefinitionBuilder>> {
+
+  Collection<StageDefinitionBuilder> builders
+
+  StageDefinitionBuildersProvider(Collection<StageDefinitionBuilder> builders) {
+    this.builders = builders
+  }
+
+  @Override
+  Collection<StageDefinitionBuilder> getObject(Object... args) throws BeansException {
+    return builders
+  }
+
+  @Override
+  Collection<StageDefinitionBuilder> getIfAvailable() throws BeansException {
+    return builders
+  }
+
+  @Override
+  Collection<StageDefinitionBuilder> getIfUnique() throws BeansException {
+    return builders
+  }
+
+  @Override
+  Collection<StageDefinitionBuilder> getObject() throws BeansException {
+    return builders
+  }
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/TaskResolverSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/TaskResolverSpec.groovy
@@ -20,6 +20,8 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask
+import org.springframework.beans.BeansException
+import org.springframework.beans.factory.ObjectProvider
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -28,10 +30,10 @@ import javax.annotation.Nonnull;
 
 class TaskResolverSpec extends Specification {
   @Subject
-  def taskResolver = new TaskResolver([
+  def taskResolver = new TaskResolver(new TasksProvider([
       new WaitTask(),
       new AliasedTask()
-  ], false)
+  ]), false)
 
   @Unroll
   def "should lookup task by name or alias"() {
@@ -47,10 +49,10 @@ class TaskResolverSpec extends Specification {
 
   def "should raise exception on duplicate alias"() {
     when:
-    new TaskResolver([
+    new TaskResolver(new TasksProvider([
         new AliasedTask(),
         new AliasedTask()
-    ], false)
+    ]), false)
 
     then:
     thrown(TaskResolver.DuplicateTaskAliasException)
@@ -71,5 +73,34 @@ class TaskResolverSpec extends Specification {
     TaskResult execute(@Nonnull StageExecution stage) {
       return TaskResult.SUCCEEDED
     }
+  }
+}
+
+class TasksProvider implements ObjectProvider<Collection<Task>> {
+
+  Collection<Task> tasks
+
+  TasksProvider(Collection<Task> tasks) {
+    this.tasks = tasks
+  }
+
+  @Override
+  Collection<Task> getObject(Object... args) throws BeansException {
+    return tasks
+  }
+
+  @Override
+  Collection<Task> getIfAvailable() throws BeansException {
+    return tasks
+  }
+
+  @Override
+  Collection<Task> getIfUnique() throws BeansException {
+    return tasks
+  }
+
+  @Override
+  Collection<Task> getObject() throws BeansException {
+    return tasks
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/StageNavigatorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/StageNavigatorSpec.groovy
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.orca.pipeline.util
 
 import com.netflix.spinnaker.orca.DefaultStageResolver
+import com.netflix.spinnaker.orca.StageDefinitionBuildersProvider
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
@@ -38,7 +39,7 @@ class StageNavigatorSpec extends Specification {
   ]
 
   @Subject
-  def stageNavigator = new StageNavigator(new DefaultStageResolver(stageBuilders))
+  def stageNavigator = new StageNavigator(new DefaultStageResolver(new StageDefinitionBuildersProvider(stageBuilders)))
 
   def execution = PipelineExecutionImpl.newPipeline("orca")
 

--- a/orca-plugins-test/src/main/kotlin/com/netflix/spinnaker/orca/plugins/PreconfiguredJobConfigurationProviderExtension.kt
+++ b/orca-plugins-test/src/main/kotlin/com/netflix/spinnaker/orca/plugins/PreconfiguredJobConfigurationProviderExtension.kt
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.orca.plugins
 
-import com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration
+import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
 import com.netflix.spinnaker.kork.plugins.api.PluginSdks
 import com.netflix.spinnaker.orca.api.preconfigured.jobs.PreconfiguredJobConfigurationProvider
 import com.netflix.spinnaker.orca.api.preconfigured.jobs.PreconfiguredJobStageProperties
@@ -41,7 +41,7 @@ class PreconfiguredJobConfigurationProviderExtension(
   }
 }
 
-@ExtensionConfiguration("preconfigured-job-config")
+@PluginConfiguration("preconfigured-job-config")
 class PreconfiguredJobConfigProperties {
   var enabled = true
 }

--- a/orca-plugins-test/src/test/resources/orca-plugins-test.yml
+++ b/orca-plugins-test/src/test/resources/orca-plugins-test.yml
@@ -22,8 +22,13 @@ spring:
   application:
     name: orca
 
+dynamic-stage-resolver:
+  enabled: true
+
 spinnaker:
   extensibility:
+    framework:
+      version: v2
     plugins-root-path: build/plugins
     plugins:
       com.netflix.orca.enabled.plugin:

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/admin/HydrateQueueCommandTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/admin/HydrateQueueCommandTest.kt
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.orca.q.DummyTask
 import com.netflix.spinnaker.orca.q.RunTask
 import com.netflix.spinnaker.orca.q.StartStage
 import com.netflix.spinnaker.orca.q.StartTask
+import com.netflix.spinnaker.orca.q.TasksProvider
 import com.netflix.spinnaker.orca.q.handler.plan
 import com.netflix.spinnaker.orca.q.stageWithSyntheticAfter
 import com.netflix.spinnaker.orca.q.stageWithSyntheticBefore
@@ -65,7 +66,7 @@ object HydrateQueueCommandTest : SubjectSpek<HydrateQueueCommand>({
 
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
-  val taskResolver = TaskResolver(emptyList())
+  val taskResolver = TaskResolver(TasksProvider(emptyList()))
 
   subject(CachingMode.GROUP) {
     HydrateQueueCommand(queue, repository, taskResolver)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandlerTest.kt
@@ -32,6 +32,8 @@ import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.q.CancelStage
+import com.netflix.spinnaker.orca.q.StageDefinitionBuildersProvider
+import com.netflix.spinnaker.orca.q.TasksProvider
 import com.netflix.spinnaker.orca.q.singleTaskStage
 import com.netflix.spinnaker.q.Queue
 import com.nhaarman.mockito_kotlin.any
@@ -52,11 +54,12 @@ object CancelStageHandlerTest : SubjectSpek<CancelStageHandler>({
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
   val executor = MoreExecutors.directExecutor()
-  val taskResolver: TaskResolver = TaskResolver(emptyList())
+  val taskResolver: TaskResolver = TaskResolver(TasksProvider(emptyList()))
   val stageNavigator: StageNavigator = mock()
 
   val cancellableStage: CancelableStageDefinitionBuilder = mock()
-  val stageResolver = DefaultStageResolver(listOf(singleTaskStage, cancellableStage))
+  whenever(cancellableStage.type) doReturn "cancellable"
+  val stageResolver = DefaultStageResolver(StageDefinitionBuildersProvider(listOf(singleTaskStage, cancellableStage)))
 
   subject(GROUP) {
     CancelStageHandler(

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
@@ -50,6 +50,7 @@ import com.netflix.spinnaker.orca.q.CompleteStage
 import com.netflix.spinnaker.orca.q.ContinueParentStage
 import com.netflix.spinnaker.orca.q.DummyTask
 import com.netflix.spinnaker.orca.q.RunTask
+import com.netflix.spinnaker.orca.q.StageDefinitionBuildersProvider
 import com.netflix.spinnaker.orca.q.StartStage
 import com.netflix.spinnaker.orca.q.buildAfterStages
 import com.netflix.spinnaker.orca.q.buildBeforeStages
@@ -157,18 +158,20 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
       registry,
       DefaultStageDefinitionBuilderFactory(
         DefaultStageResolver(
-          listOf(
-            singleTaskStage,
-            multiTaskStage,
-            stageWithSyntheticBefore,
-            stageWithSyntheticAfter,
-            stageWithParallelBranches,
-            stageWithTaskAndAfterStages,
-            stageThatBlowsUpPlanningAfterStages,
-            stageWithSyntheticOnFailure,
-            stageWithNothingButAfterStages,
-            stageWithSyntheticOnFailure,
-            emptyStage
+          StageDefinitionBuildersProvider(
+            listOf(
+              singleTaskStage,
+              multiTaskStage,
+              stageWithSyntheticBefore,
+              stageWithSyntheticAfter,
+              stageWithParallelBranches,
+              stageWithTaskAndAfterStages,
+              stageThatBlowsUpPlanningAfterStages,
+              stageWithSyntheticOnFailure,
+              stageWithNothingButAfterStages,
+              stageWithSyntheticOnFailure,
+              emptyStage
+            )
           )
         )
       )

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
@@ -38,6 +38,7 @@ import com.netflix.spinnaker.orca.q.CompleteStage
 import com.netflix.spinnaker.orca.q.CompleteTask
 import com.netflix.spinnaker.orca.q.RunTask
 import com.netflix.spinnaker.orca.q.SkipStage
+import com.netflix.spinnaker.orca.q.StageDefinitionBuildersProvider
 import com.netflix.spinnaker.orca.q.StartTask
 import com.netflix.spinnaker.orca.q.buildTasks
 import com.netflix.spinnaker.orca.q.get
@@ -70,7 +71,7 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
   val repository: ExecutionRepository = mock()
   val publisher: ApplicationEventPublisher = mock()
   val clock = fixedClock()
-  val stageResolver = DefaultStageResolver(emptyList())
+  val stageResolver = DefaultStageResolver(StageDefinitionBuildersProvider(emptyList()))
 
   subject(GROUP) {
     CompleteTaskHandler(queue, repository, DefaultStageDefinitionBuilderFactory(stageResolver), ContextParameterProcessor(), publisher, clock, NoopRegistry())

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RescheduleExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RescheduleExecutionHandlerTest.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.orca.api.test.task
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.RescheduleExecution
 import com.netflix.spinnaker.orca.q.RunTask
+import com.netflix.spinnaker.orca.q.TasksProvider
 import com.netflix.spinnaker.q.Queue
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
@@ -41,7 +42,7 @@ object RescheduleExecutionHandlerTest : SubjectSpek<RescheduleExecutionHandler>(
 
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
-  val taskResolver = TaskResolver(emptyList())
+  val taskResolver = TaskResolver(TasksProvider(emptyList()))
 
   subject(CachingMode.GROUP) {
     RescheduleExecutionHandler(queue, repository, taskResolver)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.orca.pipeline.DefaultStageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.q.RestartStage
+import com.netflix.spinnaker.orca.q.StageDefinitionBuildersProvider
 import com.netflix.spinnaker.orca.q.StartStage
 import com.netflix.spinnaker.orca.q.buildAfterStages
 import com.netflix.spinnaker.orca.q.buildBeforeStages
@@ -84,10 +85,12 @@ object RestartStageHandlerTest : SubjectSpek<RestartStageHandler>({
       repository,
       DefaultStageDefinitionBuilderFactory(
         DefaultStageResolver(
-          listOf(
-            singleTaskStage,
-            stageWithSyntheticBefore,
-            stageWithNestedSynthetics
+          StageDefinitionBuildersProvider(
+            listOf(
+              singleTaskStage,
+              stageWithSyntheticBefore,
+              stageWithNestedSynthetics
+            )
           )
         )
       ),

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ResumeTaskHandlerTest.kt
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.tasks.NoOpTask
 import com.netflix.spinnaker.orca.q.ResumeTask
 import com.netflix.spinnaker.orca.q.RunTask
+import com.netflix.spinnaker.orca.q.TasksProvider
 import com.netflix.spinnaker.q.Queue
 import com.nhaarman.mockito_kotlin.check
 import com.nhaarman.mockito_kotlin.doReturn
@@ -45,7 +46,7 @@ object ResumeTaskHandlerTest : SubjectSpek<ResumeTaskHandler>({
 
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
-  val taskResolver = TaskResolver(emptyList())
+  val taskResolver = TaskResolver(TasksProvider(emptyList()))
 
   subject(GROUP) {
     ResumeTaskHandler(queue, repository, taskResolver)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
@@ -44,6 +44,7 @@ import com.netflix.spinnaker.orca.q.DummyTask
 import com.netflix.spinnaker.orca.q.InvalidExecutionId
 import com.netflix.spinnaker.orca.q.InvalidStageId
 import com.netflix.spinnaker.orca.q.SkipStage
+import com.netflix.spinnaker.orca.q.StageDefinitionBuildersProvider
 import com.netflix.spinnaker.orca.q.StartStage
 import com.netflix.spinnaker.orca.q.StartTask
 import com.netflix.spinnaker.orca.q.buildBeforeStages
@@ -107,17 +108,19 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       stageNavigator,
       DefaultStageDefinitionBuilderFactory(
         DefaultStageResolver(
-          listOf(
-            singleTaskStage,
-            multiTaskStage,
-            stageWithSyntheticBefore,
-            stageWithSyntheticAfter,
-            stageWithParallelBranches,
-            rollingPushStage,
-            zeroTaskStage,
-            stageWithSyntheticAfterAndNoTasks,
-            webhookStage,
-            failPlanningStage
+          StageDefinitionBuildersProvider(
+            listOf(
+              singleTaskStage,
+              multiTaskStage,
+              stageWithSyntheticBefore,
+              stageWithSyntheticAfter,
+              stageWithParallelBranches,
+              rollingPushStage,
+              zeroTaskStage,
+              stageWithSyntheticAfterAndNoTasks,
+              webhookStage,
+              failPlanningStage
+            )
           )
         )
       ),

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandlerTest.kt
@@ -28,7 +28,9 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.q.DummyTask
 import com.netflix.spinnaker.orca.q.RunTask
+import com.netflix.spinnaker.orca.q.StageDefinitionBuildersProvider
 import com.netflix.spinnaker.orca.q.StartTask
+import com.netflix.spinnaker.orca.q.TasksProvider
 import com.netflix.spinnaker.orca.q.buildTasks
 import com.netflix.spinnaker.orca.q.singleTaskStage
 import com.netflix.spinnaker.q.Queue
@@ -54,8 +56,8 @@ object StartTaskHandlerTest : SubjectSpek<StartTaskHandler>({
   val queue: Queue = mock()
   val repository: ExecutionRepository = mock()
   val publisher: ApplicationEventPublisher = mock()
-  val taskResolver = TaskResolver(emptyList())
-  val stageResolver = DefaultStageResolver(emptyList())
+  val taskResolver = TaskResolver(TasksProvider(emptyList()))
+  val stageResolver = DefaultStageResolver(StageDefinitionBuildersProvider(emptyList()))
   val clock = fixedClock()
 
   subject(GROUP) {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/migration/TaskTypeDeserializerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/migration/TaskTypeDeserializerTest.kt
@@ -23,12 +23,13 @@ import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
+import com.netflix.spinnaker.orca.q.TasksProvider
 import org.assertj.core.api.Assertions
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 
 object TaskTypeDeserializerTest : Spek({
-  val taskResolver = TaskResolver(listOf(DummyTask()), false)
+  val taskResolver = TaskResolver(TasksProvider(listOf(DummyTask())), false)
 
   val objectMapper = ObjectMapper().apply {
     registerModule(KotlinModule())

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/util.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/util.kt
@@ -1,0 +1,23 @@
+package com.netflix.spinnaker.orca.q
+
+import com.netflix.spinnaker.orca.api.pipeline.Task
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
+import org.springframework.beans.factory.ObjectProvider
+
+class StageDefinitionBuildersProvider(
+  private val stageDefinitionBuilders: Collection<StageDefinitionBuilder>
+) : ObjectProvider<Collection<StageDefinitionBuilder>> {
+  override fun getIfUnique(): Collection<StageDefinitionBuilder>? = stageDefinitionBuilders
+  override fun getObject(vararg args: Any?): Collection<StageDefinitionBuilder> = stageDefinitionBuilders
+  override fun getObject(): Collection<StageDefinitionBuilder> = stageDefinitionBuilders
+  override fun getIfAvailable(): Collection<StageDefinitionBuilder>? = stageDefinitionBuilders
+}
+
+class TasksProvider(
+  private val tasks: Collection<Task>
+) : ObjectProvider<Collection<Task>> {
+  override fun getIfUnique(): Collection<Task>? = tasks
+  override fun getObject(vararg args: Any?): Collection<Task> = tasks
+  override fun getObject(): Collection<Task> = tasks
+  override fun getIfAvailable(): Collection<Task>? = tasks
+}


### PR DESCRIPTION
Use of `Task`, `StafeDefinitionBuilder`, and `PreconfiguredJobConfigurationProvider` (so all `SpinnakerExtensionPoint` implementations) must be called from an `ObjectProvider` since the v2 framework does not make guarantees about when beans are instantiated.  Additionally, we need to support loading these extensions at anytime so there are some tweaks here to re-compute caches if necessary.