### PR TITLE
feat(font50): add delete pipelines endpoint to front50 service

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -86,6 +86,9 @@ interface Front50Service {
   @POST('/actions/pipelines/reorder')
   Response reorderPipelines(@Body ReorderPipelinesCommand reorderPipelinesCommand)
 
+  @DELETE("/pipelines/{applicationName}/{pipelineName}")
+  Response deletePipeline(@Path("applicationName") String applicationName, @Path("pipelineName") String pipelineName)
+  
   @POST('/actions/strategies/reorder')
   Response reorderPipelineStrategies(@Body ReorderPipelinesCommand reorderPipelinesCommand)
 


### PR DESCRIPTION
Add the delete pipelines endpoint to Front50Service. We use this endpoint in our private cloud provider, and it was missing from the service in core.