### PR TITLE
chore(tasks): Add logging for when tasks take a long time to run

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -86,6 +86,13 @@ class RunTaskHandler(
   private val dynamicConfigService: DynamicConfigService
 ) : OrcaMessageHandler<RunTask>, ExpressionAware, AuthenticationAware {
 
+  /**
+   *  If a task takes longer than this number of ms to run, we will print a warning.
+   *  This is an indication that the task might eventually hit the dreaded message ack timeout and might end
+   *  running multiple times cause unintended side-effects.
+   */
+  private val warningInvocationTimeMs = 30000
+
   override fun handle(message: RunTask) {
     message.withTask { origStage, taskModel, task ->
       var stage = origStage
@@ -168,6 +175,7 @@ class RunTaskHandler(
               queue.push(message, task.backoffPeriod(taskModel, stage))
               trackResult(stage, thisInvocationStartTimeMs, taskModel, RUNNING)
             } else if (e is TimeoutException && stage.context["markSuccessfulOnTimeout"] == true) {
+              trackResult(stage, thisInvocationStartTimeMs, taskModel, SUCCEEDED)
               queue.push(CompleteTask(message, SUCCEEDED))
             } else {
               if (e !is TimeoutException) {
@@ -202,6 +210,10 @@ class RunTaskHandler(
         "task.invocations.duration.withType" to commonTags + detailedTags
       ).forEach { name, tags ->
         registry.timer(name, tags).record(elapsedMillis, TimeUnit.MILLISECONDS)
+      }
+
+      if (elapsedMillis >= warningInvocationTimeMs) {
+        log.info("Task invocation for task ${taskModel.implementingClass} in stage ${stage.type} with id ${stage.id} took over $warningInvocationTimeMs")
       }
     } catch (e: java.lang.Exception) {
       log.warn("Failed to track result for stage: ${stage.id}, task: ${taskModel.id}", e)

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -91,7 +91,11 @@ class RunTaskHandler(
    *  This is an indication that the task might eventually hit the dreaded message ack timeout and might end
    *  running multiple times cause unintended side-effects.
    */
-  private val warningInvocationTimeMs = 30000
+  private val warningInvocationTimeMs: Int = dynamicConfigService.getConfig(
+    Int::class.java,
+    "tasks.warningInvocationTimeMs",
+    30000
+  )
 
   override fun handle(message: RunTask) {
     message.withTask { origStage, taskModel, task ->
@@ -213,7 +217,10 @@ class RunTaskHandler(
       }
 
       if (elapsedMillis >= warningInvocationTimeMs) {
-        log.info("Task invocation for task ${taskModel.implementingClass} in stage ${stage.type} with id ${stage.id} took over $warningInvocationTimeMs")
+        log.info(
+          "Task invocation took over ${warningInvocationTimeMs}ms " +
+            "(taskType: ${taskModel.implementingClass}, stageType: ${stage.type}, stageId: ${stage.id})"
+        )
       }
     } catch (e: java.lang.Exception) {
       log.warn("Failed to track result for stage: ${stage.id}, task: ${taskModel.id}", e)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -117,6 +117,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
   val stageResolver = DefaultStageResolver(StageDefinitionBuildersProvider(emptyList()))
 
   subject(GROUP) {
+    whenever(dynamicConfigService.getConfig(eq(Int::class.java), eq("tasks.warningInvocationTimeMs"), any())) doReturn 0
+
     RunTaskHandler(
       queue,
       repository,


### PR DESCRIPTION
This change adds logging for when a tasks `execute` method takes a long time to run (over 30s).
Since tasks have a pretty sensitive ack timeout, having a long running taks might be indicative of a problem to come.

We have metrics for task invocation times as well, but once an operator knows that some task takes a long time, it's useful to find it in logs to see what it was doing for further investigation
