### PR TITLE
feat(run-task-handler): added hook in finally block that will be ran regardless of whether the task completed without exception.

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskExecutionInterceptor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskExecutionInterceptor.java
@@ -50,4 +50,7 @@ public interface TaskExecutionInterceptor {
   default TaskResult afterTaskExecution(Task task, StageExecution stage, TaskResult taskResult) {
     return taskResult;
   }
+
+  default void finallyAfterTaskExecution(
+      Task task, StageExecution stage, TaskResult taskResult, Exception e) {}
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskExecutionInterceptor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/TaskExecutionInterceptor.java
@@ -51,6 +51,18 @@ public interface TaskExecutionInterceptor {
     return taskResult;
   }
 
+  /**
+   * hook that is guaranteed to be called, even when a task throws an exception which will cause
+   * afterTaskExecution to not be called.
+   *
+   * <p>As an example you can clear the security context here if you set it in the
+   * beforeTaskExecution hook.
+   *
+   * @param task The task that is being handled.
+   * @param stage The stage for the task execution.
+   * @param taskResult Will be null if the task failed with an exception.
+   * @param e Will be not null if the task failed with an exception.
+   */
   default void finallyAfterTaskExecution(
       Task task, StageExecution stage, TaskResult taskResult, Exception e) {}
 }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -174,6 +174,7 @@ class RunTaskHandler(
               }
             }
           } catch (e: Exception) {
+            taskException = e;
             val exceptionDetails = exceptionHandlers.shouldRetry(e, taskModel.name)
             if (exceptionDetails?.shouldRetry == true) {
               log.warn("Error running ${message.taskType.simpleName} for ${message.executionType}[${message.executionId}]")
@@ -190,7 +191,6 @@ class RunTaskHandler(
                   log.error("Error running ${message.taskType.simpleName} for ${message.executionType}[${message.executionId}]", e)
                 }
               }
-              taskException = e;
               val status = stage.failureStatus(default = TERMINAL)
               stage.context["exception"] = exceptionDetails
               repository.storeStage(stage)


### PR DESCRIPTION
feat(run-task-handler): added hook in finally block that will be run regardless of whether the task completed without exception.

The existing hook doesn't execute when a task execution throws an exception.
This hook allows for an extension project to clear the security context that is set in the before task hook.