### PR TITLE
fix(events): update in-memory execution before firing events

### DIFF
--- a/orca-api-tck/src/main/kotlin/com/netflix/spinnaker/orca/api/test/PipelineBuilder.kt
+++ b/orca-api-tck/src/main/kotlin/com/netflix/spinnaker/orca/api/test/PipelineBuilder.kt
@@ -34,6 +34,7 @@ import java.lang.System.currentTimeMillis
 fun pipeline(init: PipelineExecution.() -> Unit = {}): PipelineExecution {
   val pipeline = PipelineExecutionImpl(PIPELINE, "covfefe")
   pipeline.trigger = DefaultTrigger("manual")
+  pipeline.startTime = currentTimeMillis()
   pipeline.buildTime = currentTimeMillis()
   pipeline.init()
   return pipeline

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
@@ -141,6 +141,8 @@ public interface PipelineExecution {
 
   StageExecution stageByRef(String refId);
 
+  void updateStatus(@Nonnull ExecutionStatus terminal);
+
   class AuthenticationDetails {
 
     private String user;

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
@@ -141,7 +141,10 @@ public interface PipelineExecution {
 
   StageExecution stageByRef(String refId);
 
-  void updateStatus(@Nonnull ExecutionStatus terminal);
+  /**
+   * Based on the value of `status`, will also update synthetic fields like `canceled` and `endTime`
+   */
+  void updateStatus(ExecutionStatus status);
 
   class AuthenticationDetails {
 

--- a/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/PipelineExecutionRepositoryTck.groovy
+++ b/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/PipelineExecutionRepositoryTck.groovy
@@ -428,7 +428,6 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     when:
     repository().cancel(execution.type, execution.id)
 
-
     then:
     with(repository().retrieve(execution.type, execution.id)) {
       canceled

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/DefaultPersister.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/DefaultPersister.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca.listeners;
 
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
@@ -36,11 +35,5 @@ public class DefaultPersister implements Persister {
   @Override
   public boolean isCanceled(ExecutionType type, String executionId) {
     return executionRepository.isCanceled(type, executionId);
-  }
-
-  @Override
-  public void updateStatus(
-      ExecutionType type, String executionId, ExecutionStatus executionStatus) {
-    executionRepository.updateStatus(type, executionId, executionStatus);
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/Persister.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/Persister.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.orca.listeners;
 
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 
@@ -24,6 +23,4 @@ public interface Persister {
   void save(StageExecution stage);
 
   boolean isCanceled(ExecutionType type, String executionId);
-
-  void updateStatus(ExecutionType type, String executionId, ExecutionStatus executionStatus);
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -191,7 +191,7 @@ public class ExecutionLauncher {
       log.error("Failed to start {} {}", execution.getType(), execution.getId(), failure);
     }
     execution.updateStatus(TERMINAL);
-    executionRepository.updateStatus(execution, TERMINAL);
+    executionRepository.updateStatus(execution);
     executionRepository.cancel(execution.getType(), execution.getId(), canceledBy, reason);
     return executionRepository.retrieve(execution.getType(), execution.getId());
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.pipeline;
 
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.TERMINAL;
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPELINE;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
@@ -26,7 +27,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.kork.exceptions.UserException;
 import com.netflix.spinnaker.kork.web.exceptions.ValidationException;
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.Trigger;
@@ -161,7 +161,6 @@ public class ExecutionLauncher {
   private PipelineExecution handleStartupFailure(PipelineExecution execution, Throwable failure) {
     final String canceledBy = "system";
     String reason = "Failed on startup: " + failure.getMessage();
-    final ExecutionStatus status = ExecutionStatus.TERMINAL;
 
     if (failure instanceof ValidationException) {
       ValidationException validationException = (ValidationException) failure;
@@ -191,7 +190,8 @@ public class ExecutionLauncher {
     } else {
       log.error("Failed to start {} {}", execution.getType(), execution.getId(), failure);
     }
-    executionRepository.updateStatus(execution.getType(), execution.getId(), status);
+    execution.updateStatus(TERMINAL);
+    executionRepository.updateStatus(execution, TERMINAL);
     executionRepository.cancel(execution.getType(), execution.getId(), canceledBy, reason);
     return executionRepository.retrieve(execution.getType(), execution.getId());
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
@@ -17,8 +17,10 @@
 package com.netflix.spinnaker.orca.pipeline.model;
 
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.NOT_STARTED;
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.RUNNING;
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.ORCHESTRATION;
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPELINE;
+import static java.lang.System.currentTimeMillis;
 import static java.util.stream.Collectors.toMap;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -235,6 +237,17 @@ public class PipelineExecutionImpl implements PipelineExecution, Serializable {
 
   public void setStatus(@Nonnull ExecutionStatus status) {
     this.status = status;
+  }
+
+  @Override
+  public void updateStatus(@Nonnull ExecutionStatus status) {
+    this.status = status;
+    if (status == RUNNING) {
+      canceled = false;
+      startTime = currentTimeMillis();
+    } else if (status.isComplete() && startTime != null) {
+      endTime = currentTimeMillis();
+    }
   }
 
   private AuthenticationDetails authentication;

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -61,6 +61,10 @@ public interface ExecutionRepository {
 
   boolean isCanceled(ExecutionType type, @Nonnull String id);
 
+  default void updateStatus(@Nonnull PipelineExecution execution, @Nonnull ExecutionStatus status) {
+    updateStatus(execution.getType(), execution.getId(), status);
+  }
+
   void updateStatus(ExecutionType type, @Nonnull String id, @Nonnull ExecutionStatus status);
 
   @Nonnull

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -61,8 +61,8 @@ public interface ExecutionRepository {
 
   boolean isCanceled(ExecutionType type, @Nonnull String id);
 
-  default void updateStatus(@Nonnull PipelineExecution execution, @Nonnull ExecutionStatus status) {
-    updateStatus(execution.getType(), execution.getId(), status);
+  default void updateStatus(@Nonnull PipelineExecution execution) {
+    updateStatus(execution.getType(), execution.getId(), execution.getStatus());
   }
 
   void updateStatus(ExecutionType type, @Nonnull String id, @Nonnull ExecutionStatus status);

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionPromoter.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionPromoter.kt
@@ -79,7 +79,8 @@ class DefaultExecutionPromoter(
         .also { result ->
           result.candidates.forEach {
             log.info("Promoting execution {} for work: {}", value("executionId", it.id), result.reason)
-            executionRepository.updateStatus(it.type, it.id, NOT_STARTED)
+            it.updateStatus(NOT_STARTED)
+            executionRepository.updateStatus(it, NOT_STARTED)
             executionLauncher.start(it)
           }
           registry.counter(promotedId).increment(result.candidates.size.toLong())

--- a/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionPromoter.kt
+++ b/orca-qos/src/main/kotlin/com/netflix/spinnaker/orca/qos/ExecutionPromoter.kt
@@ -80,7 +80,7 @@ class DefaultExecutionPromoter(
           result.candidates.forEach {
             log.info("Promoting execution {} for work: {}", value("executionId", it.id), result.reason)
             it.updateStatus(NOT_STARTED)
-            executionRepository.updateStatus(it, NOT_STARTED)
+            executionRepository.updateStatus(it)
             executionLauncher.start(it)
           }
           registry.counter(promotedId).increment(result.candidates.size.toLong())

--- a/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/DefaultExecutionPromoterTest.kt
+++ b/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/DefaultExecutionPromoterTest.kt
@@ -74,8 +74,8 @@ class DefaultExecutionPromoterTest : SubjectSpek<DefaultExecutionPromoter>({
         subject.tick()
 
         it("promotes all policy-selected candidate executions via status update") {
-          verify(executionRepository).updateStatus(execution1.type, execution1.id, ExecutionStatus.NOT_STARTED)
-          verify(executionRepository).updateStatus(execution2.type, execution2.id, ExecutionStatus.NOT_STARTED)
+          verify(executionRepository).updateStatus(execution1, ExecutionStatus.NOT_STARTED)
+          verify(executionRepository).updateStatus(execution2, ExecutionStatus.NOT_STARTED)
         }
 
         it("starts the executions immediately") {

--- a/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/DefaultExecutionPromoterTest.kt
+++ b/orca-qos/src/test/kotlin/com/netflix/spinnaker/orca/qos/DefaultExecutionPromoterTest.kt
@@ -16,7 +16,7 @@
 package com.netflix.spinnaker.orca.qos
 
 import com.netflix.spectator.api.NoopRegistry
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.NOT_STARTED
 import com.netflix.spinnaker.orca.api.test.pipeline
 import com.netflix.spinnaker.orca.notifications.AlwaysUnlockedNotificationClusterLock
 import com.netflix.spinnaker.orca.pipeline.ExecutionLauncher
@@ -28,6 +28,7 @@ import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
@@ -74,8 +75,10 @@ class DefaultExecutionPromoterTest : SubjectSpek<DefaultExecutionPromoter>({
         subject.tick()
 
         it("promotes all policy-selected candidate executions via status update") {
-          verify(executionRepository).updateStatus(execution1, ExecutionStatus.NOT_STARTED)
-          verify(executionRepository).updateStatus(execution2, ExecutionStatus.NOT_STARTED)
+          assertThat(execution1.status).isEqualTo(NOT_STARTED)
+          assertThat(execution2.status).isEqualTo(NOT_STARTED)
+          verify(executionRepository).updateStatus(execution1)
+          verify(executionRepository).updateStatus(execution2)
         }
 
         it("starts the executions immediately") {

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
@@ -62,8 +62,8 @@ class CompleteExecutionHandler(
         log.info("Execution ${execution.id} already completed with ${execution.status} status")
       } else {
         message.determineFinalStatus(execution) { status ->
-          repository.updateStatus(execution.type, message.executionId, status)
-          execution.status = status
+          execution.updateStatus(status)
+          repository.updateStatus(execution, status)
           publisher.publishEvent(ExecutionComplete(this, execution))
 
           registry.counter(

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
@@ -63,7 +63,7 @@ class CompleteExecutionHandler(
       } else {
         message.determineFinalStatus(execution) { status ->
           execution.updateStatus(status)
-          repository.updateStatus(execution, status)
+          repository.updateStatus(execution)
           publisher.publishEvent(ExecutionComplete(this, execution))
 
           registry.counter(

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
@@ -61,7 +61,7 @@ class RestartStageHandler(
           topStage.reset()
           restartParentPipelineIfNeeded(message, topStage)
           topStage.execution.updateStatus(RUNNING)
-          repository.updateStatus(topStage.execution, RUNNING)
+          repository.updateStatus(topStage.execution)
           queue.push(StartStage(startMessage))
         }
       }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandler.kt
@@ -60,7 +60,8 @@ class RestartStageHandler(
           topStage.addRestartDetails(message.user)
           topStage.reset()
           restartParentPipelineIfNeeded(message, topStage)
-          repository.updateStatus(topStage.execution.type, topStage.execution.id, RUNNING)
+          topStage.execution.updateStatus(RUNNING)
+          repository.updateStatus(topStage.execution, RUNNING)
           queue.push(StartStage(startMessage))
         }
       }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandler.kt
@@ -92,11 +92,11 @@ class StartExecutionHandler(
       if (initialStages.isEmpty()) {
         log.warn("No initial stages found (executionId: ${execution.id})")
         execution.updateStatus(TERMINAL)
-        repository.updateStatus(execution, TERMINAL)
+        repository.updateStatus(execution)
         publisher.publishEvent(ExecutionComplete(this, execution))
       } else {
         execution.updateStatus(RUNNING)
-        repository.updateStatus(execution, RUNNING)
+        repository.updateStatus(execution)
         initialStages.forEach { queue.push(StartStage(it)) }
         publisher.publishEvent(ExecutionStarted(this, execution))
       }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandler.kt
@@ -91,12 +91,12 @@ class StartExecutionHandler(
       val initialStages = execution.initialStages()
       if (initialStages.isEmpty()) {
         log.warn("No initial stages found (executionId: ${execution.id})")
-        execution.status = TERMINAL
-        repository.updateStatus(execution.type, execution.id, TERMINAL)
+        execution.updateStatus(TERMINAL)
+        repository.updateStatus(execution, TERMINAL)
         publisher.publishEvent(ExecutionComplete(this, execution))
       } else {
-        execution.status = RUNNING
-        repository.updateStatus(execution.type, execution.id, RUNNING)
+        execution.updateStatus(RUNNING)
+        repository.updateStatus(execution, RUNNING)
         initialStages.forEach { queue.push(StartStage(it)) }
         publisher.publishEvent(ExecutionStarted(this, execution))
       }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandlerTest.kt
@@ -91,7 +91,8 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
       }
 
       it("updates the execution") {
-        verify(repository).updateStatus(pipeline, stageStatus)
+        assertThat(pipeline.status).isEqualTo(stageStatus)
+        verify(repository).updateStatus(pipeline)
       }
 
       it("publishes an event") {
@@ -167,7 +168,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
 
       it("waits for the other branch(es)") {
         verify(repository, never()).updateStatus(eq(PIPELINE), eq(pipeline.id), any())
-        verify(repository, never()).updateStatus(any(), any())
+        verify(repository, never()).updateStatus(any())
       }
 
       it("does not publish any events") {
@@ -210,7 +211,8 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
       }
 
       it("updates the pipeline status") {
-        verify(repository).updateStatus(pipeline, stageStatus)
+        assertThat(pipeline.status).isEqualTo(stageStatus)
+        verify(repository).updateStatus(pipeline)
       }
 
       it("publishes an event") {
@@ -261,7 +263,8 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
     }
 
     it("updates the execution") {
-      verify(repository).updateStatus(pipeline, TERMINAL)
+      assertThat(pipeline.status).isEqualTo(TERMINAL)
+      verify(repository).updateStatus(pipeline)
     }
 
     it("publishes an event") {
@@ -309,7 +312,8 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
     }
 
     it("updates the execution") {
-      verify(repository).updateStatus(pipeline, SUCCEEDED)
+      assertThat(pipeline.status).isEqualTo(SUCCEEDED)
+      verify(repository).updateStatus(pipeline)
     }
 
     it("publishes an event") {
@@ -364,7 +368,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
 
     it("does not complete the execution") {
       verify(repository, never()).updateStatus(eq(PIPELINE), any(), any())
-      verify(repository, never()).updateStatus(any(), any())
+      verify(repository, never()).updateStatus(any())
     }
 
     it("publishes no events") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandlerTest.kt
@@ -91,7 +91,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
       }
 
       it("updates the execution") {
-        verify(repository).updateStatus(message.executionType, message.executionId, stageStatus)
+        verify(repository).updateStatus(pipeline, stageStatus)
       }
 
       it("publishes an event") {
@@ -100,6 +100,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
             assertThat(it.executionType).isEqualTo(pipeline.type)
             assertThat(it.executionId).isEqualTo(pipeline.id)
             assertThat(it.status).isEqualTo(stageStatus)
+            assertThat(it.execution.endTime).isNotNull()
           }
         )
       }
@@ -166,6 +167,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
 
       it("waits for the other branch(es)") {
         verify(repository, never()).updateStatus(eq(PIPELINE), eq(pipeline.id), any())
+        verify(repository, never()).updateStatus(any(), any())
       }
 
       it("does not publish any events") {
@@ -208,7 +210,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
       }
 
       it("updates the pipeline status") {
-        verify(repository).updateStatus(PIPELINE, pipeline.id, stageStatus)
+        verify(repository).updateStatus(pipeline, stageStatus)
       }
 
       it("publishes an event") {
@@ -259,7 +261,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
     }
 
     it("updates the execution") {
-      verify(repository).updateStatus(PIPELINE, message.executionId, TERMINAL)
+      verify(repository).updateStatus(pipeline, TERMINAL)
     }
 
     it("publishes an event") {
@@ -307,7 +309,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
     }
 
     it("updates the execution") {
-      verify(repository).updateStatus(PIPELINE, message.executionId, SUCCEEDED)
+      verify(repository).updateStatus(pipeline, SUCCEEDED)
     }
 
     it("publishes an event") {
@@ -362,6 +364,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
 
     it("does not complete the execution") {
       verify(repository, never()).updateStatus(eq(PIPELINE), any(), any())
+      verify(repository, never()).updateStatus(any(), any())
     }
 
     it("publishes no events") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
@@ -250,7 +250,8 @@ object RestartStageHandlerTest : SubjectSpek<RestartStageHandler>({
       }
 
       it("marks the execution as running") {
-        verify(repository).updateStatus(pipeline, RUNNING)
+        assertThat(pipeline.status).isEqualTo(RUNNING)
+        verify(repository).updateStatus(pipeline)
       }
 
       it("runs the stage") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RestartStageHandlerTest.kt
@@ -250,7 +250,7 @@ object RestartStageHandlerTest : SubjectSpek<RestartStageHandler>({
       }
 
       it("marks the execution as running") {
-        verify(repository).updateStatus(PIPELINE, pipeline.id, RUNNING)
+        verify(repository).updateStatus(pipeline, RUNNING)
       }
 
       it("runs the stage") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
@@ -93,7 +93,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
       }
 
       it("marks the execution as running") {
-        verify(repository).updateStatus(PIPELINE, message.executionId, RUNNING)
+        verify(repository).updateStatus(pipeline, RUNNING)
       }
 
       it("starts the first stage") {
@@ -105,6 +105,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
           check<ExecutionStarted> {
             assertThat(it.executionType).isEqualTo(message.executionType)
             assertThat(it.executionId).isEqualTo(message.executionId)
+            assertThat(it.execution.startTime).isNotNull()
           }
         )
       }
@@ -262,7 +263,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
       }
 
       it("marks the execution as TERMINAL") {
-        verify(repository, times(1)).updateStatus(PIPELINE, pipeline.id, TERMINAL)
+        verify(repository, times(1)).updateStatus(pipeline, TERMINAL)
       }
 
       it("publishes an event with TERMINAL status") {
@@ -347,7 +348,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         }
 
         it("does not start the new pipeline") {
-          verify(repository, never()).updateStatus(PIPELINE, message.executionId, RUNNING)
+          verify(repository, never()).updateStatus(pipeline, RUNNING)
           verify(queue, never()).push(isA<StartStage>())
         }
 
@@ -381,7 +382,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         }
 
         it("starts the new pipeline") {
-          verify(repository).updateStatus(PIPELINE, message.executionId, RUNNING)
+          verify(repository).updateStatus(pipeline, RUNNING)
           verify(queue).push(isA<StartStage>())
         }
       }
@@ -408,7 +409,7 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         }
 
         it("starts the new pipeline") {
-          verify(repository).updateStatus(PIPELINE, message.executionId, RUNNING)
+          verify(repository).updateStatus(pipeline, RUNNING)
           verify(queue).push(isA<StartStage>())
         }
       }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
@@ -93,7 +93,8 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
       }
 
       it("marks the execution as running") {
-        verify(repository).updateStatus(pipeline, RUNNING)
+        assertThat(pipeline.status).isEqualTo(RUNNING)
+        verify(repository).updateStatus(pipeline)
       }
 
       it("starts the first stage") {
@@ -263,7 +264,8 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
       }
 
       it("marks the execution as TERMINAL") {
-        verify(repository, times(1)).updateStatus(pipeline, TERMINAL)
+        assertThat(pipeline.status).isEqualTo(TERMINAL)
+        verify(repository, times(1)).updateStatus(pipeline)
       }
 
       it("publishes an event with TERMINAL status") {
@@ -348,7 +350,8 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         }
 
         it("does not start the new pipeline") {
-          verify(repository, never()).updateStatus(pipeline, RUNNING)
+          assertThat(pipeline.status).isNotEqualTo(RUNNING)
+          verify(repository, never()).updateStatus(pipeline)
           verify(queue, never()).push(isA<StartStage>())
         }
 
@@ -382,7 +385,8 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         }
 
         it("starts the new pipeline") {
-          verify(repository).updateStatus(pipeline, RUNNING)
+          assertThat(pipeline.status).isEqualTo(RUNNING)
+          verify(repository).updateStatus(pipeline)
           verify(queue).push(isA<StartStage>())
         }
       }
@@ -409,7 +413,8 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         }
 
         it("starts the new pipeline") {
-          verify(repository).updateStatus(pipeline, RUNNING)
+          assertThat(pipeline.status).isEqualTo(RUNNING)
+          verify(repository).updateStatus(pipeline)
           verify(queue).push(isA<StartStage>())
         }
       }

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -260,12 +260,7 @@ class SqlExecutionRepository(
     }
   }
 
-  override fun updateStatus(execution: PipelineExecution, status: ExecutionStatus) {
-    if (execution.status != status) {
-      throw SystemException("execution ${execution.id} with status ${execution.status} " +
-        "has not been updated with new status ${status}")
-    }
-
+  override fun updateStatus(execution: PipelineExecution) {
     withPool(poolName) {
       jooq.transactional {
         storeExecutionInternal(it, execution)
@@ -279,7 +274,7 @@ class SqlExecutionRepository(
         selectExecution(it, type, id)
           ?.let { execution ->
             execution.updateStatus(status)
-            updateStatus(execution, status)
+            updateStatus(execution)
           }
       }
     }


### PR DESCRIPTION
This fixes a regression introduced in f04f16ceac67580b4d0629c08361f885867ace4d, which caused e.g. trigger.parentExecution.endTime to be missing from child pipelines.

Before:
- a handler invoked executionRepository.updateStatus(type, id, status)
- `executionRepository` would add fields like `endTime`, `canceled` and persist them
- (before f04f16ceac67580b4d0629c08361f885867ace4d) the application events would load the execution from the db and fire the echo event
- (after f04f16ceac67580b4d0629c08361f885867ace4d) the application events would fire the echo event based on the in-memory execution, which was not updated with fields like `endTime` or `canceled`

After this change:
- handlers have to invoke execution.updateStatus(newStatus) to update the in-memory execution
- handlers then invoke executionRepository.updateStatus(execution, status) to persist the in-memory execution
- we fire echo events based on the in-memory execution, which has been updated with the required fields
