### PR TITLE
feat(disable): put the disabled flag enforcement behind a feature toggle

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCreat
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForRequiredInstancesDownTask
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.env.Environment
 import org.springframework.stereotype.Component
 import org.springframework.beans.factory.annotation.Value
 
@@ -32,6 +33,7 @@ class WaitForClusterDisableTask extends AbstractWaitForClusterWideClouddriverTas
   // to make the logic more readable, we map true and false to words
   private static final boolean RUNNING = true
   private static final boolean COMPLETED = false
+  static final String TOGGLE = "tasks.wait-for-cluster-disable.enforce-disabled-flag.enabled"
 
   @Value('${tasks.disable-cluster-min-time-millis:90000}')
   private int MINIMUM_WAIT_TIME_MS
@@ -40,6 +42,9 @@ class WaitForClusterDisableTask extends AbstractWaitForClusterWideClouddriverTas
 
   @Autowired
   WaitForRequiredInstancesDownTask waitForRequiredInstancesDownTask
+
+  @Autowired
+  Environment environment
 
   @Autowired
   public WaitForClusterDisableTask(Collection<ServerGroupCreator> serverGroupCreators) {
@@ -79,7 +84,7 @@ class WaitForClusterDisableTask extends AbstractWaitForClusterWideClouddriverTas
 
     // make sure that we wait for the disabled flag to be set
     def targetServerGroup = serverGroup.get()
-    if (!targetServerGroup.isDisabled()) {
+    if (environment.getProperty(TOGGLE, Boolean, false) && !targetServerGroup.isDisabled()) {
       return RUNNING
     }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTaskSpec.groovy
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForRequiredI
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
+import org.springframework.core.env.Environment
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -17,6 +18,9 @@ import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
 class WaitForClusterDisableTaskSpec extends Specification {
   def oortHelper = Mock(OortHelper)
+  def environment = Mock(Environment) {
+    getProperty(WaitForClusterDisableTask.TOGGLE, Boolean, false) >> true
+  }
 
   @Shared def region = "region"
   @Shared def clusterName = "clusterName"
@@ -28,7 +32,10 @@ class WaitForClusterDisableTaskSpec extends Specification {
     getOperations(_) >> [["aOp": "foo"]]
   }
 
-  @Subject def task = new WaitForClusterDisableTask([serverGroupCreator])
+  @Subject WaitForClusterDisableTask task = new WaitForClusterDisableTask([serverGroupCreator]).with {
+    environment = this.environment
+    return it
+  }
 
   @Unroll
   def "status=#status when desiredPercentage=#desiredPct, interestingHealthProviderNames=#interestingHealthProviderNames"() {


### PR DESCRIPTION
We have received user reports that the Google cloud provider does not set the `disabled` flag, so the task can't succeed in this case. Let's make enforcement configurable as a workaround for this issue.

fixes spinnaker/issues/6038
