### PR TITLE
fix(core): More accurate stage defintion builder lookup in DefaultStageResolver

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/DefaultStageResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/DefaultStageResolver.java
@@ -110,13 +110,19 @@ public class DefaultStageResolver implements StageResolver {
   }
 
   /**
-   * {@link ConcurrentHashMap#get)} throws an NPE if the parameter is null, so first ensure
-   * typeAlias is not null and then perform the necessary get.
+   * {@link ConcurrentHashMap#get)} throws an NPE if the parameter is null, so first check if
+   * typeAlias is null and then perform the necessary lookups.
    */
   private StageDefinitionBuilder getOrDefault(@Nonnull String type, String typeAlias) {
-    return typeAlias != null
-        ? stageDefinitionBuilderByAlias.getOrDefault(
-            type, stageDefinitionBuilderByAlias.get(typeAlias))
-        : stageDefinitionBuilderByAlias.get(type);
+    StageDefinitionBuilder stageDefinitionBuilder = null;
+    if (typeAlias == null) {
+      stageDefinitionBuilder = stageDefinitionBuilderByAlias.get(type);
+    }
+
+    if (stageDefinitionBuilder == null && typeAlias != null) {
+      stageDefinitionBuilder = stageDefinitionBuilderByAlias.get(typeAlias);
+    }
+
+    return stageDefinitionBuilder;
   }
 }


### PR DESCRIPTION
My change in https://github.com/spinnaker/orca/pull/3889/files#diff-0b2f668fb285224a316a086cb5d08604R116 didn't sit well with me because it will fail to find the `StageDefinitionBuilder` if the type alias is non-null but there is no alias lookup.

We don't use the `DefaultStageResolver` at NFLX but I don't want to break this for anyone - no tests were failing, but ya never know?