### PR TITLE
enable capturing task output data from clouddriver

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/model/Task.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/model/Task.groovy
@@ -27,6 +27,7 @@ class Task {
   Status status
   List<Map> resultObjects
   List<StatusLine> history
+  List<Output> outputs
 
   @Immutable
   static class Status implements Serializable {
@@ -39,5 +40,13 @@ class Task {
   static class StatusLine implements Serializable {
     String phase
     String status
+  }
+
+  @Immutable
+  static class Output implements Serializable {
+    String manifest
+    String phase
+    String stdOut
+    String stdError
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
@@ -165,7 +165,8 @@ class MonitorKatoTask implements RetryableTask, CloudProviderAware {
         id           : katoTask.id,
         status       : katoTask.status,
         history      : katoTask.history,
-        resultObjects: katoTask.resultObjects
+        resultObjects: katoTask.resultObjects,
+        outputs      : katoTask.outputs
       ]
       if (katoTask.resultObjects?.find { it.type == "EXCEPTION" }) {
         def exception = katoTask.resultObjects.find { it.type == "EXCEPTION" }

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTaskTest.java
@@ -52,6 +52,7 @@ class CloudFoundryMonitorKatoServicesTaskTest {
                 taskIdString,
                 new Task.Status(completed, failed, false),
                 resultObjects,
+                Collections.emptyList(),
                 Collections.emptyList()));
 
     CloudFoundryMonitorKatoServicesTask task = new CloudFoundryMonitorKatoServicesTask(katoService);


### PR DESCRIPTION
## Purpose
* We have seen a few transient errors spanning across Orca and Clouddriver when the Clouddriver's Kubernetes Job Executor attempts to perform a task. To gain more visibility into what was the last task action, we felt the need to extend the Kato Task object to include stdOut and stderror information in it. This PR is meant to enable orca to show this new output information that the clouddriver may have added to its task information - this is used when the API call is made to look up a task information by its id.

## Changes
* Capture the new field `outputs` that will be set by the clouddriver when querying the task information from it.


****
We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
