### PR TITLE
feat(webhooks): Allow for webhook monitor tasks without JSON processing

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTask.groovy
@@ -68,9 +68,8 @@ class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
   TaskResult execute(StageExecution stage) {
     WebhookStage.StageData stageData = stage.mapTo(WebhookStage.StageData)
 
-    if (Strings.isNullOrEmpty(stageData.statusEndpoint) || Strings.isNullOrEmpty(stageData.statusJsonPath)) {
-      throw new IllegalStateException(
-        "Missing required parameter(s): statusEndpoint = ${stageData.statusEndpoint}, statusJsonPath = ${stageData.statusJsonPath}")
+    if (Strings.isNullOrEmpty(stageData.statusEndpoint)) {
+      throw new IllegalStateException("Missing required parameter: statusEndpoint = ${stageData.statusEndpoint}")
     }
 
     // Preserve the responses we got from createWebhookTask, but reset the monitor subkey as we will overwrite it new data
@@ -130,6 +129,10 @@ class MonitorWebhookTask implements OverridableTimeoutRetryableTask {
           statusCode: response.statusCode,
           statusCodeValue: response.statusCode.value()
         ]
+
+    if (Strings.isNullOrEmpty(stageData.statusJsonPath)) {
+      return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(responsePayload).build()
+    }
 
     try {
       result = JsonPath.read(response.body, stageData.statusJsonPath)


### PR DESCRIPTION
This allows us to monitor webhook responses while allowing the recipient
server to hold the entire logic for determining status. This is possible
today with CreateWebhookTask, but CreateWebhookTask has a fixed timeout,
whereas MonitorWebhookTask has an overrideable timeout. Another option
would be to make CreateWebhookTask into an
OverrideableTimeoutRetryableTask.

> We prefer small, well tested pull requests.

It's small but I can't claim it's well tested. I could use assistance from a member of the team in determining whether this is a desireable feature and the right way to approach the problem. Please consider this a feature request that happened to reach PR form.