### PR TITLE
feat(SpelHelpers): Support parsing multi-document yaml strings

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
@@ -77,11 +77,11 @@ public class UrlExpressionFunctionProvider implements ExpressionFunctionProvider
             new FunctionParameter(String.class, "value", "A String containing JSON text")),
         new FunctionDefinition(
             "readYaml",
-            "Parses YAML from a string to be accessed, parsed JSON can be accessed as an object",
+            "Parses YAML from a string to be accessed, parsed YAML can be accessed as an object",
             new FunctionParameter(String.class, "value", "A String containing YAML text")),
         new FunctionDefinition(
             "readYamlAll",
-            "Parses multi-doc YAML from a string to be accessed, list of parsed JSON can be accessed as objects",
+            "Parses multi-doc YAML from a string to be accessed, list of parsed YAML can be accessed as objects",
             new FunctionParameter(String.class, "value", "A String containing YAML text")));
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
@@ -80,7 +80,7 @@ public class UrlExpressionFunctionProvider implements ExpressionFunctionProvider
             "Parses YAML from a string to be accessed, parsed YAML can be accessed as an object",
             new FunctionParameter(String.class, "value", "A String containing YAML text")),
         new FunctionDefinition(
-            "readYamlAll",
+            "readAllYaml",
             "Parses multi-doc YAML from a string to be accessed, list of parsed YAML can be accessed as objects",
             new FunctionParameter(String.class, "value", "A String containing YAML text")));
   }
@@ -144,7 +144,7 @@ public class UrlExpressionFunctionProvider implements ExpressionFunctionProvider
    * @param text text to read as yaml
    * @return a list of the object representations of the yaml text
    */
-  public static Object readYamlAll(String text) {
+  public static Object readAllYaml(String text) {
     try {
       List<Object> yamlDocs = new ArrayList<>();
       Iterable<Object> iterable = new Yaml().loadAll(text);
@@ -153,7 +153,7 @@ public class UrlExpressionFunctionProvider implements ExpressionFunctionProvider
       }
       return yamlDocs;
     } catch (Exception e) {
-      throw new SpelHelperFunctionException(format("#readYamlAll(%s) failed", text), e);
+      throw new SpelHelperFunctionException(format("#readAllYaml(%s) failed", text), e);
     }
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
@@ -27,10 +27,7 @@ import com.netflix.spinnaker.orca.pipeline.util.HttpClientUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -81,6 +78,10 @@ public class UrlExpressionFunctionProvider implements ExpressionFunctionProvider
         new FunctionDefinition(
             "readYaml",
             "Parses YAML from a string to be accessed, parsed JSON can be accessed as an object",
+            new FunctionParameter(String.class, "value", "A String containing YAML text")),
+        new FunctionDefinition(
+            "readYamlAll",
+            "Parses multi-doc YAML from a string to be accessed, list of parsed JSON can be accessed as objects",
             new FunctionParameter(String.class, "value", "A String containing YAML text")));
   }
 
@@ -133,6 +134,26 @@ public class UrlExpressionFunctionProvider implements ExpressionFunctionProvider
       return new Yaml().load(text);
     } catch (Exception e) {
       throw new SpelHelperFunctionException(format("#readYaml(%s) failed", text), e);
+    }
+  }
+
+  /**
+   * Attempts to read a multi-doc yaml from a text String. Will throw a parsing exception on bad
+   * yaml
+   *
+   * @param text text to read as yaml
+   * @return a list of the object representations of the yaml text
+   */
+  public static Object readYamlAll(String text) {
+    try {
+      List<Object> yamlDocs = new ArrayList<>();
+      Iterable<Object> iterable = new Yaml().loadAll(text);
+      for (Object o : iterable) {
+        yamlDocs.add(o);
+      }
+      return yamlDocs;
+    } catch (Exception e) {
+      throw new SpelHelperFunctionException(format("#readYamlAll(%s) failed", text), e);
     }
   }
 

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProviderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProviderSpec.groovy
@@ -42,9 +42,9 @@ class UrlExpressionFunctionProviderSpec extends Specification {
   }
 
   @Unroll
-  def "test readYamlAll"() {
+  def "test readAllYaml"() {
     expect:
-    UrlExpressionFunctionProvider.readYamlAll(currentYaml) == expectedYaml
+    UrlExpressionFunctionProvider.readAllYaml(currentYaml) == expectedYaml
 
     where:
     currentYaml               || expectedYaml

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProviderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProviderSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2020 Adevinta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProviderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProviderSpec.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.expressions.functions
+
+import com.netflix.spinnaker.kork.expressions.SpelHelperFunctionException
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class UrlExpressionFunctionProviderSpec extends Specification {
+
+  @Unroll
+  def "test readYaml"() {
+    expect:
+    UrlExpressionFunctionProvider.readYaml(currentYaml) == expectedYaml
+
+    where:
+    currentYaml               || expectedYaml
+    "a: 1\nb: 2\n"            || [a: 1, b: 2]
+    "---\na: 1\nb: 2\n"       || [a: 1, b: 2]
+  }
+
+  def "readYaml returns exception on multi-doc YAML"() {
+    when:
+    UrlExpressionFunctionProvider.readYaml("a: 1\nb: 2\n---\nc: 3\n")
+
+    then:
+      thrown(SpelHelperFunctionException)
+  }
+
+  @Unroll
+  def "test readYamlAll"() {
+    expect:
+    UrlExpressionFunctionProvider.readYamlAll(currentYaml) == expectedYaml
+
+    where:
+    currentYaml               || expectedYaml
+    "a: 1\nb: 2\n"            || [[a: 1, b: 2]]
+    "---\na: 1\nb: 2\n"       || [[a: 1, b: 2]]
+    "a: 1\nb: 2\n---\nc: 3\n" || [[a: 1, b: 2],[c: 3]]
+  }
+}


### PR DESCRIPTION
Added a Spel Helper function `#readYamlAll` with the ability to read multi-document YAML strings.

Previously if you tried to do so with `#readYaml` you got a `SpelHelperFunctionException`:

![imatge](https://user-images.githubusercontent.com/4490611/96683691-c65f3c00-137a-11eb-8269-661926b917de.png)
