### PR TITLE
feat(pipeline executions/orca): attribue to explicitly skip the outputs section in Deployment Manifest or Run Job stage

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.java
@@ -79,6 +79,7 @@ public class RunJobStage implements StageDefinitionBuilder, CancellableStage {
     }
   }
 
+  @Override
   public void afterStages(@Nonnull StageExecution stage, @Nonnull StageGraphBuilder graph) {
     if (stage.getContext().getOrDefault("noOutput", "false").toString().equals("true")) {
       stage.setOutputs(emptyMap());

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.java
@@ -16,9 +16,12 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.job;
 
+import static java.util.Collections.emptyMap;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.orca.api.pipeline.CancellableStage;
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageGraphBuilder;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.tasks.artifacts.ConsumeArtifactTask;
@@ -73,6 +76,12 @@ public class RunJobStage implements StageDefinitionBuilder, CancellableStage {
         .toString()
         .equalsIgnoreCase("artifact")) {
       builder.withTask(ConsumeArtifactTask.TASK_NAME, ConsumeArtifactTask.class);
+    }
+  }
+
+  public void afterStages(@Nonnull StageExecution stage, @Nonnull StageGraphBuilder graph) {
+    if (stage.getContext().getOrDefault("noOutput", "false").toString().equals("true")) {
+      stage.setOutputs(emptyMap());
     }
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.manifest;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Collections.emptyMap;
 
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
@@ -79,6 +80,9 @@ public class DeployManifestStage implements StageDefinitionBuilder {
         case NONE:
           // do nothing
       }
+    }
+    if (stage.getContext().getOrDefault("noOutput", "false").toString().equals("true")) {
+      stage.setOutputs(emptyMap());
     }
   }
 


### PR DESCRIPTION
Most K8S deployments do not use the outputs in downstream stages. So, if it is not used
users can skip the output of the Deployment Manifest and Run Job (Manifest) stage by
specifiying the attribute `noOutput` set to false in the stage json.

This significantly reduces the execution context being saved in redis/databse or
sent to the browser.r.

This attempts to address the issues mentioned in
https://github.com/spinnaker/spinnaker/issues/6159
https://github.com/spinnaker/spinnaker/issues/6159

The issue is compounded when there is a nesting of pipelines and the manifests are duplicated many times over in the execution context. There is one PR (https://github.com/spinnaker/orca/pull/3989) that also attempts to address the issue. It tries to do it at the pipeline stage. This PR attempts to apply the same fix but in a much more narrower scope - in Deploy Manifest and Run Job (Manifest) stages. One advantage of this is that it not only reduces the payload of the pipeline stages, but also of Deploy Manifest and Run Job stages. Hence overall it further reduces the data saved in redis/database as well as the amount of data transferred to the browser. 



