### PR TITLE
chore(build): remove references to jcenter/bintray

### DIFF
--- a/gradle/ktlint-root.gradle
+++ b/gradle/ktlint-root.gradle
@@ -1,7 +1,3 @@
-repositories {
-  jcenter()
-}
-
 configurations {
   ktlint
 }

--- a/gradle/spek.gradle
+++ b/gradle/spek.gradle
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-repositories {
-  jcenter()
-}
-
 dependencies {
   testImplementation("org.junit.platform:junit-platform-runner")
   testImplementation("org.jetbrains.spek:spek-api")

--- a/keiko-tck/keiko-tck.gradle
+++ b/keiko-tck/keiko-tck.gradle
@@ -1,9 +1,5 @@
 apply from: "$rootDir/gradle/kotlin.gradle"
 
-repositories {
-  maven { url "https://dl.bintray.com/jetbrains/spek" }
-}
-
 dependencies {
   api project(":keiko-core")
   api project(":keiko-test-common")

--- a/orca-deploymentmonitor/orca-deploymentmonitor.gradle
+++ b/orca-deploymentmonitor/orca-deploymentmonitor.gradle
@@ -16,10 +16,6 @@
 
 apply from: "$rootDir/gradle/spock.gradle"
 
-repositories {
-  jcenter()
-}
-
 dependencies {
   implementation(project(":orca-core"))
   implementation(project(":orca-retrofit"))

--- a/orca-dry-run/orca-dry-run.gradle
+++ b/orca-dry-run/orca-dry-run.gradle
@@ -17,10 +17,6 @@
 apply from: "$rootDir/gradle/kotlin.gradle"
 apply from: "$rootDir/gradle/spek.gradle"
 
-repositories {
-  jcenter()
-}
-
 dependencies {
   implementation(project(":orca-core"))
   implementation(project(":orca-kotlin"))

--- a/orca-queue-redis/orca-queue-redis.gradle
+++ b/orca-queue-redis/orca-queue-redis.gradle
@@ -17,10 +17,6 @@
 apply from: "$rootDir/gradle/kotlin.gradle"
 apply from: "$rootDir/gradle/spek.gradle"
 
-repositories {
-  jcenter()
-}
-
 dependencies {
   implementation(project(":orca-core"))
   implementation(project(":orca-queue"))

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,6 @@
 pluginManagement {
   repositories {
     gradlePluginPortal()
-    jcenter()
   }
 }
 


### PR DESCRIPTION
now that it's been sunset (https://status.bintray.com/).
