### PR TITLE
chore(build): replace org.funktionale:funktionale-partials with io.ar…

### DIFF
--- a/keiko-mem/keiko-mem.gradle
+++ b/keiko-mem/keiko-mem.gradle
@@ -6,5 +6,4 @@ dependencies {
   api "org.threeten:threeten-extra"
 
   testImplementation project(":keiko-tck")
-  testImplementation "org.funktionale:funktionale-partials"
 }

--- a/keiko-mem/src/test/kotlin/com/netflix/spinnaker/q/memory/InMemoryQueueTest.kt
+++ b/keiko-mem/src/test/kotlin/com/netflix/spinnaker/q/memory/InMemoryQueueTest.kt
@@ -22,19 +22,23 @@ import com.netflix.spinnaker.q.metrics.EventPublisher
 import com.netflix.spinnaker.q.metrics.MonitorableQueueTest
 import com.netflix.spinnaker.q.metrics.QueueEvent
 import java.time.Clock
-import org.funktionale.partials.invoke
 
-object InMemoryQueueTest : QueueTest<InMemoryQueue>(createQueue(p3 = null))
+object InMemoryQueueTest : QueueTest<InMemoryQueue>(createQueueNoPublisher)
 
 object InMemoryMonitorableQueueTest : MonitorableQueueTest<InMemoryQueue>(
-  createQueue,
+  ::createQueue,
   InMemoryQueue::retry
 )
 
