### PR TITLE
fix(artifacts): Do not further strip version for nuget packages

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/PackageInfo.java
@@ -325,7 +325,7 @@ public class PackageInfo {
         fileName.substring(
             fileName.indexOf(filePrefix) + filePrefix.length(),
             fileName.lastIndexOf(fileExtension));
-    if (version.contains(versionDelimiter)) {
+    if (version.contains(versionDelimiter) && !packageType.equals("nupkg")) {
       // further strip in case of _all is in the file name
       version = version.substring(0, version.indexOf(versionDelimiter));
     }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/PackageInfoSpec.groovy
@@ -27,6 +27,7 @@ import java.util.regex.Pattern
 
 import static com.netflix.spinnaker.orca.pipeline.util.PackageType.DEB
 import static com.netflix.spinnaker.orca.pipeline.util.PackageType.RPM
+import static com.netflix.spinnaker.orca.pipeline.util.PackageType.NUPKG
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 
@@ -206,6 +207,7 @@ class PackageInfoSpec extends Specification {
     [["fileName": "package_4.11.4-h02.deb"], ["fileName": "package-something_4.11.4-h02.deb"]]               | "package"           | DEB         || "package_4.11.4-h02"
     [["fileName": "package_4.11.4-h02.sha123.deb"], ["fileName": "package-something_4.11.4-h02.deb"]]        | "package-something" | DEB         || "package-something_4.11.4-h02"
     [["fileName": "package_4.11.4-h02.sha123.deb"], ["fileName": "package-something_4.11.4-h02.sha123.deb"]] | "package"           | DEB         || "package_4.11.4-h02.sha123"
+    [["fileName": "Package.1.3.3.7.nupkg"]]                                                                  | "Package"           | NUPKG       || "Package.1.3.3.7"
   }
 
   def "findTargetPackage: bake execution with only a package set and jenkins stage artifacts"() {


### PR DESCRIPTION
Nuget packages files names are written in the following format `MyPackage.1.3.3.7.nupkg` and the version separator is the `.` which is the same character used in the version Major/Minor/Patch separator (has opposed to `deb` and `rpm` which have distinct version separators).

Given this, we do not need to "further strip" in case the "version separator" is found in the version itself (since it will always happen).