### PR TITLE
fix(restart): Fix parent pipeline restart for dependent pipelines

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
@@ -371,7 +371,8 @@ public class PipelineExecutionImpl implements PipelineExecution, Serializable {
         .findFirst()
         .orElseThrow(
             () ->
-                new IllegalArgumentException(String.format("No stage with id %s exists", stageId)));
+                new IllegalArgumentException(
+                    String.format("No stage with id %s exists on execution %s", stageId, id)));
   }
 
   @Nonnull

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
@@ -73,6 +73,11 @@ class RestartStageHandler(
     }
 
     val trigger = topStage.execution.trigger as PipelineTrigger
+    if (trigger.parentPipelineStageId == null) {
+      // Must've been triggered by dependent pipeline, we don't restart those
+      return
+    }
+
     // We have a copy of the parent execution, not the live one. So we retrieve the live one.
     val parentExecution = repository.retrieve(trigger.parentExecution.type, trigger.parentExecution.id)
 


### PR DESCRIPTION
Imagine the following pipeline topology:

```
Pipeline A

Pipeline B (triggers of SUCCESS of A)
\
 \-Pipeline C (Triggered by a stage in B)
```

Now, imagine you restart a failed stage in `Pipeline C`. This stage will attempt to (correctly) restart `Pipeline B` at the appropriate stage.
This works unless `Pipeline B` was started as a result of dependent pipeline starter. In this case, restarting `Pipeline B` will fail because we will fail to restart `Pipeline A`.
This happens because while `A` is technically a parent of `B` no `parentExecutionStageId` exists so we fail to look up the stage and there fore `Pipeline B` will never actually restart as a result of restart of `C`

This change skips restarting parent if no `parentExecutionStageId` is specified