-private val createQueue = { clock: Clock,
-  deadLetterCallback: DeadMessageCallback,
-  publisher: EventPublisher? ->
-  InMemoryQueue(
+private val createQueueNoPublisher = { clock: Clock,
+  deadLetterCallback: DeadMessageCallback ->
+  createQueue(clock, deadLetterCallback, null)
+}
+
+private fun createQueue(clock: Clock,
+                        deadLetterCallback: DeadMessageCallback,
+                        publisher: EventPublisher?): InMemoryQueue {
+  return InMemoryQueue(
     clock = clock,
     deadMessageHandlers = listOf(deadLetterCallback),
     publisher = publisher ?: (

--- a/keiko-redis/keiko-redis.gradle
+++ b/keiko-redis/keiko-redis.gradle
@@ -6,7 +6,7 @@ dependencies {
   api("redis.clients:jedis")
   api "com.fasterxml.jackson.core:jackson-databind"
   api "com.fasterxml.jackson.module:jackson-module-kotlin"
-  api "org.funktionale:funktionale-partials"
+  api "io.arrow-kt:arrow-core:0.13.2"
   api "com.github.ben-manes.caffeine:guava"
 
   testImplementation project(":keiko-tck")

--- a/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisClusterQueue.kt
+++ b/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisClusterQueue.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.q.redis
 
+import arrow.core.partially1
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.KotlinOpen
@@ -30,7 +31,6 @@ import java.time.Instant
 import java.time.temporal.TemporalAmount
 import java.util.Locale
 import java.util.Optional
-import org.funktionale.partials.partially1
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled

--- a/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
+++ b/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.q.redis
 
+import arrow.core.partially1
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.KotlinOpen
@@ -46,7 +47,6 @@ import java.time.Instant
 import java.time.temporal.TemporalAmount
 import java.util.Locale
 import java.util.Optional
-import org.funktionale.partials.partially1
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled

--- a/keiko-sql/keiko-sql.gradle
+++ b/keiko-sql/keiko-sql.gradle
@@ -5,7 +5,7 @@ dependencies {
   api project(":keiko-core")
   api "com.fasterxml.jackson.core:jackson-databind"
   api "com.fasterxml.jackson.module:jackson-module-kotlin"
-  api "org.funktionale:funktionale-partials"
+  api "io.arrow-kt:arrow-core:0.13.2"
   api "com.github.ben-manes.caffeine:guava"
 
   implementation "io.spinnaker.kork:kork-core"

--- a/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
+++ b/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.q.sql
 
+import arrow.core.partially1
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -47,7 +48,6 @@ import kotlin.Exception
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.random.Random.Default.nextLong
-import org.funktionale.partials.partially1
 import org.jooq.DSLContext
 import org.jooq.SQLDialect
 import org.jooq.SortOrder

--- a/keiko-sql/src/test/kotlin/com/netflix/spinnaker/q/sql/SqlQueueTest.kt
+++ b/keiko-sql/src/test/kotlin/com/netflix/spinnaker/q/sql/SqlQueueTest.kt
@@ -18,12 +18,11 @@ import com.netflix.spinnaker.q.metrics.QueueEvent
 import java.time.Clock
 import java.time.Duration
 import java.util.Optional
-import org.funktionale.partials.invoke
 
-object SqlQueueTest : QueueTest<SqlQueue>(createQueue(p3 = null), ::cleanupCallback)
+object SqlQueueTest : QueueTest<SqlQueue>(createQueueNoPublisher, ::cleanupCallback)
 
 object SqlMonitorableQueueTest : MonitorableQueueTest<SqlQueue>(
-  createQueue,
+  ::createQueue,
   SqlQueue::retry,
   ::cleanupCallback
 )
@@ -31,10 +30,15 @@ object SqlMonitorableQueueTest : MonitorableQueueTest<SqlQueue>(
 private val testDb = SqlTestUtil.initTcMysqlDatabase()
 private val jooq = testDb.context
 
-private val createQueue = { clock: Clock,
-  deadLetterCallback: DeadMessageCallback,
-  publisher: EventPublisher? ->
-  SqlQueue(
+private val createQueueNoPublisher = { clock: Clock,
+  deadLetterCallback: DeadMessageCallback ->
+  createQueue(clock, deadLetterCallback, null)
+}
+
+private fun createQueue(clock: Clock,
+                        deadLetterCallback: DeadMessageCallback,
+                        publisher: EventPublisher?): SqlQueue {
+  return SqlQueue(
     queueName = "test",
     schemaVersion = 1,
     jooq = jooq,

--- a/orca-queue/orca-queue.gradle
+++ b/orca-queue/orca-queue.gradle
@@ -26,7 +26,7 @@ dependencies {
   implementation project(":keiko-spring")
   implementation project(":keiko-core")
   implementation("org.threeten:threeten-extra")
-  implementation("org.funktionale:funktionale-partials")
+  implementation("io.arrow-kt:arrow-core:0.13.2")
   implementation("org.springframework:spring-web")
   implementation("net.logstash.logback:logstash-logback-encoder")
   implementation("javax.ws.rs:jsr311-api:1.1.1")

--- a/orca-test-kotlin/orca-test-kotlin.gradle
+++ b/orca-test-kotlin/orca-test-kotlin.gradle
@@ -19,7 +19,7 @@ apply from: "$rootDir/gradle/kotlin.gradle"
 dependencies {
   api(project(":orca-api-tck"))
   implementation(project(":orca-core"))
-  implementation("org.funktionale:funktionale-partials")
+  implementation("io.arrow-kt:arrow-core:0.13.2")
   implementation("org.jetbrains.spek:spek-api")
   implementation("org.assertj:assertj-core")
 }

--- a/orca-test-kotlin/src/main/kotlin/com/netflix/spinnaker/spek/SpekExtensions.kt
+++ b/orca-test-kotlin/src/main/kotlin/com/netflix/spinnaker/spek/SpekExtensions.kt
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.spek
 
-import org.funktionale.partials.partially2
+import arrow.core.partially2
 import org.jetbrains.spek.api.dsl.SpecBody
 
 /**


### PR DESCRIPTION
…row-kt:arrow-core

since according to https://github.com/MarioAriasC/funKTionale, funKTionale is frozen and
made obsolete by https://github.com/arrow-kt/arrow.  As well, funKTionale isn't available
on maven central and arrow is.
