### PR TITLE
fix(bake): add baseAmiId to the outputs

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -143,7 +143,8 @@ class BakeStage implements StageDefinitionBuilder {
       "region",
       "package",
       "cloudProviderType",
-      "cloudProvider"
+      "cloudProvider",
+      "baseAmiId"
     ]
     DynamicConfigService dynamicConfigService
 


### PR DESCRIPTION
turns out you need to specify the fields that go in outputs. cool.