### PR TITLE
perf(executions): remove ability to launch executions from a json string

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pollers/EphemeralServerGroupsPoller.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pollers/EphemeralServerGroupsPoller.java
@@ -172,10 +172,7 @@ public class EphemeralServerGroupsPoller extends AbstractPollingNotificationAgen
         AuthenticatedRequest.runAs(
                 taskUser,
                 Collections.singletonList(ephemeralServerGroupTag.account),
-                () ->
-                    executionLauncher.start(
-                        ExecutionType.ORCHESTRATION,
-                        objectMapper.writeValueAsString(cleanupOperation)))
+                () -> executionLauncher.start(ExecutionType.ORCHESTRATION, cleanupOperation))
             .call();
 
         // if a server group still exists >= 30 minutes past it's TTL, flag it as stale.

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPoller.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPoller.java
@@ -182,10 +182,7 @@ public class RestorePinnedServerGroupsPoller extends AbstractPollingNotification
         AuthenticatedRequest.runAs(
                 username,
                 allowedAccount,
-                () ->
-                    executionLauncher.start(
-                        ExecutionType.ORCHESTRATION,
-                        objectMapper.writeValueAsString(cleanupOperation)))
+                () -> executionLauncher.start(ExecutionType.ORCHESTRATION, cleanupOperation))
             .call();
 
         triggeredCounter.increment();

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPollerSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pollers/RestorePinnedServerGroupsPollerSpec.groovy
@@ -114,10 +114,8 @@ class RestorePinnedServerGroupsPollerSpec extends Specification {
         )
       )
     }
-    1 * executionLauncher.start(ExecutionType.ORCHESTRATION, { String configJson ->
-      def config = objectMapper.readValue(configJson, Map)
+    1 * executionLauncher.start(ExecutionType.ORCHESTRATION, { Map config ->
       assert config.stages*.type == ["resizeServerGroup", "deleteEntityTags"]
-
       return true
     })
   }
@@ -143,12 +141,9 @@ class RestorePinnedServerGroupsPollerSpec extends Specification {
         )
       )
     }
