### PR TITLE
feat(orchestration): provide a way to allow only certain configured ad-hoc operations to be performed

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -63,9 +63,8 @@ dependencies {
   testImplementation("com.github.tomakehurst:wiremock:2.15.0")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.platform:junit-platform-runner")
-  testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("org.assertj:assertj-core")
-  testImplementation("org.mockito:mockito-core:2.25.0")
+  testImplementation("org.mockito:mockito-core")
   testImplementation("org.mockito:mockito-junit-jupiter")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
 

--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -63,7 +63,10 @@ dependencies {
   testImplementation("com.github.tomakehurst:wiremock:2.15.0")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.platform:junit-platform-runner")
+  testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("org.assertj:assertj-core")
+  testImplementation("org.mockito:mockito-core:2.25.0")
+  testImplementation("org.mockito:mockito-junit-jupiter")
 
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
   testRuntimeOnly "org.junit.vintage:junit-vintage-engine"

--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -67,6 +67,7 @@ dependencies {
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core:2.25.0")
   testImplementation("org.mockito:mockito-junit-jupiter")
+  testImplementation("org.springframework.boot:spring-boot-starter-test")
 
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
   testRuntimeOnly "org.junit.vintage:junit-vintage-engine"

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/ExecutionConfigurationProperties.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/ExecutionConfigurationProperties.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.orca.config;
 
+import com.netflix.spinnaker.orca.api.pipeline.Task;
+import java.util.Optional;
 import java.util.Set;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -25,32 +27,81 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ExecutionConfigurationProperties {
   /**
    * flag to enable/disable blocking of orchestration executions (ad-hoc operations). By default, it
-   * is turned off, which means all ad-hoc executions are supported.
+   * is turned off, which means all ad-hoc executions are supported. When set to true, it will only
+   * allow those operations that are defined in allowedOrchestrationExecutions set.
    */
   private boolean blockOrchestrationExecutions = false;
 
   /**
-   * this is only applicable when blockOrchestrationExecutions: true. This allows the user to
-   * configure only those orchestration executions(ad-hoc operations) that should be allowed. Every
-   * orchestration execution not in this set will be blocked
+   * this is only applicable when blockOrchestrationExecutions: true. This defines a set of
+   * orchestration executions that will be allowed to execute. Every orchestration execution not in
+   * this set will be blocked.
+   *
+   * <p>Finer level of control over an allowed orchestration execution can be achieved by
+   * configuring {@link OrchestrationExecution} accordingly.
    */
-  private Set<String> allowedOrchestrationExecutions =
-      Set.of(
-          "deleteApplication",
-          "saveApplication",
-          "updateApplication",
-          "deletePipeline",
-          "savePipeline",
-          "updatePipeline",
-          "reorderPipelines",
-          "createPipelineTemplate",
-          "deletePipelineTemplate",
-          "updatePipelineTemplate",
-          "createV2PipelineTemplate",
-          "deleteV2PipelineTemplate",
-          "updateV2PipelineTemplate",
-          "upsertEntityTags",
-          "deleteEntityTags",
-          "upsertPluginInfo",
-          "deletePluginInfo");
+  private Set<OrchestrationExecution> allowedOrchestrationExecutions = Set.of();
+
+  /**
+   * helper method that returns an {@link Optional<OrchestrationExecution>} object if the
+   * orchestration execution provided as an input is in the allowed orchestration executions set.
+   *
+   * @param orchestrationExecutionType orchestration type to be checked
+   * @return {@link Optional<OrchestrationExecution> object
+   */
+  public Optional<OrchestrationExecution> getAllowedOrchestrationType(
+      String orchestrationExecutionType) {
+    return allowedOrchestrationExecutions.stream()
+        .filter(type -> type.getName().equals(orchestrationExecutionType))
+        .findAny();
+  }
+
+  /**
+   * this contains metadata about an orchestration execution, in terms of what it is and who is
+   * allowed to execute it.
+   *
+   * <p>Finer level of granularity can be achieved by configuring this class appropriately. At
+   * present, it defines an orchestration execution, and whether all users or a subset of users are
+   * allowed to execute that operation
+   */
+  @Data
+  public static class OrchestrationExecution {
+    /**
+     * orchestration action
+     *
+     * <p>TODO: find a way to reconcile this with all the supported/registered {@link Task} types
+     */
+    private String name;
+
+    /**
+     * controls whether all users are permitted to perform the orchestration. NOTE: this is mutually
+     * exclusive with the permittedUsers property. Permitted users is given priority over this one
+     * in this property's setter. If there are any explicitly defined permitted users, then
+     * allowAllUsers == false.
+     */
+    private boolean allowAllUsers = true;
+
+    /**
+     * define a set of permitted users who can perform the orchestration. NOTE: this is mutually
+     * exclusive with the allowAllUsers property. Permitted users is given priority over
+     * allowAllUsers in this property's setter. If there are any explicitly defined permitted users,
+     * then allowAllUsers == false.
+     */
+    Set<String> permittedUsers = Set.of();
+
+    public void setAllowAllUsers(boolean allowAllUsers) {
+      if (!this.permittedUsers.isEmpty()) {
+        this.allowAllUsers = false;
+      } else {
+        this.allowAllUsers = allowAllUsers;
+      }
+    }
+
+    public void setPermittedUsers(Set<String> permittedUsers) {
+      this.permittedUsers = permittedUsers;
+      if (!permittedUsers.isEmpty()) {
+        this.allowAllUsers = false;
+      }
+    }
+  }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/ExecutionConfigurationProperties.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/ExecutionConfigurationProperties.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.config;
+
+import java.util.Set;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("executions")
+public class ExecutionConfigurationProperties {
+  /**
+   * flag to enable/disable blocking of orchestration executions (ad-hoc operations). By default, it
+   * is turned off, which means all ad-hoc executions are supported.
+   */
+  private boolean blockOrchestrationExecutions = false;
+
+  /**
+   * this is only applicable when blockOrchestrationExecutions: true. This allows the user to
+   * configure only those orchestration executions(ad-hoc operations) that should be allowed. Every
+   * orchestration execution not in this set will be blocked
+   */
+  private Set<String> allowedOrchestrationExecutions =
+      Set.of(
+          "deleteApplication",
+          "saveApplication",
+          "updateApplication",
+          "deletePipeline",
+          "savePipeline",
+          "updatePipeline",
+          "reorderPipelines",
+          "createPipelineTemplate",
+          "deletePipelineTemplate",
+          "updatePipelineTemplate",
+          "createV2PipelineTemplate",
+          "deleteV2PipelineTemplate",
+          "updateV2PipelineTemplate",
+          "upsertEntityTags",
+          "deleteEntityTags",
+          "upsertPluginInfo",
+          "deletePluginInfo");
+}

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -87,7 +87,10 @@ import rx.schedulers.Schedulers;
   PreprocessorConfiguration.class,
   PluginsAutoConfiguration.class,
 })
-@EnableConfigurationProperties(TaskOverrideConfigurationProperties.class)
+@EnableConfigurationProperties({
+  TaskOverrideConfigurationProperties.class,
+  ExecutionConfigurationProperties.class
+})
 public class OrcaConfiguration {
   @Bean
   public Clock clock() {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -99,23 +99,7 @@ public class ExecutionLauncher {
     persistExecution(execution);
 
     try {
-      // for security reasons, we want to allow only a few ad-hoc operations. Every other operation
-      // should be blocked.
-      if (execution.getType() == ExecutionType.ORCHESTRATION
-          && executionConfigurationProperties.isBlockOrchestrationExecutions()) {
-        for (StageExecution stage : execution.getStages()) {
-          if (!executionConfigurationProperties
-              .getAllowedOrchestrationExecutions()
-              .contains(stage.getType())) {
-            log.warn(
-                "ad-hoc execution of type: {} has been explicitly disabled. Such actions can only be run "
-                    + "via spinnaker pipelines",
-                stage.getType());
-            throw new AccessDeniedException(
-                "ad-hoc execution of type: " + stage.getType() + " has been explicitly disabled");
-          }
-        }
-      }
+      checkIfPipelineCanBeStarted(execution);
       start(execution);
     } catch (Throwable t) {
       handleStartupFailure(execution, t);
@@ -281,9 +265,12 @@ public class ExecutionLauncher {
     }
 
     orchestration.setBuildTime(clock.millis());
+
+    PipelineExecution.AuthenticationDetails auth = new PipelineExecution.AuthenticationDetails();
+    auth.setUser(getString(config, "user"));
+
     orchestration.setAuthentication(
-        PipelineExecutionImpl.AuthenticationHelper.build()
-            .orElse(new PipelineExecution.AuthenticationDetails()));
+        PipelineExecutionImpl.AuthenticationHelper.build().orElse(auth));
     orchestration.setOrigin((String) config.getOrDefault("origin", "unknown"));
     orchestration.setStartTimeExpiry((Long) config.get("startTimeExpiry"));
     orchestration.setSpelEvaluator(getString(config, "spelEvaluator"));
@@ -322,5 +309,71 @@ public class ExecutionLauncher {
   private static <E extends Enum<E>> E getEnum(Map<String, ?> map, String key, Class<E> type) {
     String value = (String) map.get(key);
     return value != null ? Enum.valueOf(type, value) : null;
+  }
+
+  /**
+   * for security reasons, we only want to allow a few explicitly configured ad-hoc operations.
+   * Every other operation should be blocked. Depending on how the allowed ad-hoc operations are
+   * configured, we also check to see if the user performing this action is allowed to run this
+   * operation
+   *
+   * @param execution pipeline execution
+   * @throws AccessDeniedException if the orchestration action is explicitly disabled or if the user
+   *     is not allowed to perform that action
+   */
+  private void checkIfPipelineCanBeStarted(PipelineExecution execution) {
+    // for now only orchestration execution types are checked to see if they need to be blocked
+    if (execution.getType() == ExecutionType.ORCHESTRATION
+        && executionConfigurationProperties.isBlockOrchestrationExecutions()) {
+      for (StageExecution stage : execution.getStages()) {
+        // get details about the orchestration type from the config
+        Optional<ExecutionConfigurationProperties.OrchestrationExecution> orchestrationType =
+            this.executionConfigurationProperties.getAllowedOrchestrationType(stage.getType());
+
+        // if we don't find the orchestration type in the config, that means it is configured to
+        // be disabled
+        if (orchestrationType.isEmpty()) {
+          log.warn(
+              "ad-hoc execution of type: {} has been explicitly disabled. Such actions can only be run "
+                  + "via spinnaker pipelines",
+              stage.getType());
+          throw new AccessDeniedException(
+              "ad-hoc execution of type: " + stage.getType() + " has been explicitly disabled");
+        }
+
+        // if all users are allowed to execute this orchestration task, then check is complete
+        if (orchestrationType.get().isAllowAllUsers()) {
+          return;
+        }
+
+        // get user info to check if the user is permitted to perform this orchestration action
+        String user = stage.getExecution().getAuthentication().getUser();
+        if (user == null || user.isEmpty()) {
+          log.warn(
+              "user details could not be found for ad-hoc execution of type: {}. This execution will "
+                  + "be blocked",
+              stage.getType());
+          throw new AccessDeniedException(
+              "user details could not be found for ad-hoc execution of type: "
+                  + stage.getType()
+                  + ". This execution will be blocked");
+        }
+
+        // check if the configured orchestration type is configured to only allow a subset of
+        // permitted users, and if this user is in that set
+        if (!orchestrationType.get().getPermittedUsers().contains(user)) {
+          log.warn(
+              "ad-hoc execution of type: {} has been explicitly disabled. Such actions can only be run "
+                  + "by a subset of users, of which {} is not a member.",
+              stage.getType(),
+              user);
+          throw new AccessDeniedException(
+              "ad-hoc execution of type: "
+                  + stage.getType()
+                  + " has been disabled for user: "
+                  + user);
+        }
+      }
+    }
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineExecutionLauncherSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineExecutionLauncherSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.pipeline
 
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.config.ExecutionConfigurationProperties
 import com.netflix.spinnaker.orca.events.BeforeInitialExecutionPersist
 import org.springframework.context.ApplicationEventPublisher
 
@@ -48,7 +49,8 @@ class PipelineExecutionLauncherSpec extends Specification {
       Clock.systemDefaultZone(),
       applicationEventPublisher,
       Optional.of(pipelineValidator),
-      Optional.<Registry> empty()
+      Optional.<Registry> empty(),
+      new ExecutionConfigurationProperties()
     )
   }
 
@@ -69,6 +71,7 @@ class PipelineExecutionLauncherSpec extends Specification {
             return "whatever"
           }
         })
+        registerSingleton("executionConfigurationProperties", new ExecutionConfigurationProperties())
       }
       register(ExecutionLauncher)
       refresh()
@@ -95,6 +98,7 @@ class PipelineExecutionLauncherSpec extends Specification {
             return "whatever"
           }
         })
+        registerSingleton("executionConfigurationProperties", new ExecutionConfigurationProperties())
       }
       register(ExecutionLauncher)
       refresh()

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
+import com.netflix.spinnaker.orca.config.ExecutionConfigurationProperties;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
+import java.time.Clock;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+public class ExecutionLauncherTest {
+
+  private ObjectMapper objectMapper;
+  @Mock private ExecutionRepository executionRepository;
+  @Mock private ExecutionRunner executionRunner;
+  @Mock private ApplicationEventPublisher applicationEventPublisher;
+  private ExecutionConfigurationProperties executionConfigurationProperties;
+  private ExecutionLauncher executionLauncher;
+
+  @BeforeEach
+  void setup() {
+    objectMapper = new ObjectMapper();
+    executionConfigurationProperties = new ExecutionConfigurationProperties();
+
+    executionLauncher =
+        new ExecutionLauncher(
+            objectMapper,
+            executionRepository,
+            executionRunner,
+            Clock.systemUTC(),
+            applicationEventPublisher,
+            Optional.empty(),
+            Optional.empty(),
+            executionConfigurationProperties);
+  }
+
+  @DisplayName(
+      "when some ad-hoc executions should be blocked, then those execution attempts should fail")
+  @Test
+  public void testOrchestrationExecutionsThatAreDisabled() throws Exception {
+    // setup
+    executionConfigurationProperties.setBlockOrchestrationExecutions(true);
+    // when
+    PipelineExecution pipelineExecution =
+        executionLauncher.start(
+            ExecutionType.ORCHESTRATION, getConfigJson("ad-hoc/deploy-manifest.json"));
+
+    // then
+    // verify that the failure reason is what we expect
+    verify(executionRepository).updateStatus(pipelineExecution);
+    verify(executionRepository)
+        .cancel(
+            ExecutionType.ORCHESTRATION,
+            pipelineExecution.getId(),
+            "system",
+            "Failed on startup: ad-hoc execution of type: deployManifest has been explicitly disabled");
+  }
+
+  @DisplayName(
+      "when some ad-hoc executions should be blocked, then executions not configured to be blocked "
+          + "should be allowed to run")
+  @Test
+  public void testOrchestrationExecutionsThatAreEnabled() throws Exception {
+    executionConfigurationProperties.setBlockOrchestrationExecutions(true);
+    // when
+    PipelineExecution pipelineExecution =
+        executionLauncher.start(
+            ExecutionType.ORCHESTRATION, getConfigJson("ad-hoc/save-pipeline.json"));
+
+    // then
+    // verify that the execution runner attempted to start the execution as expected
+    verify(executionRunner).start(pipelineExecution);
+    // verify that no errors were thrown such as the explicitly disabled ones
+    verify(executionRepository, never()).updateStatus(any());
+    verify(executionRepository, never()).cancel(any(), anyString(), anyString(), anyString());
+  }
+
+  @DisplayName(
+      "when ad-hoc executions should not be blocked, then all executions should be allowed to run")
+  @Test
+  public void testOrchestrationExecutionsThatAreDisabledWithFlagTurnedOff() throws Exception {
+    // when
+    PipelineExecution pipelineExecution =
+        executionLauncher.start(
+            ExecutionType.ORCHESTRATION, getConfigJson("ad-hoc/deploy-manifest.json"));
+
+    // then
+    // verify that the execution runner attempted to start the execution as expected
+    verify(executionRunner).start(pipelineExecution);
+    // verify that no errors were thrown such as the explicitly disabled ones
+    verify(executionRepository, never()).updateStatus(any());
+    verify(executionRepository, never()).cancel(any(), anyString(), anyString(), anyString());
+  }
+
+  private String getConfigJson(String resource) throws Exception {
+    Map requestBody =
+        objectMapper.readValue(
+            ExecutionLauncherTest.class.getResourceAsStream(resource), Map.class);
+    return objectMapper.writeValueAsString(requestBody);
+  }
+}

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherTest.java
@@ -30,11 +30,10 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,9 +41,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @ExtendWith(MockitoExtension.class)
 @ContextConfiguration(
     classes = ExecutionConfigurationProperties.class,
@@ -69,7 +66,7 @@ public class ExecutionLauncherTest extends YamlFileApplicationContextInitializer
     return "classpath:execution-launcher-properties.yml";
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     objectMapper = new ObjectMapper();
     clock = Clock.systemUTC();

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/YamlFileApplicationContextInitializer.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/YamlFileApplicationContextInitializer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline;
+
+import java.io.IOException;
+import java.util.List;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.Resource;
+
+/** source: https://stackoverflow.com/a/49716343 */
+public abstract class YamlFileApplicationContextInitializer
+    implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+  protected abstract String getResourceLocation();
+
+  @Override
+  public void initialize(ConfigurableApplicationContext applicationContext) {
+    try {
+      Resource resource = applicationContext.getResource(getResourceLocation());
+      YamlPropertySourceLoader sourceLoader = new YamlPropertySourceLoader();
+      List<PropertySource<?>> yamlTestProperties =
+          sourceLoader.load("yamlTestProperties", resource);
+      for (PropertySource<?> ps : yamlTestProperties) {
+        applicationContext.getEnvironment().getPropertySources().addLast(ps);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/orca-core/src/test/resources/com/netflix/spinnaker/orca/pipeline/ad-hoc/deploy-manifest.json
+++ b/orca-core/src/test/resources/com/netflix/spinnaker/orca/pipeline/ad-hoc/deploy-manifest.json
@@ -1,0 +1,19 @@
+{
+  "application":"amahajantest",
+  "name":"Deploy manifest",
+  "stages":[{"cloudProvider":"kubernetes","manifests":[{}],
+    "relationships":{
+      "loadBalancers":[],
+      "securityGroups":[]
+    },
+    "moniker":{"app":"amahajantest"},
+    "account":"k8s-prod-deploy-v2-account",
+    "manifestArtifactAccount":"embedded-artifact",
+    "source":"text",
+    "type":"deployManifest",
+    "user":"[anonymous]",
+    "refId":"0",
+    "requisiteStageRefIds":[]
+  }],
+  "origin":"deck"
+}

--- a/orca-core/src/test/resources/com/netflix/spinnaker/orca/pipeline/ad-hoc/save-pipeline-blocked-user.json
+++ b/orca-core/src/test/resources/com/netflix/spinnaker/orca/pipeline/ad-hoc/save-pipeline-blocked-user.json
@@ -5,10 +5,10 @@
     {
       "type":"savePipeline",
       "pipeline":"eyJhcHBsaWNhdGlvbiI6ImFtYWhhamFudGVzdCIsImluZGV4Ijo4LCJrZWVwV2FpdGluZ1BpcGVsaW5lcyI6ZmFsc2UsImxpbWl0Q29uY3VycmVudCI6dHJ1ZSwibmFtZSI6Im5ldy10ZXN0LXBpcGVsaW5lIiwic3BlbEV2YWx1YXRvciI6InY0Iiwic3RhZ2VzIjpbXSwidHJpZ2dlcnMiOltdfQ==",
-      "user":"anonymous",
       "staleCheck":false,
       "refId":"0",
       "requisiteStageRefIds":[]
     }],
-  "origin":"deck"
+  "origin":"deck",
+  "user": "not-explicitly-permitted-user@abc.com"
 }

--- a/orca-core/src/test/resources/com/netflix/spinnaker/orca/pipeline/ad-hoc/save-pipeline-permitted-user.json
+++ b/orca-core/src/test/resources/com/netflix/spinnaker/orca/pipeline/ad-hoc/save-pipeline-permitted-user.json
@@ -1,0 +1,14 @@
+{
+  "application":"amahajantest",
+  "name":"Save pipeline 'new-test-pipeline'",
+  "stages":[
+    {
+      "type":"savePipeline",
+      "pipeline":"eyJhcHBsaWNhdGlvbiI6ImFtYWhhamFudGVzdCIsImluZGV4Ijo4LCJrZWVwV2FpdGluZ1BpcGVsaW5lcyI6ZmFsc2UsImxpbWl0Q29uY3VycmVudCI6dHJ1ZSwibmFtZSI6Im5ldy10ZXN0LXBpcGVsaW5lIiwic3BlbEV2YWx1YXRvciI6InY0Iiwic3RhZ2VzIjpbXSwidHJpZ2dlcnMiOltdfQ==",
+      "staleCheck":false,
+      "refId":"0",
+      "requisiteStageRefIds":[]
+    }],
+  "origin":"deck",
+  "user": "permitted-user@abc.com"
+}

--- a/orca-core/src/test/resources/com/netflix/spinnaker/orca/pipeline/ad-hoc/save-pipeline.json
+++ b/orca-core/src/test/resources/com/netflix/spinnaker/orca/pipeline/ad-hoc/save-pipeline.json
@@ -1,0 +1,14 @@
+{
+  "application":"amahajantest",
+  "name":"Save pipeline 'new-test-pipeline'",
+  "stages":[
+    {
+      "type":"savePipeline",
+      "pipeline":"eyJhcHBsaWNhdGlvbiI6ImFtYWhhamFudGVzdCIsImluZGV4Ijo4LCJrZWVwV2FpdGluZ1BpcGVsaW5lcyI6ZmFsc2UsImxpbWl0Q29uY3VycmVudCI6dHJ1ZSwibmFtZSI6Im5ldy10ZXN0LXBpcGVsaW5lIiwic3BlbEV2YWx1YXRvciI6InY0Iiwic3RhZ2VzIjpbXSwidHJpZ2dlcnMiOltdfQ==",
+      "user":"anonymous",
+      "staleCheck":false,
+      "refId":"0",
+      "requisiteStageRefIds":[]
+    }],
+  "origin":"deck"
+}

--- a/orca-core/src/test/resources/com/netflix/spinnaker/orca/pipeline/ad-hoc/update-application.json
+++ b/orca-core/src/test/resources/com/netflix/spinnaker/orca/pipeline/ad-hoc/update-application.json
@@ -1,0 +1,72 @@
+{
+  "application":"amahajantest",
+  "name":"Update Application: amahajantest",
+  "stages":[
+    {
+      "type":"updateApplication",
+      "application": {
+        "name": "amahajantest",
+        "dataSources": {
+          "disabled": [],
+          "enabled": [
+            "serverGroups",
+            "loadBalancers",
+            "securityGroups"
+          ]
+        }
+      },
+      "newState": {
+        "name": "amahajantest",
+        "user": "any-user@abc.com",
+        "dataSources": {
+          "disabled": [],
+          "enabled": [
+            "serverGroups",
+            "loadBalancers",
+            "securityGroups"
+          ]
+        }
+      },
+      "previousState": {
+        "instancePort": 80,
+        "lastModifiedBy": "any-user@abc.com",
+        "name": "AMAHAJANTEST",
+        "customBanners": [
+          {
+            "backgroundColor": "var(--color-alert)",
+            "text": "Test App",
+            "textColor": "var(--color-text-on-dark)",
+            "enabled": false
+          },
+          {
+            "backgroundColor": "var(--color-alert)",
+            "text": "Your custom banner text",
+            "textColor": "var(--color-text-on-dark)",
+            "enabled": false
+          }
+        ],
+        "cloudProviders": "",
+        "providerSettings": {
+          "aws": {
+            "useAmiBlockDeviceMappings": false
+          }
+        },
+        "updateTs": "1639767570728",
+        "user": "any-user@abc.com",
+        "dataSources": {
+          "disabled": [
+            "serverGroups",
+            "loadBalancers",
+            "securityGroups"
+          ],
+          "enabled": []
+        },
+        "email": "some-owner@abc.com",
+        "trafficGuards": []
+      },
+      "refId":"0",
+      "requisiteStageRefIds":[]
+    }],
+  "origin":"deck",
+  "user": "any-user@abc.com"
+}

--- a/orca-core/src/test/resources/execution-launcher-properties.yml
+++ b/orca-core/src/test/resources/execution-launcher-properties.yml
@@ -1,0 +1,9 @@
+executions:
+  blockOrchestrationExecutions: true
+  allowedOrchestrationExecutions: # only applicable when blockOrchestrationExecutions: false
+    - name: savePipeline # eg. config to show how to set the name and permittedUsers properties for an execution
+      permittedUsers:
+       - "permitted-user@abc.com"
+    - name: updateApplication # eg. config to show how to set the name and allowAllUsers properties for an execution
+      allowAllUsers: true
+    - name: saveApplication # eg. config to show how to set just the name of an execution. It defaults to allowAllUsers: true


### PR DESCRIPTION
## Purpose

There are two types of tasks - pipeline initiated tasks, and ad-hoc orchestration tasks. Some of the ad-hoc tasks can be done through the UI - such as update application, delete pipeline, update pipeline etc. For security reasons, we want the capability to disable ad-hoc tasks for all users (except the few that are permitted to execute them) in production environments. 

This PR introduces a few config knobs that provide a more fine-grained control over who can perform the above actions. By default, everyone can perform all actions (which equates to the current behavior). Users can opt-in to this capability by configuring the ad-hoc tasks in the manner presented below:
```
executions:
  blockOrchestrationExecutions: true
  allowedOrchestrationExecutions: # only applicable when blockOrchestrationExecutions: false
    - name: updateApplication # eg. config to show how to set the name and allowAllUsers properties for an execution
      allowAllUsers: true
    - name: saveApplication # eg. config to show how to set just the name of an execution. It defaults to allowAllUsers: true
    - name: savePipeline # eg. config to show how to set the name and permittedUsers properties for an execution
      permittedUsers:
       - "permitted-user@abc.com"
````


