### PR TITLE
feat(echo): Support for restricting who can perform a manual judgment

### DIFF
--- a/orca-echo/orca-echo.gradle
+++ b/orca-echo/orca-echo.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("javax.validation:validation-api")
   implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+  implementation("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
 
   testImplementation("com.squareup.retrofit:retrofit-mock")
 }

--- a/orca-echo/src/main/java/com/netflix/spinnaker/orca/echo/util/ManualJudgmentAuthorization.java
+++ b/orca-echo/src/main/java/com/netflix/spinnaker/orca/echo/util/ManualJudgmentAuthorization.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.echo.util;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
+import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
+import com.netflix.spinnaker.fiat.shared.FiatStatus;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ManualJudgmentAuthorization {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final FiatPermissionEvaluator fiatPermissionEvaluator;
+
+  private final FiatStatus fiatStatus;
+
+  @Autowired
+  public ManualJudgmentAuthorization(
+      Optional<FiatPermissionEvaluator> fiatPermissionEvaluator, FiatStatus fiatStatus) {
+    this.fiatPermissionEvaluator = fiatPermissionEvaluator.orElse(null);
+
+    this.fiatStatus = fiatStatus;
+  }
+
+  /**
+   * A manual judgment will be considered "authorized" if the current user has at least one of the
+   * required judgment roles (or the current user is an admin).
+   *
+   * @param requiredJudgmentRoles Required judgment roles
+   * @param currentUser User that has attempted this judgment
+   * @return whether or not {@param currentUser} has authorization to judge
+   */
+  public boolean isAuthorized(Collection<String> requiredJudgmentRoles, String currentUser) {
+    if (!fiatStatus.isEnabled() || requiredJudgmentRoles.isEmpty()) {
+      return true;
+    }
+
+    if (Strings.isNullOrEmpty(currentUser)) {
+      return false;
+    }
+
+    UserPermission.View permission = fiatPermissionEvaluator.getPermission(currentUser);
+    if (permission == null) { // Should never happen?
+      log.warn("Attempted to get user permission for '{}' but none were found.", currentUser);
+      return false;
+    }
+
+    return permission.isAdmin()
+        || isAuthorized(
+            requiredJudgmentRoles,
+            permission.getRoles().stream().map(Role.View::getName).collect(Collectors.toList()));
+  }
+
+  private boolean isAuthorized(
+      Collection<String> requiredJudgmentRoles, Collection<String> currentUserRoles) {
+    if (requiredJudgmentRoles == null || requiredJudgmentRoles.isEmpty()) {
+      return true;
+    }
+
+    if (currentUserRoles == null) {
+      currentUserRoles = new ArrayList<>();
+    }
+
+    return !Sets.intersection(new HashSet<>(requiredJudgmentRoles), new HashSet<>(currentUserRoles))
+        .isEmpty();
+  }
+}

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/util/ManualJudgmentAuthorizationSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/util/ManualJudgmentAuthorizationSpec.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.echo.util
+
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
+import com.netflix.spinnaker.fiat.shared.FiatStatus
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class ManualJudgmentAuthorizationSpec extends Specification {
+  def fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
+  def fiatStatus = Mock(FiatStatus)
+
+  @Subject
+  def manualJudgmentAuthorization = new ManualJudgmentAuthorization(
+      Optional.of(fiatPermissionEvaluator),
+      fiatStatus
+  )
+
+  @Unroll
+  void 'should determine authorization based on intersection of userRoles and stageRoles/permissions'() {
+    when:
+    def result = manualJudgmentAuthorization.isAuthorized(requiredJudgmentRoles, currentUserRoles)
+
+    then:
+    result == isAuthorized
+
+    where:
+    requiredJudgmentRoles | currentUserRoles || isAuthorized
+    ['foo', 'blaz']       | ['foo', 'baz']   || true
+    []                    | ['foo', 'baz']   || true
+    []                    | []               || true
+    ['foo']               | ['foo']          || true
+    ['foo']               | []               || false
+    ['foo']               | null             || false
+    null                  | null             || true
+  }
+}

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/web/config/WebConfiguration.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/web/config/WebConfiguration.groovy
@@ -33,7 +33,6 @@ import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowire
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan


### PR DESCRIPTION
This PR verifies the current user roles against `context.selectedStageRoles`.

The operation is _only_ allowed if there is at least one overlapping role.

This is a rewrite of what originally went in as https://github.com/spinnaker/orca/pull/3988.