### PR TITLE
fix(manifest): Fix deployment of artifact only stages

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolveDeploySourceManifestTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolveDeploySourceManifestTask.java
@@ -63,6 +63,10 @@ public final class ResolveDeploySourceManifestTask implements Task {
   // Spel is not flattening nested List anymore
   // We flatten them because its possible have a List of manifests resolved by spel
   private List<Object> flattenNestedLists(Object manifests) {
+    if (manifests == null) {
+      return null;
+    }
+
     List<Object> result = new ArrayList<>();
     List<Object> tmp = (List<Object>) manifests;
 


### PR DESCRIPTION
When using an artifact only pipeline (such as Kustomize -> Deploy Manifest), the changes added in #4037 causes a NPE as the manifests object is null. This ensures that the manifests are only flattened when they exist.