### PR TITLE
fix(webhook): fix NPE in webhook config

### DIFF
--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStage.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStage.java
@@ -85,7 +85,7 @@ public class WebhookStage implements StageDefinitionBuilder {
     public Object payload;
     public Map<String, Object> customHeaders;
     public List<Integer> failFastStatusCodes;
-    public Boolean waitForCompletion;
+    public boolean waitForCompletion;
     public WebhookProperties.StatusUrlResolution statusUrlResolution;
     public String statusUrlJsonPath;
     public boolean monitorOnly;

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/tasks/WebhookResponseProcessor.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/tasks/WebhookResponseProcessor.java
@@ -174,7 +174,7 @@ public class WebhookResponseProcessor {
     if (status.is2xxSuccessful() || status.is3xxRedirection()) {
 
       // Retrieve status check url
-      if (stageData.waitForCompletion != null && stageData.waitForCompletion) {
+      if (stageData.waitForCompletion) {
         String statusUrl;
         try {
           statusUrl = new WebhookStatusCheckUrlRetriever().getStatusCheckUrl(response, stageData);

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStageSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStageSpec.groovy
@@ -104,6 +104,9 @@ class WebhookStageSpec extends Specification {
     data.method == method
     data.cancelMethod == method
 
+    and: 'having no waitForCompletion in the json object should default to waitForCompletion set to false'
+    data.waitForCompletion == false
+
     where:
     methodString | method
     'get'        | HttpMethod.GET


### PR DESCRIPTION
Mapping a webhook config with no `waitForCompletion` in its context results in `stageData.waitForCompletion` being null

Let's default to `false` if the value is absent, which is probably how it was before translating from Groovy to Java.