### PR TITLE
fix(jobs): use stage.execution.application as default when looking job status

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.job
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.frigga.Names
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.kork.exceptions.ConfigurationException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
@@ -120,8 +119,7 @@ public class WaitOnJobCompletion implements CloudProviderAware, OverridableTimeo
       }
 
       def name = names[0]
-      def parsedName = Names.parseName(name)
-      String appName = stage.context.moniker?.app ?: stage.context.application ?: parsedName.app
+      String appName = stage.context.moniker?.app ?: stage.context.application ?: stage.execution.application
 
       InputStream jobStream
       retrySupport.retry({

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -125,10 +125,10 @@ public class WaitOnJobCompletion implements CloudProviderAware, OverridableTimeo
 
       def name = names[0]
       def parsedName = Names.parseName(name)
-      String appName = stage.context.moniker?.app ?: stage.context.application ?: parsedName.app
+      String appName = stage.context.moniker?.app ?: stage.context.application ?: stage.execution.application
 
-      if (!applicationExists(appName)) {
-        appName = stage.execution.application
+      if (appName == null && applicationExists(parsedName.app)) {
+        appName = parsedName.app
       }
 
       InputStream jobStream
@@ -179,7 +179,7 @@ public class WaitOnJobCompletion implements CloudProviderAware, OverridableTimeo
     try {
       return front50Service.get(appName) != null
     } catch (RetrofitError e) {
-      return false
+      throw e
     }
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletion.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.job
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.frigga.Names
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.kork.exceptions.ConfigurationException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
@@ -26,12 +27,13 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.KatoRestService
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
-
+import com.netflix.spinnaker.orca.front50.Front50Service
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import retrofit.RetrofitError
 
 import javax.annotation.Nonnull
 import javax.annotation.Nullable
@@ -57,6 +59,9 @@ public class WaitOnJobCompletion implements CloudProviderAware, OverridableTimeo
 
   @Autowired
   JobUtils jobUtils
+
+  @Autowired(required = false)
+  Front50Service front50Service
 
   static final String REFRESH_TYPE = "Job"
   /**
@@ -119,7 +124,12 @@ public class WaitOnJobCompletion implements CloudProviderAware, OverridableTimeo
       }
 
       def name = names[0]
-      String appName = stage.context.moniker?.app ?: stage.context.application ?: stage.execution.application
+      def parsedName = Names.parseName(name)
+      String appName = stage.context.moniker?.app ?: stage.context.application ?: parsedName.app
+
+      if (!applicationExists(appName)) {
+        appName = stage.execution.application
+      }
 
       InputStream jobStream
       retrySupport.retry({
@@ -160,5 +170,16 @@ public class WaitOnJobCompletion implements CloudProviderAware, OverridableTimeo
     }
 
     TaskResult.builder(status).context(outputs).outputs(outputs).build()
+  }
+
+  private Boolean applicationExists(String appName) {
+    if (appName == null || front50Service == null) {
+      return false
+    }
+    try {
+      return front50Service.get(appName) != null
+    } catch (RetrofitError e) {
+      return false
+    }
   }
 }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobUtils.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobUtils.java
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.job;
 
-import com.netflix.frigga.Names;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
@@ -57,14 +56,17 @@ public class JobUtils implements CloudProviderAware {
       }
 
       String name = names.get(0);
-      Names parsedName = Names.parseName(name);
       Moniker moniker = (Moniker) stage.getContext().get("moniker");
       String appName;
 
       if (moniker != null) {
         appName = moniker.getApp();
       } else {
-        appName = (String) stage.getContext().getOrDefault("application", parsedName.getApp());
+        appName =
+            (String)
+                stage
+                    .getContext()
+                    .getOrDefault("application", stage.getExecution().getApplication());
       }
 
       retrySupport.retry(

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobUtils.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobUtils.java
@@ -72,11 +72,15 @@ public class JobUtils implements CloudProviderAware {
       if (moniker != null) {
         appName = moniker.getApp();
       } else {
-        appName = (String) stage.getContext().getOrDefault("application", parsedName.getApp());
+        appName =
+            (String)
+                stage
+                    .getContext()
+                    .getOrDefault("application", stage.getExecution().getApplication());
       }
 
-      if (!applicationExists(appName)) {
-        appName = stage.getExecution().getApplication();
+      if (appName == null && applicationExists(parsedName.getApp())) {
+        appName = parsedName.getApp();
       }
 
       validAppName = appName;
@@ -92,7 +96,7 @@ public class JobUtils implements CloudProviderAware {
     try {
       return front50Service.get(appName) != null;
     } catch (RetrofitError e) {
-      return false;
+      throw e;
     }
   }
 }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobUtils.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/JobUtils.java
@@ -17,26 +17,35 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.job;
 
+import com.netflix.frigga.Names;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.KatoRestService;
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
+import com.netflix.spinnaker.orca.front50.Front50Service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import retrofit.RetrofitError;
 
 @Component
 public class JobUtils implements CloudProviderAware {
   final RetrySupport retrySupport;
   final KatoRestService katoRestService;
+  final Front50Service front50Service;
 
   @Autowired
-  public JobUtils(RetrySupport retrySupport, KatoRestService katoRestService) {
+  public JobUtils(
+      RetrySupport retrySupport,
+      KatoRestService katoRestService,
+      Optional<Front50Service> front50Service) {
     this.retrySupport = retrySupport;
     this.katoRestService = katoRestService;
+    this.front50Service = front50Service.orElse(null);
   }
 
   public void cancelWait(StageExecution stage) {
@@ -56,21 +65,34 @@ public class JobUtils implements CloudProviderAware {
       }
 
       String name = names.get(0);
+      Names parsedName = Names.parseName(name);
       Moniker moniker = (Moniker) stage.getContext().get("moniker");
-      String appName;
+      String appName, validAppName;
 
       if (moniker != null) {
         appName = moniker.getApp();
       } else {
-        appName =
-            (String)
-                stage
-                    .getContext()
-                    .getOrDefault("application", stage.getExecution().getApplication());
+        appName = (String) stage.getContext().getOrDefault("application", parsedName.getApp());
       }
 
+      if (!applicationExists(appName)) {
+        appName = stage.getExecution().getApplication();
+      }
+
+      validAppName = appName;
       retrySupport.retry(
-          () -> katoRestService.cancelJob(appName, account, location, name), 6, 5000, false);
+          () -> katoRestService.cancelJob(validAppName, account, location, name), 6, 5000, false);
+    }
+  }
+
+  private Boolean applicationExists(String appName) {
+    if (appName == null || front50Service == null) {
+      return false;
+    }
+    try {
+      return front50Service.get(appName) != null;
+    } catch (RetrofitError e) {
+      return false;
     }
   }
 }

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletionTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletionTest.java
@@ -17,17 +17,30 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import com.netflix.spinnaker.orca.clouddriver.KatoRestService;
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.springframework.test.util.ReflectionTestUtils;
+import retrofit.client.Response;
+import retrofit.mime.TypedByteArray;
 
 @RunWith(JUnitPlatform.class)
 public final class WaitOnJobCompletionTest {
@@ -46,8 +59,110 @@ public final class WaitOnJobCompletionTest {
     assertThat(task.getDynamicTimeout(myStageInvalid)).isEqualTo(task.getTimeout());
   }
 
+  @Test
+  void taskSearchJobByApplicationUsingContextApplication() {
+    KatoRestService mockKatoRestService = mock(KatoRestService.class);
+    RetrySupport retrySupport = new RetrySupport();
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    WaitOnJobCompletion task = new WaitOnJobCompletion();
+
+    ReflectionTestUtils.setField(task, "retrySupport", retrySupport);
+    ReflectionTestUtils.setField(task, "objectMapper", objectMapper);
+    ReflectionTestUtils.setField(task, "katoRestService", mockKatoRestService);
+
+    Response mockResponse =
+        new Response(
+            "test-url",
+            200,
+            "test-reason",
+            Collections.emptyList(),
+            new TypedByteArray("application/json", "{ \"jobState\": \"Succeeded\"}".getBytes()));
+
+    when(mockKatoRestService.collectJob(any(), any(), any(), any())).thenReturn(mockResponse);
+
+    StageExecutionImpl myStage =
+        createStageWithContext(
+            ImmutableMap.of(
+                "application",
+                "context-app",
+                "deploy.jobs",
+                ImmutableMap.of("test", ImmutableList.of("job test"))));
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
+    verify(mockKatoRestService, times(1)).collectJob(eq("context-app"), any(), any(), any());
+  }
+
+  @Test
+  void taskSearchJobByApplicationUsingContextMoniker() {
+    KatoRestService mockKatoRestService = mock(KatoRestService.class);
+    RetrySupport retrySupport = new RetrySupport();
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    WaitOnJobCompletion task = new WaitOnJobCompletion();
+
+    ReflectionTestUtils.setField(task, "retrySupport", retrySupport);
+    ReflectionTestUtils.setField(task, "objectMapper", objectMapper);
+    ReflectionTestUtils.setField(task, "katoRestService", mockKatoRestService);
+
+    Response mockResponse =
+        new Response(
+            "test-url",
+            200,
+            "test-reason",
+            Collections.emptyList(),
+            new TypedByteArray("application/json", "{ \"jobState\": \"Succeeded\"}".getBytes()));
+
+    when(mockKatoRestService.collectJob(any(), any(), any(), any())).thenReturn(mockResponse);
+
+    StageExecutionImpl myStage =
+        createStageWithContext(
+            ImmutableMap.of(
+                "moniker", ImmutableMap.of("app", "moniker-app"),
+                "deploy.jobs", ImmutableMap.of("test", ImmutableList.of("job test"))));
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
+    verify(mockKatoRestService, times(1)).collectJob(eq("moniker-app"), any(), any(), any());
+  }
+
+  @Test
+  void taskSearchJobByApplicationUsingDefault() {
+    KatoRestService mockKatoRestService = mock(KatoRestService.class);
+    RetrySupport retrySupport = new RetrySupport();
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    WaitOnJobCompletion task = new WaitOnJobCompletion();
+
+    ReflectionTestUtils.setField(task, "retrySupport", retrySupport);
+    ReflectionTestUtils.setField(task, "objectMapper", objectMapper);
+    ReflectionTestUtils.setField(task, "katoRestService", mockKatoRestService);
+
+    Response mockResponse =
+        new Response(
+            "test-url",
+            200,
+            "test-reason",
+            Collections.emptyList(),
+            new TypedByteArray("application/json", "{ \"jobState\": \"Succeeded\"}".getBytes()));
+
+    when(mockKatoRestService.collectJob(any(), any(), any(), any())).thenReturn(mockResponse);
+
+    StageExecutionImpl myStage =
+        createStageWithContext(
+            ImmutableMap.of(
+                "deploy.jobs", ImmutableMap.of("test", ImmutableList.of("atest-btest-ctest"))));
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
+    verify(mockKatoRestService, times(1)).collectJob(eq("test-app"), any(), any(), any());
+  }
+
   private StageExecutionImpl createStageWithContext(Map<String, ?> context) {
     return new StageExecutionImpl(
-        new PipelineExecutionImpl(ExecutionType.PIPELINE, "test"), "test", new HashMap<>(context));
+        new PipelineExecutionImpl(ExecutionType.PIPELINE, "test-app"),
+        "test",
+        new HashMap<>(context));
   }
 }


### PR DESCRIPTION
The WaitOnJobCompletion task make http calls to clouddriver to get the job status for a Kubernetes PreconfiguredJob. By default, when the stage.context does not have a moniker or application field defined the name of the object is used but it is parsed to Frigga Names object.

When an end user execute a pipeline and the WaitOnJobCompletion task is executed, if the stage's context does not have the moniker or application field defined, the Application name will be null or the job's name.

Clouddriver uses the account & pipeline name to determinate permissions, when sending the job name as the application name we can get an Access Denied error.

![gfs-job-read-only (1)](https://user-images.githubusercontent.com/63310723/120860475-5a1cfb80-c54b-11eb-8b76-5082b13cae9b.PNG)


Instead of use the job name as default, I changed it to use the Application name in the PipelineExecution. This prevent to search permission in Applications that might not exist.
