### PR TITLE
fix(webhooks): forcefully convert response.body() to String

### DIFF
--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/tasks/WebhookResponseProcessor.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/tasks/WebhookResponseProcessor.java
@@ -202,7 +202,8 @@ public class WebhookResponseProcessor {
       if (stageExecution.getContext().containsKey("expectedArtifacts")
           && !((List) stageExecution.getContext().get("expectedArtifacts")).isEmpty()) {
         try {
-          stageOutput.put("artifacts", JsonPath.parse(response.getBody()).read("artifacts"));
+          stageOutput.put(
+              "artifacts", JsonPath.parse(response.getBody().toString()).read("artifacts"));
         } catch (Exception e) {
           webhookOutput.setError(
               "Expected artifacts in webhook response couldn't be parsed: " + e.toString());


### PR DESCRIPTION
This should fix https://github.com/spinnaker/spinnaker/issues/6454. 
Apparently, response.body(), which is returned from webhook is not a string, which breaks JsonPath parsing to bind an artifact. Forcing response.body() to be a string fixes that issue.