### PR TITLE
Fix(manifest): Fix manifests resolved by Spel

### DIFF
--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolveDeploySourceManifestTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolveDeploySourceManifestTaskTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import java.util.*;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class ResolveDeploySourceManifestTaskTest {
+
+  private static final Map<Object, Object> MANIFEST_1 =
+      ImmutableMap.of("test-key-1", "test-value-1");
+  private static final Map<Object, Object> MANIFEST_2 =
+      ImmutableMap.of("test-key-2", "test-value-2");
+
+  @Test
+  void manifestsWithObjectsIsNotFlattened() {
+    ManifestEvaluator manifestEvaluator = mock(ManifestEvaluator.class);
+    ResolveDeploySourceManifestTask task = new ResolveDeploySourceManifestTask(manifestEvaluator);
+
+    StageExecutionImpl myStage = createStageWithManifests(ImmutableList.of(MANIFEST_1, MANIFEST_2));
+
+    DeployManifestContext deployManifestContext =
+        DeployManifestContext.builder().manifests(ImmutableList.of(MANIFEST_1, MANIFEST_2)).build();
+
+    when(manifestEvaluator.evaluate(any(), eq(deployManifestContext)))
+        .thenReturn(
+            new ManifestEvaluator.Result(
+                ImmutableList.of(MANIFEST_1, MANIFEST_2), ImmutableList.of(), ImmutableList.of()));
+
+    TaskResult result = task.execute(myStage);
+    verify(manifestEvaluator, times(1)).evaluate(any(), eq(deployManifestContext));
+    assertThat(getManifests(result)).containsExactly(MANIFEST_1, MANIFEST_2);
+  }
+
+  @Test
+  void manifestsWithListIsFlattened() {
+    ManifestEvaluator manifestEvaluator = mock(ManifestEvaluator.class);
+    ResolveDeploySourceManifestTask task = new ResolveDeploySourceManifestTask(manifestEvaluator);
+
+    StageExecutionImpl myStage =
+        createStageWithManifests(ImmutableList.of(ImmutableList.of(MANIFEST_1, MANIFEST_2)));
+
+    DeployManifestContext deployManifestContext =
+        DeployManifestContext.builder().manifests(ImmutableList.of(MANIFEST_1, MANIFEST_2)).build();
+
+    when(manifestEvaluator.evaluate(any(), eq(deployManifestContext)))
+        .thenReturn(
+            new ManifestEvaluator.Result(
+                ImmutableList.of(MANIFEST_1, MANIFEST_2), ImmutableList.of(), ImmutableList.of()));
+
+    TaskResult result = task.execute(myStage);
+    verify(manifestEvaluator, times(1)).evaluate(any(), eq(deployManifestContext));
+    assertThat(getManifests(result)).containsExactly(MANIFEST_1, MANIFEST_2);
+  }
+
+  @Test
+  void manifestsWithListsAndObjectsIsFlattened() {
+    ManifestEvaluator manifestEvaluator = mock(ManifestEvaluator.class);
+    ResolveDeploySourceManifestTask task = new ResolveDeploySourceManifestTask(manifestEvaluator);
+
+    StageExecutionImpl myStage =
+        createStageWithManifests(ImmutableList.of(ImmutableList.of(MANIFEST_1), MANIFEST_2));
+
+    DeployManifestContext deployManifestContext =
+        DeployManifestContext.builder().manifests(ImmutableList.of(MANIFEST_1, MANIFEST_2)).build();
+
+    when(manifestEvaluator.evaluate(any(), eq(deployManifestContext)))
+        .thenReturn(
+            new ManifestEvaluator.Result(
+                ImmutableList.of(MANIFEST_1, MANIFEST_2), ImmutableList.of(), ImmutableList.of()));
+
+    TaskResult result = task.execute(myStage);
+    verify(manifestEvaluator, times(1)).evaluate(any(), eq(deployManifestContext));
+    assertThat(getManifests(result)).containsExactly(MANIFEST_1, MANIFEST_2);
+  }
+
+  @Test
+  void manifestsWithListsIsFlattened() {
+    ManifestEvaluator manifestEvaluator = mock(ManifestEvaluator.class);
+    ResolveDeploySourceManifestTask task = new ResolveDeploySourceManifestTask(manifestEvaluator);
+
+    StageExecutionImpl myStage =
+        createStageWithManifests(
+            ImmutableList.of(ImmutableList.of(MANIFEST_1), ImmutableList.of(MANIFEST_2)));
+
+    DeployManifestContext deployManifestContext =
+        DeployManifestContext.builder().manifests(ImmutableList.of(MANIFEST_1, MANIFEST_2)).build();
+
+    when(manifestEvaluator.evaluate(any(), eq(deployManifestContext)))
+        .thenReturn(
+            new ManifestEvaluator.Result(
+                ImmutableList.of(MANIFEST_1, MANIFEST_2), ImmutableList.of(), ImmutableList.of()));
+
+    TaskResult result = task.execute(myStage);
+    verify(manifestEvaluator, times(1)).evaluate(any(), eq(deployManifestContext));
+    assertThat(getManifests(result)).containsExactly(MANIFEST_1, MANIFEST_2);
+  }
+
+  private StageExecutionImpl createStageWithManifests(ImmutableList<Object> manifestsByNamespace) {
+    return new StageExecutionImpl(
+        new PipelineExecutionImpl(ExecutionType.PIPELINE, "test"),
+        "test",
+        new HashMap<>(ImmutableMap.of("manifests", manifestsByNamespace)));
+  }
+
+  private static List<Map<Object, Object>> getManifests(TaskResult result) {
+    Map<String, ?> context = result.getContext();
+    return Optional.ofNullable(context)
+        .map(c -> (List<Map<Object, Object>>) c.get("manifests"))
+        .orElse(ImmutableList.of());
+  }
+}


