### PR TITLE
fix(disable): skip disabled check for partially disabled server groups

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDisabledServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDisabledServerGroupTask.java
@@ -79,10 +79,8 @@ public class WaitForDisabledServerGroupTask extends AbstractCloudProviderAwareTa
   }
 
   // RRB and Monitored Deployments do "partial disables", i.e. they run DisableServerGroupTask with
-  // a `desiredPercentage`
-  // which will only disable some instances, not the entire server group (so this won't set the
-  // `disabled` flag on the
-  // server group)
+  // a `desiredPercentage` which will only disable some instances, not the entire server group (so
+  // this won't set the `disabled` flag on the server group)
   private boolean isPartialDisable(TaskInput input) {
     return input.desiredPercentage != null && input.desiredPercentage < 100;
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDisabledServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDisabledServerGroupTask.java
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
@@ -93,7 +94,8 @@ public class WaitForDisabledServerGroupTask extends AbstractCloudProviderAwareTa
             serverGroupDescriptor.getRegion(),
             serverGroupDescriptor.getName());
     var serverGroupData =
-        (Map<String, Object>) objectMapper.readValue(response.getBody().in(), Map.class);
+        objectMapper.readValue(
+            response.getBody().in(), new TypeReference<Map<String, Object>>() {});
     return new TargetServerGroup(serverGroupData);
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDisabledServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDisabledServerGroupTask.java
@@ -78,6 +78,11 @@ public class WaitForDisabledServerGroupTask extends AbstractCloudProviderAwareTa
     }
   }
 
+  // RRB and Monitored Deployments do "partial disables", i.e. they run DisableServerGroupTask with
+  // a `desiredPercentage`
+  // which will only disable some instances, not the entire server group (so this won't set the
+  // `disabled` flag on the
+  // server group)
   private boolean isPartialDisable(TaskInput input) {
     return input.desiredPercentage != null && input.desiredPercentage < 100;
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDisabledServerGroupTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForDisabledServerGroupTaskSpec.groovy
@@ -1,0 +1,51 @@
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
+
+import com.netflix.spinnaker.orca.api.pipeline.TaskResult
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
+import com.netflix.spinnaker.orca.pipeline.StageExecutionFactory
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.*
+
+class WaitForDisabledServerGroupTaskSpec extends Specification {
+  @Subject
+  WaitForDisabledServerGroupTask task = new WaitForDisabledServerGroupTask(null, null)
+
+  @Unroll
+  def "handles wonky desiredPercentage=#desiredPercentage gracefully"() {
+    given:
+    StageExecution stage = StageExecutionFactory.newStage(
+        PipelineExecutionImpl.newOrchestration("orca"),
+        "stageType", "stageName",
+        [desiredPercentage: desiredPercentage],
+    null, null)
+
+    when:
+    def taskInput = stage.mapTo(WaitForDisabledServerGroupTask.TaskInput)
+
+    then:
+    taskInput.desiredPercentage == mapsTo
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    stage.context.desiredPercentage == desiredPercentage
+    taskResult.status == expected
+
+    where:
+    desiredPercentage | mapsTo || expected
+    null              | null   || SKIPPED
+    -1                | -1     || SKIPPED
+    ""                | null   || SKIPPED
+    new Integer(100)  | 100    || SKIPPED
+    "200"             | 200    || SKIPPED
+    102.5             | 102    || SKIPPED
+    // 1L << 33, Jackson throws "Numeric value (8589934592) out of range of int"
+  }
+}


### PR DESCRIPTION
Rolling red black and monitored deployments create disable server group stages with a desiredPercentage, which only disables some instances and not the whole server group. In that case, we need to skip the check that the server group is disabled.
