### PR TITLE
Add draining health state

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/model/HealthState.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/model/HealthState.java
@@ -27,7 +27,8 @@ public enum HealthState {
   Unknown,
   Starting,
   Succeeded,
-  Up;
+  Up,
+  Draining;
 
   /**
    * {@code HealthState.valueOf} does:

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/HealthHelper.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/utils/HealthHelper.groovy
@@ -99,7 +99,7 @@ class HealthHelper {
 
     // no health indicators is indicative of being down
     boolean someAreDown = !healths || healths.any { HealthState.fromString(it.state) in [Down, OutOfService, Starting] }
-    boolean noneAreUp = !healths.any { HealthState.fromString(it.state) == Up }
+    boolean noneAreUp = !healths.any { HealthState.fromString(it.state) in [Up, Draining] }
 
     return someAreDown && noneAreUp
   }
@@ -108,7 +108,7 @@ class HealthHelper {
     List<Map> healths = filterHealths(instance, interestingHealthProviderNames)
 
     boolean someAreUp = healths.any { HealthState.fromString(it.state) == Up }
-    boolean noneAreDown = !healths.any { HealthState.fromString(it.state) in [Down, OutOfService, Starting] }
+    boolean noneAreDown = !healths.any { HealthState.fromString(it.state) in [Down, OutOfService, Starting, Draining] }
 
     return areSomeUpConsideringPlatformHealth(healths, interestingHealthProviderNames, someAreUp) && noneAreDown
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/HealthHelperSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/HealthHelperSpec.groovy
@@ -1,0 +1,80 @@
+package com.netflix.spinnaker.orca.clouddriver.utils
+
+import com.netflix.spinnaker.orca.clouddriver.model.HealthState
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static com.netflix.spinnaker.orca.clouddriver.model.HealthState.*
+
+
+class HealthHelperSpec extends Specification {
+  def health(HealthState state, String type = "SomeHealth", healthClass = "SomeHealthClass") {
+    return [state: state.toString(), type: type, healhClass: healthClass]
+  }
+
+  def instance(List<HealthState> healthStates) {
+    return [health: healthStates.collect({ it -> health(it)})]
+  }
+
+  @Unroll
+  def "someAreUpAndNoneAreDownOrStarting(#healths) is #expected"() {
+    when:
+    def actual = HealthHelper.someAreUpAndNoneAreDownOrStarting(instance(healths), null)
+
+    then:
+    actual == expected
+
+    where:
+    healths                 || expected
+    [Up]                    || true
+
+    // Unknown is up-neutral, it is not up by itself, but it does not block up checks
+    [Unknown]               || false
+    [Up, Unknown]           || true
+
+    // OutOfService, Down, Starting, Draining are up-negative, they do block up checks
+    [OutOfService]          || false
+    [Up, OutOfService]      || false
+
+    [Down]                  || false
+    [Up, Down]              || false
+
+    [Starting]              || false
+    [Up, Starting]          || false
+
+    [Draining]              || false
+    [Up, Draining]          || false
+  }
+
+  @Unroll
+  def "someAreDownAndNoneAreUp(#healths) is #expected"() {
+    when:
+    def actual = HealthHelper.someAreDownAndNoneAreUp(instance(healths), null)
+
+    then:
+    actual == expected
+
+    where:
+    healths                  || expected
+    // No health, Down, OutOfService and Starting are down-positive, i.e. they are by themselves considered down
+    []                       || true
+    [Down]                   || true
+    [OutOfService]           || true
+    [Starting]               || true
+
+    // Unknown is down-neutral, it is not down by itself, but it does not block down checks
+    [Unknown]                || false
+    [Down, Unknown]          || true
+
+    // Up and Draining are down-negative, they do block down checks
+    [Up]                     || false
+    [Down, Up]               || false
+    [OutOfService, Up]       || false
+    [Starting, Up]           || false
+
+    [Draining]               || false
+    [Down, Draining]         || false
+    [OutOfService, Draining] || false
+    [Starting, Draining]     || false
+  }
+}


### PR DESCRIPTION
Clouddriver is now exposing that state in https://github.com/spinnaker/clouddriver/pull/5060

This models `draining` as:
- up-negative, i.e. it will prevent wait-for-up checks from succeeding (to prevent issues like https://github.com/spinnaker/spinnaker/issues/5867)
- down-negative, i.e. it will prevent wait-for-down checks from succeeding. If it did, we would end up terminating instances in the draining state even though they are still potentially doing work. This could lead to errors or data loss.

