### PR TITLE
fix(web/test): create MonitorableQueue bean to fix web test

### DIFF
--- a/orca-plugins-test/src/test/kotlin/com/netflix/spinnaker/orca/plugins/test/OrcaPluginsFixture.kt
+++ b/orca-plugins-test/src/test/kotlin/com/netflix/spinnaker/orca/plugins/test/OrcaPluginsFixture.kt
@@ -33,9 +33,9 @@ import com.netflix.spinnaker.orca.plugins.PreconfiguredJobConfigurationProviderE
 import com.netflix.spinnaker.orca.plugins.StageDefinitionBuilderExtension
 import com.netflix.spinnaker.orca.plugins.TaskExtension1
 import com.netflix.spinnaker.orca.plugins.TaskExtension2
-import com.netflix.spinnaker.q.Queue
 import com.netflix.spinnaker.q.memory.InMemoryQueue
 import com.netflix.spinnaker.q.metrics.EventPublisher
+import com.netflix.spinnaker.q.metrics.MonitorableQueue
 import java.io.File
 import java.time.Clock
 import java.time.Duration
@@ -111,7 +111,7 @@ internal class PluginTestConfiguration {
 
   @Bean
   @Primary
-  fun queue(clock: Clock?, publisher: EventPublisher?): Queue {
+  fun queue(clock: Clock?, publisher: EventPublisher?): MonitorableQueue {
     return InMemoryQueue(
       clock!!, Duration.ofMinutes(1), emptyList(), false, publisher!!
     )

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/StartupTestConfiguration.java
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/StartupTestConfiguration.java
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.orca;
 
-import com.netflix.spinnaker.q.Queue;
 import com.netflix.spinnaker.q.memory.InMemoryQueue;
 import com.netflix.spinnaker.q.metrics.EventPublisher;
+import com.netflix.spinnaker.q.metrics.MonitorableQueue;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Collections;
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Primary;
 class StartupTestConfiguration {
   @Bean
   @Primary
-  Queue queue(Clock clock, EventPublisher publisher) {
+  MonitorableQueue queue(Clock clock, EventPublisher publisher) {
     return new InMemoryQueue(
         clock, Duration.ofMinutes(1), Collections.emptyList(), false, publisher);
   }


### PR DESCRIPTION
### Test Fixes

Fixes UnsatisfiedDependencyException seen in the tests when running  `./gradle build` (See: https://github.com/spinnaker/orca/runs/5069995846?check_suite_focus=true)

```
Caused by:
        org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'zombieExecutionService' defined in URL [jar:file:/home/runner/work/orca/orca/orca-queue/build/libs/orca-queue.jar!/com/netflix/spinnaker/orca/q/ZombieExecutionService.class]: Unsatisfied dependency expressed through constructor parameter 1; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'com.netflix.spinnaker.q.metrics.MonitorableQueue' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
            at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:799)
            at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:228)
            at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1356)
            at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1203)
            at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:556)
            at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:516)
            at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:324)
            at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
            at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:322)
            at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
            at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:897)
            at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:879)
            at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:551)
            at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:747)
            at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:405)
            at org.springframework.boot.SpringApplication.run(SpringApplication.java:315)
            at org.springframework.boot.test.context.SpringBootContextLoader.loadContext(SpringBootContextLoader.java:124)
            at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:99)
            at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:124)
```