### PR TITLE
feat(aws/validation): Allow hyphen in aws application name

### DIFF
--- a/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/utils/ApplicationNameValidator.groovy
+++ b/orca-applications/src/main/groovy/com/netflix/spinnaker/orca/applications/utils/ApplicationNameValidator.groovy
@@ -25,7 +25,7 @@ trait ApplicationNameValidator {
   // just validate the characters and name length.
   Map<String, NameConstraint> cloudProviderNameConstraints = [
       'appengine'   : new NameConstraint(58, '^[a-z0-9]*$'),
-      'aws'         : new NameConstraint(250, '^[a-zA-Z_0-9.]*$'),
+      'aws'         : new NameConstraint(250, '^[a-zA-Z_0-9.-]*$'),
       'dcos'        : new NameConstraint(127, '^[a-z0-9]*$'),
       'gce'         : new NameConstraint(63, '^([a-zA-Z][a-zA-Z0-9]*)?$'),
       'kubernetes'  : new NameConstraint(63, '^([a-zA-Z][a-zA-Z0-9-]*)$'),


### PR DESCRIPTION
It's quite common to have hyphen in cloud resource names. This MR allows users to add `aws` cloud provider to the application that contains `hyphen` in the name.

Fixes https://github.com/spinnaker/spinnaker/issues/6375