### PR TITLE
feat(core): Add new "stageStatus" spel helper

### DIFF
--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/StageExpressionFunctionProviderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/StageExpressionFunctionProviderSpec.groovy
@@ -187,6 +187,7 @@ class StageExpressionFunctionProviderSpec extends Specification {
     thrown(SpelHelperFunctionException)
   }
 
+  @Unroll
   def "stageExists() returns whether a stage exists or not"() {
     when:
     def exists = StageExpressionFunctionProvider.stageExists(pipeline, id)
@@ -202,5 +203,21 @@ class StageExpressionFunctionProviderSpec extends Specification {
     "2"                  | true
     "Non-existent Stage" | false
     "42"                 | false
+  }
+
+  @Unroll
+  def "stageStatus returns the string representation of a stage execution status"() {
+    when:
+    def status = StageExpressionFunctionProvider.stageStatus(pipeline, id)
+
+    then:
+    status == expected
+
+    where:
+    id                    || expected
+    "1"                   || "NOT_STARTED"
+    "My First Stage"      || "NOT_STARTED"
+    "4"                   || "SUCCEEDED"
+    "Deploy in us-east-1" || "SUCCEEDED"
   }
 }


### PR DESCRIPTION
Small quality of life improvement.

Today, if you want to interact with a stage status, you must `#stage("foo").status.toString()` before doing conditionals, since `status` is an `ExecutionStatus` enum type. This helper function just makes it so you don't need to `toString()`: `#stageStatus("foo") == "SUCCEEDED"`

