### PR TITLE
feat(echo): Support for a set of required roles in the Manual Judgment stage

### DIFF
--- a/orca-echo/orca-echo.gradle
+++ b/orca-echo/orca-echo.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("javax.validation:validation-api")
   implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+  implementation("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
 
   testImplementation("com.squareup.retrofit:retrofit-mock")
 }


### PR DESCRIPTION
The judging user _must_ have all specified roles in order for the
judgment to take.

If the user is missing one or more roles, the judgment status will be
cleared.

Supports spinnaker/spinnaker#4792
