### PR TITLE
feat(api): Add OperationsRunner interface with KatoOperationsRunner implementation

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/operations/OperationsContext.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/operations/OperationsContext.java
@@ -1,0 +1,30 @@
+package com.netflix.spinnaker.orca.api.operations;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A placeholder for the result of {@link OperationsRunner#run} invocations.
+ *
+ * <p>For example, this may be a completed operation, or perhaps it's the ID of a running operation
+ * - this would depend on the underlying operation that was invoked via the {@link OperationsRunner}
+ * implementation.
+ */
+public interface OperationsContext {
+
+  /**
+   * They operation context key. This may be used to identify the operations context value at a
+   * later point in time.
+   */
+  @Nonnull
+  String contextKey();
+
+  /**
+   * The value of the operations context. May be an ID if the system is tracking the operations
+   * execution asynchronously, or it may be the result value of the operation.
+   */
+  @Nonnull
+  OperationsContextValue contextValue();
+
+  /** Marker interface for {@link OperationsContext#contextValue()} return value. */
+  interface OperationsContextValue {}
+}

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/operations/OperationsInput.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/operations/OperationsInput.java
@@ -1,0 +1,35 @@
+package com.netflix.spinnaker.orca.api.operations;
+
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import java.util.Collection;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class OperationsInput {
+
+  /** The cloud provider (AWS, Kubernetes, Titus, etc) if the operation is a cloud operation. */
+  @Nullable private String cloudProvider;
+
+  /** The operations collection. */
+  @Nonnull private Collection<? extends Map<String, Map>> operations;
+
+  /** The {@link StageExecution} that runs this operation. */
+  @Nonnull private StageExecution stageExecution;
+
+  /**
+   * The context key is passed to {@link OperationsContext#contextKey()} and used to identify the
+   * corresponding {@link OperationsContext#contextValue()}.
+   */
+  @Nullable private String contextKey;
+
+  public boolean hasCloudProvider() {
+    return this.cloudProvider != null && !this.cloudProvider.isEmpty();
+  }
+}

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/operations/OperationsRunner.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/operations/OperationsRunner.java
@@ -1,0 +1,10 @@
+package com.netflix.spinnaker.orca.api.operations;
+
+import javax.annotation.Nonnull;
+
+/** An operations runner will run one or more operation and return the resulting context. */
+public interface OperationsRunner {
+
+  /** Run one or more operations. */
+  OperationsContext run(@Nonnull OperationsInput operationsInput);
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.groovy
@@ -172,6 +172,7 @@ class CloudDriverConfiguration {
   }
 
   @Bean
+  @ConditionalOnMissingBean(OperationsRunner.class)
   OperationsRunner katoOperationsService(KatoService katoService) {
     return new KatoOperationsRunner(katoService)
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.kork.web.selector.DefaultServiceSelector
 import com.netflix.spinnaker.kork.web.selector.SelectableService
 import com.netflix.spinnaker.kork.web.selector.ServiceSelector
+import com.netflix.spinnaker.orca.api.operations.OperationsRunner
 import com.netflix.spinnaker.orca.clouddriver.*
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.retrofit.RetrofitConfiguration
@@ -168,6 +169,11 @@ class CloudDriverConfiguration {
                           RetrySupport retrySupport,
                           ObjectMapper objectMapper) {
     return new KatoService(katoRestService, cloudDriverTaskStatusService, retrySupport, objectMapper)
+  }
+
+  @Bean
+  OperationsRunner katoOperationsService(KatoService katoService) {
+    return new KatoOperationsRunner(katoService)
   }
 
   @Bean

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.groovy
@@ -173,7 +173,7 @@ class CloudDriverConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(OperationsRunner.class)
-  OperationsRunner katoOperationsService(KatoService katoService) {
+  OperationsRunner katoOperationsRunner(KatoService katoService) {
     return new KatoOperationsRunner(katoService)
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/DeleteScalingPolicyTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/DeleteScalingPolicyTask.groovy
@@ -31,10 +31,10 @@ import javax.annotation.Nonnull
 @Component
 class DeleteScalingPolicyTask extends AbstractCloudProviderAwareTask implements Task {
 
-  private final OperationsRunner operationsService
+  private final OperationsRunner operationsRunner
 
-  DeleteScalingPolicyTask(OperationsRunner operationsService) {
-    this.operationsService = operationsService
+  DeleteScalingPolicyTask(OperationsRunner operationsRunner) {
+    this.operationsRunner = operationsRunner
   }
 
   @Nonnull
@@ -46,7 +46,7 @@ class DeleteScalingPolicyTask extends AbstractCloudProviderAwareTask implements 
       .stageExecution(stage)
       .build()
 
-    OperationsContext operationsContext = operationsService.run(operationsInput)
+    OperationsContext operationsContext = operationsRunner.run(operationsInput)
 
     TaskResult.builder(ExecutionStatus.SUCCEEDED).context(Map.of(
         operationsContext.contextKey(), operationsContext.contextValue(),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/DeleteScalingPolicyTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/DeleteScalingPolicyTask.groovy
@@ -16,13 +16,14 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.scalingpolicy
 
+import com.netflix.spinnaker.orca.api.operations.OperationsContext
+import com.netflix.spinnaker.orca.api.operations.OperationsInput
+import com.netflix.spinnaker.orca.api.operations.OperationsRunner
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
-import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 import javax.annotation.Nonnull
@@ -30,18 +31,27 @@ import javax.annotation.Nonnull
 @Component
 class DeleteScalingPolicyTask extends AbstractCloudProviderAwareTask implements Task {
 
-  @Autowired
-  KatoService kato
+  private final OperationsRunner operationsService
+
+  DeleteScalingPolicyTask(OperationsRunner operationsService) {
+    this.operationsService = operationsService
+  }
 
   @Nonnull
   @Override
   TaskResult execute(@Nonnull StageExecution stage) {
-    def taskId = kato.requestOperations(getCloudProvider(stage), [[deleteScalingPolicy: stage.context]])
+    OperationsInput operationsInput = OperationsInput.builder()
+      .cloudProvider(getCloudProvider(stage))
+      .operations([[deleteScalingPolicy: stage.context]])
+      .stageExecution(stage)
+      .build()
 
-    TaskResult.builder(ExecutionStatus.SUCCEEDED).context([
-        "deploy.account.name" : stage.context.credentials,
-        "kato.last.task.id"   : taskId,
-        "deploy.server.groups": [(stage.context.region): [stage.context.serverGroupName]]
-    ]).build()
+    OperationsContext operationsContext = operationsService.run(operationsInput)
+
+    TaskResult.builder(ExecutionStatus.SUCCEEDED).context(Map.of(
+        operationsContext.contextKey(), operationsContext.contextValue(),
+        "deploy.account.name", stage.context.credentials,
+        "deploy.server.groups", [(stage.context.region): [stage.context.serverGroupName]]
+    )).build()
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/UpsertScalingPolicyTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/UpsertScalingPolicyTask.groovy
@@ -36,10 +36,10 @@ class UpsertScalingPolicyTask extends AbstractCloudProviderAwareTask implements 
   long backoffPeriod = TimeUnit.SECONDS.toMillis(5)
   long timeout = TimeUnit.SECONDS.toMillis(100)
 
-  private final OperationsRunner operationsService
+  private final OperationsRunner operationsRunner
 
-  UpsertScalingPolicyTask(OperationsRunner operationsService) {
-    this.operationsService = operationsService
+  UpsertScalingPolicyTask(OperationsRunner operationsRunner) {
+    this.operationsRunner = operationsRunner
   }
 
   @Override
@@ -51,7 +51,7 @@ class UpsertScalingPolicyTask extends AbstractCloudProviderAwareTask implements 
           .stageExecution(stage)
           .build()
 
-      OperationsContext operationsContext = operationsService.run(operationsInput)
+      OperationsContext operationsContext = operationsRunner.run(operationsInput)
 
       return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(Map.of(
           operationsContext.contextKey(), operationsContext.contextValue(),

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/UpsertScalingPolicyTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/UpsertScalingPolicyTask.groovy
@@ -16,15 +16,16 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.scalingpolicy
 
+import com.netflix.spinnaker.orca.api.operations.OperationsContext
+import com.netflix.spinnaker.orca.api.operations.OperationsInput
+import com.netflix.spinnaker.orca.api.operations.OperationsRunner
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
 import java.util.concurrent.TimeUnit
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
-import com.netflix.spinnaker.orca.clouddriver.KatoService
 import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCloudProviderAwareTask
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import groovy.util.logging.Slf4j
 
@@ -32,22 +33,31 @@ import groovy.util.logging.Slf4j
 @Slf4j
 class UpsertScalingPolicyTask extends AbstractCloudProviderAwareTask implements RetryableTask {
 
-  @Autowired
-  KatoService kato
-
   long backoffPeriod = TimeUnit.SECONDS.toMillis(5)
   long timeout = TimeUnit.SECONDS.toMillis(100)
+
+  private final OperationsRunner operationsService
+
+  UpsertScalingPolicyTask(OperationsRunner operationsService) {
+    this.operationsService = operationsService
+  }
 
   @Override
   TaskResult execute(StageExecution stage) {
     try {
-      def taskId = kato.requestOperations(getCloudProvider(stage), [[upsertScalingPolicy: stage.context]])
+      OperationsInput operationsInput = OperationsInput.builder()
+          .cloudProvider(getCloudProvider(stage))
+          .operations([[upsertScalingPolicy: stage.context]])
+          .stageExecution(stage)
+          .build()
 
-      return TaskResult.builder(ExecutionStatus.SUCCEEDED).context([
-        "deploy.account.name" : stage.context.credentials,
-        "kato.last.task.id"   : taskId,
-        "deploy.server.groups": [(stage.context.region): [stage.context.serverGroupName]]
-      ]).build()
+      OperationsContext operationsContext = operationsService.run(operationsInput)
+
+      return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(Map.of(
+          operationsContext.contextKey(), operationsContext.contextValue(),
+          "deploy.account.name", stage.context.credentials,
+          "deploy.server.groups", [(stage.context.region): [stage.context.serverGroupName]]
+      )).build()
     }
     catch (Exception e) {
       log.error("Failed upsertScalingPolicy task (stageId: ${stage.id}, executionId: ${stage.execution.id})", e)

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/KatoOperationsRunner.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/KatoOperationsRunner.java
@@ -1,0 +1,31 @@
+package com.netflix.spinnaker.orca.clouddriver;
+
+import com.netflix.spinnaker.orca.api.operations.OperationsContext;
+import com.netflix.spinnaker.orca.api.operations.OperationsInput;
+import com.netflix.spinnaker.orca.api.operations.OperationsRunner;
+import com.netflix.spinnaker.orca.clouddriver.model.KatoOperationsContext;
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KatoOperationsRunner implements OperationsRunner {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final KatoService katoService;
+
+  public KatoOperationsRunner(KatoService katoService) {
+    this.katoService = katoService;
+  }
+
+  @Override
+  public OperationsContext run(@Nonnull OperationsInput operationsInput) {
+    TaskId taskId =
+        operationsInput.hasCloudProvider()
+            ? katoService.requestOperations(
+                operationsInput.getCloudProvider(), operationsInput.getOperations())
+            : katoService.requestOperations(operationsInput.getOperations());
+
+    return KatoOperationsContext.from(taskId, operationsInput.getContextKey());
+  }
+}

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/model/KatoOperationsContext.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/model/KatoOperationsContext.java
@@ -1,0 +1,39 @@
+package com.netflix.spinnaker.orca.clouddriver.model;
+
+import com.netflix.spinnaker.orca.api.operations.OperationsContext;
+import javax.annotation.Nonnull;
+
+public class KatoOperationsContext implements OperationsContext {
+
+  private String contextKey;
+  private TaskId contextValue;
+
+  public static KatoOperationsContext from(TaskId taskId, String resultKey) {
+    if (resultKey != null && !resultKey.isEmpty()) {
+      return new KatoOperationsContext(taskId, resultKey);
+    }
+
+    return new KatoOperationsContext(taskId);
+  }
+
+  public KatoOperationsContext(TaskId taskId) {
+    this.contextValue = taskId;
+  }
+
+  public KatoOperationsContext(TaskId taskId, String contextKey) {
+    this.contextValue = taskId;
+    this.contextKey = contextKey;
+  }
+
+  @Nonnull
+  @Override
+  public String contextKey() {
+    return contextKey != null ? contextKey : "kato.last.task.id";
+  }
+
+  @Nonnull
+  @Override
+  public OperationsContextValue contextValue() {
+    return contextValue;
+  }
+}

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/model/TaskId.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/model/TaskId.java
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.orca.clouddriver.model;
 
+import com.netflix.spinnaker.orca.api.operations.OperationsContext.OperationsContextValue;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,6 +9,6 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class TaskId implements Serializable {
+public class TaskId implements Serializable, OperationsContextValue {
   private String id;
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoOperationsRunnerSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoOperationsRunnerSpec.groovy
@@ -1,0 +1,63 @@
+package com.netflix.spinnaker.orca.clouddriver
+
+import com.netflix.spinnaker.orca.api.operations.OperationsContext
+import com.netflix.spinnaker.orca.api.operations.OperationsInput
+import com.netflix.spinnaker.orca.clouddriver.model.KatoOperationsContext
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+
+class KatoOperationsRunnerSpec extends Specification {
+
+  @Unroll
+  def "Runs a kato operation based on operation input"() {
+    given:
+    def taskId = new TaskId(UUID.randomUUID().toString())
+    def katoService = Mock(KatoService)
+    def katoOperationsRunner = new KatoOperationsRunner(katoService)
+    def stage = stage {
+      type = "test"
+      context = ["account.name" : "test"]
+    }
+
+    def operationsInput = OperationsInput.builder()
+      .cloudProvider(cloudProvider)
+      .operations([[:]])
+      .stageExecution(stage)
+      .contextKey(contextKey)
+      .build()
+
+    when:
+    def operationsContextResult = katoOperationsRunner.run(operationsInput)
+
+    then:
+    if (cloudProvider != null) {
+      1 * katoService.requestOperations(operationsInput.cloudProvider, operationsInput.operations) >> { taskId }
+    } else {
+      1 * katoService.requestOperations(operationsInput.operations) >> { taskId }
+    }
+    operationsContextResult.contextKey() == expectedContextKey
+
+    where:
+    cloudProvider | contextKey    || expectedContextKey
+    "aws"         | "example.key" || "example.key"
+    null          | null          || "kato.last.task.id"
+  }
+
+  def "OperationsContext objectMappered to string succeeds"() {
+    given:
+    def mapper = OrcaObjectMapper.newInstance()
+    TaskId taskId = new TaskId(UUID.randomUUID().toString())
+    OperationsContext operationsContext = KatoOperationsContext.from(taskId, "test.key")
+    def context = Map.of(operationsContext.contextKey(), operationsContext.contextValue())
+
+    when:
+    def result = mapper.writeValueAsString(context)
+
+    then:
+    result.contains("test.key")
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/UpsertScalingPolicyTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/scalingpolicy/UpsertScalingPolicyTaskSpec.groovy
@@ -15,7 +15,8 @@
  */
 package com.netflix.spinnaker.orca.clouddriver.tasks.scalingpolicy
 
-import com.netflix.spinnaker.orca.clouddriver.KatoService
+import com.netflix.spinnaker.orca.api.operations.OperationsRunner
+import com.netflix.spinnaker.orca.clouddriver.model.KatoOperationsContext
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
@@ -32,8 +33,8 @@ class UpsertScalingPolicyTaskSpec extends Specification {
   def "should retry task on exception"() {
 
     given:
-    KatoService katoService = Mock(KatoService)
-    def task = new UpsertScalingPolicyTask(kato: katoService)
+    OperationsRunner operationsRunner = Mock(OperationsRunner)
+    def task = new UpsertScalingPolicyTask(operationsRunner)
     def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "upsertScalingPolicy",
       [credentials                : "abc", cloudProvider: "aCloud",
        estimatedInstanceWarmup    : "300",
@@ -46,7 +47,7 @@ class UpsertScalingPolicyTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    1 * katoService.requestOperations(_, _) >> { throw new Exception() }
+    1 * operationsRunner.run(_) >> { throw new Exception() }
     result.status.toString() == "RUNNING"
 
   }
@@ -55,8 +56,8 @@ class UpsertScalingPolicyTaskSpec extends Specification {
   def "should set the task status to SUCCEEDED for successful execution"() {
 
     given:
-    KatoService katoService = Mock(KatoService)
-    def task = new UpsertScalingPolicyTask(kato: katoService)
+    OperationsRunner operationsRunner = Mock(OperationsRunner)
+    def task = new UpsertScalingPolicyTask(operationsRunner)
     def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "upsertScalingPolicy",
       [credentials                : "abc", cloudProvider: "aCloud",
        estimatedInstanceWarmup    : "300",
@@ -69,7 +70,7 @@ class UpsertScalingPolicyTaskSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    1 * katoService.requestOperations(_, _) >> { taskId }
+    1 * operationsRunner.run(_) >> { KatoOperationsContext.from(taskId, null) }
     result.status.toString() == "SUCCEEDED"
   }
 }


### PR DESCRIPTION
Implementations of OperationsRunner can be used to fork operations to different services (besides CloudDriver, for example).

Implemented in `DeleteScalingPolicyStage` and `UpsertScalingPolicyStage` stages, though we'll probably eventually sweep through and replace all instances of `katoService` in these stages with `operationsRunner`.