### PR TITLE
fix(tasks): Only lookup task by type in RunTaskHandler; remove code introduced to support one-off case for now obsolete SimpleTask

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/TaskNode.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/TaskNode.java
@@ -169,23 +169,8 @@ public interface TaskNode {
     }
   }
 
-  /**
-   * This is an abstraction above TaskDefinition that allows more flexibility for the implementing
-   * class name.
-   */
-  interface DefinedTask {
-
-    /** Returns the name of the task */
-    @Nonnull
-    String getName();
-
-    /** Returns the name of the class implementing the stage */
-    @Nonnull
-    String getImplementingClassName();
-  }
-
   /** An individual task. */
-  class TaskDefinition implements TaskNode, DefinedTask {
+  class TaskDefinition implements TaskNode {
     private final String name;
     private final Class<? extends Task> implementingClass;
 
@@ -194,18 +179,12 @@ public interface TaskNode {
       this.implementingClass = implementingClass;
     }
 
-    @Override
     public @Nonnull String getName() {
       return name;
     }
 
     public @Nonnull Class<? extends Task> getImplementingClass() {
       return implementingClass;
-    }
-
-    @Override
-    public @Nonnull String getImplementingClassName() {
-      return getImplementingClass().getCanonicalName();
     }
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskResolver.java
@@ -86,6 +86,8 @@ public class TaskResolver {
   /**
    * Fetch a {@code Task} by {@code taskTypeIdentifier}.
    *
+   * <p>If the task is not found from the type, attempts to re-compute tasks and lookup again.
+   *
    * @param taskTypeIdentifier Task identifier (class name or alias)
    * @return the Task matching {@code taskTypeIdentifier}
    * @throws NoSuchTaskException if Task does not exist
@@ -110,8 +112,7 @@ public class TaskResolver {
   /**
    * Fetch a {@code Task} by {@code Class type}.
    *
-   * <p>This method is used as a fallback when looking up tasks, so if the task is not found from
-   * the type, attempts to re-compute tasks and lookup again.
+   * <p>If the task is not found from the type, attempts to re-compute tasks and lookup again.
    *
    * @param taskType Task type (class of task)
    * @return the Task matching {@code taskType}

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/StageDefinitionBuilders.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/StageDefinitionBuilders.kt
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner
 import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner.STAGE_BEFORE
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
-import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.DefinedTask
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.TaskDefinition
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.TaskGraph
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
@@ -52,11 +52,11 @@ private fun processTaskNode(
 ) {
   element.apply {
     when (value) {
-      is DefinedTask -> {
+      is TaskDefinition -> {
         val task = TaskExecutionImpl()
         task.id = (stage.tasks.size + 1).toString()
         task.name = value.name
-        task.implementingClass = value.implementingClassName
+        task.implementingClass = value.implementingClass.name
         if (isSubGraph) {
           task.isLoopStart = isFirst
           task.isLoopEnd = isLast

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -232,14 +232,10 @@ class RunTaskHandler(
   private fun RunTask.withTask(block: (StageExecution, TaskExecution, Task) -> Unit) =
     withTask { stage, taskModel ->
       try {
-        taskResolver.getTask(taskModel.implementingClass)
+        taskResolver.getTask(taskType)
       } catch (e: TaskResolver.NoSuchTaskException) {
-        try {
-          taskResolver.getTask(taskType)
-        } catch (e: TaskResolver.NoSuchTaskException) {
-          queue.push(InvalidTaskType(this, taskType.name))
-          null
-        }
+        queue.push(InvalidTaskType(this, taskType.name))
+        null
       }?.let {
         block.invoke(stage, taskModel, it)
       }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -43,7 +43,6 @@ import com.netflix.spinnaker.orca.pipeline.RestrictExecutionDuringTimeWindow
 import com.netflix.spinnaker.orca.pipeline.model.DefaultTrigger
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl.STAGE_TIMEOUT_OVERRIDE_KEY
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
-import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.q.CompleteTask
@@ -150,141 +149,6 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
       val stage = pipeline.stages.first()
       val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTask::class.java)
-
-      and("has no context updates outputs") {
-        val taskResult = TaskResult.SUCCEEDED
-
-        beforeGroup {
-          tasks.forEach { whenever(it.extensionClass) doReturn it::class.java }
-          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
-          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
-          whenever(task.execute(any())) doReturn taskResult
-          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
-        }
-
-        afterGroup(::resetMocks)
-
-        action("the handler receives a message") {
-          subject.handle(message)
-        }
-
-        it("executes the task") {
-          verify(task).execute(pipeline.stages.first())
-        }
-
-        it("completes the task") {
-          verify(queue).push(
-            check<CompleteTask> {
-              assertThat(it.status).isEqualTo(SUCCEEDED)
-            }
-          )
-        }
-
-        it("does not update the stage or global context") {
-          verify(repository, never()).storeStage(any())
-        }
-      }
-
-      and("has context updates") {
-        val stageOutputs = mapOf("foo" to "covfefe")
-        val taskResult = TaskResult.builder(SUCCEEDED).context(stageOutputs).build()
-
-        beforeGroup {
-          tasks.forEach { whenever(it.extensionClass) doReturn it::class.java }
-          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
-          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
-          whenever(task.execute(any())) doReturn taskResult
-          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
-        }
-
-        afterGroup(::resetMocks)
-
-        action("the handler receives a message") {
-          subject.handle(message)
-        }
-
-        it("updates the stage context") {
-          verify(repository).storeStage(
-            check {
-              assertThat(stageOutputs).isEqualTo(it.context)
-            }
-          )
-        }
-      }
-
-      and("has outputs") {
-        val outputs = mapOf("foo" to "covfefe")
-        val taskResult = TaskResult.builder(SUCCEEDED).outputs(outputs).build()
-
-        beforeGroup {
-          tasks.forEach { whenever(it.extensionClass) doReturn it::class.java }
-          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
-          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
-          whenever(task.execute(any())) doReturn taskResult
-          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
-        }
-
-        afterGroup(::resetMocks)
-
-        action("the handler receives a message") {
-          subject.handle(message)
-        }
-
-        it("updates the stage outputs") {
-          verify(repository).storeStage(
-            check {
-              assertThat(it.outputs).isEqualTo(outputs)
-            }
-          )
-        }
-      }
-
-      and("outputs a stageTimeoutMs value") {
-        val outputs = mapOf(
-          "foo" to "covfefe",
-          "stageTimeoutMs" to Long.MAX_VALUE
-        )
-        val taskResult = TaskResult.builder(SUCCEEDED).outputs(outputs).build()
-
-        beforeGroup {
-          tasks.forEach { whenever(it.extensionClass) doReturn it::class.java }
-          taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(task, stage)) doReturn stage }
-          taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(task, stage, taskResult)) doReturn taskResult }
-          whenever(task.execute(any())) doReturn taskResult
-          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
-        }
-
-        afterGroup(::resetMocks)
-
-        action("the handler receives a message") {
-          subject.handle(message)
-        }
-
-        it("does not write stageTimeoutMs to outputs") {
-          verify(repository).storeStage(
-            check {
-              assertThat(it.outputs)
-                .containsKey("foo")
-                .doesNotContainKey("stageTimeoutMs")
-            }
-          )
-        }
-      }
-    }
-
-    describe("that completes successfully prefering specified TaskExecution implementingClass") {
-      val pipeline = pipeline {
-        stage {
-          type = "whatever"
-          task {
-            id = "1"
-            startTime = clock.instant().toEpochMilli()
-            implementingClass = task.javaClass.canonicalName
-          }
-        }
-      }
-      val stage = pipeline.stages.first()
-      val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", WaitTask::class.java)
 
       and("has no context updates outputs") {
         val taskResult = TaskResult.SUCCEEDED
@@ -730,8 +594,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
 
       it("does not execute the task") {
-        verify(task, times(2)).aliases()
-        verify(task, times(2)).extensionClass
+        verify(task).aliases()
+        verify(task).extensionClass
         verifyNoMoreInteractions(task)
       }
     }
@@ -814,8 +678,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
 
       it("does not execute the task") {
-        verify(task, times(2)).aliases()
-        verify(task, times(2)).extensionClass
+        verify(task).aliases()
+        verify(task).extensionClass
         verifyNoMoreInteractions(task)
       }
     }
@@ -1738,8 +1602,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
     }
 
     it("does not run any tasks") {
-      verify(task, times(3)).aliases()
-      verify(task, times(3)).extensionClass
+      verify(task, times(2)).aliases()
+      verify(task, times(2)).extensionClass
       verifyNoMoreInteractions(task)
     }
 


### PR DESCRIPTION
Removes most of what was introduced here: https://github.com/spinnaker/orca/pull/3574

This is mostly a performance improvement so that we don't needlessly rebuild the task cache.