### PR TITLE
fix(docker): Support finding image from a docker registry

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTask.groovy
@@ -324,6 +324,14 @@ class FindImageFromClusterTask extends AbstractCloudProviderAwareTask implements
             mkDeploymentDetail((String) image.imageName, (String) image.amis[location.value][0], deploymentDetailTemplate, config)
           ]
         }
+        //Docker registry to deployment detail conversion
+        else if (imageSummaries[location] == null && image.repository != null && image.tag != null) {
+          String imageId = (String) image.repository + ":" + (String) image.tag
+          imageSummaries[location] = [
+              //In the context of Spinnaker Docker images the imageId and imageName are the same
+              mkDeploymentDetail(imageId, imageId, deploymentDetailTemplate, config)
+          ]
+        }
       }
     }
   }


### PR DESCRIPTION
This is part 1 of essentially a three part change (one more PR to clouddriver and then another internal change).  This will allow us to fallback properly when looking up docker images from clusters wherein the cluster doesn't exist but we still want to gracefully find an image.

CloudDriver OSS change: https://github.com/spinnaker/clouddriver/pull/5019