### PR TITLE
fix(webhook): Pass stage configuration data to rest template provider…

### DIFF
--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/DefaultRestTemplateProvider.java
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/DefaultRestTemplateProvider.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.webhook.service;
 
+import com.netflix.spinnaker.orca.webhook.pipeline.WebhookStage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -23,7 +24,7 @@ import org.springframework.web.client.RestTemplate;
 
 @Order
 @Component
-public class DefaultRestTemplateProvider implements RestTemplateProvider {
+public class DefaultRestTemplateProvider implements RestTemplateProvider<WebhookStage.StageData> {
   private final RestTemplate restTemplate;
 
   @Autowired
@@ -32,12 +33,17 @@ public class DefaultRestTemplateProvider implements RestTemplateProvider {
   }
 
   @Override
-  public boolean supports(String targetUrl) {
+  public boolean supports(String targetUrl, WebhookStage.StageData stageData) {
     return true;
   }
 
   @Override
   public RestTemplate getRestTemplate(String targetUrl) {
     return restTemplate;
+  }
+
+  @Override
+  public Class<WebhookStage.StageData> getStageDataType() {
+    return WebhookStage.StageData.class;
   }
 }

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/RestTemplateProvider.java
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/RestTemplateProvider.java
@@ -27,7 +27,10 @@ import org.springframework.web.client.RestTemplate;
  */
 public interface RestTemplateProvider<T extends WebhookStage.StageData> {
 
-  /** @return true if this {@code RestTemplateProvider} supports the given url */
+  /**
+   * @return true if this {@code RestTemplateProvider} supports the given url and stage
+   *     configuration
+   */
   boolean supports(String targetUrl, T stageData);
 
   /**

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/RestTemplateProvider.java
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/RestTemplateProvider.java
@@ -16,11 +16,19 @@
 
 package com.netflix.spinnaker.orca.webhook.service;
 
+import com.netflix.spinnaker.orca.webhook.pipeline.WebhookStage;
 import org.springframework.web.client.RestTemplate;
 
-public interface RestTemplateProvider {
+/**
+ * Concrete implementations will provide a rest template customized to call webhook related
+ * endpoints.
+ *
+ * @param <T> stage configuration data.
+ */
+public interface RestTemplateProvider<T extends WebhookStage.StageData> {
+
   /** @return true if this {@code RestTemplateProvider} supports the given url */
-  boolean supports(String targetUrl);
+  boolean supports(String targetUrl, T stageData);
 
   /**
    * Provides an opportunity for a {@code RestTemplateProvider} to modify any aspect of the target
@@ -30,10 +38,13 @@ public interface RestTemplateProvider {
    *
    * @return a potentially modified target url
    */
-  default String getTargetUrl(String targetUrl) {
+  default String getTargetUrl(String targetUrl, T stageData) {
     return targetUrl;
   }
 
   /** @return a configured {@code RestTemplate} */
   RestTemplate getRestTemplate(String targetUrl);
+
+  /** @return type of stage data that the template provider is expecting */
+  Class<T> getStageDataType();
 }

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookService.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookService.groovy
@@ -17,16 +17,27 @@
 
 package com.netflix.spinnaker.orca.webhook.service
 
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions
 import com.netflix.spinnaker.orca.webhook.config.WebhookProperties
+import com.netflix.spinnaker.orca.webhook.pipeline.WebhookStage
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpStatusCodeException
+import org.springframework.web.client.RestTemplate
 
+/**
+ * Service that interacts with webhook endpoints for initiating a webhook call, checking the status of webhook
+ * or cancelling a webhook call.
+ */
 @Service
+@Slf4j
 class WebhookService {
 
   // These headers create a security vulnerability.
@@ -36,7 +47,7 @@ class WebhookService {
     "X-SPINNAKER-USER-ORIGIN",
     "X-SPINNAKER-REQUEST-ID",
     "X-SPINNAKER-EXECUTION-ID"
-  ];
+  ]
 
   @Autowired
   private List<RestTemplateProvider> restTemplateProviders = []
@@ -47,30 +58,83 @@ class WebhookService {
   @Autowired
   private WebhookProperties preconfiguredWebhookProperties
 
-  ResponseEntity<Object> exchange(HttpMethod httpMethod, String url, Object payload, Object customHeaders) {
-    def restTemplateProvider = restTemplateProviders.find {
-      it.supports(url)
+  ResponseEntity<Object> callWebhook(StageExecution stageExecution) {
+    RestTemplateData restTemplateData = getRestTemplateData('CreateWebhook', stageExecution)
+    if (restTemplateData == null) {
+      throw new SpinnakerException("Unable to determine rest template to call webhook")
     }
-
-    URI validatedUri = userConfiguredUrlRestrictions.validateURI(
-      restTemplateProvider.getTargetUrl(url)
-    )
-    HttpHeaders headers = buildHttpHeaders(customHeaders)
-    HttpEntity<Object> payloadEntity = new HttpEntity<>(payload, headers)
-    return restTemplateProvider.getRestTemplate(url).exchange(validatedUri, httpMethod, payloadEntity, Object)
+    return  restTemplateData.exchange()
   }
 
-  ResponseEntity<Object> getStatus(String url, Object customHeaders) {
-    def restTemplateProvider = restTemplateProviders.find {
-      it.supports(url)
+  ResponseEntity<Object> getWebhookStatus(StageExecution stageExecution) {
+    RestTemplateData restTemplateData = getRestTemplateData('MonitorWebhook', stageExecution)
+    if (restTemplateData == null) {
+      throw new SpinnakerException("Unable to determine rest template to monitor webhook")
+    }
+    return restTemplateData.exchange()
+  }
+
+  ResponseEntity<Object> cancelWebhook(StageExecution stageExecution) {
+    RestTemplateData restTemplateData = getRestTemplateData("CancelWebhook", stageExecution)
+
+    // Only do cancellation if we can determine the rest template to use.
+    if (restTemplateData == null) {
+      log.warn("Cannot determine rest template to cancel the webhook")
+      return null
+    }
+    WebhookStage.StageData stageData = restTemplateData.stageData
+    try {
+      log.info("Sending best effort webhook cancellation to ${stageData.cancelEndpoint}")
+      ResponseEntity<Object> response = restTemplateData.exchange()
+      log.debug(
+          "Received status code {} from cancel endpoint {} in execution {} in stage {}",
+          response.statusCode,
+          stageData.cancelEndpoint,
+          stageExecution.execution.id,
+          stageExecution.id
+      )
+    } catch (HttpStatusCodeException e) {
+      log.warn("Failed to cancel webhook ${stageData.cancelEndpoint} with statusCode=${e.getStatusCode().value()}", e)
+    } catch (Exception e) {
+      log.warn("Failed to cancel webhook ${stageData.cancelEndpoint}", e)
     }
 
-    URI validatedUri = userConfiguredUrlRestrictions.validateURI(
-      restTemplateProvider.getTargetUrl(url)
-    )
-    HttpHeaders headers = buildHttpHeaders(customHeaders)
-    HttpEntity<Object> httpEntity = new HttpEntity<>(headers)
-    return restTemplateProvider.getRestTemplate(url).exchange(validatedUri, HttpMethod.GET, httpEntity, Object)
+  }
+
+  private RestTemplateData getRestTemplateData(String taskType, StageExecution stageExecution) {
+    for (RestTemplateProvider provider : restTemplateProviders) {
+      WebhookStage.StageData stageData = stageExecution.mapTo(provider.getStageDataType())
+      String destinationUrl
+      HttpHeaders headers = buildHttpHeaders(stageData.customHeaders)
+      HttpMethod httpMethod = HttpMethod.GET
+      HttpEntity<Object> payloadEntity = null
+      switch (taskType) {
+        case 'CreateWebhook':
+          destinationUrl = stageData.url
+          payloadEntity = new HttpEntity<>(stageData.payload, headers)
+          httpMethod = stageData.method
+          break
+        case 'MonitorWebhook':
+          destinationUrl = stageData.statusEndpoint
+          payloadEntity = new HttpEntity<>(null, headers)
+          break
+        case 'CancelWebhook':
+          destinationUrl = stageData.cancelEndpoint
+          payloadEntity = new HttpEntity<>(stageData.cancelPayload, headers)
+          httpMethod = stageData.cancelMethod
+          break
+        default:
+          destinationUrl = ''
+          break
+      }
+
+      // Return on the first match
+      if (destinationUrl != null && !destinationUrl.isEmpty() && provider.supports(destinationUrl, stageData)) {
+        URI validatedUri = userConfiguredUrlRestrictions.validateURI(provider.getTargetUrl(destinationUrl, stageData))
+        RestTemplate restTemplate = provider.getRestTemplate(destinationUrl)
+        return new RestTemplateData(restTemplate, validatedUri, httpMethod, payloadEntity, stageData)
+      }
+    }
   }
 
   List<WebhookProperties.PreconfiguredWebhook> getPreconfiguredWebhooks() {
@@ -81,7 +145,7 @@ class WebhookService {
     HttpHeaders headers = new HttpHeaders()
     customHeaders?.each { key, value ->
       if (headerDenyList.contains(key.toUpperCase())) {
-        return;
+        return
       }
       if (value instanceof List<String>) {
         headers.put(key as String, value as List<String>)
@@ -91,4 +155,27 @@ class WebhookService {
     }
     return headers
   }
+
+  private static class RestTemplateData {
+
+    final RestTemplate restTemplate
+    final URI validatedUri
+    final HttpMethod httpMethod
+    final HttpEntity<Object> payloadEntity
+    final WebhookStage.StageData stageData
+
+    RestTemplateData(RestTemplate restTemplate, URI validatedUri, HttpMethod httpMethod, HttpEntity<Object> payloadEntity, WebhookStage.StageData stageData) {
+      this.restTemplate = restTemplate
+      this.validatedUri = validatedUri
+      this.httpMethod = httpMethod
+      this.payloadEntity = payloadEntity
+      this.stageData = stageData
+    }
+
+    ResponseEntity<Object> exchange() {
+      return this.restTemplate.exchange(validatedUri, httpMethod, payloadEntity, Object)
+    }
+
+  }
+
 }

--- a/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
+++ b/orca-webhook/src/main/groovy/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.groovy
@@ -48,12 +48,10 @@ class CreateWebhookTask implements RetryableTask {
 
   @Override
   TaskResult execute(StageExecution stage) {
-    WebhookStage.StageData stageData = stage.mapTo(WebhookStage.StageData)
 
     WebhookResponseProcessor responseProcessor = new WebhookResponseProcessor(objectMapper, stage, webhookProperties)
-
     try {
-      def response = webhookService.exchange(stageData.method, stageData.url, stageData.payload, stageData.customHeaders)
+      def response = webhookService.callWebhook(stage)
       return responseProcessor.process(response, null)
     } catch (Exception e) {
       return responseProcessor.process(null, e)

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
@@ -18,7 +18,9 @@
 package com.netflix.spinnaker.orca.webhook.service
 
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import com.netflix.spinnaker.orca.webhook.config.WebhookProperties
 import com.netflix.spinnaker.orca.webhook.config.WebhookConfiguration
 import org.springframework.http.HttpHeaders
@@ -88,12 +90,13 @@ class WebhookServiceSpec extends Specification {
     when:
     HttpHeaders headers = new HttpHeaders()
     headers.add("customHeader", "value")
-    def responseEntity = webhookService.exchange(
-      HttpMethod.POST,
-      "https://localhost/v1/test",
-      payload,
-      customHeaders
-    )
+    StageExecution stageExecution = new StageExecutionImpl(null, null, null, [
+        'url': "https://localhost/v1/test",
+        'method': HttpMethod.POST,
+        'customHeaders': customHeaders,
+        'payload': payload
+    ])
+    def responseEntity = webhookService.callWebhook(stageExecution)
 
     then:
     server.verify()
@@ -123,7 +126,13 @@ class WebhookServiceSpec extends Specification {
       responseActions.andRespond(withSuccess('["element1", 123, false]', MediaType.APPLICATION_JSON))
 
     when:
-    def responseEntity = webhookService.getStatus("https://localhost/v1/status/123", [Authorization: "Basic password"])
+    StageExecution stageExecution = new StageExecutionImpl(null, null, null, [
+        'statusEndpoint': "https://localhost/v1/status/123",
+        'method': HttpMethod.GET,
+        'customHeaders': customHeaders,
+        'payload': null
+    ])
+    def responseEntity = webhookService.getWebhookStatus(stageExecution)
 
     then:
     server.verify()
@@ -158,12 +167,13 @@ class WebhookServiceSpec extends Specification {
 
     when:
     webhookService
-    def responseEntity = webhookService.exchange(
-      HttpMethod.GET,
-      "https://localhost/v1/text/test",
-      null,
-      null
-    )
+    StageExecution stageExecution = new StageExecutionImpl(null, null, null, [
+        'url': "https://localhost/v1/text/test",
+        'method': HttpMethod.GET,
+        'customHeaders': null,
+        'payload': null
+    ])
+    def responseEntity = webhookService.callWebhook(stageExecution)
 
     then:
     server.verify()
@@ -179,12 +189,13 @@ class WebhookServiceSpec extends Specification {
 
     when:
     webhookService
-    def responseEntity = webhookService.exchange(
-      HttpMethod.PATCH,
-      "https://localhost/v1/test",
-      null,
-      null
-    )
+    StageExecution stageExecution = new StageExecutionImpl(null, null, null, [
+        'url': "https://localhost/v1/test",
+        'method': HttpMethod.PATCH,
+        'customHeaders': null,
+        'payload': null
+    ])
+    def responseEntity = webhookService.callWebhook(stageExecution)
 
     then:
     noExceptionThrown()

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTaskSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/tasks/MonitorWebhookTaskSpec.groovy
@@ -80,7 +80,7 @@ class MonitorWebhookTaskSpec extends Specification {
       statusJsonPath: '$.status'])
 
     monitorWebhookTask.webhookService = Stub(WebhookService) {
-      getStatus(_, _) >> {
+      getWebhookStatus(_) >> {
         throw new IllegalArgumentException("Invalid URL")
       }
     }
@@ -100,7 +100,7 @@ class MonitorWebhookTaskSpec extends Specification {
       statusJsonPath: '$.status'])
 
     monitorWebhookTask.webhookService = Stub(WebhookService) {
-      getStatus(_, _) >> {
+      getWebhookStatus(_) >> {
         throw new Exception("Invalid URL", new UnknownHostException())
       }
     }
@@ -119,7 +119,7 @@ class MonitorWebhookTaskSpec extends Specification {
       statusJsonPath: '$.status'])
 
     monitorWebhookTask.webhookService = Stub(WebhookService) {
-      getStatus(_, _) >> {
+      getWebhookStatus(_) >> {
         throw new ResourceAccessException('I/O error on GET request for "https://my-service.io/api/status/123"', new SocketTimeoutException("timeout"))
       }
     }
@@ -147,7 +147,7 @@ class MonitorWebhookTaskSpec extends Specification {
     webhookProperties.defaultRetryStatusCodes = [429,403]
     monitorWebhookTask.webhookProperties = webhookProperties
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123", _) >> {
+      1 * getWebhookStatus(_) >> {
         throw new HttpServerErrorException(statusCode, statusCode.name())
       }
     }
@@ -171,7 +171,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "should do a get request to the defined statusEndpoint"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123", [Authorization: "Basic password"]) >> new ResponseEntity<Map>([status:"RUNNING"], HttpStatus.OK)
+      1 * getWebhookStatus(_) >> new ResponseEntity<Map>([status:"RUNNING"], HttpStatus.OK)
     }
     def stage = new StageExecutionImpl(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',
@@ -194,7 +194,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "should find correct element using statusJsonPath parameter"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123", null) >> new ResponseEntity<Map>([status:"TERMINAL"], HttpStatus.OK)
+      1 * getWebhookStatus(_) >> new ResponseEntity<Map>([status:"TERMINAL"], HttpStatus.OK)
     }
     def stage = new StageExecutionImpl(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',
@@ -216,7 +216,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "should return percentComplete if supported by endpoint"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123", [:]) >> new ResponseEntity<Map>([status:42], HttpStatus.OK)
+      1 * getWebhookStatus(_) >> new ResponseEntity<Map>([status:42], HttpStatus.OK)
     }
     def stage = new StageExecutionImpl(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',
@@ -239,7 +239,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "100 percent complete should result in SUCCEEDED status"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123", null) >> new ResponseEntity<Map>([status:100], HttpStatus.OK)
+      1 * getWebhookStatus(_) >> new ResponseEntity<Map>([status:100], HttpStatus.OK)
     }
     def stage = new StageExecutionImpl(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',
@@ -261,7 +261,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "should return TERMINAL status if jsonPath can not be found"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123", null) >> new ResponseEntity<Map>([status:"SUCCESS"], HttpStatus.OK)
+      1 * getWebhookStatus(_) >> new ResponseEntity<Map>([status:"SUCCESS"], HttpStatus.OK)
     }
     def stage = new StageExecutionImpl(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',
@@ -280,7 +280,7 @@ class MonitorWebhookTaskSpec extends Specification {
   def "should return TERMINAL status if jsonPath isn't evaluated to single value"() {
     setup:
     monitorWebhookTask.webhookService = Mock(WebhookService) {
-      1 * getStatus("https://my-service.io/api/status/123", null) >> new ResponseEntity<Map>([status:["some", "complex", "list"]], HttpStatus.OK)
+      1 * getWebhookStatus(_) >> new ResponseEntity<Map>([status:["some", "complex", "list"]], HttpStatus.OK)
     }
     def stage = new StageExecutionImpl(pipeline, "webhook", [
       statusEndpoint: 'https://my-service.io/api/status/123',


### PR DESCRIPTION
- To allow better customizations of `RestTemplateProvider`,  adding `StageData` as an additional arg that we can pass into provider impls.  This will allow us to take decisions using `StageData` instead of just url that we currently pass into these providers.
- Also allows us to extract some other stage configuration data provided and use for further processing as needed.
- Moved all the cancel webhook logic into `WebhookService`
- `WebhookService` now will  issue all calls related to `Webhook` stage