### PR TITLE
test(discovery): fixes admin controller test intermittent failures

### DIFF
--- a/orca-web/src/test/kotlin/com/netflix/spinnaker/orca/controllers/AdminControllerTest.kt
+++ b/orca-web/src/test/kotlin/com/netflix/spinnaker/orca/controllers/AdminControllerTest.kt
@@ -40,6 +40,16 @@ class AdminControllerTest : JUnit5Minutests {
     }
 
     test("/admin/instance/enabled endpoint can disable queue Activator") {
+      // wait up to 5 seconds for discoveryActivator to initialize
+      for (i in 1..5) {
+         if (discoveryActivator.enabled){
+            println("discoveryActivator.enabled = true. Start")
+            break
+         }
+         println("discoveryActivator.enabled = false. Sleep 1sec")
+         Thread.sleep(1000L)
+      }
+
       expectThat(discoveryActivator.enabled).isTrue()
 
       val response = mockMvc.post("/admin/instance/enabled") {


### PR DESCRIPTION
Fixes com.netflix.spinnaker.orca.controllers.AdminControllerTest intermittent failures. The failure seems to be caused by a start up issue. The DiscoveryActivator is not initialized when the test is checking for its initial status. This fix adds wait/sleep, so DiscoveryActivator can be fully initialized.

Here is the test log showing failure: 
[TEST-com.netflix.spinnaker.orca.controllers.AdminControllerTest.xml.log](https://github.com/spinnaker/orca/files/7685484/TEST-com.netflix.spinnaker.orca.controllers.AdminControllerTest.xml.log)
>
Here is the partial output of test when it encounters issue, and successful:
>2021-12-09T04:09:24.5943329Z 2021-12-09 04:08:58.103  INFO 7552 --- [    Test worker] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 239 ms
2021-12-09T04:09:24.5945652Z 2021-12-09 04:08:58.580  WARN 7552 --- [       events-6] c.n.s.k.d.NoDiscoveryStatusPublisher     : No service discovery client is available, assuming application is UP
2021-12-09T04:09:24.5948049Z 2021-12-09 04:08:58.606  INFO 7552 --- [    Test worker] c.n.s.o.c.AdminControllerTest$Fixture    : Started AdminControllerTest.Fixture in 32.505 seconds (JVM running for 44.683)
>
> // DiscoveryActivator not ready when test starts 
2021-12-09T04:09:24.5949692Z discoveryActivator.enabled = false. Sleep 1sec
>
>2021-12-09T04:09:24.5951472Z 2021-12-09 04:08:58.788  INFO 7552 --- [       events-1] c.n.s.k.d.DiscoveryStatusListener        : Instance status has changed to UP in service discovery
2021-12-09T04:09:24.5953626Z 2021-12-09 04:08:58.788  INFO 7552 --- [      events-19] c.n.s.q.discovery.DiscoveryActivator     : Instance is UP... DiscoveryActivator starting
2021-12-09T04:09:24.5955891Z 2021-12-09 04:08:58.826  INFO 7552 --- [    scheduler-6] s.k.p.u.r.r.RemotePluginInfoReleaseCache : Cached 0 remote plugin configurations.
>
> // After sleeping 1 second, DiscoveryActivator is ready
>2021-12-09T04:09:24.5957448Z discoveryActivator.enabled = true. Start
>
>2021-12-09T04:09:24.5959311Z 2021-12-09 04:08:59.838  INFO 7552 --- [       events-4] c.n.s.q.discovery.DiscoveryActivator     : Instance is OUT_OF_SERVICE... DiscoveryActivator stopping
2021-12-09T04:09:24.5961573Z 2021-12-09 04:08:59.838  INFO 7552 --- [       events-7] c.n.s.k.d.DiscoveryStatusListener        : Instance status has changed to OUT_OF_SERVICE in service discovery