-    1 * executionLauncher.start(ExecutionType.ORCHESTRATION, { String configJson ->
-      def config = objectMapper.readValue(configJson, Map)
-
+    1 * executionLauncher.start(ExecutionType.ORCHESTRATION, { Map config ->
       // no resize necessary!
       assert config.stages*.type == ["deleteEntityTags"]
-
       return true
     })
   }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineExecutionLauncherSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineExecutionLauncherSpec.groovy
@@ -109,7 +109,7 @@ class PipelineExecutionLauncherSpec extends Specification {
     @Subject def launcher = create()
 
     when:
-    launcher.start(PIPELINE, json)
+    launcher.start(PIPELINE, config)
 
     then:
     1 * applicationEventPublisher.publishEvent(_ as BeforeInitialExecutionPersist)
@@ -117,6 +117,5 @@ class PipelineExecutionLauncherSpec extends Specification {
 
     where:
     config = [id: "whatever", stages: []]
-    json = objectMapper.writeValueAsString(config)
   }
 }

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
@@ -67,12 +67,11 @@ class DependentPipelineStarterSpec extends Specification {
     }
     def gotMDC = [:]
     def executionLauncher = Stub(ExecutionLauncher) {
-      start(*_) >> {
+      start(*_) >> { _, p ->
         gotMDC.putAll([
           "X-SPINNAKER-USER": MDC.get("X-SPINNAKER-USER"),
           "X-SPINNAKER-ACCOUNTS": MDC.get("X-SPINNAKER-ACCOUNTS"),
         ])
-        def p = mapper.readValue(it[1], Map)
         return pipeline {
           name = p.name
           id = p.name
@@ -145,8 +144,7 @@ class DependentPipelineStarterSpec extends Specification {
     )
 
     and:
-    executionLauncher.start(*_) >> {
-      def p = mapper.readValue(it[1], Map)
+    executionLauncher.start(*_) >> { _, p ->
       return pipeline {
         name = p.name
         id = p.name
@@ -201,8 +199,7 @@ class DependentPipelineStarterSpec extends Specification {
     )
 
     and:
-    executionLauncher.start(*_) >> {
-      def p = mapper.readValue(it[1], Map)
+    executionLauncher.start(*_) >> { _, p ->
       return pipeline {
         name = p.name
         id = p.name
@@ -210,7 +207,7 @@ class DependentPipelineStarterSpec extends Specification {
       }
     }
     artifactUtils.getArtifactsForPipelineId(*_) >> {
-      return new ArrayList<Artifact>();
+      return new ArrayList<Artifact>()
     }
 
     when:
@@ -271,8 +268,7 @@ class DependentPipelineStarterSpec extends Specification {
     )
 
     and:
-    executionLauncher.start(*_) >> {
-      def p = mapper.readValue(it[1], Map)
+    executionLauncher.start(*_) >> { _, p ->
       return pipeline {
         name = p.name
         id = p.name
@@ -332,8 +328,7 @@ class DependentPipelineStarterSpec extends Specification {
     )
 
     and:
-    executionLauncher.start(*_) >> {
-      def p = mapper.readValue(it[1], Map)
+    executionLauncher.start(*_) >> { _, p ->
       return pipeline {
         name = p.name
         id = p.name
@@ -383,8 +378,7 @@ class DependentPipelineStarterSpec extends Specification {
     )
 
     and:
-    executionLauncher.start(*_) >> {
-      def p = mapper.readValue(it[1], Map)
+    executionLauncher.start(*_) >> { _, p ->
       return pipeline {
         trigger = mapper.convertValue(p.trigger, Trigger)
       }
@@ -431,8 +425,7 @@ class DependentPipelineStarterSpec extends Specification {
     )
 
     and:
-    executionLauncher.start(*_) >> {
-      def p = mapper.readValue(it[1], Map)
+    executionLauncher.start(*_) >> { _, p ->
       return pipeline {
         trigger = mapper.convertValue(p.trigger, Trigger)
       }
@@ -542,8 +535,7 @@ class DependentPipelineStarterSpec extends Specification {
     )
 
     and:
-    1 * executionLauncher.start(*_) >> {
-      def p = mapper.readValue(it[1], Map)
+    1 * executionLauncher.start(*_) >> { _, p ->
       return pipeline {
         JavaType type = mapper.getTypeFactory().constructCollectionType(List, StageExecution)
         trigger = mapper.convertValue(p.trigger, Trigger)
@@ -675,9 +667,8 @@ class DependentPipelineStarterSpec extends Specification {
 
     and:
     def execution
-    1 * executionLauncher.start(*_) >> {
-      execution = it[0]
-      execution = mapper.readValue(it[1], Map)
+    1 * executionLauncher.start(*_) >> { _, config ->
+      execution = config
       return pipeline {
         JavaType type = mapper.getTypeFactory().constructCollectionType(List, StageExecution)
         trigger = mapper.convertValue(execution.trigger, Trigger)


### PR DESCRIPTION
At a high level, all this does is that it replaces

  ExecutionLauncher.start(ExecutionType type, String configJson)

with

  ExecutionLauncher.start(ExecutionType type, Map<String, Object> config)

In general, the lifecycle of an execution is that it can live as:
- a json string, e.g. when it is submitted to the API
- a Map<String, Object> "config" that needs to be munged and massaged (with things like a user, origin, trigger...)
- a PipelineExecution model when it is fully formed

With this PR, we try to only move "up the chain" (string -> map -> model) and never back down (string -> map -> string -> map -> model).

In practice this means avoiding calls to objectMapper.writeValueAsString() followed by objectMapper.readValue(), which in turns simplifies some tests quite a bit.
