### PR TITLE
refactor(auth): refactor auth propagation for pipelines

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
@@ -15,14 +15,14 @@
  */
 package com.netflix.spinnaker.orca.api.pipeline.models;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 
-import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.kork.annotations.Beta;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -161,18 +161,25 @@ public interface PipelineExecution {
     private Collection<String> allowedAccounts = emptySet();
 
     public Collection<String> getAllowedAccounts() {
-      return ImmutableSet.copyOf(allowedAccounts);
+      return allowedAccounts;
     }
 
     public void setAllowedAccounts(Collection<String> allowedAccounts) {
-      this.allowedAccounts = ImmutableSet.copyOf(allowedAccounts);
+      this.allowedAccounts = Set.copyOf(allowedAccounts);
     }
 
-    public AuthenticationDetails() {}
+    public AuthenticationDetails() {
+      this(null, Collections.emptySet());
+    }
 
     public AuthenticationDetails(String user, String... allowedAccounts) {
+      this(user, Set.of(allowedAccounts));
+    }
+
+    public AuthenticationDetails(String user, Collection<String> allowedAccounts) {
       this.user = user;
-      this.allowedAccounts = asList(allowedAccounts);
+      this.allowedAccounts =
+          allowedAccounts == null ? Collections.emptySet() : Set.copyOf(allowedAccounts);
     }
   }
 

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
@@ -17,7 +17,6 @@ package com.netflix.spinnaker.orca.api.pipeline.models;
 
 import static java.util.Collections.emptySet;
 
-import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.kork.annotations.Beta;
 import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner;
 import java.util.*;
@@ -195,11 +194,11 @@ public interface StageExecution {
     @NonNull private Long lastModifiedTime;
 
     public @Nonnull Collection<String> getAllowedAccounts() {
-      return ImmutableSet.copyOf(allowedAccounts);
+      return Set.copyOf(allowedAccounts);
     }
 
     public void setAllowedAccounts(@Nonnull Collection<String> allowedAccounts) {
-      this.allowedAccounts = ImmutableSet.copyOf(allowedAccounts);
+      this.allowedAccounts = Set.copyOf(allowedAccounts);
     }
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/AuthenticatedStage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/AuthenticatedStage.java
@@ -15,8 +15,8 @@
  */
 package com.netflix.spinnaker.orca;
 
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
-import com.netflix.spinnaker.security.User;
 import java.util.Optional;
 
 /**
@@ -28,5 +28,5 @@ import java.util.Optional;
  * module for just the User class?
  */
 public interface AuthenticatedStage {
-  Optional<User> authenticatedUser(StageExecution stage);
+  Optional<PipelineExecution.AuthenticationDetails> authenticatedUser(StageExecution stage);
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/StageExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/StageExpressionFunctionProvider.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.ExecutionContext;
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Predicate;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -53,6 +54,8 @@ public class StageExpressionFunctionProvider implements ExpressionFunctionProvid
                 PipelineExecution.class,
                 "execution",
                 "The execution containing the currently executing stage")),
+        new FunctionDefinition(
+            "currentUser", "Looks up the current authenticated user within the execution context."),
         new FunctionDefinition(
             "stageByRefId",
             "Locates and returns a stage with the given refId",
@@ -104,6 +107,14 @@ public class StageExpressionFunctionProvider implements ExpressionFunctionProvid
         .orElseThrow(
             () ->
                 new SpelHelperFunctionException("No stage found with id '" + currentStageId + "'"));
+  }
+
+  /** @return the current authenticated user in the Execution or anonymous. */
+  @SuppressWarnings("unused")
+  public static String currentUser() {
+    return Optional.ofNullable(ExecutionContext.get())
+        .map(ExecutionContext::getAuthenticatedUser)
+        .orElse("anonymous");
   }
 
   /**
@@ -186,6 +197,7 @@ public class StageExpressionFunctionProvider implements ExpressionFunctionProvid
   }
 
   /** Alias to judgment */
