### PR TITLE
fix(bake): Log when bake request amiSuffix and stage context amiSuffix values are different and resolve the difference

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
@@ -61,7 +61,15 @@ class BakeRequest {
   StoreType storeType
   Boolean enhancedNetworking
   String amiName
-  String amiSuffix
+  private String amiSuffix
+
+  public void setAmiSuffix(String amiSuffix) {
+    this.amiSuffix = amiSuffix
+  }
+
+  public getAmiSuffix() {
+    return this.amiSuffix
+  }
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   Integer rootVolumeSize

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -92,8 +92,14 @@ class CreateBakeTask implements RetryableTask {
     try {
       // If the user has specified a base OS that is unrecognized by Rosco, this method will
       // throw a Retrofit exception (HTTP 404 Not Found)
-      def bake = bakeFromContext(stage, bakery)
+      BakeRequest bake = bakeFromContext(stage, bakery)
       String rebake = shouldRebake(stage) ? "1" : null
+
+      if (stage.context.amiSuffix != null && bake.amiSuffix != null && bake.amiSuffix != stage.context.amiSuffix) {
+        log.warn("Bake request amiSuffix ${bake.amiSuffix} differs from stage context amiSuffix ${stage.context.amiSuffix}, resolving...")
+        bake.amiSuffix = stage.context.amiSuffix
+      }
+
       def bakeStatus = bakery.service.createBake(stage.context.region as String, bake, rebake)
 
       def stageOutputs = [


### PR DESCRIPTION
We encountered an issue wherein the `amiSuffix` sent in the bake request was different than the `amiSuffix` value set in the stage context.  I have not found a logical reason for how this could happen, but if it does happen let's just set it to what is in the stage context and log it out.