### PR TITLE
chore(build): Bump kork version & fix tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 fiatVersion=1.28.0
-korkVersion=7.115.0
+korkVersion=7.115.2
 kotlinVersion=1.4.32
 org.gradle.parallel=true
 spinnakerGradleVersion=8.15.0

--- a/orca-plugins-test/src/test/kotlin/com/netflix/spinnaker/orca/plugins/test/OrcaPluginsFixture.kt
+++ b/orca-plugins-test/src/test/kotlin/com/netflix/spinnaker/orca/plugins/test/OrcaPluginsFixture.kt
@@ -33,9 +33,9 @@ import com.netflix.spinnaker.orca.plugins.PreconfiguredJobConfigurationProviderE
 import com.netflix.spinnaker.orca.plugins.StageDefinitionBuilderExtension
 import com.netflix.spinnaker.orca.plugins.TaskExtension1
 import com.netflix.spinnaker.orca.plugins.TaskExtension2
-import com.netflix.spinnaker.q.Queue
 import com.netflix.spinnaker.q.memory.InMemoryQueue
 import com.netflix.spinnaker.q.metrics.EventPublisher
+import com.netflix.spinnaker.q.metrics.MonitorableQueue
 import java.io.File
 import java.time.Clock
 import java.time.Duration
@@ -111,7 +111,7 @@ internal class PluginTestConfiguration {
 
   @Bean
   @Primary
-  fun queue(clock: Clock?, publisher: EventPublisher?): Queue {
+  fun queue(clock: Clock?, publisher: EventPublisher?): MonitorableQueue {
     return InMemoryQueue(
       clock!!, Duration.ofMinutes(1), emptyList(), false, publisher!!
     )

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/StartupTestConfiguration.java
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/StartupTestConfiguration.java
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.orca;
 
-import com.netflix.spinnaker.q.Queue;
 import com.netflix.spinnaker.q.memory.InMemoryQueue;
 import com.netflix.spinnaker.q.metrics.EventPublisher;
+import com.netflix.spinnaker.q.metrics.MonitorableQueue;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Collections;
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Primary;
 class StartupTestConfiguration {
   @Bean
   @Primary
-  Queue queue(Clock clock, EventPublisher publisher) {
+  MonitorableQueue queue(Clock clock, EventPublisher publisher) {
     return new InMemoryQueue(
         clock, Duration.ofMinutes(1), Collections.emptyList(), false, publisher);
   }


### PR DESCRIPTION
We bumped korkVersion to 7.115.2 but there were issues in the integration test due to bean not created.

https://github.com/spinnaker/orca/pull/4217

After taking a look I found the zombieExecutionService requires a MonitorableQueue and in our integration test we created a Queue bean. So this makes the tests to fail.
