### PR TITLE
feat(interlink): support for restarting stages of foreign executions

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperator.java
@@ -106,6 +106,19 @@ public class CompoundExecutionOperator {
         executionId);
   }
 
+  public PipelineExecution restartStage(@Nonnull String executionId, @Nonnull String stageId) {
+    PipelineExecution execution = repository.retrieve(ExecutionType.PIPELINE, executionId);
+    if (repository.handlesPartition(execution.getPartition())) {
+      runner.restart(execution, stageId);
+    } else {
+      log.info(
+          "Not pushing queue message action='restart' for execution with foreign partition='{}'",
+          execution.getPartition());
+      repository.restartStage(executionId, stageId);
+    }
+    return execution;
+  }
+
   private PipelineExecution doInternal(
       Consumer<PipelineExecution> runnerAction,
       Runnable repositoryAction,

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -177,6 +177,11 @@ public interface ExecutionRepository {
         || partitionOfExecution.equals(getPartition()); // both are set and must match
   }
 
+  // defaulting to a no-op because in normal cases, this is a no-op for execution repositories
+  // execution repositories that support foreign peers can override this to support restarting
+  // foreign executions
+  default void restartStage(String executionId, String stageId) {}
+
   final class ExecutionCriteria {
     private int pageSize = 3500;
     private Collection<ExecutionStatus> statuses = new ArrayList<>();

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/InterlinkEvent.java
@@ -43,7 +43,8 @@ import javax.validation.constraints.NotNull;
   @JsonSubTypes.Type(value = PauseInterlinkEvent.class, name = "PAUSE"),
   @JsonSubTypes.Type(value = ResumeInterlinkEvent.class, name = "RESUME"),
   @JsonSubTypes.Type(value = DeleteInterlinkEvent.class, name = "DELETE"),
-  @JsonSubTypes.Type(value = PatchStageInterlinkEvent.class, name = "PATCH")
+  @JsonSubTypes.Type(value = PatchStageInterlinkEvent.class, name = "PATCH"),
+  @JsonSubTypes.Type(value = RestartStageInterlinkEvent.class, name = "RESTART")
 })
 public interface InterlinkEvent {
   enum EventType {
@@ -51,7 +52,8 @@ public interface InterlinkEvent {
     PAUSE,
     DELETE,
     RESUME,
-    PATCH
+    PATCH,
+    RESTART
   }
 
   @JsonIgnore

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PatchStageInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/PatchStageInterlinkEvent.java
@@ -83,10 +83,6 @@ public class PatchStageInterlinkEvent implements InterlinkEvent {
 
             if (stageFromMessage.getLastModified() != null) {
               stageFromRepo.setLastModified(stageFromMessage.getLastModified());
-            } else {
-              log.warn(
-                  "Unexpected state: stageFromMessage.getLastModified() is null, stageFromMessage={}",
-                  stageFromMessage);
             }
           });
     } catch (JsonProcessingException e) {

--- a/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/RestartStageInterlinkEvent.java
+++ b/orca-interlink/src/main/java/com/netflix/spinnaker/orca/interlink/events/RestartStageInterlinkEvent.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.interlink.events;
+
+import static com.netflix.spinnaker.orca.interlink.events.InterlinkEvent.EventType.RESTART;
+
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This event is published on the interlink as a result of a user RESTARTING a stage on an orca
+ * instance that can't handle the partition for the given execution.
+ *
+ * <p>The event is then handled by an orca instance (listening on interlink) whose partition matches
+ * that of the execution. The resulting repository mutations of this event will then be peered by
+ * the PeeringAgent
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RestartStageInterlinkEvent implements InterlinkEvent {
+  final EventType eventType = RESTART;
+  @Nullable String partition;
+  @Nonnull ExecutionType executionType;
+  @Nonnull String executionId;
+  @Nonnull String stageId;
+
+  public RestartStageInterlinkEvent(
+      @Nonnull ExecutionType executionType, @Nonnull String executionId, @Nonnull String stageId) {
+    // for the moment, only ExecutionType.PIPELINE can be restarted
+    // but since we are defining the protocol on the wire here, let's be a bit future proof and
+    // accept potentially different execution types
+    this.executionType = executionType;
+    this.executionId = executionId;
+    this.stageId = stageId;
+  }
+
+  @Override
+  public void applyTo(CompoundExecutionOperator executionOperator) {
+    executionOperator.restartStage(executionId, stageId);
+  }
+}

--- a/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/InterlinkSpec.groovy
+++ b/orca-interlink/src/test/groovy/com/netflix/spinnaker/orca/interlink/InterlinkSpec.groovy
@@ -43,6 +43,7 @@ class InterlinkSpec extends Specification {
   @Shared def delete = new DeleteInterlinkEvent(ORCHESTRATION, "execId").withPartition("partition")
   @Shared def patch = new PatchStageInterlinkEvent(ORCHESTRATION, "execId", "stageId",
       '{"id": "someId", "context": {"value": 42}}').withPartition("partition")
+  @Shared def restart = new RestartStageInterlinkEvent(PIPELINE, "execId", "stageId")
 
   @Unroll
   def "can parse execution event type #event.getEventType()"() {
@@ -59,7 +60,8 @@ class InterlinkSpec extends Specification {
         pause,
         resume,
         delete,
-        patch
+        patch,
+        restart
     ]
   }
 
@@ -81,6 +83,7 @@ class InterlinkSpec extends Specification {
     resume | "resume"
     delete | "delete"
     patch  | "updateStage"
+    restart | "restartStage"
   }
 
   @Unroll

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -38,6 +38,7 @@ import com.netflix.spinnaker.orca.interlink.events.DeleteInterlinkEvent
 import com.netflix.spinnaker.orca.interlink.events.InterlinkEvent
 import com.netflix.spinnaker.orca.interlink.events.PatchStageInterlinkEvent
 import com.netflix.spinnaker.orca.interlink.events.PauseInterlinkEvent
+import com.netflix.spinnaker.orca.interlink.events.RestartStageInterlinkEvent
 import com.netflix.spinnaker.orca.interlink.events.ResumeInterlinkEvent
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionNotFoundException
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
@@ -250,6 +251,12 @@ class SqlExecutionRepository(
           .where(id.toWhereCondition())
           .and(field("canceled").eq(true))
       )
+    }
+  }
+
+  override fun restartStage(executionId: String, stageId: String) {
+    doForeignAware(RestartStageInterlinkEvent(PIPELINE, executionId, stageId)) {
+      _, _ -> log.debug("restartStage is a no-op for local executions")
     }
   }
 

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -70,7 +70,7 @@ class TaskController {
   ExecutionRunner executionRunner
 
   @Autowired
-  CompoundExecutionOperator executionOperator;
+  CompoundExecutionOperator executionOperator
 
   @Autowired
   Collection<StageDefinitionBuilder> stageBuilders
@@ -502,9 +502,7 @@ class TaskController {
   @RequestMapping(value = "/pipelines/{id}/stages/{stageId}/restart", method = RequestMethod.PUT)
   PipelineExecution retryPipelineStage(
     @PathVariable String id, @PathVariable String stageId) {
-    def pipeline = executionRepository.retrieve(PIPELINE, id)
-    executionRunner.restart(pipeline, stageId)
-    pipeline
+    return executionOperator.restartStage(id, stageId)
   }
 
   @PreAuthorize("hasPermission(this.getPipeline(#id)?.application, 'APPLICATION', 'READ')")


### PR DESCRIPTION
Without this PR, calling the restart endpoint causes orca to push a RestartStage message on the queue. But for foreign executions, this doesn't do anything.

With this PR, we follow the model of delegating to a CompoundExecutionOperator instead, which handles local vs foreign executions and queue vs execution repository routing. If the execution is foreign, it will rely on the execution repository to emit the appropriate interlink message.
