### PR TITLE
fix(zombies): Avoid ambiguous REST method overload by adding specific applications endpoint

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/admin/web/QueueAdminController.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/admin/web/QueueAdminController.kt
@@ -75,7 +75,7 @@ class QueueAdminController(
     getZombieExecutionService().killZombie(getPipelineOrOrchestration(executionId))
   }
 
-  @PostMapping(value = ["/zombies/{application}:kill"])
+  @PostMapping(value = ["/zombies/application/{application}:kill"])
   @ResponseStatus(HttpStatus.NO_CONTENT)
   fun killApplicationZombies(@PathVariable application: String,
                              @QueryParam("minimumActivity") minimumActivity: Duration = Duration.ofMinutes(60)) {


### PR DESCRIPTION
Previous PR introduced an ambiguous endpoint, this cleans that up. 
 Previous change: https://github.com/spinnaker/orca/commit/c0a94d275eae2718be27e442f3ddcc3c140872aa