### PR TITLE
fix(api): Rename TaskNode.Builder method to not conflict with class name

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/StageDefinitionBuilder.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/StageDefinitionBuilder.java
@@ -44,7 +44,7 @@ import javax.annotation.Nonnull;
 public interface StageDefinitionBuilder extends SpinnakerExtensionPoint {
 
   default @Nonnull TaskGraph buildTaskGraph(@Nonnull StageExecution stage) {
-    Builder graphBuilder = Builder(FULL);
+    Builder graphBuilder = TaskNode.newBuilder(FULL);
     taskGraph(stage, graphBuilder);
     return graphBuilder.build();
   }

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/TaskNode.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/graph/TaskNode.java
@@ -81,7 +81,7 @@ public interface TaskNode {
     return new TaskDefinition(name, implementingClass);
   }
 
-  static Builder Builder(GraphType type) {
+  static Builder newBuilder(GraphType type) {
     return new Builder(type);
   }
 
@@ -124,7 +124,7 @@ public interface TaskNode {
      * ExecutionStatus#SUCCEEDED} the sub-graph will exit.
      *
      * @param subGraph a lambda that defines the tasks for the sub-graph by adding them to a @{link
-     *     {@link TaskNode#Builder}.
+     *     {@link TaskNode#newBuilder}.
      * @return this builder with the sub-graph appended.
      */
     public Builder withLoop(Consumer<Builder> subGraph) {

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/cf/CloudFoundryDeployServiceStagePreprocessorTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/cf/CloudFoundryDeployServiceStagePreprocessorTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 class CloudFoundryDeployServiceStagePreprocessorTest {
   @Test
   void ensureThatCorrectTasksAreAddedForDeployingCloudFoundryService() {
-    TaskNode.Builder expectedBuilder = TaskNode.Builder(TaskNode.GraphType.FULL);
+    TaskNode.Builder expectedBuilder = TaskNode.newBuilder(TaskNode.GraphType.FULL);
     expectedBuilder
         .withTask("deployService", CloudFoundryDeployServiceTask.class)
         .withTask("monitorDeployService", CloudFoundryMonitorKatoServicesTask.class)

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/cf/CloudFoundryDestroyServiceStagePreprocessorTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/cf/CloudFoundryDestroyServiceStagePreprocessorTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class CloudFoundryDestroyServiceStagePreprocessorTest {
   @Test
   void ensureThatCorrectTasksAreAddedForDestroyingCloudFoundryService() {
-    TaskNode.Builder expectedBuilder = TaskNode.Builder(TaskNode.GraphType.FULL);
+    TaskNode.Builder expectedBuilder = TaskNode.newBuilder(TaskNode.GraphType.FULL);
     expectedBuilder
         .withTask("destroyService", CloudFoundryDestroyServiceTask.class)
         .withTask("monitorDestroyService", CloudFoundryMonitorKatoServicesTask.class)

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/cf/CloudFoundryShareServiceStagePreprocessorTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/cf/CloudFoundryShareServiceStagePreprocessorTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 class CloudFoundryShareServiceStagePreprocessorTest {
   @Test
   void ensureThatCorrectTasksAreAddedForSharingCloudFoundryService() {
-    TaskNode.Builder expectedBuilder = TaskNode.Builder(TaskNode.GraphType.FULL);
+    TaskNode.Builder expectedBuilder = TaskNode.newBuilder(TaskNode.GraphType.FULL);
     expectedBuilder
         .withTask("shareService", CloudFoundryShareServiceTask.class)
         .withTask("monitorShareService", CloudFoundryMonitorKatoServicesTask.class);

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/cf/CloudFoundryUnshareServiceStagePreprocessorTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/cf/CloudFoundryUnshareServiceStagePreprocessorTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 class CloudFoundryUnshareServiceStagePreprocessorTest {
   @Test
   void ensureThatCorrectTasksAreAddedForUnsharingCloudFoundryService() {
-    TaskNode.Builder expectedBuilder = TaskNode.Builder(TaskNode.GraphType.FULL);
+    TaskNode.Builder expectedBuilder = TaskNode.newBuilder(TaskNode.GraphType.FULL);
     expectedBuilder
         .withTask("unshareService", CloudFoundryUnshareServiceTask.class)
         .withTask("monitorUnshareService", CloudFoundryMonitorKatoServicesTask.class);

--- a/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunStage.kt
+++ b/orca-dry-run/src/main/kotlin/com/netflix/spinnaker/orca/dryrun/DryRunStage.kt
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.orca.dryrun
 
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageGraphBuilder
-import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.Builder
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.ext.withTask
 
 class DryRunStage(private val delegate: StageDefinitionBuilder) : StageDefinitionBuilder {
 
-  override fun taskGraph(stage: StageExecution, builder: Builder) {
+  override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
     builder.withTask<DryRunTask>("dry run")
   }
 

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -31,7 +31,7 @@ import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner.STAGE_BEFORE
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageGraphBuilder
-import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.Builder
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.CANCELED
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.FAILED_CONTINUE
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.NOT_STARTED
@@ -874,7 +874,7 @@ class TestConfig {
 
   @Bean
   fun dummyStage() = object : StageDefinitionBuilder {
-    override fun taskGraph(stage: StageExecution, builder: Builder) {
+    override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
       builder.withTask<DummyTask>("dummy")
     }
 
@@ -898,7 +898,7 @@ class TestConfig {
   fun syntheticFailureStage() = object : StageDefinitionBuilder {
     override fun getType() = "syntheticFailure"
 
-    override fun taskGraph(stage: StageExecution, builder: Builder) {
+    override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
       builder.withTask<DummyTask>("dummy")
     }
 
@@ -920,7 +920,7 @@ class TestConfig {
   @Bean
   fun pipelineStage(@Autowired repository: ExecutionRepository): StageDefinitionBuilder =
     object : CancellableStage, StageDefinitionBuilder {
-      override fun taskGraph(stage: StageExecution, builder: Builder) {
+      override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
         builder.withTask<DummyTask>("dummy")
       }
 

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/Stages.kt
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner.STAGE_AFTER
 import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner.STAGE_BEFORE
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageGraphBuilder
-import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.Builder
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.ext.withTask
 import com.netflix.spinnaker.orca.pipeline.StageExecutionFactory
@@ -28,7 +28,7 @@ import java.lang.RuntimeException
 
 val singleTaskStage = object : StageDefinitionBuilder {
   override fun getType() = "singleTaskStage"
-  override fun taskGraph(stage: StageExecution, builder: Builder) {
+  override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
     builder.withTask<DummyTask>("dummy")
   }
 }
@@ -39,7 +39,7 @@ val zeroTaskStage = object : StageDefinitionBuilder {
 
 val multiTaskStage = object : StageDefinitionBuilder {
   override fun getType() = "multiTaskStage"
-  override fun taskGraph(stage: StageExecution, builder: Builder) {
+  override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
     builder
       .withTask<DummyTask>("dummy1")
       .withTask<DummyTask>("dummy2")
@@ -49,7 +49,7 @@ val multiTaskStage = object : StageDefinitionBuilder {
 
 val stageWithSyntheticBefore = object : StageDefinitionBuilder {
   override fun getType() = "stageWithSyntheticBefore"
-  override fun taskGraph(stage: StageExecution, builder: Builder) {
+  override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
     builder.withTask<DummyTask>("dummy")
   }
 
@@ -61,7 +61,7 @@ val stageWithSyntheticBefore = object : StageDefinitionBuilder {
 
 val stageWithSyntheticOnFailure = object : StageDefinitionBuilder {
   override fun getType() = "stageWithSyntheticOnFailure"
-  override fun taskGraph(stage: StageExecution, builder: Builder) {
+  override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
     builder.withTask<DummyTask>("dummy")
   }
 
@@ -101,7 +101,7 @@ val stageWithSyntheticBeforeAndAfterAndNoTasks = object : StageDefinitionBuilder
 
 val stageWithSyntheticAfter = object : StageDefinitionBuilder {
   override fun getType() = "stageWithSyntheticAfter"
-  override fun taskGraph(stage: StageExecution, builder: Builder) {
+  override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
     builder.withTask<DummyTask>("dummy")
   }
 
@@ -121,7 +121,7 @@ val stageWithSyntheticAfter = object : StageDefinitionBuilder {
 
 val stageWithParallelAfter = object : StageDefinitionBuilder {
   override fun getType() = "stageWithParallelAfter"
-  override fun taskGraph(stage: StageExecution, builder: Builder) {
+  override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
     builder.withTask<DummyTask>("dummy")
   }
 
@@ -167,14 +167,14 @@ val stageWithParallelBranches = object : StageDefinitionBuilder {
       }
   }
 
-  override fun taskGraph(stage: StageExecution, builder: Builder) {
+  override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
     builder.withTask<DummyTask>("post-branch")
   }
 }
 
 val rollingPushStage = object : StageDefinitionBuilder {
   override fun getType() = "rolling"
-  override fun taskGraph(stage: StageExecution, builder: Builder) {
+  override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
     builder
       .withTask<DummyTask>("beforeLoop")
       .withLoop { subGraph ->
@@ -189,14 +189,14 @@ val rollingPushStage = object : StageDefinitionBuilder {
 
 val webhookStage = object : StageDefinitionBuilder {
   override fun getType() = "webhook"
-  override fun taskGraph(stage: StageExecution, builder: Builder) {
+  override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
     builder.withTask<DummyTask>("createWebhook")
   }
 }
 
 val failPlanningStage = object : StageDefinitionBuilder {
   override fun getType() = "failPlanning"
-  override fun taskGraph(stage: StageExecution, builder: Builder) {
+  override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
     throw RuntimeException("o noes")
   }
 }


### PR DESCRIPTION
When using Kotlin, the method name `TaskNode.Builder(GraphType)` conflicts with the class `TaskNode.Builder`, since the constructor arg is the same as the method on `TaskNode`. This alters the method on `TaskNode` to be `newBuilder` so there is no conflict.