### PR TITLE
chore(dependencies): Upgrade Spring Boot to 2.2.13

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
@@ -104,7 +104,7 @@ class EchoNotifyingStageListener implements StageListener {
 
   private void recordEvent(String type, String phase, StageExecution stage, Optional<TaskExecution> maybeTask) {
     try {
-      def event = [
+      def event = (LinkedHashMap<String,LinkedHashMap<String,Object>>) [
         details: [
           source     : "orca",
           type       : "orca:${type}:${phase}".toString(),


### PR DESCRIPTION
Refer spinnaker/spinnaker#6537

During verification of Orca by upgrading spring boot, build failed with below error:
```
Task :orca-echo:compileGroovy
startup failed:
/home/opsmxbuild/spinnaker-comp/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy: 126: [Static type checking] - Cannot assign value of type java.lang.String to variable of type ?
 @ line 126, column 34.
           event.content.taskName = "${stage.type}.${task.name}".toString()
                                     ^

/home/opsmxbuild/spinnaker-comp/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy: 130: [Static type checking] - Cannot assign value of type com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution to variable of type ?
 @ line 130, column 35.
           event.content.execution = stage.execution
                                     ^

/home/opsmxbuild/spinnaker-comp/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy: 135: [Static type checking] - Cannot assign value of type com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution to variable of type ?
 @ line 135, column 37.
             event.content.execution = stage.execution
                                       ^
```
Error is due to a bug, fixed in groovy 4.0.0 version,  suggesting failure in assignment of Object used with generics. https://issues.apache.org/jira/browse/GROOVY-8001  
Workaround is to introduce explicit type casting to LinkedHasMap<String, LinkedHasMap<String, Object>> for object referenced by event variable. 