### PR TITLE
fix(tasks): Fetch missing tasks from task provider on cache miss and add to cache

### DIFF
--- a/orca-plugins-test/src/test/kotlin/com/netflix/spinnaker/orca/plugins/test/OrcaPluginsTest.kt
+++ b/orca-plugins-test/src/test/kotlin/com/netflix/spinnaker/orca/plugins/test/OrcaPluginsTest.kt
@@ -63,12 +63,12 @@ class OrcaPluginsTest : PluginsTck<OrcaPluginsFixture>() {
       }
 
       test("Task extensions are resolved to the correct type") {
-        val taskExtension1 = taskResolver.getTaskClass(TaskExtension1::class.java.name)
-        val taskExtension2 = taskResolver.getTaskClass(TaskExtension2::class.java.name)
+        val taskExtension1 = taskResolver.getTask(TaskExtension1::class.java.name)
+        val taskExtension2 = taskResolver.getTask(TaskExtension2::class.java.name)
 
         expect {
-          that(taskExtension1.typeName).isEqualTo(TaskExtension1().javaClass.typeName)
-          that(taskExtension2.typeName).isEqualTo(TaskExtension2().javaClass.typeName)
+          that(taskExtension1.extensionClass.canonicalName).isEqualTo(TaskExtension1::class.java.canonicalName)
+          that(taskExtension2.extensionClass.canonicalName).isEqualTo(TaskExtension2::class.java.canonicalName)
         }
       }
     }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -730,8 +730,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
 
       it("does not execute the task") {
-        verify(task, times(2)).aliases()
-        verify(task, times(2)).extensionClass
+        verify(task, times(1)).aliases()
+        verify(task, times(3)).extensionClass
         verifyNoMoreInteractions(task)
       }
     }
@@ -814,8 +814,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       }
 
       it("does not execute the task") {
-        verify(task, times(2)).aliases()
-        verify(task, times(2)).extensionClass
+        verify(task, times(1)).aliases()
+        verify(task, times(3)).extensionClass
         verifyNoMoreInteractions(task)
       }
     }
@@ -1738,8 +1738,8 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
     }
 
     it("does not run any tasks") {
-      verify(task, times(3)).aliases()
-      verify(task, times(3)).extensionClass
+      verify(task, times(1)).aliases()
+      verify(task, times(5)).extensionClass
       verifyNoMoreInteractions(task)
     }
 


### PR DESCRIPTION
Previous implementation was naive - it turns out we have a number of codepaths that will trigger that rebuild and I don't want to rebuild that cache over and over again as it is wasteful and could potentially have very negative performance consequences.  This is much simpler and cleaner and what I should've done from the get go.