### PR TITLE
feat(pipeline executions/orca): Add support for max concurrent pipeline executions

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
@@ -65,6 +65,10 @@ public interface PipelineExecution {
 
   void setLimitConcurrent(boolean limitConcurrent);
 
+  int getMaxConcurrentExecutions();
+
+  void setMaxConcurrentExecutions(int maxConcurrentExecutions);
+
   boolean isKeepWaitingPipelines();
 
   void setKeepWaitingPipelines(boolean keepWaitingPipelines);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.pipeline;
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.TERMINAL;
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPELINE;
 import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -214,6 +215,7 @@ public class ExecutionLauncher {
         .withTrigger(objectMapper.convertValue(config.get("trigger"), Trigger.class))
         .withStages((List<Map<String, Object>>) config.get("stages"))
         .withLimitConcurrent(getBoolean(config, "limitConcurrent"))
+        .withMaxConcurrentExecutions(getInt(config, "maxConcurrentExecutions"))
         .withKeepWaitingPipelines(getBoolean(config, "keepWaitingPipelines"))
         .withNotifications((List<Map<String, Object>>) config.get("notifications"))
         .withInitialConfig((Map<String, Object>) config.get("initialConfig"))
@@ -281,6 +283,10 @@ public class ExecutionLauncher {
 
   private final boolean getBoolean(Map<String, ?> map, String key) {
     return parseBoolean(getString(map, key));
+  }
+
+  private final int getInt(Map<String, ?> map, String key) {
+    return map.containsKey(key) ? parseInt(getString(map, key)) : 0;
   }
 
   private final String getString(Map<String, ?> map, String key) {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
@@ -112,6 +112,11 @@ public class PipelineBuilder {
     return this;
   }
 
+  public PipelineBuilder withMaxConcurrentExecutions(int maxConcurrentExecutions) {
+    pipeline.setMaxConcurrentExecutions(maxConcurrentExecutions);
+    return this;
+  }
+
   public PipelineBuilder withKeepWaitingPipelines(boolean waiting) {
     pipeline.setKeepWaitingPipelines(waiting);
     return this;

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
@@ -152,6 +152,16 @@ public class PipelineExecutionImpl implements PipelineExecution, Serializable {
     this.limitConcurrent = limitConcurrent;
   }
 
+  private int maxConcurrentExecutions = 0;
+
+  public int getMaxConcurrentExecutions() {
+    return maxConcurrentExecutions;
+  }
+
+  public void setMaxConcurrentExecutions(int maxConcurrentExecutions) {
+    this.maxConcurrentExecutions = maxConcurrentExecutions;
+  }
+
   private boolean keepWaitingPipelines = false;
 
   public boolean isKeepWaitingPipelines() {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequest.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequest.java
@@ -34,6 +34,7 @@ public class TemplatedPipelineRequest {
   String executionId;
   Boolean plan = false;
   boolean limitConcurrent = true;
+  int maxConcurrentExecutions = 0;
   boolean keepWaitingPipelines = false;
 
   @JsonProperty("config")
@@ -123,6 +124,10 @@ public class TemplatedPipelineRequest {
 
   public boolean isLimitConcurrent() {
     return limitConcurrent;
+  }
+
+  public int getMaxConcurrentExecutions() {
+    return maxConcurrentExecutions;
   }
 
   public boolean isKeepWaitingPipelines() {

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutator.java
@@ -174,6 +174,9 @@ public class TemplatedPipelineModelMutator implements PipelineModelMutator {
     if (concurrentExecutions.containsKey("limitConcurrent")) {
       pipeline.put("limitConcurrent", concurrentExecutions.get("limitConcurrent"));
     }
+    if (concurrentExecutions.containsKey("maxConcurrentExecutions")) {
+      pipeline.put("maxConcurrentExecutions", concurrentExecutions.get("maxConcurrentExecutions"));
+    }
     if (concurrentExecutions.containsKey("keepWaitingPipelines")) {
       pipeline.put("keepWaitingPipelines", concurrentExecutions.get("keepWaitingPipelines"));
     }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaExecutionGenerator.java
@@ -55,11 +55,16 @@ public class V1SchemaExecutionGenerator implements ExecutionGenerator {
     Configuration c = template.getConfiguration();
     if (c.getConcurrentExecutions().isEmpty()) {
       pipeline.put("limitConcurrent", request.isLimitConcurrent());
+      pipeline.put("maxConcurrentExecutions", request.getMaxConcurrentExecutions());
       pipeline.put("keepWaitingPipelines", request.isKeepWaitingPipelines());
     } else {
       pipeline.put(
           "limitConcurrent",
           c.getConcurrentExecutions().getOrDefault("limitConcurrent", request.isLimitConcurrent()));
+      pipeline.put(
+          "maxConcurrentExecutions",
+          c.getConcurrentExecutions()
+              .getOrDefault("maxConcurrentExecutions", request.getMaxConcurrentExecutions()));
       pipeline.put(
           "keepWaitingPipelines",
           c.getConcurrentExecutions()

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/converter/PipelineTemplateConverter.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/converter/PipelineTemplateConverter.java
@@ -77,6 +77,7 @@ public class PipelineTemplateConverter {
     Map<String, Object> m = new LinkedHashMap<>();
     Map<String, Object> cm = new LinkedHashMap<>();
     cm.put("limitConcurrent", true);
+    cm.put("maxConcurrentExecutions", 0);
     m.put("concurrentExecutions", cm);
     m.put("triggers", convertTriggers((List) pipeline.get("triggers")));
     m.put("parameters", pipeline.getOrDefault("parameterConfig", new ArrayList<>()));

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v2schema/V2SchemaExecutionGenerator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v2schema/V2SchemaExecutionGenerator.java
@@ -45,6 +45,9 @@ public class V2SchemaExecutionGenerator implements V2ExecutionGenerator {
     if (!pipeline.containsKey("limitConcurrent")) {
       pipeline.put("limitConcurrent", request.isLimitConcurrent());
     }
+    if (!pipeline.containsKey("maxConcurrentExecutions")) {
+      pipeline.put("maxConcurrentExecutions", request.getMaxConcurrentExecutions());
+    }
     if (!pipeline.containsKey("keepWaitingPipelines")) {
       pipeline.put("keepWaitingPipelines", request.isKeepWaitingPipelines());
     }

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -124,6 +124,7 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
       name: 'Unnamed Execution',
       keepWaitingPipelines: false,
       limitConcurrent: true,
+      maxConcurrentExecutions: 0,
       notifications: [],
       source: [
         id: source("simple-001.yml"),
@@ -322,7 +323,8 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
         stages: []
       ],
       plan: true,
-      limitConcurrent: false
+      limitConcurrent: false,
+      maxConcurrentExecutions: 0
     ]
 
     when:

--- a/orca-pipelinetemplate/src/test/resources/convertedPipelineTemplate.yml
+++ b/orca-pipelinetemplate/src/test/resources/convertedPipelineTemplate.yml
@@ -27,6 +27,7 @@ protect: false
 configuration:
   concurrentExecutions:
     limitConcurrent: true
+    maxConcurrentExecutions: 0
   triggers:
   - enabled: false
     job: ZZ-demo

--- a/orca-pipelinetemplate/src/test/resources/convertedPipelineTemplateSource.json
+++ b/orca-pipelinetemplate/src/test/resources/convertedPipelineTemplateSource.json
@@ -2,6 +2,7 @@
   "description": "This is my favorite pipeline!",
   "lastModifiedBy": "example@example.com",
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "notifications": [
     {
       "address": "example@example.com",

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/conditionalStage-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/conditionalStage-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Unnamed Execution",
   "stages": [],

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-expected.json
@@ -50,6 +50,7 @@
   ],
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "notifications": [],
   "parameterConfig": [],
   "id": "unknown",

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-template.yml
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/dependsOn-template.yml
@@ -7,6 +7,7 @@ configuration:
   concurrentExecutions:
     parallel: true
     limitConcurrent: true
+    maxConcurrentExecutions: 0
 stages:
 - id: wait1
   type: wait

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/example-expected.json
@@ -1,6 +1,7 @@
 {
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "myApp",
   "name": "My super awesome pipeline",
   "source": {

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/exampleCombined-expected.json
@@ -1,6 +1,7 @@
 {
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "myApp",
   "name": "My super awesome pipeline",
   "source": {

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/expectedArtifactsInheritance-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/expectedArtifactsInheritance-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Unnamed Execution",
   "stages": [],

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/inheritance-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/inheritance-expected.json
@@ -1,6 +1,7 @@
 {
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "MPT Inheritance Test",
   "source": {

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/loops-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Unnamed Execution",
   "stages": [

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/modularStageConfig-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/modularStageConfig-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Unnamed Execution",
   "stages": [

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/modules-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/modules-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Unnamed Execution",
   "stages": [

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/nestedConditionalStage-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/nestedConditionalStage-expected.json
@@ -1,6 +1,7 @@
 {
   "id": "unknown",
   "keepWaitingPipelines": false,
+  "maxConcurrentExecutions": 0,
   "limitConcurrent": true,
   "application": "orca",
   "name": "Unnamed Execution",

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/parameterInheritance-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/parameterInheritance-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Unnamed Execution",
   "stages": [],

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/partials-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/partials-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Unnamed Execution",
   "stages": [

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/partialsAndModules-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/partialsAndModules-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Unnamed Execution",
   "stages": [

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/simple-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/simple-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Unnamed Execution",
   "stages": [],

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/stageInjection-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/stageInjection-expected.json
@@ -1,6 +1,7 @@
 {
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Stage Injection Test",
   "stages": [

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/stageReplacement-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/stageReplacement-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "MPT Stage Replacement Test",
   "notifications": [],

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/triggerInheritance-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/triggerInheritance-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Unnamed Execution",
   "stages": [],

--- a/orca-pipelinetemplate/src/test/resources/integration/v1schema/variableParameters-expected.json
+++ b/orca-pipelinetemplate/src/test/resources/integration/v1schema/variableParameters-expected.json
@@ -2,6 +2,7 @@
   "id": "unknown",
   "keepWaitingPipelines": false,
   "limitConcurrent": true,
+  "maxConcurrentExecutions": 0,
   "application": "orca",
   "name": "Unnamed Execution",
   "stages": [],

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -858,6 +858,10 @@ public class RedisExecutionRepository implements ExecutionRepository {
       execution.setCanceledBy(map.get("canceledBy"));
       execution.setCancellationReason(map.get("cancellationReason"));
       execution.setLimitConcurrent(Boolean.parseBoolean(map.get("limitConcurrent")));
+      execution.setMaxConcurrentExecutions(
+          (map.containsKey("maxConcurrentExecutions"))
+              ? Integer.parseInt(map.get("maxConcurrentExecutions"))
+              : 0);
       execution.setBuildTime(NumberUtils.createLong(map.get("buildTime")));
       execution.setStartTime(NumberUtils.createLong(map.get("startTime")));
       if (map.get("startTimeExpiry") != null) {
@@ -990,6 +994,7 @@ public class RedisExecutionRepository implements ExecutionRepository {
       map.put("application", execution.getApplication());
       map.put("canceled", String.valueOf(execution.isCanceled()));
       map.put("limitConcurrent", String.valueOf(execution.isLimitConcurrent()));
+      map.put("maxConcurrentExecutions", String.valueOf(execution.getMaxConcurrentExecutions()));
       map.put(
           "buildTime",
           String.valueOf(execution.getBuildTime() != null ? execution.getBuildTime() : 0L));


### PR DESCRIPTION
It adds support for max concurrent pipeline executions. If concurrent pipeline execution is enabled, pipelines will queue when the max concurrent pipeline executions is reached. Any queued pipelines will be allowed to run once the number of running pipeline executions drops below the max. If the max is set to 0, then pipelines will not queue.

This is the proposed change for https://github.com/spinnaker/spinnaker/issues/6558.

Changes to deck, front50 and echo are also needed in order to expose max concurrent pipeline executions as a pipeline configuration to Spinnaker users.

(Front50 pull request: spinnaker/front50#1080)
(Echo pull request: https://github.com/spinnaker/echo/pull/1134)
(Deck pull request: https://github.com/spinnaker/deck/pull/9777)