### PR TITLE
fix(plugins): Rebuild task cache on call to get task by type identifier

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskResolver.java
@@ -95,7 +95,13 @@ public class TaskResolver {
     Task task = taskByAlias.get(taskTypeIdentifier);
 
     if (task == null) {
-      throw new NoSuchTaskException(taskTypeIdentifier);
+      computeTasks();
+      log.debug(
+          "Task type '{}' not found in initial task cache, re-computing...", taskTypeIdentifier);
+      task = taskByAlias.get(taskTypeIdentifier);
+      if (task == null) {
+        throw new NoSuchTaskException(taskTypeIdentifier);
+      }
     }
 
     return task;

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -730,8 +730,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
 
       it("does not execute the task") {
-        verify(task).aliases()
-        verify(task).extensionClass
+        verify(task, times(2)).aliases()
+        verify(task, times(2)).extensionClass
         verifyNoMoreInteractions(task)
       }
     }
@@ -814,8 +814,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
 
       it("does not execute the task") {
-        verify(task).aliases()
-        verify(task).extensionClass
+        verify(task, times(2)).aliases()
+        verify(task, times(2)).extensionClass
         verifyNoMoreInteractions(task)
       }
     }
@@ -1738,8 +1738,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
     }
 
     it("does not run any tasks") {
-      verify(task, times(2)).aliases()
-      verify(task, times(2)).extensionClass
+      verify(task, times(3)).aliases()
+      verify(task, times(3)).extensionClass
       verifyNoMoreInteractions(task)
     }
 


### PR DESCRIPTION
I overlooked calls to `getTaskClass` when doing the initial pass through of Orca for v2 plugin framework compatibility.  Turns out we call `getTaskClass` in a number of places and it's possible the task cache needs to be rebuilt. 