### PR TITLE
feat(jenkins): Automatically set a build description that links back to Spinnaker

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/BuildService.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/BuildService.java
@@ -62,4 +62,9 @@ public class BuildService {
       Integer buildNumber, String fileName, String master, String job) {
     return igorService.getArtifacts(buildNumber, fileName, master, encode(job));
   }
+
+  public Response updateBuild(
+      String master, String jobName, Integer buildNumber, IgorService.UpdatedBuild updatedBuild) {
+    return igorService.update(master, jobName, buildNumber, updatedBuild);
+  }
 }

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.igor.model.GoogleCloudBuildRepoSource;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import lombok.Data;
 import retrofit.client.Response;
 import retrofit.http.*;
 
@@ -40,6 +41,13 @@ public interface IgorService {
       @Path(encode = false, value = "queuedBuild") String queuedBuild,
       @Path(encode = false, value = "buildNumber") Integer buildNumber,
       @Body String ignored);
+
+  @PATCH("/masters/{name}/jobs/{jobName}/update/{buildNumber}")
+  Response update(
+      @Path("name") String master,
+      @Path(encode = false, value = "jobName") String jobName,
+      @Path(encode = false, value = "buildNumber") Integer buildNumber,
+      @Body UpdatedBuild updatedBuild);
 
   @GET("/builds/queue/{master}/{item}")
   Map queuedBuild(@Path("master") String master, @Path("item") String item);
@@ -113,4 +121,13 @@ public interface IgorService {
       @Query("directory") @Nullable String directory,
       @Query("manifest") @Nullable String manifest,
       @Query("ref") @Nullable String ref);
+
+  @Data
+  class UpdatedBuild {
+    private final String description;
+
+    public UpdatedBuild(String description) {
+      this.description = description;
+    }
+  }
 }


### PR DESCRIPTION
Requires that `spinnaker.wwwHost` be set in your `orca` configuration.

```
spinnaker:
  wwwHost: https://www.spinnaker.net
```

![image](https://user-images.githubusercontent.com/388652/106333273-2482a180-623d-11eb-9ef6-016bdf5edb31.png)

