### PR TITLE
fix(waitforup): Don't use the min of snapshot capacity

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTask.groovy
@@ -127,15 +127,6 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
       splainer.add("setting targetDesiredSize=${targetDesiredSize} from the desired size in current serverGroup capacity=${currentCapacity}")
     }
 
-    if (stage.context.capacitySnapshot) {
-      Integer snapshotCapacity = ((Map) stage.context.capacitySnapshot).desiredCapacity as Integer
-      // if the server group is being actively scaled down, this operation might never complete,
-      // so take the min of the latest capacity from the server group and the snapshot
-      def newTargetDesiredSize = Math.min(targetDesiredSize, snapshotCapacity)
-      splainer.add("setting targetDesiredSize=${newTargetDesiredSize} as the min of desired in capacitySnapshot=${stage.context.capacitySnapshot} and the previous targetDesiredSize=${targetDesiredSize})")
-      targetDesiredSize = newTargetDesiredSize
-    }
-
     if (stage.context.targetHealthyDeployPercentage != null) {
       Integer percentage = (Integer) stage.context.targetHealthyDeployPercentage
       if (percentage < 0 || percentage > 100) {
@@ -159,7 +150,7 @@ class WaitForUpInstancesTask extends AbstractWaitingForInstancesTask {
     return targetDesiredSize
   }
 
-  // If either the configured capacity or current serverGroup has autoscaling diasbled, calculate
+  // If either the configured capacity or current serverGroup has autoscaling disabled, calculate
   // targetDesired from the configured capacity. This relaxes the need for clouddriver onDemand
   // cache updates while resizing serverGroups.
   static boolean useConfiguredCapacity(StageExecution stage, Map<String, Integer> current) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
@@ -347,9 +347,7 @@ class WaitForUpInstancesTaskSpec extends Specification {
       ]
     ]
 
-    def context = [
-      source: [useSourceCapacity: (snapshot != null)],
-    ]
+    def context = [:]
 
     if (snapshot) {
       context.capacitySnapshot = [desiredCapacity: snapshot]
@@ -378,19 +376,23 @@ class WaitForUpInstancesTaskSpec extends Specification {
     where:
     result || snapshot | healthy | asg                          | configured
     false  || null     | 2       | [min: 3, max: 3, desired: 3] | null
+
     // configured is used if present and min == max == desired
     true   || null     | 2       | [min: 3, max: 3, desired: 3] | [min: 2, max: 2, desired: 2, pinned: true]
     true   || null     | 2       | [min: 3, max: 3, desired: 3] | [min: "2", max: "2", desired: "2", pinned: "true"]
+
     // configured is used if current allows autoscaling but configured doesn't
     true   || null     | 2       | [min: 3, max: 3, desired: 3] | [min: 2, max: 500, desired: 2]
     true   || null     | 2       | [min: 3, max: 3, desired: 3] | [min: "2", max: "500", desired: "2"]
     true   || null     | 2       | [min: 5, max: 5, desired: 5] | [min: 1, max: 5, desired: 2]
     true   || null     | 2       | [min: 5, max: 5, desired: 5] | [min: "1", max: "5", desired: "2"]
-    // useSourceCapacity with a snapshot is used over configured and current
-    true   || 3        | 3       | [min: 5, max: 5, desired: 5] | [min: 5, max: 5, desired: 5]
-    true   || 3        | 3       | [min: 5, max: 5, desired: 5] | [min: "5", max: "5", desired: "5"]
-    true   || 3        | 3       | [min: 5, max: 5, desired: 5] | null
-    false  || 4        | 3       | [min: 5, max: 5, desired: 5] | null
+
+    // configured and current are used over snapshot
+    false  || 3        | 3       | [min: 5, max: 5, desired: 5] | [min: 5, max: 5, desired: 5]
+    false  || 3        | 3       | [min: 5, max: 5, desired: 5] | [min: "5", max: "5", desired: "5"]
+    false  || 3        | 3       | [min: 5, max: 5, desired: 5] | null
+    true   || 3        | 5       | [min: 5, max: 5, desired: 5] | null
+
     // sourceCapacity is ignored if > than the calculated target due to a scale down corner case
     true   || 4        | 3       | [min: 3, max: 3, desired: 3] | null
     false  || 4        | 3       | [min: 3, max: 3, desired: 3] | [min: 4, max: 4, desired: 4]

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/WaitForUpInstancesTaskSpec.groovy
@@ -303,9 +303,7 @@ class WaitForUpInstancesTaskSpec extends Specification {
       ]
     ]
 
-    def context = [
-      source: [useSourceCapacity: useSource],
-    ]
+    def context = [:]
     if (configured) {
       context.capacity = [desired: configured]
     }
@@ -325,15 +323,14 @@ class WaitForUpInstancesTaskSpec extends Specification {
     )
 
     where:
-    result || useSource | healthy | configured | snapshot | asg | description
-    true   || true      | 3       | 4          | 4        | 3   | 'using source capacity of 3, ignoring snapshot capacity and configured capacity'
-    false  || true      | 3       | 3          | null     | 4   | 'using source capacity of 4 with no snapshot, ignoring configured capacity'
-    true   || true      | 3       | 4          | 3        | 5   | 'using source capacity of 4, snapshot overrides to account for autoscaling'
-    true   || true      | 3       | 4          | 4        | 3   | 'using source capacity of 4, snapshot ignored because it is larger than actual desired capacity'
-    true   || false     | 2       | null       | null     | 2   | 'source not specified, falling back to ASG desired size of 2'
-    false  || false     | 2       | null       | null     | 3   | 'source not specified, falling back to ASG desired size of 3'
-    false  || false     | 2       | 2          | null     | 3   | 'not using source, using configured size of 3, ignoring source size of 2'
-    true   || false     | 3       | 2          | null     | 3   | 'not using source, using configured size of 2, ignoring source size of 3'
+    result || healthy | configured | snapshot | asg | description
+    true   || 3       | 4          | 4        | 3   | 'using source capacity of 3, ignoring snapshot capacity and configured capacity'
+    false  || 3       | 3          | null     | 4   | 'using source capacity of 4 with no snapshot, ignoring configured capacity'
+    true   || 3       | 4          | 4        | 3   | 'using source capacity of 4, snapshot ignored because it is larger than actual desired capacity'
+    true   || 2       | null       | null     | 2   | 'source not specified, falling back to ASG desired size of 2'
+    false  || 2       | null       | null     | 3   | 'source not specified, falling back to ASG desired size of 3'
+    false  || 2       | 2          | null     | 3   | 'not using source, using configured size of 3, ignoring source size of 2'
+    true   || 3       | 2          | null     | 3   | 'not using source, using configured size of 2, ignoring source size of 3'
   }
 
   @Unroll


### PR DESCRIPTION
There are situations where we capture the snapshot capacity that is wrong. For example, if we resize a cluster `1->10`, then we do a force cache refresh and if that doesn't actually get the new state of `10`,
`WaitForUp` will wait for `1` instead of `10` instances (we defer to `WaitForUp` from `WaitForCapacityMatch`).
The other situation is when we do a rollback to a `0` size ASG, the first step of resizing it will resize it to correct rollback number, but since `WaitForUp` will succeed immediately we will tear down the old ASG and thus leave a rollback with no ASG ready to take traffic.
This is mostly an issue on Titus because `ForceRefresh` is a no-op on Titus.

It appears there already was an attempt to "fixing" this issue in https://github.com/spinnaker/orca/pull/2923, however it doesn't seem to cover all the cases.

This is an initial attempt that still needs figuring out that it doesn't break any other scenarios

