### PR TITLE
perf(events): create execution events with a ref to the execution

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/events/ExecutionComplete.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/events/ExecutionComplete.java
@@ -17,22 +17,19 @@
 package com.netflix.spinnaker.orca.events;
 
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import javax.annotation.Nonnull;
+import lombok.Getter;
 
 public final class ExecutionComplete extends ExecutionEvent {
-  private final ExecutionStatus status;
+  @Getter private final PipelineExecution execution;
 
-  public ExecutionComplete(
-      @Nonnull Object source,
-      @Nonnull ExecutionType executionType,
-      @Nonnull String executionId,
-      @Nonnull ExecutionStatus status) {
-    super(source, executionType, executionId);
-    this.status = status;
+  public ExecutionComplete(@Nonnull Object source, @Nonnull PipelineExecution execution) {
+    super(source, execution.getType(), execution.getId());
+    this.execution = execution;
   }
 
   public @Nonnull ExecutionStatus getStatus() {
-    return status;
+    return execution.getStatus();
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/events/ExecutionListenerAdapter.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/events/ExecutionListenerAdapter.java
@@ -17,8 +17,6 @@
 package com.netflix.spinnaker.orca.events;
 
 import com.netflix.spinnaker.kork.common.Header;
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
-import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.listeners.DefaultPersister;
 import com.netflix.spinnaker.orca.listeners.ExecutionListener;
 import com.netflix.spinnaker.orca.listeners.Persister;
@@ -28,14 +26,11 @@ import org.springframework.context.ApplicationListener;
 
 /** Adapts events emitted by the nu-orca queue to an old-style listener. */
 public final class ExecutionListenerAdapter implements ApplicationListener<ExecutionEvent> {
-
   private final ExecutionListener delegate;
-  private final ExecutionRepository repository;
   private final Persister persister;
 
   public ExecutionListenerAdapter(ExecutionListener delegate, ExecutionRepository repository) {
     this.delegate = delegate;
-    this.repository = repository;
     persister = new DefaultPersister(repository);
   }
 
@@ -54,15 +49,11 @@ public final class ExecutionListenerAdapter implements ApplicationListener<Execu
   }
 
   private void onExecutionStarted(ExecutionStarted event) {
-    delegate.beforeExecution(persister, executionFor(event));
+    delegate.beforeExecution(persister, event.getExecution());
   }
 
   private void onExecutionComplete(ExecutionComplete event) {
-    ExecutionStatus status = event.getStatus();
-    delegate.afterExecution(persister, executionFor(event), status, status.isSuccessful());
-  }
-
-  private PipelineExecution executionFor(ExecutionEvent event) {
-    return repository.retrieve(event.getExecutionType(), event.getExecutionId());
+    delegate.afterExecution(
+        persister, event.getExecution(), event.getStatus(), event.getStatus().isSuccessful());
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/events/ExecutionStarted.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/events/ExecutionStarted.java
@@ -16,12 +16,15 @@
 
 package com.netflix.spinnaker.orca.events;
 
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import javax.annotation.Nonnull;
+import lombok.Getter;
 
 public final class ExecutionStarted extends ExecutionEvent {
-  public ExecutionStarted(
-      @Nonnull Object source, @Nonnull ExecutionType executionType, @Nonnull String executionId) {
-    super(source, executionType, executionId);
+  @Getter private final PipelineExecution execution;
+
+  public ExecutionStarted(@Nonnull Object source, @Nonnull PipelineExecution execution) {
+    super(source, execution.getType(), execution.getId());
+    this.execution = execution;
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/events/StageComplete.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/events/StageComplete.java
@@ -17,55 +17,28 @@
 package com.netflix.spinnaker.orca.events;
 
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import javax.annotation.Nonnull;
+import lombok.Getter;
 
 public final class StageComplete extends ExecutionEvent {
-  private final String stageId;
-  private final String stageType;
-  private final String stageName;
-  private final ExecutionStatus status;
-
-  public StageComplete(
-      @Nonnull Object source,
-      @Nonnull ExecutionType executionType,
-      @Nonnull String executionId,
-      @Nonnull String stageId,
-      @Nonnull String stageType,
-      @Nonnull String stageName,
-      @Nonnull ExecutionStatus status) {
-    super(source, executionType, executionId);
-    this.stageId = stageId;
-    this.stageType = stageType;
-    this.stageName = stageName;
-    this.status = status;
-  }
+  @Getter private final StageExecution stage;
 
   public StageComplete(@Nonnull Object source, @Nonnull StageExecution stage) {
-    this(
-        source,
-        stage.getExecution().getType(),
-        stage.getExecution().getId(),
-        stage.getId(),
-        stage.getType(),
-        stage.getName(),
-        stage.getStatus());
+    super(source, stage.getExecution().getType(), stage.getExecution().getId());
+
+    this.stage = stage;
   }
 
   public @Nonnull String getStageId() {
-    return stageId;
+    return stage.getId();
   }
 
   public @Nonnull String getStageType() {
-    return stageType;
-  }
-
-  public @Nonnull String getStageName() {
-    return stageName;
+    return stage.getType();
   }
 
   public @Nonnull ExecutionStatus getStatus() {
-    return status;
+    return stage.getStatus();
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/events/StageStarted.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/events/StageStarted.java
@@ -16,47 +16,16 @@
 
 package com.netflix.spinnaker.orca.events;
 
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import javax.annotation.Nonnull;
+import lombok.Getter;
 
 public final class StageStarted extends ExecutionEvent {
-  private final String stageId;
-  private final String stageType;
-  private final String stageName;
-
-  public StageStarted(
-      @Nonnull Object source,
-      @Nonnull ExecutionType executionType,
-      @Nonnull String executionId,
-      @Nonnull String stageId,
-      @Nonnull String stageType,
-      @Nonnull String stageName) {
-    super(source, executionType, executionId);
-    this.stageId = stageId;
-    this.stageType = stageType;
-    this.stageName = stageName;
-  }
+  @Getter private final StageExecution stage;
 
   public StageStarted(@Nonnull Object source, @Nonnull StageExecution stage) {
-    this(
-        source,
-        stage.getExecution().getType(),
-        stage.getExecution().getId(),
-        stage.getId(),
-        stage.getType(),
-        stage.getName());
-  }
+    super(source, stage.getExecution().getType(), stage.getExecution().getId());
 
-  public @Nonnull String getStageId() {
-    return stageId;
-  }
-
-  public @Nonnull String getStageType() {
-    return stageType;
-  }
-
-  public @Nonnull String getStageName() {
-    return stageName;
+    this.stage = stage;
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/events/TaskComplete.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/events/TaskComplete.java
@@ -16,82 +16,21 @@
 
 package com.netflix.spinnaker.orca.events;
 
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.TaskExecution;
 import javax.annotation.Nonnull;
+import lombok.Getter;
 
 public class TaskComplete extends ExecutionEvent {
-  private final String stageId;
-  private final String stageType;
-  private final String stageName;
-  private final String taskId;
-  private final String taskType;
-  private final String taskName;
-  private final ExecutionStatus status;
+  @Getter private final StageExecution stage;
 
-  public TaskComplete(
-      @Nonnull Object source,
-      @Nonnull ExecutionType executionType,
-      @Nonnull String executionId,
-      @Nonnull String stageId,
-      @Nonnull String stageType,
-      @Nonnull String stageName,
-      @Nonnull String taskId,
-      @Nonnull String taskType,
-      @Nonnull String taskName,
-      @Nonnull ExecutionStatus status) {
-    super(source, executionType, executionId);
-    this.stageId = stageId;
-    this.stageType = stageType;
-    this.stageName = stageName;
-    this.taskId = taskId;
-    this.taskType = taskType;
-    this.taskName = taskName;
-    this.status = status;
-  }
+  @Getter private final TaskExecution task;
 
   public TaskComplete(
       @Nonnull Object source, @Nonnull StageExecution stage, @Nonnull TaskExecution task) {
-    this(
-        source,
-        stage.getExecution().getType(),
-        stage.getExecution().getId(),
-        stage.getId(),
-        stage.getType(),
-        stage.getName(),
-        task.getId(),
-        task.getImplementingClass(),
-        task.getName(),
-        task.getStatus());
-  }
+    super(source, stage.getExecution().getType(), stage.getExecution().getId());
 
-  public @Nonnull String getStageId() {
-    return stageId;
-  }
-
-  public @Nonnull String getStageType() {
-    return stageType;
-  }
-
-  public @Nonnull String getStageName() {
-    return stageName;
-  }
-
-  public @Nonnull String getTaskId() {
-    return taskId;
-  }
-
-  public @Nonnull String getTaskType() {
-    return taskType;
-  }
-
-  public @Nonnull String getTaskName() {
-    return taskName;
-  }
-
-  public @Nonnull ExecutionStatus getStatus() {
-    return status;
+    this.stage = stage;
+    this.task = task;
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/events/TaskStarted.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/events/TaskStarted.java
@@ -16,73 +16,21 @@
 
 package com.netflix.spinnaker.orca.events;
 
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.TaskExecution;
 import javax.annotation.Nonnull;
+import lombok.Getter;
 
 public class TaskStarted extends ExecutionEvent {
-  private final String stageId;
-  private final String stageType;
-  private final String stageName;
-  private final String taskId;
-  private final String taskType;
-  private final String taskName;
+  @Getter private final StageExecution stage;
 
-  public TaskStarted(
-      @Nonnull Object source,
-      @Nonnull ExecutionType executionType,
-      @Nonnull String executionId,
-      @Nonnull String stageId,
-      @Nonnull String stageType,
-      @Nonnull String stageName,
-      @Nonnull String taskId,
-      @Nonnull String taskType,
-      @Nonnull String taskName) {
-    super(source, executionType, executionId);
-    this.stageId = stageId;
-    this.stageType = stageType;
-    this.stageName = stageName;
-    this.taskId = taskId;
-    this.taskType = taskType;
-    this.taskName = taskName;
-  }
+  @Getter private final TaskExecution task;
 
   public TaskStarted(
       @Nonnull Object source, @Nonnull StageExecution stage, @Nonnull TaskExecution task) {
-    this(
-        source,
-        stage.getExecution().getType(),
-        stage.getExecution().getId(),
-        stage.getId(),
-        stage.getType(),
-        stage.getName(),
-        task.getId(),
-        task.getImplementingClass(),
-        task.getName());
-  }
+    super(source, stage.getExecution().getType(), stage.getExecution().getId());
 
-  public @Nonnull String getStageId() {
-    return stageId;
-  }
-
-  public @Nonnull String getStageType() {
-    return stageType;
-  }
-
-  public @Nonnull String getStageName() {
-    return stageName;
-  }
-
-  public @Nonnull String getTaskId() {
-    return taskId;
-  }
-
-  public @Nonnull String getTaskType() {
-    return taskType;
-  }
-
-  public @Nonnull String getTaskName() {
-    return taskName;
+    this.stage = stage;
+    this.task = task;
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/ExecutionCleanupListener.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/ExecutionCleanupListener.java
@@ -22,11 +22,6 @@ import java.util.List;
 
 public class ExecutionCleanupListener implements ExecutionListener {
   @Override
-  public void beforeExecution(Persister persister, PipelineExecution execution) {
-    // do nothing
-  }
-
-  @Override
   public void afterExecution(
       Persister persister,
       PipelineExecution execution,

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/StageListener.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/StageListener.java
@@ -21,16 +21,15 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.TaskExecution;
 
 public interface StageListener {
-  default void beforeTask(Persister persister, StageExecution stage, TaskExecution task) {
+  default void beforeTask(StageExecution stage, TaskExecution task) {
     // do nothing
   }
 
-  default void beforeStage(Persister persister, StageExecution stage) {
+  default void beforeStage(StageExecution stage) {
     // do nothing
   }
 
   default void afterTask(
-      Persister persister,
       StageExecution stage,
       TaskExecution task,
       ExecutionStatus executionStatus,
@@ -38,7 +37,7 @@ public interface StageListener {
     // do nothing
   }
 
-  default void afterStage(Persister persister, StageExecution stage) {
+  default void afterStage(StageExecution stage) {
     // do nothing
   }
 }

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
@@ -79,12 +79,12 @@ class EchoConfiguration {
   EchoNotifyingStageListener echoNotifyingStageExecutionListener(EchoService echoService, ExecutionRepository repository,
                                                                  ContextParameterProcessor contextParameterProcessor,
                                                                  DynamicConfigService dynamicConfigService) {
-    new EchoNotifyingStageListener(echoService, repository, contextParameterProcessor, dynamicConfigService)
+    new EchoNotifyingStageListener(echoService, contextParameterProcessor, dynamicConfigService)
   }
 
   @Bean
-  ApplicationListener<ExecutionEvent> echoNotifyingStageExecutionListenerAdapter(EchoNotifyingStageListener echoNotifyingStageListener, ExecutionRepository repository) {
-    return new StageListenerAdapter(echoNotifyingStageListener, repository)
+  ApplicationListener<ExecutionEvent> echoNotifyingStageExecutionListenerAdapter(EchoNotifyingStageListener echoNotifyingStageListener) {
+    return new StageListenerAdapter(echoNotifyingStageListener)
   }
 
   @Bean

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
@@ -22,9 +22,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.TaskExecution
 import com.netflix.spinnaker.orca.echo.EchoService
-import com.netflix.spinnaker.orca.listeners.Persister
 import com.netflix.spinnaker.orca.listeners.StageListener
-import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.transform.CompileDynamic
@@ -32,6 +30,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
+
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.*
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.ORCHESTRATION
 
@@ -43,34 +42,31 @@ import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.ORCHE
 class EchoNotifyingStageListener implements StageListener {
   public static final String INCLUDE_FULL_EXECUTION_PROPERTY = "echo.events.includeFullExecution"
   private final EchoService echoService
-  private final ExecutionRepository repository
   private final ContextParameterProcessor contextParameterProcessor
   private final DynamicConfigService dynamicConfigService
 
   @Autowired
-  EchoNotifyingStageListener(EchoService echoService, ExecutionRepository repository,
+  EchoNotifyingStageListener(EchoService echoService,
                              ContextParameterProcessor contextParameterProcessor,
                              DynamicConfigService dynamicConfigService) {
     this.echoService = echoService
-    this.repository = repository
     this.contextParameterProcessor = contextParameterProcessor
     this.dynamicConfigService = dynamicConfigService
   }
 
   @Override
-  void beforeTask(Persister persister, StageExecution stage, TaskExecution task) {
+  void beforeTask(StageExecution stage, TaskExecution task) {
     recordEvent('task', 'starting', stage, task)
   }
 
   @Override
   @CompileDynamic
-  void beforeStage(Persister persister, StageExecution stage) {
+  void beforeStage(StageExecution stage) {
     recordEvent("stage", "starting", stage)
   }
 
   @Override
-  void afterTask(Persister persister,
-                 StageExecution stage,
+  void afterTask(StageExecution stage,
                  TaskExecution task,
                  ExecutionStatus executionStatus,
                  boolean wasSuccessful) {
@@ -83,7 +79,7 @@ class EchoNotifyingStageListener implements StageListener {
 
   @Override
   @CompileDynamic
-  void afterStage(Persister persister, StageExecution stage) {
+  void afterStage(StageExecution stage) {
     // STOPPED stages are "successful" because they allow the pipeline to
     // proceed but they are still failures in terms of the stage and should
     // send failure notifications

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandler.kt
@@ -52,7 +52,8 @@ class CancelExecutionHandler(
       // then, make sure those runTask messages get run right away
       queue.push(RescheduleExecution(execution))
 
-      publisher.publishEvent(ExecutionComplete(this, message.executionType, message.executionId, CANCELED))
+      execution.status = CANCELED
+      publisher.publishEvent(ExecutionComplete(this, execution))
     }
   }
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/TaskResultMonitor.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/metrics/TaskResultMonitor.kt
@@ -29,8 +29,8 @@ class TaskResultMonitor(private val registry: Registry) :
 
   override fun onApplicationEvent(event: TaskComplete) {
     id
-      .withTag("status", event.status.name)
-      .withTag("task", event.taskType)
+      .withTag("status", event.task.status.name)
+      .withTag("task", event.task.implementingClass)
       .let { id ->
         registry
           .counter(id)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/AbortStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/AbortStageHandlerTest.kt
@@ -136,7 +136,7 @@ object AbortStageHandlerTest : SubjectSpek<AbortStageHandler>({
       it("emits an event") {
         verify(publisher).publishEvent(
           check<StageComplete> {
-            assertThat(it.status).isEqualTo(TERMINAL)
+            assertThat(it.stage.status).isEqualTo(TERMINAL)
           }
         )
       }
@@ -190,7 +190,7 @@ object AbortStageHandlerTest : SubjectSpek<AbortStageHandler>({
       it("emits an event") {
         verify(publisher).publishEvent(
           check<StageComplete> {
-            assertThat(it.status).isEqualTo(TERMINAL)
+            assertThat(it.stage.status).isEqualTo(TERMINAL)
           }
         )
       }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
@@ -257,10 +257,10 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
           it("publishes an event") {
             verify(publisher).publishEvent(
               check<StageComplete> {
-                assertThat(it.executionType).isEqualTo(pipeline.type)
-                assertThat(it.executionId).isEqualTo(pipeline.id)
-                assertThat(it.stageId).isEqualTo(message.stageId)
-                assertThat(it.status).isEqualTo(taskStatus)
+                assertThat(it.stage.execution.type).isEqualTo(pipeline.type)
+                assertThat(it.stage.execution.id).isEqualTo(pipeline.id)
+                assertThat(it.stage.id).isEqualTo(message.stageId)
+                assertThat(it.stage.status).isEqualTo(taskStatus)
               }
             )
           }
@@ -614,10 +614,10 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
         it("publishes an event") {
           verify(publisher).publishEvent(
             check<StageComplete> {
-              assertThat(it.executionType).isEqualTo(pipeline.type)
-              assertThat(it.executionId).isEqualTo(pipeline.id)
-              assertThat(it.stageId).isEqualTo(message.stageId)
-              assertThat(it.status).isEqualTo(taskStatus)
+              assertThat(it.stage.execution.type).isEqualTo(pipeline.type)
+              assertThat(it.stage.execution.id).isEqualTo(pipeline.id)
+              assertThat(it.stage.id).isEqualTo(message.stageId)
+              assertThat(it.stage.status).isEqualTo(taskStatus)
             }
           )
         }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
@@ -138,9 +138,9 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
             check<TaskComplete> {
               assertThat(it.executionType).isEqualTo(pipeline.type)
               assertThat(it.executionId).isEqualTo(pipeline.id)
-              assertThat(it.stageId).isEqualTo(message.stageId)
-              assertThat(it.taskId).isEqualTo(message.taskId)
-              assertThat(it.status).isEqualTo(successfulStatus)
+              assertThat(it.stage.id).isEqualTo(message.stageId)
+              assertThat(it.task.id).isEqualTo(message.taskId)
+              assertThat(it.task.status).isEqualTo(successfulStatus)
             }
           )
         }
@@ -316,9 +316,9 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
           check<TaskComplete> {
             assertThat(it.executionType).isEqualTo(pipeline.type)
             assertThat(it.executionId).isEqualTo(pipeline.id)
-            assertThat(it.stageId).isEqualTo(message.stageId)
-            assertThat(it.taskId).isEqualTo(message.taskId)
-            assertThat(it.status).isEqualTo(status)
+            assertThat(it.stage.id).isEqualTo(message.stageId)
+            assertThat(it.task.id).isEqualTo(message.taskId)
+            assertThat(it.task.status).isEqualTo(status)
           }
         )
       }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
@@ -390,6 +390,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         beforeGroup {
           pipeline.isLimitConcurrent = true
           runningPipeline.isLimitConcurrent = true
+          pipeline.status = NOT_STARTED
 
           whenever(
             repository.retrievePipelinesForPipelineConfigId(eq(configId), any())

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
@@ -190,7 +190,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
           check<StageStarted> {
             assertThat(it.executionType).isEqualTo(pipeline.type)
             assertThat(it.executionId).isEqualTo(pipeline.id)
-            assertThat(it.stageId).isEqualTo(message.stageId)
+            assertThat(it.stage.id).isEqualTo(message.stageId)
           }
         )
       }
@@ -236,7 +236,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
             check<StageStarted> {
               assertThat(it.executionType).isEqualTo(pipeline.type)
               assertThat(it.executionId).isEqualTo(pipeline.id)
-              assertThat(it.stageId).isEqualTo(message.stageId)
+              assertThat(it.stage.id).isEqualTo(message.stageId)
             }
           )
         }
@@ -281,7 +281,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
             check<StageStarted> {
               assertThat(it.executionType).isEqualTo(pipeline.type)
               assertThat(it.executionId).isEqualTo(pipeline.id)
-              assertThat(it.stageId).isEqualTo(message.stageId)
+              assertThat(it.stage.id).isEqualTo(message.stageId)
             }
           )
         }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartTaskHandlerTest.kt
@@ -128,8 +128,8 @@ object StartTaskHandlerTest : SubjectSpek<StartTaskHandler>({
         firstValue.apply {
           assertThat(executionType).isEqualTo(pipeline.type)
           assertThat(executionId).isEqualTo(pipeline.id)
-          assertThat(stageId).isEqualTo(message.stageId)
-          assertThat(taskId).isEqualTo(message.taskId)
+          assertThat(stage.id).isEqualTo(message.stageId)
+//          assertThat(task.id).isEqualTo(message.taskId)
         }
       }
     }
@@ -181,8 +181,8 @@ object StartTaskHandlerTest : SubjectSpek<StartTaskHandler>({
         firstValue.apply {
           assertThat(executionType).isEqualTo(pipeline.type)
           assertThat(executionId).isEqualTo(pipeline.id)
-          assertThat(stageId).isEqualTo(message.stageId)
-          assertThat(taskId).isEqualTo(message.taskId)
+          assertThat(stage.id).isEqualTo(message.stageId)
+//          assertThat(task.id).isEqualTo(message.taskId)
         }
       }
     }


### PR DESCRIPTION
This avoid loading things for the repository twice, e.g.:
- on a StartTask message, the handler loads the entire execution
- it then emits a TaskStarted event, which will load the entire execution again
- ... and so on for TaskComplete, StageStarted, StageComplete, etc.

On simple executions, it decreases the amount of executions fetched by 40%, which should translate to less load on the database and lower memory pressure on orca.
