### PR TITLE
fix(kayenta): Fixing nullable duration

### DIFF
--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/KayentaService.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/KayentaService.kt
@@ -103,7 +103,7 @@ data class CanaryResults(
 
 data class CanaryResult(
   val judgeResult: JudgeResult,
-  val canaryDuration: Duration
+  val canaryDuration: Duration?
 )
 
 data class JudgeResult(

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/MonitorKayentaCanaryTask.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/tasks/MonitorKayentaCanaryTask.kt
@@ -63,7 +63,7 @@ class MonitorKayentaCanaryTask(
             "canaryPipelineStatus" to SUCCEEDED,
             "lastUpdated" to canaryResults.endTimeIso?.toEpochMilli(),
             "lastUpdatedIso" to canaryResults.endTimeIso,
-            "durationString" to canaryResults.result.canaryDuration.toString(),
+            "durationString" to canaryResults.result.canaryDuration?.toString(),
             "canaryScore" to canaryScore,
             "canaryScoreMessage" to "Canary score is not above the marginal score threshold.",
             "warnings" to warnings
@@ -75,7 +75,7 @@ class MonitorKayentaCanaryTask(
             "canaryPipelineStatus" to SUCCEEDED,
             "lastUpdated" to canaryResults.endTimeIso?.toEpochMilli(),
             "lastUpdatedIso" to canaryResults.endTimeIso,
-            "durationString" to canaryResults.result.canaryDuration.toString(),
+            "durationString" to canaryResults.result.canaryDuration?.toString(),
             "canaryScore" to canaryScore,
             "warnings" to warnings
           )


### PR DESCRIPTION
This was causing an issue for Kayenta for cases where there were multiple scopes sent as part of the stage. If the stage ended up with slightly different start/end times for each scope, Kayenta would return a null for the duration. This was happening due to each start/end being calculated for each scope which was causing them to be off by a ms or two. The stage would then explode when Kayenta returned null for the duration.

This fixes the different times issue and the nullable field causing the stage to explode. 