### PR TITLE
feat(tasks): Enable capturing task output data from clouddriver

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
@@ -165,7 +165,8 @@ class MonitorKatoTask implements RetryableTask, CloudProviderAware {
         id           : katoTask.id,
         status       : katoTask.status,
         history      : katoTask.history,
-        resultObjects: katoTask.resultObjects
+        resultObjects: katoTask.resultObjects,
+        outputs      : katoTask.outputs
       ]
       if (katoTask.resultObjects?.find { it.type == "EXCEPTION" }) {
         def exception = katoTask.resultObjects.find { it.type == "EXCEPTION" }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/model/Task.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/model/Task.java
@@ -15,6 +15,7 @@ public class Task {
   private Status status;
   private List<Map> resultObjects;
   private List<StatusLine> history;
+  private List<Output> outputs;
 
   @Data
   @AllArgsConstructor
@@ -31,5 +32,15 @@ public class Task {
   public static class StatusLine implements Serializable {
     private String phase;
     private String status;
+  }
+
+  @Data
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class Output implements Serializable {
+    String manifest;
+    String phase;
+    String stdOut;
+    String stdError;
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTaskSpec.groovy
@@ -51,7 +51,7 @@ class MonitorKatoTaskSpec extends Specification {
   @Unroll("result is #expectedResult if kato task is #katoStatus")
   def "result depends on Kato task status"() {
     given:
-    kato.lookupTask(taskId, false) >> new Task(taskId, new Task.Status(completed: completed, failed: failed), [], [])
+    kato.lookupTask(taskId, false) >> new Task(taskId, new Task.Status(completed: completed, failed: failed), [], [], [])
 
     and:
     def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "whatever", [
@@ -74,7 +74,7 @@ class MonitorKatoTaskSpec extends Specification {
   @Unroll("result is #expectedResult if katoResultExpected is #katoResultExpected and resultObject is #resultObjects")
   def "result depends on Kato task status and result object size for create/upsert operations"() {
     given:
-    kato.lookupTask(taskId, false) >> new Task(taskId, new Task.Status(completed: true), resultObjects, [])
+    kato.lookupTask(taskId, false) >> new Task(taskId, new Task.Status(completed: true), resultObjects, [], [])
 
     and:
     def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "whatever", [
@@ -148,7 +148,7 @@ class MonitorKatoTaskSpec extends Specification {
     notThrown(RetrofitError)
 
     when: 'task is found, but not completed'
-    1 * kato.lookupTask(taskId, false) >> new Task(taskId, new Task.Status(completed: false, failed: false), [], [])
+    1 * kato.lookupTask(taskId, false) >> new Task(taskId, new Task.Status(completed: false, failed: false), [], [], [])
     result = task.execute(stage)
 
     then: 'should reset the retry count'
@@ -158,7 +158,7 @@ class MonitorKatoTaskSpec extends Specification {
 
   def "should retry clouddriver task if classified as retryable"() {
     given:
-    def katoTask = new Task("katoTaskId", new Task.Status(true, true, true), [], [])
+    def katoTask = new Task("katoTaskId", new Task.Status(true, true, true), [], [], [])
 
     def stage = stage {
       type = "type"
@@ -202,6 +202,40 @@ class MonitorKatoTaskSpec extends Specification {
 
     then:
     thrown(RetrofitError)
+  }
+
+  @Unroll
+  def "verify task outputs"() {
+    given:
+    kato.lookupTask(taskId, false) >> new Task(
+        taskId,
+        new Task.Status(completed: true, failed: false),
+        [],
+        [],
+        [new Task.Output(manifest: manifest, phase: phase, stdOut: stdOut, stdError: stdError)]
+    )
+
+    and:
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "whatever", [
+        "kato.last.task.id": new TaskId(taskId)
+    ])
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    !result.context.isEmpty()
+    result.context.containsKey("kato.tasks")
+    result.context.get("kato.tasks").collect().size() == 1
+    result.context["kato.tasks"].collect().get(0)['outputs'] == [new Task.Output(manifest: manifest, phase: phase, stdOut: stdOut, stdError: stdError)]
+
+    where:
+    manifest        | phase                 | stdOut        | stdError
+    "some-manifest" | "Deploy K8s Manifest" | "some output" | ""
+    "some-manifest" | "Deploy K8s Manifest" | ""            | "error logs"
+    ""              | ""                    | ""            | ""
+
+    taskId = "kato-task-id"
   }
 
   def retrofit404() {

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTaskTest.java
@@ -52,6 +52,7 @@ class CloudFoundryMonitorKatoServicesTaskTest {
                 taskIdString,
                 new Task.Status(completed, failed, false),
                 resultObjects,
+                Collections.emptyList(),
                 Collections.emptyList()));
 
     CloudFoundryMonitorKatoServicesTask task = new CloudFoundryMonitorKatoServicesTask(katoService);


### PR DESCRIPTION
## Purpose
* We have seen a few transient errors spanning across Orca and Clouddriver when the Clouddriver's Kubernetes Job Executor attempts to perform a task. To gain more visibility into what was the last task action, we felt the need to extend the Kato Task object to include stdOut and stderror information in it. This PR is meant to enable orca to show this new output information that the clouddriver may have added to its task information - this is used when the API call is made to look up a task information by its id.

## Changes
* Capture the new field `outputs` that will be set by the clouddriver when querying the task information from it. Corresponding PR in clouddriver to add this info: https://github.com/spinnaker/clouddriver/pull/5182