### PR TITLE
chore(bake): add base ami if present in bake response

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/Bake.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/Bake.groovy
@@ -38,4 +38,5 @@ class Bake {
   String imageName
   Artifact artifact
   // TODO(duftler): Add a cloudProviderType property here? Will be straightforward once rosco is backed by redis.
+  String baseAmi
 }

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy
@@ -47,6 +47,11 @@ class CompletedBakeTask implements Task {
       imageId: bake.ami ?: bake.imageName,
       artifacts: bake.artifact ? [bake.artifact] : []
     ]
+
+    if (bake.baseAmi != null) {
+      results.put("baseAmiId", bake.baseAmi)
+    }
+
     if (stage.context.cloudProvider) {
       results.cloudProvider = stage.context.cloudProvider
     }


### PR DESCRIPTION
I want to consume the base ami id in `keel` for managed delivery. At netflix we have it in the bakery response, so this PR adds it to the outputs if it's present.