### PR TITLE
fix(preconfigured job): Fix for k8s manifest resources limit/request …

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStage.groovy
@@ -65,6 +65,21 @@ class PreconfiguredJobStage extends RunJobStage {
     // to override the underlying job. this avoids that problem by giving us a fresh "copy"
     // to work wit
     Map<String, Object> preconfiguredMap = objectMapper.convertValue(preconfiguredJob, Map.class)
+    
+    // Solution patch to resolve spec.template.spec.container.resources.limit
+    // and spec.template.spec.container.resources.requests parsed by io.kubernetes.client library
+    Map<String, Object> manifestMap= preconfiguredMap.get("manifest")
+    List<Map<String, Object>> containers = ((Map<String, Object>)((Map<String, Object>)((Map<String, Object>)manifestMap.get("spec")).get("template")).get("spec")).get("containers")
+
+        containers.stream()
+            .filter {e -> e.containsKey("resources") && e.get("resources")!= null}
+            .flatMap{e -> ((Map<String, Object>)e.get("resources")).entrySet().stream()}
+            .filter{e -> e.getKey().equals("limits") || e.getKey().equals("requests") }
+            .flatMap{e -> ((Map<String, Object>)e.getValue()).entrySet().stream()}
+            .forEach{e -> String number = ((Map<String, Object>) e.getValue()).get("number").toString()
+              e.setValue(number)};
+              
+    // till here
 
     // if we don't specify an application for this preconfigured job, assign the current one.
     if (preconfiguredMap["cluster"] != null && preconfiguredMap["cluster"].application == null) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/job/PreconfiguredJobStage.groovy
@@ -68,18 +68,22 @@ class PreconfiguredJobStage extends RunJobStage {
     
     // Solution patch to resolve spec.template.spec.container.resources.limit
     // and spec.template.spec.container.resources.requests parsed by io.kubernetes.client library
-    Map<String, Object> manifestMap= preconfiguredMap.get("manifest")
-    List<Map<String, Object>> containers = ((Map<String, Object>)((Map<String, Object>)((Map<String, Object>)manifestMap.get("spec")).get("template")).get("spec")).get("containers")
-
-        containers.stream()
-            .filter {e -> e.containsKey("resources") && e.get("resources")!= null}
-            .flatMap{e -> ((Map<String, Object>)e.get("resources")).entrySet().stream()}
-            .filter{e -> e.getKey().equals("limits") || e.getKey().equals("requests") }
-            .flatMap{e -> ((Map<String, Object>)e.getValue()).entrySet().stream()}
-            .forEach{e -> String number = ((Map<String, Object>) e.getValue()).get("number").toString()
-              e.setValue(number)};
-              
-    // till here
+    if (preconfiguredMap["manifest"] != null) {
+      Map<String, Object> manifestMap = preconfiguredMap.get("manifest")
+      if (manifestMap["spec"] != null){
+        List<Map<String, Object>> containers = ((Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) manifestMap.get("spec")).get("template")).get("spec")).get("containers")
+          containers.stream()
+            .filter { e -> e.containsKey("resources") && e.get("resources") != null }
+            .flatMap { e -> ((Map<String, Object>) e.get("resources")).entrySet().stream() }
+            .filter { e -> e.getKey().equals("limits") || e.getKey().equals("requests") }
+            .flatMap { e -> ((Map<String, Object>) e.getValue()).entrySet().stream() }
+            .forEach { e ->
+              String number = ((Map<String, Object>) e.getValue()).get("number").toString()
+              e.setValue(number)
+            }
+      }
+    }
+    //till here
 
     // if we don't specify an application for this preconfigured job, assign the current one.
     if (preconfiguredMap["cluster"] != null && preconfiguredMap["cluster"].application == null) {


### PR DESCRIPTION
Fix for #6257

Issue Summary:

Putting limits/request in a custom job through ~/.hal/default/profiles/orca-local.yml, the custom stage breaks with an error as shown below.
![image](https://user-images.githubusercontent.com/30489233/106035762-7bcc2900-60fa-11eb-98d7-b9af54e174f7.png)

About the fix:
In order to format above Map suitable for kubectl, "resources.request/limit.memory/cpu" field must take single value. This can be achieved by intercepting the preconfiguredMap object from class com.netflix.spinnaker.orca.clouddriver.pipeline.job.PreconfiguredJobStage and update it with required "resource" field format before passing it further.