### PR TITLE
feat(stages): Add stage to monitor specific execution(s)

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
@@ -20,10 +20,8 @@ import static java.util.Collections.emptySet;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.kork.annotations.Beta;
 import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.io.Serializable;
+import java.util.*;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -181,6 +179,8 @@ public interface StageExecution {
   void setContinuePipelineOnFailure(boolean continuePipelineOnFailure);
 
   boolean isJoin();
+
+  void appendErrorMessage(String errorMessage);
 
   @Nonnull
   List<StageExecution> downstreamStages();

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
@@ -20,7 +20,6 @@ import static java.util.Collections.emptySet;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.kork.annotations.Beta;
 import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner;
-import java.io.Serializable;
 import java.util.*;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
@@ -623,6 +623,20 @@ public class StageExecutionImpl implements StageExecution, Serializable {
     }
   }
 
+  public void appendErrorMessage(String errorMessage) {
+    Map<String, Object> exception =
+        (Map<String, Object>) getContext().getOrDefault("exception", new HashMap<String, Object>());
+    Map<String, Object> exceptionDetails =
+        (Map<String, Object>) exception.getOrDefault("details", new HashMap<String, Object>());
+    List<String> errors =
+        (List<String>) exceptionDetails.getOrDefault("errors", new ArrayList<String>());
+
+    errors.add(errorMessage);
+    // This might be a no-op, but if there wasn't an exception object there, we should add it to the
+    // context
+    getContext().put("exception", exception);
+  }
+
   private JsonNode getPointer(String pointer, ObjectNode rootNode) {
     return pointer != null ? rootNode.at(pointer) : rootNode;
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
@@ -626,12 +626,16 @@ public class StageExecutionImpl implements StageExecution, Serializable {
   public void appendErrorMessage(String errorMessage) {
     Map<String, Object> exception =
         (Map<String, Object>) getContext().getOrDefault("exception", new HashMap<String, Object>());
+
     Map<String, Object> exceptionDetails =
         (Map<String, Object>) exception.getOrDefault("details", new HashMap<String, Object>());
+    exception.putIfAbsent("details", exceptionDetails);
     List<String> errors =
         (List<String>) exceptionDetails.getOrDefault("errors", new ArrayList<String>());
+    exceptionDetails.putIfAbsent("errors", errors);
 
     errors.add(errorMessage);
+
     // This might be a no-op, but if there wasn't an exception object there, we should add it to the
     // context
     getContext().put("exception", exception);

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/MonitorPipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/MonitorPipelineStage.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.front50.pipeline;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.netflix.spinnaker.kork.annotations.DeprecationInfo;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
@@ -77,6 +78,12 @@ public class MonitorPipelineStage implements StageDefinitionBuilder {
      * DO NOT USE: Legacy from PipelineStage Use {@link executionIds} instead (even if you only have
      * one execution ID to monitor)
      */
+    @Deprecated
+    @DeprecationInfo(
+        reason = "Used for backwards compat with PipelineStage",
+        replaceWith = "Use executionIds instead even if you only have one execution ID",
+        since = "2020.4",
+        eol = "n/a")
     public String executionId;
 
     /** List of executions IDs to monitor */

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/MonitorPipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/MonitorPipelineStage.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.pipeline;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.front50.tasks.MonitorPipelineTask;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
+import com.netflix.spinnaker.orca.pipeline.tasks.artifacts.BindProducedArtifactsTask;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MonitorPipelineStage implements StageDefinitionBuilder {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  public static final String PIPELINE_CONFIG_TYPE =
+      StageDefinitionBuilder.getType(MonitorPipelineStage.class);
+
+  final ExecutionRepository executionRepository;
+
+  @Autowired
+  public MonitorPipelineStage(ExecutionRepository executionRepository) {
+    this.executionRepository = executionRepository;
+  }
+
+  @Override
+  public void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {
+    StageParameters stageData = stage.mapTo(StageParameters.class);
+
+    builder.withTask("monitorPipeline", MonitorPipelineTask.class);
+
+    if (stageData.expectedArtifacts != null) {
+      builder.withTask(BindProducedArtifactsTask.TASK_NAME, BindProducedArtifactsTask.class);
+    }
+  }
+
+  public enum MonitorBehavior {
+    /**
+     * During monitor, wait for all pipelines to complete before completing the stage even if a
+     * monitored pipeline fails
+     */
+    WaitForAllToComplete,
+
+    /** As soon as (at least) one monitored pipeline fails, terminate this stage */
+    FailFast
+  }
+
+  public static class StageParameters {
+    /**
+     * DO NOT USE: Legacy from PipelineStage Use {@link executionIds} instead (even if you only have
+     * one execution ID to monitor)
+     */
+    public String executionId;
+
+    /** List of executions IDs to monitor */
+    public List<String> executionIds;
+
+    /** How to handle terminal pipelines */
+    public MonitorBehavior monitorBehavior;
+
+    /** List of expected artifacts */
+    public List<ExpectedArtifact> expectedArtifacts;
+  }
+
+  public static class ChildPipelineException {
+    public ChildPipelineExceptionSource source;
+    public ChildPipelineExceptionDetails details;
+
+    public ChildPipelineException() {
+      source = new ChildPipelineExceptionSource();
+      details = new ChildPipelineExceptionDetails();
+    }
+
+    public static class ChildPipelineExceptionDetails {
+      public List<String> errors;
+    }
+
+    public static class ChildPipelineExceptionSource {
+      public String executionId;
+      public String stageId;
+      public String stageName;
+      public int stageIndex;
+    }
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class ChildPipelineStatusDetails {
+    public ExecutionStatus status;
+
+    public ChildPipelineException exception;
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class StageResult {
+    public Map<String, ChildPipelineStatusDetails> executionStatuses;
+
+    @JsonIgnore private final Map<String, Object> monitoredPipelineContext = new HashMap<>();
+
+    @JsonAnyGetter
+    public Map<String, Object> pipelineContext() {
+      return this.monitoredPipelineContext;
+    }
+
+    public void insertPipelineContext(Map<String, Object> pipelineContext) {
+      monitoredPipelineContext.putAll(pipelineContext);
+    }
+  }
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/MonitorPipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/MonitorPipelineStage.java
@@ -120,6 +120,7 @@ public class MonitorPipelineStage implements StageDefinitionBuilder {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public static class ChildPipelineStatusDetails {
     public ExecutionStatus status;
+    public String application;
 
     public ChildPipelineException exception;
   }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
@@ -43,8 +43,12 @@ public class PipelineStage implements StageDefinitionBuilder, CancellableStage {
   public static final String PIPELINE_CONFIG_TYPE =
       StageDefinitionBuilder.getType(PipelineStage.class);
 
-  @Autowired(required = false)
-  ExecutionRepository executionRepository;
+  final ExecutionRepository executionRepository;
+
+  @Autowired
+  public PipelineStage(ExecutionRepository executionRepository) {
+    this.executionRepository = executionRepository;
+  }
 
   @Override
   public void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
@@ -66,7 +66,7 @@ class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
     pipelineIds.forEach { pipelineId ->
       PipelineExecution childPipeline = executionRepository.retrieve(PIPELINE, pipelineId)
       if (firstPipeline == null) {
-        // Capture the first pipeline, since if there is only, we will return its context as part of taskresult
+        // Capture the first pipeline, since if there is only one, we will return its context as part of TaskResult
         firstPipeline = childPipeline
       }
       MonitorPipelineStage.ChildPipelineStatusDetails details = new MonitorPipelineStage.ChildPipelineStatusDetails()
@@ -138,7 +138,8 @@ class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
       }
     }
 
-    // Finally, if all completed and we didn't catch that case yet that means they all were cancelled
+    // Finally, if all pipelines completed and we didn't catch that case above it means at least one of those pipelines was CANCELED
+    // and we should propagate that result up
     if (allPipelinesCompleted) {
       return buildTaskResult(ExecutionStatus.CANCELED, context, result)
     }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
@@ -71,6 +71,7 @@ class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
       }
       MonitorPipelineStage.ChildPipelineStatusDetails details = new MonitorPipelineStage.ChildPipelineStatusDetails()
       details.status = childPipeline.status
+      details.application = childPipeline.application
       pipelineStatuses.put(pipelineId, details)
 
       if (childPipeline.status.halt) {

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
@@ -16,8 +16,10 @@
 
 package com.netflix.spinnaker.orca.front50.tasks
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
+import com.netflix.spinnaker.orca.front50.pipeline.MonitorPipelineStage
 
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
@@ -33,74 +35,134 @@ import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPEL
 @Component
 class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
 
-  @Autowired
   ExecutionRepository executionRepository
+  ObjectMapper objectMapper
 
   long backoffPeriod = TimeUnit.SECONDS.toMillis(15)
   long timeout = TimeUnit.HOURS.toMillis(12)
 
-  @Override
-  TaskResult execute(StageExecution stage) {
-    String pipelineId = stage.context.executionId
-    PipelineExecution childPipeline = executionRepository.retrieve(PIPELINE, pipelineId)
-
-    if (childPipeline.status == ExecutionStatus.SUCCEEDED) {
-      return TaskResult.builder(ExecutionStatus.SUCCEEDED).context([status: childPipeline.status]).outputs(childPipeline.getContext()).build()
-    }
-
-    if (childPipeline.status.halt) {
-      // indicates a failure of some sort
-      def terminalStages = childPipeline.stages.findAll { s -> s.status == ExecutionStatus.TERMINAL }
-      List<String> errors = terminalStages
-        .findResults { s ->
-          if (s.context["exception"]?.details) {
-            return [(s.context["exception"].details.errors ?: s.context["exception"].details.error)]
-              .flatten()
-              .collect {e -> buildExceptionMessage(childPipeline.name, e, s)}
-          }
-          if (s.context["kato.tasks"]) {
-            return s.context["kato.tasks"]
-              .findAll { k -> k.status?.failed }
-              .findResults { k ->
-                String message = k.exception?.message ?: k.history ? ((List<String>) k.history).last() : null
-                return message ? buildExceptionMessage(childPipeline.name, message, s) : null
-              }
-          }
-        }
-        .flatten()
-
-      def exceptionDetails = [:]
-      if (errors) {
-        exceptionDetails.details = [
-            errors: errors
-        ]
-      }
-
-      def haltingStage = terminalStages.find { it.status.halt }
-      if (haltingStage) {
-        exceptionDetails.source = [
-          executionId: childPipeline.id,
-          stageId    : haltingStage.id,
-          stageName  : haltingStage.name,
-          stageIndex : childPipeline.stages.indexOf(haltingStage)
-        ]
-      }
-
-      return TaskResult.builder(terminalStatus(childPipeline.status)).context([
-        status   : childPipeline.status,
-        exception: exceptionDetails
-      ]).outputs(childPipeline.getContext())
-        .build()
-    }
-
-    return TaskResult.builder(ExecutionStatus.RUNNING).context([status: childPipeline.status]).build()
+  @Autowired
+  public MonitorPipelineTask(ExecutionRepository executionRepository, ObjectMapper objectMapper) {
+    this.executionRepository = executionRepository
+    this.objectMapper = objectMapper
   }
 
-  private static terminalStatus(ExecutionStatus childStatus) {
-    if (childStatus == ExecutionStatus.CANCELED) {
-      return childStatus
+  @Override
+  TaskResult execute(StageExecution stage) {
+    List<String> pipelineIds
+    boolean isLegacyStage = false
+    MonitorPipelineStage.StageParameters stageData = stage.mapTo(MonitorPipelineStage.StageParameters.class)
+
+    if (stage.type == MonitorPipelineStage.PIPELINE_CONFIG_TYPE) {
+      pipelineIds = stageData.executionIds
+    } else {
+      pipelineIds = Collections.singletonList(stageData.executionId)
+      isLegacyStage = true
     }
-    return ExecutionStatus.TERMINAL;
+
+    HashMap<String, MonitorPipelineStage.ChildPipelineStatusDetails> pipelineStatuses = new HashMap<>(pipelineIds.size())
+    PipelineExecution firstPipeline
+
+    pipelineIds.forEach { pipelineId ->
+      PipelineExecution childPipeline = executionRepository.retrieve(PIPELINE, pipelineId)
+      if (firstPipeline == null) {
+        // Capture the first pipeline, since if there is only, we will return its context as part of taskresult
+        firstPipeline = childPipeline
+      }
+      MonitorPipelineStage.ChildPipelineStatusDetails details = new MonitorPipelineStage.ChildPipelineStatusDetails()
+      details.status = childPipeline.status
+      pipelineStatuses.put(pipelineId, details)
+
+      if (childPipeline.status.halt) {
+        details.exception = new MonitorPipelineStage.ChildPipelineException()
+
+        // indicates a failure of some sort
+        def terminalStages = childPipeline.stages.findAll { s -> s.status == ExecutionStatus.TERMINAL }
+        List<String> errors = terminalStages
+            .findResults { s ->
+              if (s.context["exception"]?.details) {
+                return [(s.context["exception"].details.errors ?: s.context["exception"].details.error)]
+                    .flatten()
+                    .collect { e -> buildExceptionMessage(childPipeline.name, e as String, s) }
+              }
+              if (s.context["kato.tasks"]) {
+                return s.context["kato.tasks"]
+                    .findAll { k -> k.status?.failed }
+                    .findResults { k ->
+                      String message = k.exception?.message ?: k.history ? ((List<String>) k.history).last() : null
+                      return message ? buildExceptionMessage(childPipeline.name, message, s) : null
+                    }
+              }
+            }
+            .flatten()
+
+        details.exception.details.errors = errors
+
+        def haltingStage = terminalStages.find { it.status.halt }
+        if (haltingStage) {
+          details.exception.source.executionId = childPipeline.id
+          details.exception.source.stageId = haltingStage.id
+          details.exception.source.stageName = haltingStage.name
+          details.exception.source.stageIndex = childPipeline.stages.indexOf(haltingStage)
+        }
+      }
+    }
+
+    boolean allPipelinesSucceeded = pipelineStatuses.every { it.value.status == ExecutionStatus.SUCCEEDED }
+    boolean allPipelinesCompleted = pipelineStatuses.every { it.value.status.complete }
+    boolean anyPipelinesFailed = pipelineStatuses.any { effectiveStatus(it.value.status) == ExecutionStatus.TERMINAL }
+
+    MonitorPipelineStage.StageResult result = new MonitorPipelineStage.StageResult()
+    Map<String, Object> context = new HashMap<>()
+
+    if (isLegacyStage) {
+      context.put("status", firstPipeline.status)
+      if (anyPipelinesFailed) {
+        context.put("exception", objectMapper.convertValue(pipelineStatuses.values().first().exception, Map))
+      }
+    } else {
+      result.executionStatuses = pipelineStatuses
+    }
+
+    if (pipelineIds.size() == 1) {
+      result.insertPipelineContext(firstPipeline.getContext())
+    }
+
+    if (allPipelinesSucceeded) {
+      return buildTaskResult(ExecutionStatus.SUCCEEDED, context, result)
+    }
+
+    if (anyPipelinesFailed) {
+      if (allPipelinesCompleted || stageData.monitorBehavior == MonitorPipelineStage.MonitorBehavior.FailFast) {
+        return buildTaskResult(ExecutionStatus.TERMINAL, context, result)
+      }
+    }
+
+    // Finally, if all completed and we didn't catch that case yet that means they all were cancelled
+    if (allPipelinesCompleted) {
+      return buildTaskResult(ExecutionStatus.CANCELED, context, result)
+    }
+
+    return buildTaskResult(ExecutionStatus.RUNNING, context, result)
+  }
+
+  private buildTaskResult(ExecutionStatus status, Map<String, Object> context, MonitorPipelineStage.StageResult result) {
+    return TaskResult.builder(status)
+        .context(context)
+        .outputs(objectMapper.convertValue(result, Map))
+        .build()
+  }
+
+  private static effectiveStatus(ExecutionStatus status) {
+    if (!status.halt) {
+      return status
+    }
+
+    if (status == ExecutionStatus.CANCELED) {
+      return ExecutionStatus.CANCELED
+    }
+
+    return ExecutionStatus.TERMINAL
   }
 
   private static String buildExceptionMessage(String pipelineName, String message, StageExecution stage) {

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
@@ -135,6 +135,7 @@ class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
 
     if (anyPipelinesFailed) {
       if (allPipelinesCompleted || stageData.monitorBehavior == MonitorPipelineStage.MonitorBehavior.FailFast) {
+        stage.appendErrorMessage("At least one monitored pipeline failed, look for errors in failed pipelines")
         return buildTaskResult(ExecutionStatus.TERMINAL, context, result)
       }
     }
@@ -142,6 +143,7 @@ class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
     // Finally, if all pipelines completed and we didn't catch that case above it means at least one of those pipelines was CANCELED
     // and we should propagate that result up
     if (allPipelinesCompleted) {
+      stage.appendErrorMessage("At least one monitored pipeline was cancelled")
       return buildTaskResult(ExecutionStatus.CANCELED, context, result)
     }
 

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStageSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStageSpec.groovy
@@ -28,7 +28,7 @@ class PipelineStageSpec extends Specification {
   def executionRepository = Mock(ExecutionRepository)
 
   @Subject
-  def pipelineStage = new PipelineStage(executionRepository: executionRepository)
+  def pipelineStage = new PipelineStage(executionRepository)
 
   @Unroll
   def "should cancel child pipeline (if started and not already canceled)"() {

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.front50.tasks
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.front50.pipeline.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
@@ -28,14 +29,13 @@ import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
 class MonitorPipelineTaskSpec extends Specification {
 
-
-  @Subject
-  MonitorPipelineTask task = new MonitorPipelineTask()
   ExecutionRepository repo = Mock(ExecutionRepository)
   StageExecutionImpl stage = new StageExecutionImpl(type: "whatever")
 
+  @Subject
+  MonitorPipelineTask task = new MonitorPipelineTask(repo, new ObjectMapper())
+
   def setup() {
-    task.executionRepository = repo
     stage.context.executionId = 'abc'
   }
 

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
@@ -18,12 +18,18 @@ package com.netflix.spinnaker.orca.front50.tasks
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
+import com.netflix.spinnaker.orca.front50.pipeline.MonitorPipelineStage
 import com.netflix.spinnaker.orca.front50.pipeline.PipelineStage
+import com.netflix.spinnaker.orca.pipeline.WaitStage
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
@@ -214,5 +220,67 @@ class MonitorPipelineTaskSpec extends Specification {
       "myVar1": "myValue1",
       "myVar2": "myValue2"
     ]
+  }
+
+  @Unroll
+  def "respect #behavior behavior when monitoring multiple pipelines"() {
+    ObjectMapper objectMapper = new ObjectMapper()
+
+    def child1 = pipeline {
+      application = "orca"
+      name = "child 1"
+      stage {
+        type = WaitStage.typeName
+        name = "Wait that failed"
+        status = ExecutionStatus.TERMINAL
+      }
+      status = ExecutionStatus.TERMINAL
+    }
+
+    def child2 = pipeline {
+      application = "orca"
+      name = "child 2"
+      stage {
+        type = WaitStage.typeName
+        name = "Wait that is running"
+        status = ExecutionStatus.RUNNING
+      }
+      status = ExecutionStatus.RUNNING
+    }
+
+    MonitorPipelineStage.StageParameters parameters = new MonitorPipelineStage.StageParameters()
+    parameters.executionIds = [child1.id, child2.id]
+    parameters.monitorBehavior = MonitorPipelineStage.MonitorBehavior.FailFast
+
+    def parent = pipeline {
+      application = "orca"
+      name = "a pipeline"
+      stage {
+        type = MonitorPipelineStage.PIPELINE_CONFIG_TYPE
+        name = "Monitor multiple executions"
+      }
+    }
+
+    parent.stages[0].context.putAll(objectMapper.convertValue(parameters, Map))
+
+    repo.retrieve(ExecutionType.PIPELINE, child1.id) >> child1
+    repo.retrieve(ExecutionType.PIPELINE, child2.id) >> child2
+
+    when:
+    def result = task.execute(parent.stages[0])
+    def typedResult =  objectMapper.convertValue(result.outputs, MonitorPipelineStage.StageResult.class)
+
+
+    then:
+    result.status == ExecutionStatus.TERMINAL
+    typedResult.executionStatuses.size() == 2
+    typedResult.executionStatuses[child1.id].status == child1.status
+    typedResult.executionStatuses[child2.id].status == child2.status
+    parent.stages[0].context.exception.details.errors[0] == "At least one monitored pipeline failed, look for errors in failed pipelines"
+
+    where:
+    behavior                                                    || expectedStatus
+    MonitorPipelineStage.MonitorBehavior.FailFast               || ExecutionStatus.TERMINAL
+    MonitorPipelineStage.MonitorBehavior.WaitForAllToComplete   || ExecutionStatus.RUNNING
   }
 }


### PR DESCRIPTION
This change adds a `MonitorPipelineStage` stage that allows one to monitor a given set of executions, similar to how `PipelineStage` starts and monitors that pipelins.
The difference is that this stage doesn't start any pipelines, it simply performs the monitoring.

Ideally, I would use the `MonitorPipelineStage` as a synthetic child of `PipelineStage` but that requires a bit more finesse and refactor that I don't think is worth it right now.

I will also be making corresponding `deck` changes to visualize the stage execution
