### PR TITLE
perf(web): Avoid copying `stage.context` into `orchestration.variables`

### DIFF
--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -717,25 +717,12 @@ class TaskController {
   }
 
   private OrchestrationViewModel convert(PipelineExecution orchestration) {
-    def variables = [:]
-    for (stage in orchestration.stages) {
-      for (entry in stage.context.entrySet()) {
-        if (shouldReplace(entry, variables)) {
-          variables[entry.key] = entry.value
-        }
-      }
-    }
     new OrchestrationViewModel(
       id: orchestration.id,
       name: orchestration.description,
       application: orchestration.application,
       status: orchestration.getStatus(),
-      variables: variables.collect { key, value ->
-        [
-          "key"  : key,
-          "value": value
-        ]
-      },
+      variables: [:],
       steps: orchestration.stages.tasks.flatten(),
       buildTime: orchestration.buildTime,
       startTime: orchestration.startTime,


### PR DESCRIPTION
This has existed since 2014 yet I cannot reason about the motivation. It
does however significantly increase serialization time for large executions.