### PR DESCRIPTION
**Issue Summary**
The way an array of manifests passed into a pipeline as YAML using `Spel` is getting mapped changed from v1.21.5 to v1.22.0.  In v1.21, the manifests resolved by a `Spel` function are flattened to have a list of manifests. In v1.22, the manifest are not flattened so it throws a `java.lang.IllegalArgumentException` exception.

The behavior changed because this fix: https://github.com/spinnaker/kork/pull/720

**Steps to reproduce**
switch spinnaker to 1.22 or higher, execute the following stage:
```json
{
  "account": "kubernetes",
  "cloudProvider": "kubernetes",
  "manifests": [
    "${#yamlFromUrl(\"https://raw.githubusercontent.com/dmrogers7/spinnaker-issues/main/manifests/array-of-manifests.yaml\")}"
  ],
  "moniker": {
    "app": "bugs-reproduced"
  },
  "name": "Deploy (Manifest)",
  "skipExpressionEvaluation": false,
  "source": "text",
  "trafficManagement": {
    "enabled": false,
    "options": {
      "enableTraffic": false,
      "services": []
    }
  },
  "type": "deployManifest"
}
```
**About the fix**
This issue only happen when the manifest uses `Spel` function to get the manifests and it return a list. Before the fix on kork, `Spel` flattening the list so it ensure that the `ResolveDeploySourceManifestTask` received only a list of manifest. Now the flattening logic is gone so when execute `#yamlFromUrl` it unmarshal the yaml and pass thru `ResolveDeploySourceManifestTask` as it is. This break the models because it expect a list of manifest and it's possible to get a nested list at this point. The following link has an example yaml that shows the below issue: https://github.com/dmrogers7/spinnaker-issues/blob/main/manifests/array-of-manifests.yaml

I included test to show the current behavior, then I just flattened the nested lists in the manifests before it is map to `DeployManifestContext` because this is something specific for the `ResolveDeploySourceManifestTask`

