### PR TITLE
Revert "fix(aws): do not filter scaling processes to resume/suspend"

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/scalingprocess/ResumeAwsScalingProcessTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/scalingprocess/ResumeAwsScalingProcessTask.groovy
@@ -15,9 +15,25 @@
  */
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.scalingprocess
 
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
 import org.springframework.stereotype.Component
 
 @Component
 class ResumeAwsScalingProcessTask extends AbstractAwsScalingProcessTask {
   String type = "resumeAsgProcessesDescription"
+
+  @Override
+  List<String> filterProcesses(TargetServerGroup targetServerGroup, List<String> processes) {
+    if (!processes) {
+      return []
+    }
+
+    def targetAsgConfiguration = targetServerGroup.asg as Map<String, Object>
+    if (targetAsgConfiguration.suspendedProcesses) {
+      def suspendedProcesses = targetAsgConfiguration.suspendedProcesses*.processName as List<String>
+      return suspendedProcesses.intersect(processes) ?: []
+    }
+
+    return []
+  }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/scalingprocess/SuspendAwsScalingProcessTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/scalingprocess/SuspendAwsScalingProcessTask.groovy
@@ -15,9 +15,25 @@
  */
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.scalingprocess
 
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
 import org.springframework.stereotype.Component
 
 @Component
 class SuspendAwsScalingProcessTask extends AbstractAwsScalingProcessTask {
   String type = "suspendAsgProcessesDescription"
+
+  @Override
+  List<String> filterProcesses(TargetServerGroup targetServerGroup, List<String> processes) {
+    if (!processes) {
+      return []
+    }
+
+    def targetAsgConfiguration = targetServerGroup.asg as Map<String, Object>
+    if (targetAsgConfiguration.suspendedProcesses) {
+      def suspendedProcesses = targetAsgConfiguration.suspendedProcesses*.processName as List<String>
+      return processes - suspendedProcesses
+    }
+
+    return processes
+  }
 }


### PR DESCRIPTION
Reverts spinnaker/orca#3910

Seeing that if a user manually selects a server group and issues a resize operation then we will always resume launch/terminate at the start of that and suspend launch/terminate at the end leaving the ASG in a bad state