### PR TITLE
fix(build): bump kork to 7.110.0 & change groupid for dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
 allprojects {
   apply plugin: 'io.spinnaker.project'
 
-  group = "com.netflix.spinnaker.orca"
+  group = "io.spinnaker.orca"
 
   tasks.withType(JavaExec) {
     if (System.getProperty('DEBUG', 'false') == 'true') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-fiatVersion=1.26.0
-korkVersion=7.109.0
+fiatVersion=1.27.0
+korkVersion=7.110.0
 kotlinVersion=1.4.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.10.1

--- a/orca-applications/orca-applications.gradle
+++ b/orca-applications/orca-applications.gradle
@@ -22,7 +22,7 @@ dependencies {
   implementation(project(":orca-front50"))
   implementation(project(":orca-keel"))
   implementation(project(":orca-retrofit"))
-  implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+  implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
 
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")

--- a/orca-bakery/orca-bakery.gradle
+++ b/orca-bakery/orca-bakery.gradle
@@ -24,7 +24,7 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-core")
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava")
-  implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+  implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
 
   api("io.spinnaker.kork:kork-web")
 

--- a/orca-bom/orca-bom.gradle
+++ b/orca-bom/orca-bom.gradle
@@ -25,8 +25,8 @@ dependencies {
   api(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
 
   constraints {
-    api("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
-    api("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+    api("io.spinnaker.fiat:fiat-api:$fiatVersion")
+    api("io.spinnaker.fiat:fiat-core:$fiatVersion")
 
     rootProject
       .subprojects

--- a/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca-clouddriver/orca-clouddriver.gradle
@@ -54,7 +54,7 @@ dependencies {
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core:2.25.0")
   testImplementation("org.mockito:mockito-junit-jupiter")
-  testImplementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+  testImplementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
   testImplementation("dev.minutest:minutest")
   testImplementation("io.strikt:strikt-core")
   testImplementation("io.mockk:mockk")

--- a/orca-echo/orca-echo.gradle
+++ b/orca-echo/orca-echo.gradle
@@ -26,8 +26,8 @@ dependencies {
   implementation("io.spinnaker.kork:kork-core")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("javax.validation:validation-api")
-  implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
-  implementation("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
+  implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
+  implementation("io.spinnaker.fiat:fiat-api:$fiatVersion")
 
   testImplementation("com.squareup.retrofit:retrofit-mock")
 }

--- a/orca-front50/orca-front50.gradle
+++ b/orca-front50/orca-front50.gradle
@@ -22,8 +22,8 @@ dependencies {
 
   api("org.codehaus.groovy:groovy")
 
-  implementation("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
-  implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+  implementation("io.spinnaker.fiat:fiat-api:$fiatVersion")
+  implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
   implementation("com.netflix.spectator:spectator-api")
   implementation("org.jetbrains:annotations")
   implementation("org.springframework.boot:spring-boot-autoconfigure")

--- a/orca-igor/orca-igor.gradle
+++ b/orca-igor/orca-igor.gradle
@@ -30,5 +30,5 @@ dependencies {
 
   testImplementation(project(":orca-test-groovy"))
   testImplementation("org.springframework:spring-test")
-  testImplementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+  testImplementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
 }

--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -29,5 +29,5 @@ dependencies {
   testImplementation("org.slf4j:slf4j-simple")
   testImplementation("org.spockframework:spock-unitils")
   testImplementation("org.codehaus.groovy:groovy-json")
-  testImplementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+  testImplementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
 }

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -26,7 +26,7 @@ run {
   systemProperty('spring.config.additional-location', project.springConfigLocation)
 }
 
-mainClassName = 'com.netflix.spinnaker.orca.Main'
+mainClassName = 'io.spinnaker.orca.Main'
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-web")
@@ -68,8 +68,8 @@ dependencies {
   implementation("io.spinnaker.kork:kork-web")
   implementation("io.spinnaker.kork:kork-plugins")
   implementation("net.logstash.logback:logstash-logback-encoder")
-  implementation("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
-  implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+  implementation("io.spinnaker.fiat:fiat-api:$fiatVersion")
+  implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
 
   runtimeOnly("io.spinnaker.kork:kork-runtime")
 

--- a/orca-webhook/orca-webhook.gradle
+++ b/orca-webhook/orca-webhook.gradle
@@ -31,8 +31,8 @@ dependencies {
 //  testImplementation project(':orca-test')
   testImplementation("org.springframework:spring-test")
 
-  implementation("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
-  implementation("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+  implementation("io.spinnaker.fiat:fiat-api:$fiatVersion")
+  implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
   implementation("org.apache.httpcomponents:httpclient")
   implementation("org.springframework.security:spring-security-config")
   implementation("org.springframework.security:spring-security-core")


### PR DESCRIPTION
There is an issue in the Plugins Framework that was solved in this PR: spinnaker/kork#866

but this fix was released in kork 7.110.0

I bumped the version of kork to include the fix in VersionManager in the plugins framework but this involved changing the groupId of kork because now it's been published under "io.spinnaker" and this release branch is pretty old.

I had to bump the version of Fiat as well because it has issues when trying to download the kork version in fiat due to the groupId change.
