### PR TITLE
fix(json): remove `pinned` from serialized Capacity objects

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/Capacity.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/Capacity.java
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import javax.annotation.Nonnegative;
@@ -17,6 +18,7 @@ public class Capacity {
    * @return true if the capacity of this server group is fixed, i.e min, max and desired are all
    *     the same
    */
+  @JsonIgnore
   public boolean isPinned() {
     return (max == desired) && (desired == min);
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
@@ -16,10 +16,12 @@
 
 package com.netflix.spinnaker.orca.clouddriver.utils
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.moniker.Moniker
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Capacity
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location.Type
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
@@ -66,6 +68,14 @@ class TrafficGuardSpec extends Specification {
         instances: [[healthState: 'Up']] * up + [[healthState: 'OutOfService']] * down,
         capacity: [min: 0, max: 4, desired: 3]
     ] + overrides
+  }
+
+  def "is pinned in serialized capacity?"() {
+    def mapper = new ObjectMapper()
+    def capacity = new Capacity(1, 1, 1)
+
+    expect:
+    !mapper.writeValueAsString(capacity).contains('pinned')
   }
 
   void "should ignore disabled traffic guards"() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
@@ -70,7 +70,7 @@ class TrafficGuardSpec extends Specification {
     ] + overrides
   }
 
-  def "is pinned in serialized capacity?"() {
+  def "pinned should not appear in serialized capacity"() {
     def mapper = new ObjectMapper()
     def capacity = new Capacity(1, 1, 1)
 


### PR DESCRIPTION
It was meant as a helper function, but actually becomes a field in serialized server groups. It can make its way to deck and be confusing to users.
