### PR TITLE
feat(pipeline executions/orca) : Added code to save multiple pipelines at once to sql database.

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -74,6 +74,9 @@ interface Front50Service {
   @POST("/pipelines")
   Response savePipeline(@Body Map pipeline, @Query("staleCheck") boolean staleCheck)
 
+  @POST("/pipelines/bulksave")
+  Response savePipelineList(@Body List<Map<String, Object>> pipelineList, @Query("staleCheck") boolean staleCheck)
+
   @PUT("/pipelines/{pipelineId}")
   Response updatePipeline(@Path("pipelineId") String pipelineId, @Body Map pipeline)
 

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -47,6 +47,9 @@ tasks:
   executionWindow:
     timezone: ${global.spinnaker.timezone:America/Los_Angeles}
 
+okhttp:
+  timeout: 10
+
 logging:
   config: classpath:logback-defaults.xml
 


### PR DESCRIPTION
feat(pipeline executions/orca) : Added code to save multiple pipelines at once to sql database.

This is part of: spinnaker/spinnaker#6147.

Enhanced SavePipelineTask.java to

Added code to ensure that the SavePipelineTask.java also accepts list of pipelines json.
This method will validate all the pipelines.
This method will call the front50 service to save the pipelines list.

Enhanced Front50Service.groovy to

Added new rest api which accepts list of pipelines json.