### PR TITLE
feat(pipeline executions/orca): Add support for explicit opt-out from…

### DIFF
--- a/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/KubernetesPreconfiguredJobSpec.kt
+++ b/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/KubernetesPreconfiguredJobSpec.kt
@@ -85,7 +85,7 @@ class KubernetesPreconfiguredJobSpec : JUnit5Minutests {
             .contains("\"ref\":\"/pipelines")
         }
 
-        verify(timeout = 1500) { katoRestService.requestOperations(any(), "kubernetes", match { it.toString().contains("alias=preconfiguredJob") }) }
+        verify(timeout = 2000) { katoRestService.requestOperations(any(), "kubernetes", match { it.toString().contains("alias=preconfiguredJob") }) }
       }
     }
   }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
@@ -21,6 +21,7 @@ import static java.util.Collections.emptyMap;
 
 import com.netflix.spinnaker.orca.api.pipeline.CancellableStage;
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageGraphBuilder;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
@@ -68,6 +69,17 @@ public class PipelineStage implements StageDefinitionBuilder, CancellableStage {
 
     if (stage.getContext().containsKey("expectedArtifacts")) {
       builder.withTask(BindProducedArtifactsTask.TASK_NAME, BindProducedArtifactsTask.class);
+    }
+  }
+
+  @Override
+  public void afterStages(@Nonnull StageExecution parent, @Nonnull StageGraphBuilder graph) {
+    if (parent
+        .getContext()
+        .getOrDefault("skipDownstreamOutput", "false")
+        .toString()
+        .equals("true")) {
+      parent.setOutputs(emptyMap());
     }
   }
 

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
@@ -73,13 +73,9 @@ public class PipelineStage implements StageDefinitionBuilder, CancellableStage {
   }
 
   @Override
-  public void afterStages(@Nonnull StageExecution parent, @Nonnull StageGraphBuilder graph) {
-    if (parent
-        .getContext()
-        .getOrDefault("skipDownstreamOutput", "false")
-        .toString()
-        .equals("true")) {
-      parent.setOutputs(emptyMap());
+  public void afterStages(@Nonnull StageExecution stage, @Nonnull StageGraphBuilder graph) {
+    if (shouldSkipDownstreamOutput(stage)) {
+      stage.setOutputs(emptyMap());
     }
   }
 
@@ -136,5 +132,13 @@ public class PipelineStage implements StageDefinitionBuilder, CancellableStage {
   @Override
   public boolean canManuallySkip(StageExecution stage) {
     return (Boolean) stage.getContext().getOrDefault("skippable", false);
+  }
+
+  private boolean shouldSkipDownstreamOutput(StageExecution stage) {
+    return stage
+        .getContext()
+        .getOrDefault("skipDownstreamOutput", "false")
+        .toString()
+        .equals("true");
   }
 }


### PR DESCRIPTION
… passing outputs to child executions

This PR introduces a feature flag `skipDownstreamOutput` that can be defined in `Run Pipeline` stage. By enabling it, clears the output of the parent pipeline, without affecting the child pipeline. 
This helps for stability issues when there are large deployment pipelines with multiple levels of parents. It can be set any parent level of the hierarchy.

Issue: https://github.com/spinnaker/spinnaker/issues/6159