### PR TITLE
refactor(orca-api): move ExecutionPreprocessor and TaskExecutionInterceptor into orca-api

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/ExecutionPreprocessor.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/ExecutionPreprocessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.orca.extensionpoint.pipeline;
+package com.netflix.spinnaker.orca.api.pipeline;
 
+import com.netflix.spinnaker.kork.annotations.Beta;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
-/** A preprocessor that can modify an Execution upon initial receipt of the configuration. */
-public interface ExecutionPreprocessor {
+/**
+ * ExecutionPreprocessor is a hook point that can modify an Execution upon initial receipt of the
+ * configuration.
+ *
+ * <p>A common use case is to inspect and update a pipeline with configured context, such an
+ * application name.
+ */
+@Beta
+public interface ExecutionPreprocessor extends SpinnakerExtensionPoint {
 
   /** Returns whether or not the preprocess can handle the inbound execution. */
   boolean supports(@Nonnull Map<String, Object> execution, @Nonnull Type type);

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/TaskExecutionInterceptor.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/TaskExecutionInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.orca;
+package com.netflix.spinnaker.orca.api.pipeline;
 
-import com.netflix.spinnaker.orca.api.pipeline.Task;
-import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
+import com.netflix.spinnaker.kork.annotations.Beta;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import java.util.concurrent.TimeUnit;
 
@@ -37,16 +37,41 @@ import java.util.concurrent.TimeUnit;
  * longer than the lock extension. The minimum maxTaskBackoff among all registered
  * TaskExecutionInterceptors will be used to constrain the task backoff supplied by a RetryableTask.
  */
-public interface TaskExecutionInterceptor {
+@Beta
+public interface TaskExecutionInterceptor extends SpinnakerExtensionPoint {
 
+  /**
+   * hook that is called to program the collective maximum backoff of all TaskExecutionInterceptors.
+   * A retryable task has a backoff period which is configured by defaults and then constrained by
+   * the minimum backoff configured by all registered interceptors.
+   *
+   * @return long
+   */
   default long maxTaskBackoff() {
     return TimeUnit.MINUTES.toMillis(2);
   }
 
+  /**
+   * hook that is called before a task executes.
+   *
+   * @param task The task that is being handled.
+   * @param stage The stage for the task execution.
+   * @return stage The stage for the task execution.
+   */
   default StageExecution beforeTaskExecution(Task task, StageExecution stage) {
     return stage;
   }
 
+  /**
+   * hook that is called after a task executes successfully.
+   *
+   * <p>As an example you can modify the taskResult here before it gets propagated.
+   *
+   * @param task The task that is being handled.
+   * @param stage The stage for the task execution.
+   * @param taskResult The result of executing the task.
+   * @return taskResult The result of executing the task.
+   */
   default TaskResult afterTaskExecution(Task task, StageExecution stage, TaskResult taskResult) {
     return taskResult;
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/V2Util.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/V2Util.java
@@ -17,9 +17,9 @@
 package com.netflix.spinnaker.orca.pipelinetemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor;
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.exceptions.PipelineTemplateValidationException;
-import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor;
 import com.netflix.spinnaker.orca.pipeline.expressions.PipelineExpressionEvaluator;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
 import java.util.Collections;

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/preprocessors/DefaultApplicationExecutionPreprocessor.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/preprocessors/DefaultApplicationExecutionPreprocessor.kt
@@ -16,7 +16,7 @@
 package com.netflix.spinnaker.orca.preprocessors
 
 import com.netflix.spinnaker.orca.config.DefaultApplicationConfigurationProperties
-import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
+import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor
 import javax.annotation.Nonnull
 import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.kork.exceptions.ConfigurationException
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.Trigger
 import com.netflix.spinnaker.orca.exceptions.PipelineTemplateValidationException
-import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
+import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor
 import com.netflix.spinnaker.orca.pipeline.ExecutionLauncher
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.exceptions.PipelineTemplateValidationException
-import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
+import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor
 import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.listeners.ExecutionListener

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
-import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
+import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor
 import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
@@ -22,7 +22,7 @@ import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
-import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
+import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.ExecutionLauncher
 import com.netflix.spinnaker.orca.pipeline.model.DefaultTrigger

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTaskSpec.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.orca.front50.tasks
 
 
-import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
+import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor
 import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.orca.pipelinetemplate
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
+import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.PipelineMissingTemplateVariabledException
 import com.netflix.spinnaker.orca.pipelinetemplate.handler.DefaultHandlerChain
 import com.netflix.spinnaker.orca.pipelinetemplate.handler.GlobalPipelineTemplateContext

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/PlanTemplateDependentsTask.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/tasks/PlanTemplateDependentsTask.java
@@ -16,11 +16,11 @@
 package com.netflix.spinnaker.orca.pipelinetemplate.tasks;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor;
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
-import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -20,7 +20,7 @@ import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.exceptions.UserException
-import com.netflix.spinnaker.orca.TaskExecutionInterceptor
+import com.netflix.spinnaker.orca.api.pipeline.TaskExecutionInterceptor
 import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.orca.q.handler
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.orca.DefaultStageResolver
-import com.netflix.spinnaker.orca.TaskExecutionInterceptor
+import com.netflix.spinnaker.orca.api.pipeline.TaskExecutionInterceptor
 import com.netflix.spinnaker.orca.TaskResolver
 import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy
@@ -28,7 +28,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.Trigger
 import com.netflix.spinnaker.orca.clouddriver.service.JobService
 import com.netflix.spinnaker.orca.exceptions.OperationFailedException
 import com.netflix.spinnaker.orca.exceptions.PipelineTemplateValidationException
-import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor
+import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.front50.PipelineModelMutator
 import com.netflix.spinnaker.orca.igor.BuildService

--- a/orca-web/src/main/java/com/netflix/spinnaker/orca/controllers/V2PipelineTemplateController.java
+++ b/orca-web/src/main/java/com/netflix/spinnaker/orca/controllers/V2PipelineTemplateController.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.orca.controllers;
 
-import com.netflix.spinnaker.orca.extensionpoint.pipeline.ExecutionPreprocessor;
+import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
 import com.netflix.spinnaker.orca.pipelinetemplate.V2Util;
 import java.util.ArrayList;


### PR DESCRIPTION
Moving two existing interfaces from `orca-core` into `orca-api`. The purpose is to communicate that these interfaces are safe to use for extending orca functionality.
- `ExecutionPreprocessor`
- `TaskExecutionInterceptor`
