### PR TITLE
fix(application): Fix deletion of Managed Delivery data from keel

### DIFF
--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/KeelService.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/KeelService.kt
@@ -20,7 +20,6 @@ import com.netflix.spinnaker.orca.keel.model.DeliveryConfig
 import retrofit.client.Response
 import retrofit.http.Body
 import retrofit.http.DELETE
-import retrofit.http.Header
 import retrofit.http.Headers
 import retrofit.http.POST
 import retrofit.http.Path
@@ -28,7 +27,7 @@ import retrofit.http.Path
 interface KeelService {
   @POST("/delivery-configs/")
   @Headers("Accept: application/json")
-  fun publishDeliveryConfig(@Body deliveryConfig: DeliveryConfig, @Header(value = "X-SPINNAKER-USER") user: String): Response
+  fun publishDeliveryConfig(@Body deliveryConfig: DeliveryConfig): Response
 
   @DELETE("/application/{application}/config")
   fun deleteDeliveryConfig(@Path("application") application: String): Response

--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/config/KeelConfiguration.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/config/KeelConfiguration.kt
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import retrofit.Endpoint
 import retrofit.Endpoints
+import retrofit.RequestInterceptor
 import retrofit.RestAdapter
 import retrofit.converter.JacksonConverter
 
@@ -51,9 +52,11 @@ class KeelConfiguration {
     keelEndpoint: Endpoint,
     keelObjectMapper: ObjectMapper,
     clientProvider: OkHttpClientProvider,
-    retrofitLogLevel: RestAdapter.LogLevel
+    retrofitLogLevel: RestAdapter.LogLevel,
+    spinnakerRequestInterceptor: RequestInterceptor
   ) =
     RestAdapter.Builder()
+      .setRequestInterceptor(spinnakerRequestInterceptor)
       .setEndpoint(keelEndpoint)
       .setClient(Ok3Client(clientProvider.getClient(DefaultServiceEndpoint("keel", keelEndpoint.url))))
       .setLogLevel(retrofitLogLevel)

--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
@@ -61,7 +61,7 @@ constructor(
       )
 
       log.debug("Publishing manifest ${context.manifest} to keel on behalf of $user")
-      keelService.publishDeliveryConfig(deliveryConfig, user)
+      keelService.publishDeliveryConfig(deliveryConfig)
 
       TaskResult.builder(ExecutionStatus.SUCCEEDED).context(emptyMap<String, Any?>()).build()
     } catch (e: RetrofitError) {

--- a/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
+++ b/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
@@ -94,7 +94,7 @@ internal class ImportDeliveryConfigTaskTests : JUnit5Minutests {
 
     val keelService: KeelService = mockk(relaxUnitFun = true) {
       every {
-        publishDeliveryConfig(any(), any())
+        publishDeliveryConfig(any())
       } returns Response("http://keel", 200, "", emptyList(), null)
     }
 
@@ -164,7 +164,7 @@ internal class ImportDeliveryConfigTaskTests : JUnit5Minutests {
           )
         }
         verify(exactly = 1) {
-          keelService.publishDeliveryConfig(manifest, trigger.user!!)
+          keelService.publishDeliveryConfig(manifest)
         }
       }
     }


### PR DESCRIPTION
While testing deletion of a managed app, I ran into an authorization error in keel as the call was being made without the `X-SPINNAKER-USER` header and so was treated as anonymous. This PR fixes the configuration of the keel service object so that the `SpinnakerRequestInterceptor` is used (which automatically adds that and other useful headers).