### PR TITLE
fix(echo events/orca): Echo events will be generated when the pipeline is deleted.

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -88,7 +88,7 @@ interface Front50Service {
 
   @DELETE("/pipelines/{applicationName}/{pipelineName}")
   Response deletePipeline(@Path("applicationName") String applicationName, @Path("pipelineName") String pipelineName)
-  
+
   @POST('/actions/strategies/reorder')
   Response reorderPipelineStrategies(@Body ReorderPipelinesCommand reorderPipelinesCommand)
 
@@ -158,6 +158,9 @@ interface Front50Service {
 
   @DELETE("/applications/{application}/deliveries/{id}")
   Response deleteDeliveryConfig(@Path("application") String application, @Path("id") String id)
+
+  @DELETE("/pipelines/{app}/{name}")
+  Response deletePipelineConfig(@Path("app") String app, @Path("name") String name, @Query("staleCheck") boolean staleCheck)
 
   static class Project {
     String id

--- a/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/pipeline/DeletePipelineStage.java
+++ b/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/pipeline/DeletePipelineStage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.pipeline;
+
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode.Builder;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.front50.tasks.DeletePipelineTask;
+import javax.annotation.Nonnull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeletePipelineStage implements StageDefinitionBuilder {
+
+  @Override
+  public void taskGraph(@Nonnull StageExecution stage, @Nonnull Builder builder) {
+
+    builder.withTask("deletePipeline", DeletePipelineTask.class);
+  }
+}

--- a/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/DeletePipelineTask.java
+++ b/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/DeletePipelineTask.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.api.pipeline.RetryableTask;
+import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.front50.PipelineModelMutator;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+@Component
+public class DeletePipelineTask implements CloudProviderAware, RetryableTask {
+
+  private Logger log = LoggerFactory.getLogger(getClass());
+
+  @Autowired
+  DeletePipelineTask(
+      Optional<Front50Service> front50Service,
+      Optional<List<PipelineModelMutator>> pipelineModelMutators,
+      ObjectMapper objectMapper) {
+    this.front50Service = front50Service.orElse(null);
+    this.pipelineModelMutators = pipelineModelMutators.orElse(new ArrayList<>());
+    this.objectMapper = objectMapper;
+  }
+
+  private final Front50Service front50Service;
+  private final List<PipelineModelMutator> pipelineModelMutators;
+  ObjectMapper objectMapper;
+
+  @Override
+  public TaskResult execute(StageExecution stage) {
+    if (front50Service == null) {
+      throw new UnsupportedOperationException(
+          "Front50 is not enabled, no way to delete pipeline. Fix this by setting front50.enabled: true");
+    }
+
+    if (!stage.getContext().containsKey("pipeline")) {
+      throw new IllegalArgumentException("pipeline context must be provided");
+    }
+
+    Map<String, Object> pipeline;
+    if (!(stage.getContext().get("pipeline") instanceof String)) {
+      pipeline = (Map<String, Object>) stage.getContext().get("pipeline");
+    } else {
+      pipeline = (Map<String, Object>) stage.decodeBase64("/pipeline", Map.class);
+    }
+
+    if (!pipeline.containsKey("index")) {
+      Map<String, Object> existingPipeline = fetchExistingPipeline(pipeline);
+      if (existingPipeline != null) {
+        pipeline.put("index", existingPipeline.get("index"));
+      }
+    }
+    String serviceAccount = (String) stage.getContext().get("pipeline.serviceAccount");
+    if (serviceAccount != null) {
+      updateServiceAccount(pipeline, serviceAccount);
+    }
+    final Boolean isSavingMultiplePipelines =
+        (Boolean)
+            Optional.ofNullable(stage.getContext().get("isSavingMultiplePipelines")).orElse(false);
+    final Boolean staleCheck =
+        (Boolean) Optional.ofNullable(stage.getContext().get("staleCheck")).orElse(false);
+    if (stage.getContext().get("pipeline.id") != null
+        && pipeline.get("id") == null
+        && !isSavingMultiplePipelines) {
+      pipeline.put("id", stage.getContext().get("pipeline.id"));
+
+      // We need to tell front50 to regenerate cron trigger id's
+      pipeline.put("regenerateCronTriggerIds", true);
+    }
+
+    pipelineModelMutators.stream()
+        .filter(m -> m.supports(pipeline))
+        .forEach(m -> m.mutate(pipeline));
+
+    Response response =
+        front50Service.deletePipelineConfig(
+            pipeline.get("application").toString(), pipeline.get("name").toString(), staleCheck);
+
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put("notification.type", "deletepipeline");
+    outputs.put("application", pipeline.get("application"));
+    outputs.put("pipeline.name", pipeline.get("name"));
+
+    try {
+      Map<String, Object> savedPipeline =
+          (Map<String, Object>) objectMapper.readValue(response.getBody().in(), Map.class);
+      outputs.put("pipeline.id", savedPipeline.get("id"));
+    } catch (Exception e) {
+      log.error("Unable to deserialize saved pipeline, reason: ", e.getMessage());
+
+      if (pipeline.containsKey("id")) {
+        outputs.put("pipeline.id", pipeline.get("id"));
+      }
+    }
+
+    final ExecutionStatus status;
+    if (response.getStatus() == HttpStatus.OK.value()) {
+      status = ExecutionStatus.SUCCEEDED;
+    } else {
+      if (isSavingMultiplePipelines) {
+        status = ExecutionStatus.FAILED_CONTINUE;
+      } else {
+        status = ExecutionStatus.TERMINAL;
+      }
+    }
+    return TaskResult.builder(status).context(outputs).build();
+  }
+
+  @Override
+  public long getBackoffPeriod() {
+    return 1000;
+  }
+
+  @Override
+  public long getTimeout() {
+    return TimeUnit.SECONDS.toMillis(30);
+  }
+
+  private void updateServiceAccount(Map<String, Object> pipeline, String serviceAccount) {
+    if (StringUtils.isEmpty(serviceAccount) || !pipeline.containsKey("triggers")) {
+      return;
+    }
+
+    List<Map<String, Object>> triggers = (List<Map<String, Object>>) pipeline.get("triggers");
+    List<String> roles = (List<String>) pipeline.get("roles");
+    // Managed service acct but no roles; Remove runAsUserFrom triggers
+    if (roles == null || roles.isEmpty()) {
+      triggers.forEach(t -> t.remove("runAsUser", serviceAccount));
+      return;
+    }
+  }
+
+  private Map<String, Object> fetchExistingPipeline(Map<String, Object> newPipeline) {
+    String applicationName = (String) newPipeline.get("application");
+    String newPipelineID = (String) newPipeline.get("id");
+    if (!StringUtils.isEmpty(newPipelineID)) {
+      return front50Service.getPipelines(applicationName).stream()
+          .filter(m -> m.containsKey("id"))
+          .filter(m -> m.get("id").equals(newPipelineID))
+          .findFirst()
+          .orElse(null);
+    }
+    return null;
+  }
+}

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/DeletePipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/DeletePipelineTaskSpec.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.front50.tasks
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.collect.ImmutableMap
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.PipelineModelMutator
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
+import retrofit.client.Response
+import spock.lang.Specification
+import spock.lang.Subject
+
+class DeletePipelineTaskSpec extends Specification {
+
+  Front50Service front50Service = Mock()
+
+  PipelineModelMutator mutator = Mock()
+
+  ObjectMapper objectMapper = new ObjectMapper()
+
+  @Subject
+  SavePipelineTask sTask = new SavePipelineTask(Optional.of(front50Service), Optional.of([mutator]), objectMapper)
+
+  @Subject
+  DeletePipelineTask task = new DeletePipelineTask(Optional.of(front50Service), Optional.of([mutator]), objectMapper)
+
+  def "should delete the pipeline"() {
+    given:
+    def pipeline = [
+      application: 'orca',
+      name: 'my pipeline',
+      stages: []
+    ]
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "whatever", [
+      pipeline: Base64.encoder.encodeToString(objectMapper.writeValueAsString(pipeline).bytes)
+    ])
+
+    when:
+    sTask.execute(stage)
+    def result = task.execute(stage)
+
+    then:
+    2 * mutator.supports(pipeline) >> true
+    2 * mutator.mutate(pipeline)
+    1 * front50Service.savePipeline(pipeline, _) >> {
+      new Response('http://front50', 200, 'OK', [], null)
+    }
+    1 * front50Service.deletePipelineConfig(pipeline.application, pipeline.name, _) >> {
+      new Response('http://front50', 200, 'OK', [], null)
+    }
+    result.status == ExecutionStatus.SUCCEEDED
+    result.context == ImmutableMap.copyOf([
+      'notification.type': 'deletepipeline',
+      'application': 'orca',
+      'pipeline.name': 'my pipeline'
+    ])
+  }
+}


### PR DESCRIPTION
This is part of: spinnaker/spinnaker#6530.

Existing design:

When a delete pipeline request is received in GATE service. GATE authenticates the request and routes it to the front50 service.
This will only delete the pipeline from the database but, events will not be generated.
New design:

==GATE service changes:==

When a delete pipeline request is received in GATE service. GATE authenticates the request and form a task object.
This task object is passed as a parameter to /ops API in ORCA service.
Once submitted GATE service will keep polling the ORCA service to track the task status.
This is exactly the same process followed for other operations like, savePipeline, updatePipeline etc.
==ORCA service changes:==

A new task type "deletePipeline" is created and registered in ORCA.
ORCA service already have the support to process , monitor the task and generate events by routing it to Echo service.
Only changes needed was to register the new task "deletePipeline"
Once the task is registered , ORCA service takes up the responsibility of generating events by routing it to Echo service.
The request will also be routed to Front50 service to actually delete the pipeline.
Rest API:

==GATE service:==

endpoint : /pipelines/{application}/{pipelineName:.+} - DELETE API
==ORCA service:==

endpoint : /ops - POST API
sample request payload:

{ "description": "Delete pipeline pc", "application": "demopc", "job": [{ "type": "deletePipeline", "pipeline": { "keepWaitingPipelines": false, "limitConcurrent": true, "application": "demopc", "spelEvaluator": "v4", "lastModifiedBy": "user2", "name": "pc", "stages": [{ "name": "Wait", "refId": "1", "requisiteStageRefIds": [], "type": "wait", "waitTime": 5.0 }, { "name": "testgate", "parameters": { "connectors": [{ "connectorType": "PRISMACLOUD", "helpText": "PrismaCloud", "isMultiSupported": false, "label": "PrismaCloud", "supportedParams": [{ "helpText": "ImageID", "label": "ImageID", "name": "imageId" }], "values": [{ "imageId": "sha256:390cc7609d3bd3ab1fe8620fbf28d3e9c912c69a901f99e93af7d3b081ff6de2,sha25,sha256:ddbd686f8b5e3d3744443ebbdb0d91284da61f30f78604eabf193e065870f0726:6fed5fb61064c25e91e8afad7e199f20fd1422893bac05fdd2cae274790319fb" }] }], "gateUrl": "https://example.com/xxx/xxx/xxx/xxx/trigger", "imageIds": "nginx:1.14.2" }, "refId": "2", "requisiteStageRefIds": ["1"], "type": "approval" }, { "account": "kubeacc", "cloudProvider": "kubernetes", "manifests": [{ "apiVersion": "apps/v1", "kind": "Deployment", "metadata": { "labels": { "app": "nginx" }, "name": "nginx-deployment" }, "spec": { "replicas": 3.0, "selector": { "matchLabels": { "app": "nginx" } }, "template": { "metadata": { "labels": { "app": "nginx" } }, "spec": { "containers": [{ "image": "nginx:1.14.2", "name": "nginx", "ports": [{ "containerPort": 80.0 }] }] } } } }], "moniker": { "app": "demopc" }, "name": "Deploy (Manifest)", "namespaceOverride": "oes-agent", "refId": "3", "requisiteStageRefIds": ["2"], "skipExpressionEvaluation": false, "source": "text", "trafficManagement": { "enabled": false, "options": { "enableTraffic": false } }, "type": "deployManifest" }], "index": 0.0, "id": "4a5bd769-1887-42ed-a1e1-277417a8e366", "triggers": [], "updateTs": "1628769454000" }, "user": "user2" }] }