### PR TITLE
feat(managed-delivery): Delete Managed Delivery data upon application deletion

### DIFF
--- a/orca-applications/orca-applications.gradle
+++ b/orca-applications/orca-applications.gradle
@@ -20,6 +20,7 @@ dependencies {
   implementation(project(":orca-core"))
   implementation(project(":orca-clouddriver"))
   implementation(project(":orca-front50"))
+  implementation(project(":orca-keel"))
   implementation(project(":orca-retrofit"))
   implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
 

--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTask.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTask.groovy
@@ -51,7 +51,10 @@ class DeleteApplicationTask extends AbstractFront50Task {
           return TaskResult.builder(ExecutionStatus.TERMINAL).outputs(outputs).build()
         }
         // delete Managed Delivery data
-        keelService.deleteDeliveryConfig(application.name)
+        if (keelService != null) {
+          log.debug("Deleting Managed Delivery data for {}", application.name)
+          keelService.deleteDeliveryConfig(application.name)
+        }
       }
     } catch (RetrofitError e) {
       if (e.response?.status == 404) {

--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTask.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTask.groovy
@@ -50,9 +50,9 @@ class DeleteApplicationTask extends AbstractFront50Task {
           log.error("Could not delete application permission: {}", re.toString(), re)
           return TaskResult.builder(ExecutionStatus.TERMINAL).outputs(outputs).build()
         }
+        // delete Managed Delivery data
+        keelService.deleteDeliveryConfig(application.name)
       }
-      // delete Managed Delivery data
-      keelService.deleteDeliveryConfig(application.name)
     } catch (RetrofitError e) {
       if (e.response?.status == 404) {
         return TaskResult.SUCCEEDED

--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTask.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTask.groovy
@@ -16,17 +16,22 @@
 
 package com.netflix.spinnaker.orca.applications.tasks
 
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.front50.model.Application
 import com.netflix.spinnaker.orca.front50.tasks.AbstractFront50Task
+import com.netflix.spinnaker.orca.KeelService
 import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 
 @Slf4j
 @Component
 class DeleteApplicationTask extends AbstractFront50Task {
+  @Autowired(required = false)
+  KeelService keelService
+
   @Override
   TaskResult performRequest(Application application) {
     Map<String, Object> outputs = [:]
@@ -42,15 +47,17 @@ class DeleteApplicationTask extends AbstractFront50Task {
           if (re.response?.status == 404) {
             return TaskResult.SUCCEEDED
           }
-          log.error("Could not create or update application permission", re)
+          log.error("Could not delete application permission: {}", re.toString(), re)
           return TaskResult.builder(ExecutionStatus.TERMINAL).outputs(outputs).build()
         }
       }
+      // delete Managed Delivery data
+      keelService.deleteDeliveryConfig(application.name)
     } catch (RetrofitError e) {
       if (e.response?.status == 404) {
         return TaskResult.SUCCEEDED
       }
-      log.error("Could not create or update application permission", e)
+      log.error("Could not delete application: {}", e.toString(), e)
       return TaskResult.builder(ExecutionStatus.TERMINAL).outputs(outputs).build()
     }
     return TaskResult.builder(ExecutionStatus.SUCCEEDED).outputs(outputs).build()

--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTask.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTask.groovy
@@ -47,7 +47,7 @@ class DeleteApplicationTask extends AbstractFront50Task {
           if (re.response?.status == 404) {
             return TaskResult.SUCCEEDED
           }
-          log.error("Could not delete application permission: {}", re.toString(), re)
+          log.error("Could not delete application permission", re)
           return TaskResult.builder(ExecutionStatus.TERMINAL).outputs(outputs).build()
         }
         // delete Managed Delivery data
@@ -57,7 +57,7 @@ class DeleteApplicationTask extends AbstractFront50Task {
       if (e.response?.status == 404) {
         return TaskResult.SUCCEEDED
       }
-      log.error("Could not delete application: {}", e.toString(), e)
+      log.error("Could not delete application", e)
       return TaskResult.builder(ExecutionStatus.TERMINAL).outputs(outputs).build()
     }
     return TaskResult.builder(ExecutionStatus.SUCCEEDED).outputs(outputs).build()

--- a/orca-applications/src/test/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTaskSpec.groovy
+++ b/orca-applications/src/test/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTaskSpec.groovy
@@ -100,22 +100,4 @@ class DeleteApplicationTaskSpec extends Specification {
     then:
     taskResult.status == ExecutionStatus.SUCCEEDED
   }
-
-
-  void "should attempt to delete managed delivery data even if application is not found in front50"() {
-    given:
-    task.front50Service = Mock(Front50Service) {
-      get(config.application.name) >> null
-    }
-    task.keelService = Mock(KeelService)
-
-    when:
-    def taskResult = task.execute(pipeline.stages.first())
-
-    then:
-    1 * task.keelService.deleteDeliveryConfig(config.application.name)
-
-    and:
-    taskResult.status == ExecutionStatus.SUCCEEDED
-  }
 }

--- a/orca-applications/src/test/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTaskSpec.groovy
+++ b/orca-applications/src/test/groovy/com/netflix/spinnaker/orca/applications/tasks/DeleteApplicationTaskSpec.groovy
@@ -20,8 +20,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.front50.model.Application
+import com.netflix.spinnaker.orca.KeelService
+import retrofit.client.Response
 import spock.lang.Specification
 import spock.lang.Subject
+
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
@@ -50,6 +53,9 @@ class DeleteApplicationTaskSpec extends Specification {
       1 * deletePermission(config.application.name)
       0 * _._
     }
+    task.keelService = Mock(KeelService) {
+      1 * deleteDeliveryConfig(config.application.name)
+    }
 
     when:
     def taskResult = task.execute(pipeline.stages.first())
@@ -67,11 +73,49 @@ class DeleteApplicationTaskSpec extends Specification {
       1 * deletePermission(config.application.name)
       0 * _._
     }
+    task.keelService = Mock(KeelService) {
+      1 * deleteDeliveryConfig(config.application.name)
+    }
 
     when:
     def taskResult = task.execute(pipeline.stages.first())
 
     then:
     taskResult.context.previousState == application
+  }
+
+  void "should ignore not found errors when deleting managed delivery data"() {
+    given:
+    task.front50Service = Mock(Front50Service) {
+      get(config.application.name) >> new Application()
+    }
+    task.keelService = Mock(KeelService) {
+      1 * deleteDeliveryConfig(config.application.name) >>
+          new Response("http://keel", 404, "not found", [], null)
+    }
+
+    when:
+    def taskResult = task.execute(pipeline.stages.first())
+
+    then:
+    taskResult.status == ExecutionStatus.SUCCEEDED
+  }
+
+
+  void "should attempt to delete managed delivery data even if application is not found in front50"() {
+    given:
+    task.front50Service = Mock(Front50Service) {
+      get(config.application.name) >> null
+    }
+    task.keelService = Mock(KeelService)
+
+    when:
+    def taskResult = task.execute(pipeline.stages.first())
+
+    then:
+    1 * task.keelService.deleteDeliveryConfig(config.application.name)
+
+    and:
+    taskResult.status == ExecutionStatus.SUCCEEDED
   }
 }

--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/KeelService.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/KeelService.kt
@@ -19,12 +19,17 @@ package com.netflix.spinnaker.orca
 import com.netflix.spinnaker.orca.keel.model.DeliveryConfig
 import retrofit.client.Response
 import retrofit.http.Body
+import retrofit.http.DELETE
 import retrofit.http.Header
 import retrofit.http.Headers
 import retrofit.http.POST
+import retrofit.http.Path
 
 interface KeelService {
   @POST("/delivery-configs/")
   @Headers("Accept: application/json")
   fun publishDeliveryConfig(@Body deliveryConfig: DeliveryConfig, @Header(value = "X-SPINNAKER-USER") user: String): Response
+
+  @DELETE("/application/{application}/config")
+  fun deleteDeliveryConfig(@Path("application") application: String): Response
 }


### PR DESCRIPTION
Adds a call from the `DeleteApplicationTask` to Keel to delete any associated records for Managed Delivery.

Closes https://github.com/spinnaker/keel/issues/1567