### PR TITLE
fix(script stage): Retry if igor's build endpoint returns an invalid identifier

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartScriptTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/StartScriptTask.groovy
@@ -107,6 +107,11 @@ class StartScriptTask implements RetryableTask {
 
       if (igorResponse.getStatus() == HttpStatus.OK.value()) {
         String queuedBuild = igorResponse.body.in().text
+        if(queuedBuild == null || queuedBuild == "" || queuedBuild == "null") {
+          // If an invalid build identifier is returned, consider that a failure and retry
+          log.warn("Igor returned an empty body: " + queuedBuild)
+          throw new SystemException("Failure starting script")
+        }
         return TaskResult
             .builder(ExecutionStatus.SUCCEEDED)
             .context([master: master, job: job, queuedBuild: queuedBuild, REPO_URL: repoUrl ?: 'default'])


### PR DESCRIPTION
When lots of jobs are launched in parallel, sometimes the identifier is either null or "null" (Don't know which, formatting either in a string will result in the same output)
Orca then fails when polling the queued job:
HTTP 400 http://spin-igor.spinnaker:8088/builds/queue/jenkins.dep/null (2ms)

In the code, the "execute" method will not directly fail if igor returns an empty queuedBuild id. This is an attempt to fix that

Let me know if that looks acceptable. As we have more and more Spinnaker pipelines calling our Jenkins instance, this is starting to happen more often