### PR TITLE
fix(queue): fixes bug in SqlQueue doContainsMessage to handle multiple batches

### DIFF
--- a/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
+++ b/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
@@ -186,8 +186,7 @@ class SqlQueue(
     }
   }
 
-  private fun doContainsMessage(predicate: (Message) -> Boolean): Boolean {
-    val batchSize = 100
+  fun doContainsMessage(predicate: (Message) -> Boolean, batchSize: Int = 100): Boolean {
     var found = false
     var lastId = "0"
 
@@ -201,7 +200,7 @@ class SqlQueue(
           .intoResultSet()
       }
 
-      while (!found && rs.next()) {
+      while (!found && rs.row < batchSize && rs.next()) {
         try {
           found = predicate.invoke(mapper.readValue(rs.getString("body")))
         } catch (e: Exception) {


### PR DESCRIPTION
A small bug fix which ensures the SqlQueue implementation of `containsMessage` works when there are more messages than the currently hardcoded batch size (`100`). 

This problem was discovered by the `ZombieExecutionService` detecting false zombie executions because the underlying `SqlQueue.doContainsMessage` implementation wasn not searching through all batches of messages available.