### PR TITLE
chore(md): make sending git metadata the default behavior

### DIFF
--- a/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
+++ b/orca-keel/src/test/kotlin/com/netflix/spinnaker/orca/keel/ImportDeliveryConfigTaskTests.kt
@@ -293,7 +293,7 @@ internal class ImportDeliveryConfigTaskTests : JUnit5Minutests {
 
       context("parsing git metadata") {
         test("parses correctly") {
-          execute(mutableMapOf("sendGitInfo" to true))
+          execute(mutableMapOf())
           val submittedConfig = slot<DeliveryConfig>()
           verify(exactly = 1) {
             keelService.publishDeliveryConfig(capture(submittedConfig))


### PR DESCRIPTION
This works nicely, promoting it to be the default behavior.