### PR TITLE
fix(kotlin): create kotlinModule using Builder instead constructor

### DIFF
--- a/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
+++ b/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
@@ -194,7 +194,7 @@ class RedisQueueConfiguration {
   @ConditionalOnMissingBean
   fun redisQueueObjectMapper(properties: Optional<ObjectMapperSubtypeProperties>): ObjectMapper =
     ObjectMapper().apply {
-      registerModule(KotlinModule())
+      registerModule(KotlinModule.Builder().build())
       disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
       SpringObjectMapperConfigurer(

--- a/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisClusterDeadMessageHandler.kt
+++ b/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisClusterDeadMessageHandler.kt
@@ -16,7 +16,7 @@ class RedisClusterDeadMessageHandler(
 
   private val dlqKey = "{$deadLetterQueueName}.messages"
 
-  private val mapper = ObjectMapper().registerModule(KotlinModule())
+  private val mapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
 
   override fun invoke(queue: Queue, message: Message) {
     jedisCluster.use { cluster ->

--- a/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisDeadMessageHandler.kt
+++ b/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisDeadMessageHandler.kt
@@ -36,7 +36,7 @@ class RedisDeadMessageHandler(
 
   private val dlqKey = "$deadLetterQueueName.messages"
 
-  private val mapper = ObjectMapper().registerModule(KotlinModule())
+  private val mapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
 
   override fun invoke(queue: Queue, message: Message) {
     pool.resource.use { redis ->

--- a/keiko-redis/src/test/kotlin/com/netflix/spinnaker/q/redis/RedisQueueTest.kt
+++ b/keiko-redis/src/test/kotlin/com/netflix/spinnaker/q/redis/RedisQueueTest.kt
@@ -61,7 +61,7 @@ private fun createQueue(clock: Clock,
       }
       ),
     mapper = ObjectMapper().apply {
-      registerModule(KotlinModule())
+      registerModule(KotlinModule.Builder().build())
       disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
       registerSubtypes(TestMessage::class.java)

--- a/keiko-sql/src/test/kotlin/com/netflix/spinnaker/q/sql/SqlQueueTest.kt
+++ b/keiko-sql/src/test/kotlin/com/netflix/spinnaker/q/sql/SqlQueueTest.kt
@@ -45,7 +45,7 @@ private fun createQueue(clock: Clock,
     clock = clock,
     lockTtlSeconds = 2,
     mapper = ObjectMapper().apply {
-      registerModule(KotlinModule())
+      registerModule(KotlinModule.Builder().build())
       disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
       registerSubtypes(TestMessage::class.java)

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/jackson/OrcaObjectMapper.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/jackson/OrcaObjectMapper.java
@@ -50,7 +50,7 @@ public class OrcaObjectMapper {
     instance.registerModule(new Jdk8Module());
     instance.registerModule(new GuavaModule());
     instance.registerModule(new JavaTimeModule());
-    instance.registerModule(new KotlinModule());
+    instance.registerModule(new KotlinModule.Builder().build());
     instance.disable(READ_DATE_TIMESTAMPS_AS_NANOSECONDS);
     instance.disable(WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
     instance.disable(FAIL_ON_UNKNOWN_PROPERTIES);

--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/config/KeelConfiguration.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/config/KeelConfiguration.kt
@@ -66,6 +66,6 @@ class KeelConfiguration {
 
   @Bean fun keelObjectMapper() =
     OrcaObjectMapper.newInstance()
-      .registerModule(KotlinModule())
+      .registerModule(KotlinModule.Builder().build())
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/config/PipelineTemplateConfiguration.java
@@ -56,7 +56,7 @@ public class PipelineTemplateConfiguration {
     return new ObjectMapper()
         .enable(SerializationFeature.INDENT_OUTPUT)
         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-        .registerModule(new KotlinModule());
+        .registerModule(new KotlinModule.Builder().build());
   }
 
   @Bean

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequestSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequestSpec.groovy
@@ -27,7 +27,7 @@ class TemplatedPipelineRequestSpec extends Specification {
   def objectMapper = new ObjectMapper()
     .enable(SerializationFeature.INDENT_OUTPUT)
     .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-    .registerModule(new KotlinModule())
+    .registerModule(new KotlinModule.Builder().build())
 
   @Unroll
   def 'should deserialize config'() {

--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisOrcaQueueConfiguration.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisOrcaQueueConfiguration.kt
@@ -60,7 +60,7 @@ class RedisOrcaQueueConfiguration : RedisQueueConfiguration() {
     taskResolver: TaskResolver
   ) {
     mapper.apply {
-      registerModule(KotlinModule())
+      registerModule(KotlinModule.Builder().build())
       registerModule(
         SimpleModule()
           .addDeserializer(ExecutionType::class.java, ExecutionTypeDeserializer())

--- a/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/pending/RedisPendingExecutionServiceTest.kt
+++ b/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/pending/RedisPendingExecutionServiceTest.kt
@@ -15,7 +15,7 @@ internal object RedisPendingExecutionServiceTest : SubjectSpek<RedisPendingExecu
 
   val redis = EmbeddedRedis.embed()
   val mapper = ObjectMapper().apply {
-    registerModule(KotlinModule())
+    registerModule(KotlinModule.Builder().build())
     registerSubtypes(StartExecution::class.java, RestartStage::class.java)
   }
 

--- a/orca-queue-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlOrcaQueueConfiguration.kt
+++ b/orca-queue-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlOrcaQueueConfiguration.kt
@@ -53,7 +53,7 @@ class SqlOrcaQueueConfiguration : SqlQueueConfiguration() {
     taskResolver: TaskResolver
   ) {
     mapper.apply {
-      registerModule(KotlinModule())
+      registerModule(KotlinModule.Builder().build())
       registerModule(
         SimpleModule()
           .addDeserializer(ExecutionType::class.java, ExecutionTypeDeserializer())

--- a/orca-queue-sql/src/test/kotlin/com/netflix/spinnaker/orca/q/sql/SqlQueueIntegrationTest.kt
+++ b/orca-queue-sql/src/test/kotlin/com/netflix/spinnaker/orca/q/sql/SqlQueueIntegrationTest.kt
@@ -74,7 +74,7 @@ class SqlTestConfig {
     taskResolver: TaskResolver
   ) {
     mapper.apply {
-      registerModule(KotlinModule())
+      registerModule(KotlinModule.Builder().build())
       registerModule(
         SimpleModule()
           .addDeserializer(ExecutionType::class.java, ExecutionTypeDeserializer())

--- a/orca-queue-sql/src/test/kotlin/com/netflix/spinnaker/orca/q/sql/pending/SqlPendingExecutionServiceTest.kt
+++ b/orca-queue-sql/src/test/kotlin/com/netflix/spinnaker/orca/q/sql/pending/SqlPendingExecutionServiceTest.kt
@@ -44,7 +44,7 @@ internal object SqlPendingExecutionServiceTest : SubjectSpek<SqlPendingExecution
   val maxDepth = 4
 
   val mapper = ObjectMapper().apply {
-    registerModule(KotlinModule())
+    registerModule(KotlinModule.Builder().build())
     registerSubtypes(StartExecution::class.java, RestartStage::class.java)
   }
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/migration/TaskTypeDeserializerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/migration/TaskTypeDeserializerTest.kt
@@ -32,7 +32,7 @@ object TaskTypeDeserializerTest : Spek({
   val taskResolver = TaskResolver(TasksProvider(listOf(DummyTask())), false)
 
   val objectMapper = ObjectMapper().apply {
-    registerModule(KotlinModule())
+    registerModule(KotlinModule.Builder().build())
     registerModule(
       SimpleModule()
         .addDeserializer(Class::class.java, TaskTypeDeserializer(taskResolver))

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/pending/DualPendingExecutionServiceTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/pending/DualPendingExecutionServiceTest.kt
@@ -30,7 +30,7 @@ internal object DualPendingExecutionServiceTest : SubjectSpek<DualPendingExecuti
   val primaryRedis = EmbeddedRedis.embed()
   val previousRedis = EmbeddedRedis.embed()
   val mapper = ObjectMapper().apply {
-    registerModule(KotlinModule())
+    registerModule(KotlinModule.Builder().build())
     registerSubtypes(StartExecution::class.java, RestartStage::class.java)
   }
 

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -46,7 +46,7 @@ import static java.time.temporal.ChronoUnit.DAYS
 abstract class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
   @Shared
   ObjectMapper mapper = OrcaObjectMapper.newInstance().with {
-    registerModule(new KotlinModule())
+    registerModule(new KotlinModule.Builder().build())
     it
   }
 

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
@@ -43,7 +43,7 @@ import static java.time.temporal.ChronoUnit.DAYS
 abstract class TopApplicationExecutionCleanupPollingNotificationAgentSpec extends Specification {
   @Shared
   ObjectMapper mapper = OrcaObjectMapper.newInstance().with {
-    registerModule(new KotlinModule())
+    registerModule(new KotlinModule.Builder().build())
     it
   }
 

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
@@ -55,7 +55,7 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
 
   @Shared
   ObjectMapper mapper = OrcaObjectMapper.newInstance().with {
-    registerModule(new KotlinModule())
+    registerModule(new KotlinModule.Builder().build())
     it
   }
 


### PR DESCRIPTION
I found issues in Orca when starting up.

```
2022-02-14 05:08:43.009  WARN 1 --- [           main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'redisOrcaQueueConfiguration': Injection of autowired dependencies failed; nested exception is java.lang.NoSuchMethodError: 'void com.fasterxml.jackson.module.kotlin.KotlinModule.<init>(int, boolean, boolean, boolean, com.fasterxml.jackson.module.kotlin.SingletonSupport, int, kotlin.jvm.internal.DefaultConstructorMarker)'
```

This issues is related to the `jackson-module-kotlin` used. It's hard to know what version of jackson will end in the service. So I changed how the KotlinModule is created. Instead creating it using the constructor I used its Builder. This ensure that KotlinModule will be created without rely in what version of jackson we have.

There is a breaking change between Jackson 2.11.1 <-> 2.12.3. Using the builder will helps us deal with it.
