### PR TITLE
fix(keel): read configuration for keel from services

### DIFF
--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/config/KeelConfiguration.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/config/KeelConfiguration.kt
@@ -35,7 +35,7 @@ import retrofit.RestAdapter
 import retrofit.converter.JacksonConverter
 
 @Configuration
-@ConditionalOnProperty("keel.enabled")
+@ConditionalOnProperty("services.keel.enabled")
 @ComponentScan(
   basePackages = [
     "com.netflix.spinnaker.orca.keel.task",
@@ -43,7 +43,7 @@ import retrofit.converter.JacksonConverter
   ]
 )
 class KeelConfiguration {
-  @Bean fun keelEndpoint(@Value("\${keel.base-url}") keelBaseUrl: String): Endpoint {
+  @Bean fun keelEndpoint(@Value("\${services.keel.base-url}") keelBaseUrl: String): Endpoint {
     return Endpoints.newFixedEndpoint(keelBaseUrl)
   }
 


### PR DESCRIPTION
This is to make it compatible with igor and other services
that have dependencies on keel

This is most likely a breaking change for Netflix
@luispollo @robfletcher 