+  @SuppressWarnings("unused")
   public static String judgement(PipelineExecution execution, String id) {
     return judgment(execution, id);
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
@@ -33,7 +33,6 @@ import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.Trigger;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
-import com.netflix.spinnaker.security.User;
 import de.huxhorn.sulky.ulid.ULID;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -434,18 +433,6 @@ public class PipelineExecutionImpl implements PipelineExecution, Serializable {
       }
 
       return Optional.empty();
-    }
-
-    public static Optional<User> toKorkUser(AuthenticationDetails authentication) {
-      return Optional.ofNullable(authentication)
-          .map(AuthenticationDetails::getUser)
-          .map(
-              it -> {
-                User user = new User();
-                user.setEmail(it);
-                user.setAllowedAccounts(authentication.getAllowedAccounts());
-                return user;
-              });
     }
   }
 }

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
@@ -236,7 +236,7 @@ class ManualJudgmentStageSpec extends Specification {
 
     then:
     authenticatedUser.isPresent() == isPresent
-    !isPresent || (authenticatedUser.get().username == "modifiedUser" && authenticatedUser.get().allowedAccounts == ["group1"])
+    !isPresent || (authenticatedUser.get().user == "modifiedUser" && authenticatedUser.get().allowedAccounts.toList() == ["group1"])
 
     where:
     judgmentStatus | propagateAuthenticationContext || isPresent

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingPipelineExecutionListenerSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingPipelineExecutionListenerSpec.groovy
@@ -225,7 +225,7 @@ class EchoNotifyingPipelineExecutionListenerSpec extends Specification {
 
     1 * front50Service.getApplicationNotifications("myapp") >> {
       assert MDC.get(Header.USER.header) == "user@schibsted.com"
-      assert MDC.get(Header.ACCOUNTS.header) == "someAccount,anotherAccount"
+      assert MDC.get(Header.ACCOUNTS.header).split(",").toList().toSorted() == ["anotheraccount", "someaccount"]
       return notifications
     }
     1 * echoService.recordEvent(_)

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.orca.listeners.Persister
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipelinetemplate.V2Util
 import com.netflix.spinnaker.security.AuthenticatedRequest
-import com.netflix.spinnaker.security.User
 import groovy.transform.CompileDynamic
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
@@ -101,11 +100,10 @@ class DependentPipelineExecutionListener implements ExecutionListener {
             trigger.pipeline == execution.pipelineConfigId &&
             trigger.status.contains(status)
           ) {
-            User authenticatedUser = null
+            PipelineExecution.AuthenticationDetails authenticatedUser = null
 
             if (fiatStatus.enabled && trigger.runAsUser) {
-              authenticatedUser = new User()
-              authenticatedUser.setEmail(trigger.runAsUser)
+              authenticatedUser = new PipelineExecution.AuthenticationDetails(trigger.runAsUser)
             }
 
             dependentPipelineStarter.trigger(

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
@@ -39,7 +39,6 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.handler.v2.V2SchemaH
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer
-import com.netflix.spinnaker.security.User
 import org.slf4j.MDC
 import org.springframework.context.ApplicationContext
 import org.springframework.context.support.StaticApplicationContext
@@ -405,10 +404,8 @@ class DependentPipelineStarterSpec extends Specification {
     result.trigger.parameters.a == true
   }
 
-  private static User buildAuthenticatedUser(String email, List<String> allowedAccounts) {
-    def authenticatedUser = new User()
-    authenticatedUser.setEmail(email)
-    authenticatedUser.setAllowedAccounts(allowedAccounts)
+  private static PipelineExecution.AuthenticationDetails buildAuthenticatedUser(String email, List<String> allowedAccounts) {
+    def authenticatedUser = new PipelineExecution.AuthenticationDetails(email, allowedAccounts)
 
     return authenticatedUser
   }

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListenerSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListenerSpec.groovy
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.orca.front50.spring
 
 import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.TaskExecution
 import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.front50.pipeline.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipelinetemplate.V2Util
-import com.netflix.spinnaker.security.User
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -75,7 +75,7 @@ class DependentPipelineExecutionListenerSpec extends Specification {
 
     then:
     1 * dependentPipelineStarter.trigger(_, _, _, _, _, null)
-    1 * dependentPipelineStarter.trigger(_, _, _, _, _, { User user -> user.email == "my_run_as_user" })
+    1 * dependentPipelineStarter.trigger(_, _, _, _, _, { PipelineExecution.AuthenticationDetails user -> user.user == "my_run_as_user" })
 
     where:
     status << [ExecutionStatus.SUCCEEDED, ExecutionStatus.TERMINAL]
@@ -100,7 +100,7 @@ class DependentPipelineExecutionListenerSpec extends Specification {
 
     then:
     2 * dependentPipelineStarter.trigger(_, _, _, _, _, null)
-    1 * dependentPipelineStarter.trigger(_, _, _, _, _, { User user -> user.email == "my_run_as_user" })
+    1 * dependentPipelineStarter.trigger(_, _, _, _, _, { PipelineExecution.AuthenticationDetails user -> user.user == "my_run_as_user" })
 
     where:
     status << [ExecutionStatus.SUCCEEDED, ExecutionStatus.TERMINAL]

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTaskSpec.groovy
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
 import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
-import com.netflix.spinnaker.security.User
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -68,7 +67,7 @@ class StartPipelineTaskSpec extends Specification {
 
     def gotContext
     def parentPipelineStageId
-    User authenticatedUser
+    AuthenticationDetails authenticatedUser
 
     when:
     def result = task.execute(stage)
@@ -100,11 +99,11 @@ class StartPipelineTaskSpec extends Specification {
     ]
     parentPipelineStageId == stage.id
 
-    authenticatedUser?.email == expectedAuthenticatedEmail
+    authenticatedUser?.user == expectedAuthenticatedUsername
     authenticatedUser?.allowedAccounts?.toList() == expectedAuthenticatedAllowedAccounts
 
     where:
-    authentication || expectedAuthenticatedEmail || expectedAuthenticatedAllowedAccounts
+    authentication || expectedAuthenticatedUsername || expectedAuthenticatedAllowedAccounts
     null           || null                       || null
     new AuthenticationDetails(
       "authenticated_user",


### PR DESCRIPTION
Cleans up a bunch of deprecations to enable some further refactors in
kork around auth:
* explicitly use runAs (rather than deprecated propagate with a principal
object) when invoking as a specific user
* refactors away from deprecated kork-security object in favor of
Pipeline.AuthenticationDetails for passing auth
* adds a #currentUser() SpEL expression that will retrieve the user in the
current execution context (for example downstream of a manual judgment
with auth propagation it will return the new user)