### PR TITLE
chore(jenkins): Include breadcrumb error message when jenkins job fails

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
@@ -634,6 +634,7 @@ public class StageExecutionImpl implements StageExecution, Serializable {
         (List<String>) exceptionDetails.getOrDefault("errors", new ArrayList<String>());
     exceptionDetails.putIfAbsent("errors", errors);
 
+    // Path: exception.details.errors
     errors.add(errorMessage);
 
     // This might be a no-op, but if there wasn't an exception object there, we should add it to the


### PR DESCRIPTION
This should help provide users better hints at what went wrong when Jenkins jobs fail in child pipeline hierarchies.