### PR TITLE
feat(pipeline executions/orca): Add configurable default for skipDown…

### DIFF
--- a/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
+++ b/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java
@@ -34,12 +34,16 @@ import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PipelineStage implements StageDefinitionBuilder, CancellableStage {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
+
+  @Value("${stages.pipeline.defaultSkipDownstreamOutput:false}")
+  private boolean defaultSkipDownstreamOutput;
 
   public static final String PIPELINE_CONFIG_TYPE =
       StageDefinitionBuilder.getType(PipelineStage.class);
@@ -137,7 +141,7 @@ public class PipelineStage implements StageDefinitionBuilder, CancellableStage {
   private boolean shouldSkipDownstreamOutput(StageExecution stage) {
     return stage
         .getContext()
-        .getOrDefault("skipDownstreamOutput", "false")
+        .getOrDefault("skipDownstreamOutput", defaultSkipDownstreamOutput)
         .toString()
         .equals("true");
   }


### PR DESCRIPTION
This PR adds the possibility to set a default value for the `skipDownstreamOutput` introduced in [this](https://github.com/spinnaker/orca/pull/3989) PR.
This way we can control the behaviour globally and decide which one is the exception.
In our case none of the child pipelines uses the output of a previous one.

Issue: https://github.com/spinnaker/spinnaker/issues/6159