### PR TITLE
feat(expressions): add option to disable retry for fromUrl expression function

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -59,6 +59,7 @@ dependencies {
 
   testImplementation(project(":orca-test"))
   testImplementation(project(":orca-test-groovy"))
+  testImplementation("com.github.tomakehurst:wiremock:2.15.0")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.platform:junit-platform-runner")
   testImplementation("org.assertj:assertj-core")

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/UserConfiguredUrlRestrictions.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/UserConfiguredUrlRestrictions.java
@@ -134,8 +134,7 @@ public class UserConfiguredUrlRestrictions {
 
       if (StringUtils.isBlank(allowedHostnames.pattern())) {
         throw new IllegalArgumentException(
-            "Allowed Hostnames are not set, external HTTP requests are not enabled. Please configure 'user-configured-url-restrictions.allowedHostnamesRegex' in your orca config."
-        );
+            "Allowed Hostnames are not set, external HTTP requests are not enabled. Please configure 'user-configured-url-restrictions.allowedHostnamesRegex' in your orca config.");
       }
 
       if (!allowedHostnames.matcher(host).matches()) {

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/UserConfiguredUrlRestrictions.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/UserConfiguredUrlRestrictions.java
@@ -37,7 +37,7 @@ import org.springframework.security.web.util.matcher.IpAddressMatcher;
 public class UserConfiguredUrlRestrictions {
   @Data
   public static class Builder {
-    private String allowedHostnamesRegex = "";
+    private String allowedHostnamesRegex = ".*";
     private List<String> allowedSchemes = new ArrayList<>(Arrays.asList("http", "https"));
     private boolean rejectLocalhost = true;
     private boolean rejectLinkLocal = true;
@@ -203,8 +203,8 @@ public class UserConfiguredUrlRestrictions {
   @NoArgsConstructor
   @AllArgsConstructor
   public static class HttpClientProperties {
-    @lombok.Builder.Default private boolean enableRetry = false;
-    @lombok.Builder.Default private int maxRetryAttempts = 5;
+    @lombok.Builder.Default private boolean enableRetry = true;
+    @lombok.Builder.Default private int maxRetryAttempts = 1;
     @lombok.Builder.Default private int retryInterval = 5000;
     @lombok.Builder.Default private int timeoutMillis = 30000;
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/UserConfiguredUrlRestrictions.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/UserConfiguredUrlRestrictions.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -204,13 +203,9 @@ public class UserConfiguredUrlRestrictions {
   @NoArgsConstructor
   @AllArgsConstructor
   public static class HttpClientProperties {
-    @lombok.Builder.Default
-    private boolean enableRetry = false;
-    @lombok.Builder.Default
-    private int maxRetryAttempts = 5;
-    @lombok.Builder.Default
-    private int retryInterval = 5000;
-    @lombok.Builder.Default
-    private int timeoutMillis = 30000;
+    @lombok.Builder.Default private boolean enableRetry = false;
+    @lombok.Builder.Default private int maxRetryAttempts = 5;
+    @lombok.Builder.Default private int retryInterval = 5000;
+    @lombok.Builder.Default private int timeoutMillis = 30000;
   }
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
@@ -38,12 +38,15 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 @SuppressWarnings("unused")
 @Component
 public class UrlExpressionFunctionProvider implements ExpressionFunctionProvider {
+  private static AtomicReference<HttpClientUtils> httpClientUtils = new AtomicReference<>();
   private static AtomicReference<UserConfiguredUrlRestrictions> helperFunctionUrlRestrictions =
       new AtomicReference<>();
   private static final ObjectMapper mapper = OrcaObjectMapper.getInstance();
 
-  public UrlExpressionFunctionProvider(UserConfiguredUrlRestrictions urlRestrictions) {
+  public UrlExpressionFunctionProvider(
+      UserConfiguredUrlRestrictions urlRestrictions, HttpClientUtils httpClient) {
     helperFunctionUrlRestrictions.set(urlRestrictions);
+    httpClientUtils.set(httpClient);
   }
 
   @Nullable
@@ -195,8 +198,7 @@ public class UrlExpressionFunctionProvider implements ExpressionFunctionProvider
   public static String fromUrl(String url) {
     try {
       URL u = helperFunctionUrlRestrictions.get().validateURI(url).toURL();
-      return HttpClientUtils.httpGetAsString(
-          u.toString(), helperFunctionUrlRestrictions.get().isRetryEnabled());
+      return httpClientUtils.get().httpGetAsString(u.toString());
     } catch (Exception e) {
       throw new SpelHelperFunctionException(format("#from(%s) failed", url), e);
     }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
@@ -195,7 +195,7 @@ public class UrlExpressionFunctionProvider implements ExpressionFunctionProvider
   public static String fromUrl(String url) {
     try {
       URL u = helperFunctionUrlRestrictions.get().validateURI(url).toURL();
-      return HttpClientUtils.httpGetAsString(u.toString());
+      return HttpClientUtils.httpGetAsString(u.toString(), helperFunctionUrlRestrictions.get().isRetryEnabled());
     } catch (Exception e) {
       throw new SpelHelperFunctionException(format("#from(%s) failed", url), e);
     }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/UrlExpressionFunctionProvider.java
@@ -195,7 +195,8 @@ public class UrlExpressionFunctionProvider implements ExpressionFunctionProvider
   public static String fromUrl(String url) {
     try {
       URL u = helperFunctionUrlRestrictions.get().validateURI(url).toURL();
-      return HttpClientUtils.httpGetAsString(u.toString(), helperFunctionUrlRestrictions.get().isRetryEnabled());
+      return HttpClientUtils.httpGetAsString(
+          u.toString(), helperFunctionUrlRestrictions.get().isRetryEnabled());
     } catch (Exception e) {
       throw new SpelHelperFunctionException(format("#from(%s) failed", url), e);
     }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
@@ -64,7 +64,8 @@ public class ContextParameterProcessor {
             new ManifestLabelValueExpressionFunctionProvider(),
             new StageExpressionFunctionProvider(),
             new UrlExpressionFunctionProvider(
-                new UserConfiguredUrlRestrictions.Builder().build(), new HttpClientUtils(new UserConfiguredUrlRestrictions.Builder().build()))),
+                new UserConfiguredUrlRestrictions.Builder().build(),
+                new HttpClientUtils(new UserConfiguredUrlRestrictions.Builder().build()))),
         new DefaultPluginManager(),
         DynamicConfigService.NOOP);
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ContextParameterProcessor.java
@@ -63,7 +63,8 @@ public class ContextParameterProcessor {
             new DeployedServerGroupsExpressionFunctionProvider(),
             new ManifestLabelValueExpressionFunctionProvider(),
             new StageExpressionFunctionProvider(),
-            new UrlExpressionFunctionProvider(new UserConfiguredUrlRestrictions.Builder().build())),
+            new UrlExpressionFunctionProvider(
+                new UserConfiguredUrlRestrictions.Builder().build(), new HttpClientUtils(new UserConfiguredUrlRestrictions.Builder().build()))),
         new DefaultPluginManager(),
         DynamicConfigService.NOOP);
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtils.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtils.java
@@ -121,8 +121,7 @@ public class HttpClientUtils {
   }
 
   private static CloseableHttpClient httpClientNoRetry() {
-    HttpClientBuilder httpClientBuilder =
-        HttpClients.custom().disableAutomaticRetries();
+    HttpClientBuilder httpClientBuilder = HttpClients.custom().disableAutomaticRetries();
     httpClientAddConfiguration(httpClientBuilder);
     return httpClientBuilder.build();
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtils.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtils.java
@@ -24,6 +24,7 @@ import java.io.Reader;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -39,12 +40,13 @@ import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpCoreContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
+@Component
 public class HttpClientUtils {
+
+  private CloseableHttpClient httpClient;
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpClientUtils.class);
-  private static final int MAX_RETRIES = 5;
-  private static final int RETRY_INTERVAL = 5000;
-  private static final int TIMEOUT_MILLIS = 30000;
   private static final String JVM_HTTP_PROXY_HOST = "http.proxyHost";
   private static final String JVM_HTTP_PROXY_PORT = "http.proxyPort";
   private static List<Integer> RETRYABLE_500_HTTP_STATUS_CODES =
@@ -53,80 +55,76 @@ public class HttpClientUtils {
           HttpStatus.SC_INTERNAL_SERVER_ERROR,
           HttpStatus.SC_GATEWAY_TIMEOUT);
 
-  private static CloseableHttpClient httpClient = httpClientNoRetry();
-
-  private static CloseableHttpClient httpClientWithServiceUnavailableRetryStrategy() {
-    HttpClientBuilder httpClientBuilder =
-        HttpClients.custom()
-            .setServiceUnavailableRetryStrategy(
-                new ServiceUnavailableRetryStrategy() {
-                  @Override
-                  public boolean retryRequest(
-                      HttpResponse response, int executionCount, HttpContext context) {
-                    int statusCode = response.getStatusLine().getStatusCode();
-                    HttpUriRequest currentReq =
-                        (HttpUriRequest) context.getAttribute(HttpCoreContext.HTTP_REQUEST);
-                    LOGGER.info("Response code {} for {}", statusCode, currentReq.getURI());
-
-                    if (statusCode >= HttpStatus.SC_OK && statusCode <= 299) {
-                      return false;
-                    }
-
-                    boolean shouldRetry =
-                        (statusCode == 429 || RETRYABLE_500_HTTP_STATUS_CODES.contains(statusCode))
-                            && executionCount <= MAX_RETRIES;
-
-                    if ((statusCode >= 300) && (statusCode <= 399)) {
-                      throw new RetryRequestException(
-                          String.format(
-                              "Attempted redirect from %s to %s which is not supported",
-                              currentReq.getURI(), response.getFirstHeader("LOCATION").getValue()));
-                    }
-                    if (!shouldRetry) {
-                      throw new RetryRequestException(
-                          String.format(
-                              "Not retrying %s. Count %d, Max %d",
-                              currentReq.getURI(), executionCount, MAX_RETRIES));
-                    }
-
-                    LOGGER.error(
-                        "Retrying request on response status {}. Count {} Max is {}",
-                        statusCode,
-                        executionCount,
-                        MAX_RETRIES);
-                    return true;
-                  }
-
-                  @Override
-                  public long getRetryInterval() {
-                    return RETRY_INTERVAL;
-                  }
-                });
-
-    httpClientBuilder.setRetryHandler(
-        (exception, executionCount, context) -> {
-          HttpUriRequest currentReq =
-              (HttpUriRequest) context.getAttribute(HttpCoreContext.HTTP_REQUEST);
-          Uninterruptibles.sleepUninterruptibly(RETRY_INTERVAL, TimeUnit.MILLISECONDS);
-          LOGGER.info(
-              "Encountered network error. Retrying request {},  Count {} Max is {}",
-              currentReq.getURI(),
-              executionCount,
-              MAX_RETRIES);
-          return executionCount <= MAX_RETRIES;
-        });
-
-    httpClientAddConfiguration(httpClientBuilder);
-    return httpClientBuilder.build();
+  public HttpClientUtils(UserConfiguredUrlRestrictions userConfiguredUrlRestrictions) {
+    this.httpClient = create(userConfiguredUrlRestrictions.getHttpClientProperties());
   }
 
-  private static CloseableHttpClient httpClientNoRetry() {
-    HttpClientBuilder httpClientBuilder = HttpClients.custom().disableAutomaticRetries();
-    httpClientAddConfiguration(httpClientBuilder);
-    return httpClientBuilder.build();
-  }
+  private CloseableHttpClient create(UserConfiguredUrlRestrictions.HttpClientProperties httpClientProperties) {
+    HttpClientBuilder httpClientBuilder = HttpClients.custom();
 
-  private static void httpClientAddConfiguration(HttpClientBuilder httpClientBuilder) {
+    if (httpClientProperties.isEnableRetry()) {
+      httpClientBuilder
+          .setServiceUnavailableRetryStrategy(
+              new ServiceUnavailableRetryStrategy() {
+                @Override
+                public boolean retryRequest(
+                    HttpResponse response, int executionCount, HttpContext context) {
+                  int statusCode = response.getStatusLine().getStatusCode();
+                  HttpUriRequest currentReq =
+                      (HttpUriRequest) context.getAttribute(HttpCoreContext.HTTP_REQUEST);
+                  LOGGER.info("Response code {} for {}", statusCode, currentReq.getURI());
+
+                  if (statusCode >= HttpStatus.SC_OK && statusCode <= 299) {
+                    return false;
+                  }
+
+                  boolean shouldRetry =
+                      (statusCode == 429 || RETRYABLE_500_HTTP_STATUS_CODES.contains(statusCode))
+                          && executionCount <= httpClientProperties.getMaxRetryAttempts();
+
+                  if ((statusCode >= 300) && (statusCode <= 399)) {
+                    throw new RetryRequestException(
+                        String.format(
+                            "Attempted redirect from %s to %s which is not supported",
+                            currentReq.getURI(), response.getFirstHeader("LOCATION").getValue()));
+                  }
+                  if (!shouldRetry) {
+                    throw new RetryRequestException(
+                        String.format(
+                            "Not retrying %s. Count %d, Max %d",
+                            currentReq.getURI(), executionCount, httpClientProperties.getMaxRetryAttempts()));
+                  }
+
+                  LOGGER.error(
+                      "Retrying request on response status {}. Count {} Max is {}",
+                      statusCode,
+                      executionCount,
+                      httpClientProperties.getMaxRetryAttempts());
+                  return true;
+                }
+
+                @Override
+                public long getRetryInterval() {
+                  return httpClientProperties.getRetryInterval();
+                }
+              });
+
+      httpClientBuilder.setRetryHandler(
+          (exception, executionCount, context) -> {
+            HttpUriRequest currentReq =
+                (HttpUriRequest) context.getAttribute(HttpCoreContext.HTTP_REQUEST);
+            Uninterruptibles.sleepUninterruptibly(httpClientProperties.getRetryInterval(), TimeUnit.MILLISECONDS);
+            LOGGER.info(
+                "Encountered network error. Retrying request {},  Count {} Max is {}",
+                currentReq.getURI(),
+                executionCount,
+                httpClientProperties.getMaxRetryAttempts());
+            return executionCount <= httpClientProperties.getMaxRetryAttempts();
+          });
+    } else {
+      httpClientBuilder.disableAutomaticRetries();
+    }
+
     String proxyHostname = System.getProperty(JVM_HTTP_PROXY_HOST);
     if (proxyHostname != null) {
       int proxyPort =
@@ -143,17 +141,15 @@ public class HttpClientUtils {
 
     httpClientBuilder.setDefaultRequestConfig(
         RequestConfig.custom()
-            .setConnectionRequestTimeout(TIMEOUT_MILLIS)
-            .setConnectTimeout(TIMEOUT_MILLIS)
-            .setSocketTimeout(TIMEOUT_MILLIS)
+            .setConnectionRequestTimeout(httpClientProperties.getTimeoutMillis())
+            .setConnectTimeout(httpClientProperties.getTimeoutMillis())
+            .setSocketTimeout(httpClientProperties.getTimeoutMillis())
             .build());
+
+    return httpClientBuilder.build();
   }
 
-  public static String httpGetAsString(String url, Boolean retry) throws IOException {
-    if (retry) {
-      httpClient = httpClientWithServiceUnavailableRetryStrategy();
-    }
-
+  public String httpGetAsString(String url) throws IOException {
     try (CloseableHttpResponse response = httpClient.execute(new HttpGet(url))) {
       try (final Reader reader = new InputStreamReader(response.getEntity().getContent())) {
         return CharStreams.toString(reader);
@@ -161,7 +157,7 @@ public class HttpClientUtils {
     }
   }
 
-  static class RetryRequestException extends RuntimeException {
+  class RetryRequestException extends RuntimeException {
     RetryRequestException(String cause) {
       super(cause);
     }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/config/UserConfiguredUrlRestrictionsSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/config/UserConfiguredUrlRestrictionsSpec.groovy
@@ -27,4 +27,24 @@ class UserConfiguredUrlRestrictionsSpec extends Specification {
     uri << ['https://www.test.com', 'https://201.152.178.212', 'https://www.test_underscore.com']
   }
 
+  @Unroll
+  def 'should verify allowedHostnamesRegex is set'() {
+    given:
+    UserConfiguredUrlRestrictions config = new UserConfiguredUrlRestrictions.Builder()
+        .withRejectedIps([])
+        .withAllowedSchemes(['https'])
+        .withRejectLocalhost(false)
+        .withRejectLinkLocal(false)
+        .build()
+
+    when:
+    config.validateURI(uri)
+
+    then:
+    thrown(IllegalArgumentException.class)
+
+    where:
+    uri << ['https://www.test.com', 'https://201.152.178.212', 'https://www.test_underscore.com']
+  }
+
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/config/UserConfiguredUrlRestrictionsSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/config/UserConfiguredUrlRestrictionsSpec.groovy
@@ -31,6 +31,7 @@ class UserConfiguredUrlRestrictionsSpec extends Specification {
   def 'should verify allowedHostnamesRegex is set'() {
     given:
     UserConfiguredUrlRestrictions config = new UserConfiguredUrlRestrictions.Builder()
+        .withAllowedHostnamesRegex("")
         .withRejectedIps([])
         .withAllowedSchemes(['https'])
         .withRejectLocalhost(false)

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtilsTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtilsTest.java
@@ -16,10 +16,14 @@
 
 package com.netflix.spinnaker.orca.pipeline.util;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Fail.fail;
+
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
+import java.io.IOException;
 import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,23 +31,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.assertj.core.api.Fail.fail;
-
 @RunWith(JUnitPlatform.class)
 public class HttpClientUtilsTest {
 
   private final String host = "localhost";
   private final int port = 8080;
   private final String resource = "/v1/text";
-  private final UserConfiguredUrlRestrictions.Builder config = new UserConfiguredUrlRestrictions.Builder();
+  private final UserConfiguredUrlRestrictions.Builder config =
+      new UserConfiguredUrlRestrictions.Builder();
 
   WireMockServer wireMockServer = new WireMockServer();
 
-  @Rule
-  public WireMockRule wireMockRule = new WireMockRule(port);
+  @Rule public WireMockRule wireMockRule = new WireMockRule(port);
 
   @BeforeEach
   public void setup() {
@@ -60,8 +59,7 @@ public class HttpClientUtilsTest {
   public void testZeroRetryFor503StatusCode() {
     // given:
     HttpClientUtils httpClientUtils = new HttpClientUtils(config.build());
-    stubFor(get(resource)
-        .willReturn(aResponse().withStatus(503)));
+    stubFor(get(resource).willReturn(aResponse().withStatus(503)));
 
     // when:
     try {
@@ -78,13 +76,9 @@ public class HttpClientUtilsTest {
   public void testDefaultRetryForSocketException() {
     // given:
     config.setHttpClientProperties(
-        UserConfiguredUrlRestrictions.HttpClientProperties.builder()
-            .enableRetry(true)
-            .build()
-    );
+        UserConfiguredUrlRestrictions.HttpClientProperties.builder().enableRetry(true).build());
     HttpClientUtils httpClientUtils = new HttpClientUtils(config.build());
-    stubFor(get(resource)
-        .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+    stubFor(get(resource).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
     // when:
     try {
@@ -104,11 +98,9 @@ public class HttpClientUtilsTest {
         UserConfiguredUrlRestrictions.HttpClientProperties.builder()
             .enableRetry(true)
             .maxRetryAttempts(2)
-            .build()
-    );
+            .build());
     HttpClientUtils httpClientUtils = new HttpClientUtils(config.build());
-    stubFor(get(resource)
-        .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+    stubFor(get(resource).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
     // when:
     try {

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtilsTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtilsTest.java
@@ -58,6 +58,8 @@ public class HttpClientUtilsTest {
   @Test
   public void testZeroRetryFor503StatusCode() {
     // given:
+    config.setHttpClientProperties(
+        UserConfiguredUrlRestrictions.HttpClientProperties.builder().enableRetry(false).build());
     HttpClientUtils httpClientUtils = new HttpClientUtils(config.build());
     stubFor(get(resource).willReturn(aResponse().withStatus(503)));
 
@@ -75,8 +77,6 @@ public class HttpClientUtilsTest {
   @Test
   public void testDefaultRetryForSocketException() {
     // given:
-    config.setHttpClientProperties(
-        UserConfiguredUrlRestrictions.HttpClientProperties.builder().enableRetry(true).build());
     HttpClientUtils httpClientUtils = new HttpClientUtils(config.build());
     stubFor(get(resource).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
@@ -88,7 +88,7 @@ public class HttpClientUtilsTest {
     }
 
     // then:
-    verify(6, getRequestedFor(urlEqualTo(resource)));
+    verify(2, getRequestedFor(urlEqualTo(resource)));
   }
 
   @Test

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtilsTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtilsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.util;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
+import org.junit.Rule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Fail.fail;
+
+@RunWith(JUnitPlatform.class)
+public class HttpClientUtilsTest {
+
+  private final String host = "localhost";
+  private final int port = 8080;
+  private final String resource = "/v1/text";
+  private final UserConfiguredUrlRestrictions.Builder config = new UserConfiguredUrlRestrictions.Builder();
+
+  WireMockServer wireMockServer = new WireMockServer();
+
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(port);
+
+  @BeforeEach
+  public void setup() {
+    wireMockServer.start();
+    configureFor(host, port);
+  }
+
+  @AfterEach
+  public void destroy() {
+    wireMockServer.stop();
+  }
+
+  @Test
+  public void testZeroRetryFor503StatusCode() {
+    // given:
+    HttpClientUtils httpClientUtils = new HttpClientUtils(config.build());
+    stubFor(get(resource)
+        .willReturn(aResponse().withStatus(503)));
+
+    // when:
+    try {
+      httpClientUtils.httpGetAsString(String.format("http://%s:%s%s", host, port, resource));
+    } catch (IOException e) {
+      fail("Should not have thrown an exception");
+    }
+
+    // then:
+    verify(1, getRequestedFor(urlEqualTo(resource)));
+  }
+
+  @Test
+  public void testDefaultRetryForSocketException() {
+    // given:
+    config.setHttpClientProperties(
+        UserConfiguredUrlRestrictions.HttpClientProperties.builder()
+            .enableRetry(true)
+            .build()
+    );
+    HttpClientUtils httpClientUtils = new HttpClientUtils(config.build());
+    stubFor(get(resource)
+        .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+    // when:
+    try {
+      httpClientUtils.httpGetAsString(String.format("http://%s:%s%s", host, port, resource));
+    } catch (IOException | HttpClientUtils.RetryRequestException ignored) {
+
+    }
+
+    // then:
+    verify(6, getRequestedFor(urlEqualTo(resource)));
+  }
+
+  @Test
+  public void testTwoRetryForSocketException() {
+    // given:
+    config.setHttpClientProperties(
+        UserConfiguredUrlRestrictions.HttpClientProperties.builder()
+            .enableRetry(true)
+            .maxRetryAttempts(2)
+            .build()
+    );
+    HttpClientUtils httpClientUtils = new HttpClientUtils(config.build());
+    stubFor(get(resource)
+        .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+    // when:
+    try {
+      httpClientUtils.httpGetAsString(String.format("http://%s:%s%s", host, port, resource));
+    } catch (IOException | HttpClientUtils.RetryRequestException ignored) {
+
+    }
+
+    // then:
+    verify(3, getRequestedFor(urlEqualTo(resource)));
+  }
+}

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
@@ -51,7 +51,7 @@ class WebhookServiceSpec extends Specification {
   def webhookConfiguration = new WebhookConfiguration(webhookProperties)
 
   @Shared
-  def userConfiguredUrlRestrictions = new UserConfiguredUrlRestrictions.Builder().withRejectLocalhost(false).build()
+  def userConfiguredUrlRestrictions = new UserConfiguredUrlRestrictions.Builder().withRejectLocalhost(false).withAllowedHostnamesRegex(".*").build()
 
   @Shared
   def requestFactory = webhookConfiguration.webhookRequestFactory(


### PR DESCRIPTION
To allow better customizations of CloseableHttpClient, adding HttpClientProperties as an additional property in UserConfiguredUrlRestrictions that we can use in HttpClientUtils. This will allow us to enable/disable retry options and configure other HttpClient options.

Now, you will be able to configure `httpClientProperties`
e.g
```yaml
user-configured-url-restrictions:
  httpClientProperties:
    enableRetry: true
    maxRetryAttempts: 1
    retryInterval: 1000
    timeoutMillis: 10000
```