### PR TITLE
Revert "fix(tasks): Only lookup task by type in RunTaskHandler; remove code introduced to support one-off case for now obsolete SimpleTask"

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/TaskNode.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/TaskNode.java
@@ -169,8 +169,23 @@ public interface TaskNode {
     }
   }
 
+  /**
+   * This is an abstraction above TaskDefinition that allows more flexibility for the implementing
+   * class name.
+   */
+  interface DefinedTask {
+
+    /** Returns the name of the task */
+    @Nonnull
+    String getName();
+
+    /** Returns the name of the class implementing the stage */
+    @Nonnull
+    String getImplementingClassName();
+  }
+
   /** An individual task. */
-  class TaskDefinition implements TaskNode {
+  class TaskDefinition implements TaskNode, DefinedTask {
     private final String name;
     private final Class<? extends Task> implementingClass;
 
@@ -179,12 +194,18 @@ public interface TaskNode {
       this.implementingClass = implementingClass;
     }
 
+    @Override
     public @Nonnull String getName() {
       return name;
     }
 
     public @Nonnull Class<? extends Task> getImplementingClass() {
       return implementingClass;
+    }
+
+    @Override
+    public @Nonnull String getImplementingClassName() {
+      return getImplementingClass().getCanonicalName();
     }
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskResolver.java
@@ -86,8 +86,6 @@ public class TaskResolver {
   /**
    * Fetch a {@code Task} by {@code taskTypeIdentifier}.
    *
-   * <p>If the task is not found from the type, attempts to re-compute tasks and lookup again.
-   *
    * @param taskTypeIdentifier Task identifier (class name or alias)
    * @return the Task matching {@code taskTypeIdentifier}
    * @throws NoSuchTaskException if Task does not exist
@@ -112,7 +110,8 @@ public class TaskResolver {
   /**
    * Fetch a {@code Task} by {@code Class type}.
    *
-   * <p>If the task is not found from the type, attempts to re-compute tasks and lookup again.
+   * <p>This method is used as a fallback when looking up tasks, so if the task is not found from
+   * the type, attempts to re-compute tasks and lookup again.
    *
    * @param taskType Task type (class of task)
    * @return the Task matching {@code taskType}

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/StageDefinitionBuilders.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/StageDefinitionBuilders.kt
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner
 import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner.STAGE_BEFORE
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
-import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.TaskDefinition
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.DefinedTask
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.TaskGraph
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
@@ -52,11 +52,11 @@ private fun processTaskNode(
 ) {
   element.apply {
     when (value) {
-      is TaskDefinition -> {
+      is DefinedTask -> {
         val task = TaskExecutionImpl()
         task.id = (stage.tasks.size + 1).toString()
         task.name = value.name
-        task.implementingClass = value.implementingClass.name
+        task.implementingClass = value.implementingClassName
         if (isSubGraph) {
           task.isLoopStart = isFirst
           task.isLoopEnd = isLast

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -232,10 +232,14 @@ class RunTaskHandler(
   private fun RunTask.withTask(block: (StageExecution, TaskExecution, Task) -> Unit) =
     withTask { stage, taskModel ->
       try {
-        taskResolver.getTask(taskType)
+        taskResolver.getTask(taskModel.implementingClass)
       } catch (e: TaskResolver.NoSuchTaskException) {
-        queue.push(InvalidTaskType(this, taskType.name))
-        null
+        try {
+          taskResolver.getTask(taskType)
+        } catch (e: TaskResolver.NoSuchTaskException) {
+          queue.push(InvalidTaskType(this, taskType.name))
+          null
+        }
       }?.let {
         block.invoke(stage, taskModel, it)
       }


### PR DESCRIPTION
Reverts spinnaker/orca#3939

Didn't work as I hoped.