### PR TITLE
fix(igor): Handle timeouts kicking off builds

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/BuildService.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/BuildService.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriUtils;
+import retrofit.client.Response;
 
 @Component
 @RequiredArgsConstructor
@@ -31,7 +32,7 @@ public class BuildService {
     return UriUtils.encodeFragment(uri, "UTF-8");
   }
 
-  public String build(String master, String jobName, Map<String, String> queryParams) {
+  public Response build(String master, String jobName, Map<String, String> queryParams) {
     return igorService.build(master, encode(jobName), queryParams, "");
   }
 

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -22,11 +22,12 @@ import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildRepoSource;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import retrofit.client.Response;
 import retrofit.http.*;
 
 public interface IgorService {
   @PUT("/masters/{name}/jobs/{jobName}")
-  String build(
+  Response build(
       @Path("name") String master,
       @Path(encode = false, value = "jobName") String jobName,
       @QueryMap Map<String, String> queryParams,

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTask.groovy
@@ -75,7 +75,7 @@ class StartJenkinsJobTask implements RetryableTask {
       throw e
     }
 
-    throw new SystemException("Failure starting script")
+    throw new SystemException("Failure starting jenkins job")
   }
 
   @Override

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTask.groovy
@@ -17,18 +17,27 @@
 package com.netflix.spinnaker.orca.igor.tasks
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.exceptions.SystemException
+import com.netflix.spinnaker.orca.api.pipeline.RetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.igor.BuildService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import retrofit.RetrofitError
+import retrofit.client.Response
 
 import javax.annotation.Nonnull
+import java.time.Duration
 
 @Component
-class StartJenkinsJobTask implements Task {
+class StartJenkinsJobTask implements RetryableTask {
+  private final Logger log = LoggerFactory.getLogger(getClass())
 
   @Autowired
   BuildService buildService
@@ -41,7 +50,41 @@ class StartJenkinsJobTask implements Task {
   TaskResult execute(@Nonnull StageExecution stage) {
     String master = stage.context.master
     String job = stage.context.job
-    String queuedBuild = buildService.build(master, job, stage.context.parameters)
-    TaskResult.builder(ExecutionStatus.SUCCEEDED).context([queuedBuild: queuedBuild]).build()
+
+    try {
+      Response igorResponse = buildService.build(master, job, stage.context.parameters)
+
+      if (igorResponse.getStatus() == HttpStatus.ACCEPTED.value()) {
+        log.info("build start for $master $job is pending, waiting")
+        return TaskResult.RUNNING
+      }
+
+      if (igorResponse.getStatus() == HttpStatus.OK.value()) {
+        String queuedBuild = igorResponse.body.in().text
+        return TaskResult
+            .builder(ExecutionStatus.SUCCEEDED)
+            .context([queuedBuild: queuedBuild])
+            .build()
+      }
+    }
+    catch (RetrofitError e) {
+      if (e.kind == RetrofitError.Kind.NETWORK) {
+        log.warn("Network failure communicating with igor to start a jenkins job, will retry", e)
+        return TaskResult.RUNNING
+      }
+      throw e
+    }
+
+    throw new SystemException("Failure starting script")
+  }
+
+  @Override
+  long getBackoffPeriod() {
+    return Duration.ofSeconds(30).toMillis()
+  }
+
+  @Override
+  long getTimeout() {
+    return Duration.ofMinutes(15).toMillis()
   }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartScriptTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartScriptTask.groovy
@@ -17,19 +17,29 @@
 package com.netflix.spinnaker.orca.igor.tasks
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import com.netflix.spinnaker.kork.exceptions.SystemException
+import com.netflix.spinnaker.orca.api.pipeline.RetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.igor.BuildService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import retrofit.RetrofitError
+import retrofit.client.Response
 
 import javax.annotation.Nonnull
+import java.time.Duration
 
 @Component
-class StartScriptTask implements Task {
+class StartScriptTask implements RetryableTask {
+  private final Logger log = LoggerFactory.getLogger(getClass())
 
   @Autowired
   BuildService buildService
@@ -66,13 +76,13 @@ class StartScriptTask implements Task {
     }
 
     def parameters = [
-      SCRIPT_PATH  : scriptPath,
-      COMMAND      : command,
-      IMAGE_ID     : image,
-      REGION_PARAM : region,
-      ENV_PARAM    : account,
-      CLUSTER_PARAM: cluster,
-      CMC          : cmc
+        SCRIPT_PATH  : scriptPath,
+        COMMAND      : command,
+        IMAGE_ID     : image,
+        REGION_PARAM : region,
+        ENV_PARAM    : account,
+        CLUSTER_PARAM: cluster,
+        CMC          : cmc
     ]
 
     if (repoUrl) {
@@ -83,8 +93,40 @@ class StartScriptTask implements Task {
       parameters.REPO_BRANCH = repoBranch
     }
 
-    String queuedBuild = buildService.build(master, job, parameters)
-    TaskResult.builder(ExecutionStatus.SUCCEEDED).context([master: master, job: job, queuedBuild: queuedBuild, REPO_URL: repoUrl?:'default' ]).build()
+    try {
+      Response igorResponse = buildService.build(master, job, parameters)
+
+      if (igorResponse.getStatus() == HttpStatus.ACCEPTED.value()) {
+        log.info("script start for $master $job is pending, waiting")
+        return TaskResult.RUNNING
+      }
+
+      if (igorResponse.getStatus() == HttpStatus.OK.value()) {
+        String queuedBuild = igorResponse.body.in().text
+        return TaskResult
+            .builder(ExecutionStatus.SUCCEEDED)
+            .context([master: master, job: job, queuedBuild: queuedBuild, REPO_URL: repoUrl ?: 'default'])
+            .build()
+      }
+    }
+    catch (RetrofitError e) {
+      if (e.kind == RetrofitError.Kind.NETWORK) {
+        log.warn("Network failure communicating with igor to start a jenkins job, will retry", e)
+        return TaskResult.RUNNING
+      }
+      throw e
+    }
+
+    throw new SystemException("Failure starting script")
   }
 
+  @Override
+  long getBackoffPeriod() {
+    return Duration.ofSeconds(30).toMillis()
+  }
+
+  @Override
+  long getTimeout() {
+    return Duration.ofMinutes(15).toMillis()
+  }
 }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTaskSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.igor.BuildService
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
+import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler
 import retrofit.RetrofitError
 import retrofit.client.Response
 import retrofit.mime.TypedString
@@ -37,6 +38,8 @@ class StartJenkinsJobTaskSpec extends Specification {
     task.objectMapper = Mock(ObjectMapper) {
       convertValue(_,_) >> [:]
     }
+
+    task.retrofitExceptionHandler = new RetrofitExceptionHandler()
   }
 
   @Shared

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTaskSpec.groovy
@@ -91,4 +91,21 @@ class StartJenkinsJobTaskSpec extends Specification {
         then:
         thrown(RetrofitError)
     }
+
+  def "handle 202 response from igor"() {
+    given:
+    def stage = new StageExecutionImpl(pipeline, "jenkins", [master: "builds", job: "orca"])
+
+    and:
+    task.buildService = Stub(BuildService) {
+      build(stage.context.master, stage.context.job, stage.context.parameters) >>
+          new Response("", 202, "OK", [], null)
+    }
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.status == ExecutionStatus.RUNNING
+  }
 }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/StartJenkinsJobTaskSpec.groovy
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.orca.igor.BuildService
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import retrofit.RetrofitError
+import retrofit.client.Response
+import retrofit.mime.TypedString
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -46,7 +48,8 @@ class StartJenkinsJobTaskSpec extends Specification {
 
         and:
         task.buildService = Stub(BuildService) {
-           build(stage.context.master, stage.context.job, stage.context.parameters) >> [result: 'SUCCESS', running: true, number: 4]
+          build(stage.context.master, stage.context.job, stage.context.parameters) >>
+              new Response("", 200, "OK", [], new TypedString(new ObjectMapper().writeValueAsString([result: 'SUCCESS', running: true, number: 4])))
         }
 
         when:
@@ -62,7 +65,8 @@ class StartJenkinsJobTaskSpec extends Specification {
 
       and:
       task.buildService = Stub(BuildService) {
-          build(stage.context.master, stage.context.job, stage.context.parameters) >> [ result : 'SUCCESS', running: true, number: 4 ]
+        build(stage.context.master, stage.context.job, stage.context.parameters) >>
+            new Response("", 200, "OK", [], new TypedString(new ObjectMapper().writeValueAsString([result: 'SUCCESS', running: true, number: 4])))
       }
 
       when:

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
@@ -77,7 +77,7 @@ class RetrofitExceptionHandler implements ExceptionHandler {
     }
 
     // retry on 503 even for non-idempotent requests
-    if (e.kind == HTTP && e.response.status == HTTP_UNAVAILABLE) {
+    if (e.kind == HTTP && e.response?.status == HTTP_UNAVAILABLE) {
       return true
     }
 
@@ -85,13 +85,13 @@ class RetrofitExceptionHandler implements ExceptionHandler {
   }
 
   boolean isGatewayErrorCode(RetrofitError e) {
-    e.kind == HTTP && e.response.status in [HTTP_BAD_GATEWAY, HTTP_UNAVAILABLE, HTTP_GATEWAY_TIMEOUT]
+    e.kind == HTTP && e.response?.status in [HTTP_BAD_GATEWAY, HTTP_UNAVAILABLE, HTTP_GATEWAY_TIMEOUT]
   }
 
   private static final int HTTP_TOO_MANY_REQUESTS = 429
 
   boolean isThrottle(RetrofitError e) {
-    e.kind == HTTP && e.response.status == HTTP_TOO_MANY_REQUESTS
+    e.kind == HTTP && e.response?.status == HTTP_TOO_MANY_REQUESTS
   }
 
   private boolean isNetworkError(RetrofitError e) {

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
@@ -100,7 +100,7 @@ class RetrofitExceptionHandler implements ExceptionHandler {
 
   private boolean isMalformedRequest(RetrofitError e) {
     // We never want to retry errors like "Path parameter "blah" value must not be null.
-    return e.kind == UNEXPECTED && e.message.contains("Path parameter")
+    return e.kind == UNEXPECTED && e.message?.contains("Path parameter")
   }
 
   private static boolean isIdempotentRequest(RetrofitError e) {


### PR DESCRIPTION
This a companion PR to https://github.com/spinnaker/igor/pull/863

The issue here is that when kicking off a build takes a long time (e.g. when jenkins has a lot of job configs) orca might kick off a lot of builds instead of just one (and might still fail!)
Igor now adds support for "pending" operation so if the same request is received twice it will return 202. This change adds the corresponding support to orca, on 202, we just need to retry, because eventually igor will give us the build number
