### PR TITLE
feat(clouddriver): Look ahead region detection for "aws" can be disabled

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -92,6 +92,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
     List<String> zones
     List<String> namespaces
     Boolean onlyEnabled = true
+    Boolean skipRegionDetection = false
     Boolean resolveMissingLocations
     SelectionStrategy selectionStrategy = SelectionStrategy.NEWEST
     String imageNamePattern
@@ -124,7 +125,7 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
     Map<Location, String> imageIds = [:]
     Set<String> inferredRegions = new HashSet<>()
 
-    if (cloudProvider == 'aws') {
+    if (cloudProvider == 'aws' && !config.skipRegionDetection) {
       // Supplement config with regions from subsequent deploy/canary stages:
       def deployRegions = regionCollector.getRegionsFromChildStages(stage)
 


### PR DESCRIPTION
Similar to the bake stage, `skipRegionDetection` can be used to determine
whether or not additional regions are inferred from downstream deploy stages.

The default value is `false` which preserves the existing behavior.

```
{
  ...
  "skipRegionDetection": true
}

```
