### PR TITLE
fix(aws/cloudformation): Add onDemandCache refresh logic

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/CloudFormationForceCacheRefreshTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/CloudFormationForceCacheRefreshTask.java
@@ -16,57 +16,181 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.cloudformation;
 
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.RUNNING;
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.SUCCEEDED;
+import static java.net.HttpURLConnection.HTTP_OK;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService;
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheStatusService;
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.io.IOException;
+import java.time.Clock;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.Data;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import retrofit.RetrofitError;
+import retrofit.client.Response;
 
+@Slf4j
 @Component
 public class CloudFormationForceCacheRefreshTask
     implements CloudProviderAware, OverridableTimeoutRetryableTask {
   static final String REFRESH_TYPE = "CloudFormation";
 
-  @Autowired CloudDriverCacheService cacheService;
+  Clock clock = Clock.systemUTC();
+  private final ObjectMapper objectMapper;
+  private final Registry registry;
+  private final Id durationTimerId;
 
   private final long backoffPeriod = TimeUnit.SECONDS.toMillis(10);
-  private final long timeout = TimeUnit.MINUTES.toMillis(5);
+  private final long timeout = TimeUnit.MINUTES.toMillis(20);
+  private final long autoSucceedAfterMs = TimeUnit.MINUTES.toMillis(12);
+
+  private final CloudDriverCacheService cacheService;
+  private final CloudDriverCacheStatusService cacheStatusService;
+
+  public CloudFormationForceCacheRefreshTask(
+      Registry registry,
+      CloudDriverCacheService cacheService,
+      CloudDriverCacheStatusService cacheStatusService,
+      ObjectMapper objectMapper) {
+
+    this.registry = registry;
+    this.cacheService = cacheService;
+    this.cacheStatusService = cacheStatusService;
+    this.objectMapper = objectMapper;
+    this.durationTimerId = registry.createId("cloudformationStackForceCacheRefreshTask.duration");
+  }
 
   @Override
   public TaskResult execute(@Nonnull StageExecution stage) {
+    Long startTime = stage.getStartTime();
+    if (startTime == null) {
+      throw new IllegalStateException("Stage has no start time, cannot be executed.");
+    }
+    long duration = clock.millis() - startTime;
+    if (duration > autoSucceedAfterMs) {
+      log.info(
+          "{}: Force cache refresh never finished processing... assuming the cache is in sync and continuing...",
+          stage.getExecution().getId());
+      registry
+          .timer(durationTimerId.withTags("success", "true", "outcome", "autoSucceed"))
+          .record(duration, TimeUnit.MILLISECONDS);
+      return TaskResult.SUCCEEDED;
+    }
+
     String cloudProvider = getCloudProvider(stage);
 
-    Map<String, Object> data = new HashMap<>();
+    CloudFormationForceCacheRefreshTask.StageData stageData = fromStage(stage);
 
+    if (stageData.deployedStacks.isEmpty()) {
+      stageData.deployedStacks = getDeployedStacks(stage);
+    }
+
+    checkPendingRefreshes(cloudProvider, stageData, startTime);
+    refreshStacks(cloudProvider, stageData);
+
+    if (stageData.processedStacks.equals(stageData.deployedStacks)) {
+      stageData.reset();
+      return TaskResult.builder(SUCCEEDED).context(toContext(stageData)).build();
+    }
+
+    return TaskResult.builder(RUNNING).context(toContext(stageData)).build();
+  }
+
+  private void checkPendingRefreshes(
+      String provider, CloudFormationForceCacheRefreshTask.StageData stageData, long startTime) {
+    Set<ScopedStack> toCheck = new HashSet<ScopedStack>(stageData.refreshedStacks);
+    toCheck.removeAll(stageData.processedStacks);
+
+    List<ScopedStack> stacksToCheck =
+        stageData.refreshedStacks.stream()
+            .filter(m -> !stageData.processedStacks.contains(m))
+            .collect(Collectors.toList());
+
+    if (stacksToCheck.isEmpty()) {
+      return;
+    }
+
+    List<PendingScopedStack> pendingRefreshes =
+        objectMapper.convertValue(
+            cacheStatusService.pendingForceCacheUpdates(provider, REFRESH_TYPE),
+            new TypeReference<List<PendingScopedStack>>() {});
+
+    for (PendingScopedStack stack : pendingRefreshes) {
+      ScopedStack matchingStack =
+          stageData.getRefreshedStacks().stream()
+              .filter(t -> t.getFullStackName().contains(stack.getScopedStack().getStackName()))
+              .findFirst()
+              .orElse(null);
+
+      if (matchingStack == null) {
+        continue;
+      }
+
+      if (stack.getProcessedCount() > 0 && stack.getCacheTime() > startTime) {
+        log.info("Refresh for {} has been processed {}", stack);
+        stageData.processedStacks.add(matchingStack);
+      }
+    }
+  }
+
+  private void refreshStacks(
+      String provider, CloudFormationForceCacheRefreshTask.StageData stageData) {
+    Set<ScopedStack> toRefresh = new HashSet<ScopedStack>(stageData.deployedStacks);
+    toRefresh.removeAll(stageData.refreshedStacks);
+
+    for (ScopedStack stack : toRefresh) {
+      CloudDriverScopedStack cloudDriverStack = new CloudDriverScopedStack(stack);
+      Map<String, Object> request =
+          objectMapper.convertValue(cloudDriverStack, new TypeReference<Map<String, Object>>() {});
+
+      try {
+        Response response = cacheService.forceCacheUpdate(provider, REFRESH_TYPE, request);
+        if (response.getStatus() == HTTP_OK) {
+          log.info("Refresh of {} succeeded immediately", stack);
+          stageData.processedStacks.add(stack);
+        } else {
+          stack.fullStackName = extractFullStackName(response).get();
+        }
+
+        stageData.refreshedStacks.add(stack);
+      } catch (Exception e) {
+        log.warn("Failed to refresh {}: ", stack, e);
+        stageData.errors.add(e.getMessage());
+      }
+    }
+  }
+
+  private Set<ScopedStack> getDeployedStacks(StageExecution stage) {
     String credentials = getCredentials(stage);
-    if (credentials != null) {
-      data.put("credentials", credentials);
-    }
-
     List<String> regions = (List<String>) stage.getContext().get("regions");
-    if (regions != null && !regions.isEmpty()) {
-      data.put("region", regions);
-    }
-
     String stackName = (String) stage.getContext().get("stackName");
-    if (stackName != null) {
-      data.put("stackName", stackName);
+
+    if (credentials.isEmpty() || regions.isEmpty() || stackName.isEmpty()) {
+      throw new IllegalStateException("Missing stage context in " + stage);
     }
 
-    try {
-      cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, data);
-    } catch (RetrofitError e) {
-      return TaskResult.RUNNING;
-    }
-    return TaskResult.SUCCEEDED;
+    return regions.stream()
+        .map(
+            r -> {
+              ScopedStack scopedStack = new ScopedStack(credentials, r, stackName);
+              return scopedStack;
+            })
+        .collect(Collectors.toSet());
   }
 
   @Override
@@ -77,5 +201,124 @@ public class CloudFormationForceCacheRefreshTask
   @Override
   public long getTimeout() {
     return timeout;
+  }
+
+  private CloudFormationForceCacheRefreshTask.StageData fromStage(StageExecution stage) {
+    try {
+      return objectMapper.readValue(
+          objectMapper.writeValueAsString(stage.getContext()),
+          CloudFormationForceCacheRefreshTask.StageData.class);
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "Malformed stage context in " + stage + ": " + e.getMessage(), e);
+    }
+  }
+
+  private Map<String, Object> toContext(CloudFormationForceCacheRefreshTask.StageData stageData) {
+    return objectMapper.convertValue(stageData, new TypeReference<Map<String, Object>>() {});
+  }
+
+  private Optional<String> extractFullStackName(Response response) {
+    try {
+      CachedResponse cachedResponse =
+          objectMapper.readValue(
+              response.getBody().in(), CloudFormationForceCacheRefreshTask.CachedResponse.class);
+      return cachedResponse.getCachedResponseStacks().getStacks().stream().findFirst();
+    } catch (IOException e) {
+      throw new IllegalStateException("Malformed response from clouddriver" + e.getMessage(), e);
+    }
+  }
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class StageData {
+    Set<CloudFormationForceCacheRefreshTask.ScopedStack> deployedStacks = new HashSet<>();
+
+    @JsonProperty("refreshed.scopedStacks")
+    Set<CloudFormationForceCacheRefreshTask.ScopedStack> refreshedStacks = new HashSet<>();
+
+    @JsonProperty("processed.scopedStacks")
+    Set<CloudFormationForceCacheRefreshTask.ScopedStack> processedStacks = new HashSet<>();
+
+    Set<String> errors = new HashSet<>();
+
+    void reset() {
+      deployedStacks = Collections.emptySet();
+      refreshedStacks = Collections.emptySet();
+      processedStacks = Collections.emptySet();
+    }
+  }
+
+  @Value
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class PendingScopedStack {
+    @JsonProperty("details")
+    ScopedStack scopedStack;
+
+    Long processedTime;
+    Long cacheTime;
+    Long processedCount;
+
+    PendingScopedStack(
+        @JsonProperty("processedTime") Long processedTime,
+        @JsonProperty("cacheTime") Long cacheTime,
+        @JsonProperty("processedCount") Long processedCount,
+        @JsonProperty("details") ScopedStack scopedStack) {
+      this.cacheTime = cacheTime;
+      this.processedCount = processedCount;
+      this.scopedStack = scopedStack;
+      this.processedTime = processedTime;
+    }
+  }
+
+  @Data
+  private static class CloudDriverScopedStack {
+    final String credentials;
+    final String stackName;
+    final List<String> region;
+
+    CloudDriverScopedStack(ScopedStack scopedStack) {
+      this.credentials = scopedStack.credentials;
+      this.region = Arrays.asList(scopedStack.region);
+      this.stackName = scopedStack.stackName;
+    }
+  }
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class ScopedStack {
+    final String credentials;
+    final String stackName;
+    final String region;
+    String fullStackName;
+
+    ScopedStack(
+        @JsonProperty("account") String credentials,
+        @JsonProperty("region") String region,
+        @JsonProperty("id") String stackName) {
+      this.credentials = credentials;
+      this.region = region;
+      this.stackName = stackName;
+      this.fullStackName = new String();
+    }
+  }
+
+  @Value
+  private static class CachedResponse {
+    final CachedResponseStacks cachedResponseStacks;
+
+    CachedResponse(
+        @JsonProperty("cachedIdentifiersByType") CachedResponseStacks cachedReponseStacks) {
+      this.cachedResponseStacks = cachedReponseStacks;
+    }
+  }
+
+  @Value
+  private static class CachedResponseStacks {
+    List<String> stacks;
+
+    CachedResponseStacks(@JsonProperty("stacks") List<String> stacks) {
+      this.stacks = stacks;
+    }
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/CloudFormationForceCacheRefreshTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/CloudFormationForceCacheRefreshTaskSpec.groovy
@@ -16,54 +16,147 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.cloudformation
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheStatusService
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
+import retrofit.client.Response
+import retrofit.mime.TypedString
 import spock.lang.Specification
 import spock.lang.Subject
-import spock.lang.Unroll
-
+import static java.net.HttpURLConnection.HTTP_ACCEPTED
+import static java.net.HttpURLConnection.HTTP_OK
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+import java.time.Instant
 
 class CloudFormationForceCacheRefreshTaskSpec extends Specification {
-  @Subject task = new CloudFormationForceCacheRefreshTask()
+  static final String CREDENTIALS = "aws-account"
+  static final List<String> REGIONS = ["eu-west-1"]
+  static final String PROVIDER = "aws"
+  static final String REFRESH_TYPE = "CloudFormation"
+  static final String STACK_NAME = "StackName"
 
-  void "should force cache refresh cloud formations via mort"() {
+  def defaultContext = [
+      credentials: CREDENTIALS,
+      regions: REGIONS,
+      stackName: STACK_NAME
+  ]
+  def refreshDetails = [
+      credentials: CREDENTIALS,
+      region:  REGIONS,
+      stackName: STACK_NAME
+  ]
+  def cacheService = Mock(CloudDriverCacheService)
+  def cacheStatusService = Mock(CloudDriverCacheStatusService)
+  def objectMapper = new ObjectMapper()
+  def registry = new DefaultRegistry()
+  def now = Instant.now()
+
+  @Subject task = new CloudFormationForceCacheRefreshTask(registry, cacheService, cacheStatusService, objectMapper)
+
+  void "returns RUNNING when the refresh request is accepted but not processed"() {
     given:
-    def stage = stage()
-    task.cacheService = Mock(CloudDriverCacheService)
+    def stage = mockStage(defaultContext)
 
     when:
-    task.execute(stage)
+    def taskResult = task.execute(stage)
 
     then:
-    1 * task.cacheService.forceCacheUpdate('aws', CloudFormationForceCacheRefreshTask.REFRESH_TYPE, Collections.emptyMap())
+    1 * cacheService.forceCacheUpdate(PROVIDER, CloudFormationForceCacheRefreshTask.REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    0 * cacheService._
+    taskResult.getStatus() == ExecutionStatus.RUNNING
   }
 
-  @Unroll
-  void "should add scoping data if available"() {
-    given:      
-    task.cacheService = Mock(CloudDriverCacheService)
-    
-    and:
-    def stage = stage()
-    stage.context.put("credentials", credentials)
-    stage.context.put("regions", regions)
-    stage.context.put("stackName", stackName)
+  void "returns SUCCEED when the request is immediately processed"() {
+    given:
+    def stage = mockStage(defaultContext)
 
     when:
-    task.execute(stage)
+    def taskResult = task.execute(stage)
 
     then:
-    1 * task.cacheService.forceCacheUpdate('aws', CloudFormationForceCacheRefreshTask.REFRESH_TYPE, expectedData)
+    1 * cacheService.forceCacheUpdate(PROVIDER, CloudFormationForceCacheRefreshTask.REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_OK)
+    0 * cacheService._
+    taskResult.getStatus() == ExecutionStatus.SUCCEEDED
+  }
 
-    where:
-    credentials   | regions       | stackName    || expectedData
-    null          | null          | null         || [:]
-    "credentials" | null          | null         || [credentials: "credentials"]
-    null          | ["eu-west-1"] | null         || [region: ["eu-west-1"]]
-    "credentials" | ["eu-west-1"] | null         || [credentials: "credentials", region: ["eu-west-1"]]
-    null          | null          | "stackName"  || [stackName: "stackName"]
-    "credentials" | ["eu-west-1"] | "stackName"  || [credentials: "credentials", region: ["eu-west-1"], stackName: "stackName"]
+  void "waits for a pending refresh"(){
+    given:
+    def stage = mockStage(defaultContext)
+    def context = defaultContext
+
+    when:
+    def taskResult = task.execute(stage)
+
+    then:
+    1 * cacheService.forceCacheUpdate(PROVIDER, REFRESH_TYPE, refreshDetails) >> mockResponse(HTTP_ACCEPTED)
+    0 * cacheService._
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.getContext()
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [pendingRefresh(refreshDetails)]
+    0 * cacheService._
+    taskResult.getStatus() == ExecutionStatus.RUNNING
+
+    when:
+    context << taskResult.context
+    stage = mockStage(context)
+    taskResult = task.execute(stage)
+
+    then:
+    1 * cacheStatusService.pendingForceCacheUpdates(PROVIDER, REFRESH_TYPE) >> [processedRefresh(refreshDetails)]
+    0 * cacheService._
+    taskResult.getStatus() == ExecutionStatus.SUCCEEDED
+  }
+
+  private StageExecutionImpl mockStage(Object context) {
+    def stage = stage()
+    stage.setContext(context)
+    stage.setStartTime(now.toEpochMilli())
+    return stage
+  }
+
+  private Response mockResponse(int status ) {
+    def oortResponse
+    if (status == HTTP_ACCEPTED) {
+      oortResponse = "{\"cachedIdentifiersByType\" : {\"stacks\" : [ \"aws:stacks:delivery-dev:eu-west-1:arn:aws:cloudformation:eu-west-1:549172523946:stack/StackName/676a9750-3baa-11eb-80fb-061510aab3dd\" ] } }".stripIndent()
+      return new Response('', status, 'OK', [], new TypedString(oortResponse))
+    } else {
+      return new Response( "", status, "", [], null)
+    }
+  }
 
 
+  private Map pendingRefresh(Map refreshDetails) {
+    return [
+        details: [
+            account:  CREDENTIALS,
+            id: STACK_NAME,
+            region: "eu-west-1"
+            ],
+        processedCount: 0,
+        processedTime: -1,
+        cacheTime: now.plusMillis(10).toEpochMilli()
+    ]
+  }
+
+  private Map processedRefresh(Map refreshDetails) {
+    return [
+        details       : [
+            account: CREDENTIALS,
+            id: STACK_NAME,
+            region: "eu-west-1"
+        ] ,
+        processedCount: 1,
+        processedTime : now.plusMillis(5000).toEpochMilli(),
+        cacheTime     : now.plusMillis(10).toEpochMilli()
+    ]
   }
 }


### PR DESCRIPTION
Add onDemand cache polling logic for cloud formation stacks.

Right now orca asks for the cache refresh and finishes the task.
This is most likely the cause of this issue:
https://github.com/spinnaker/spinnaker/issues/6125

This enables orca to start polling for the status of the force cache refresh
when the status received from clouddriver indicates that the force cache
the operation did not finish and has been queued.

This PR is complemented with https://github.com/spinnaker/clouddriver/pull/5276 
which add the OnDemand cache logic on the clouddriver side
