### PR TITLE
chore(build): specify an artifact for bumpdeps to look for

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -13,5 +13,8 @@ jobs:
         ref: ${{ github.event.client_payload.ref }}
         key: orcaVersion
         repositories: kayenta
+        mavenRepositoryUrl: https://repo.maven.apache.org/maven2
+        groupId: io.spinnaker.orca
+        artifactId: orca-bom
       env:
         GITHUB_OAUTH: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}


### PR DESCRIPTION
to avoid a hard-coded 10 minute timeout.  See
e.g. https://github.com/spinnaker/bumpdeps/blob/c5ca595ec6211aae4160c46a14a4f2fd04359638/src/main/kotlin/io/spinnaker/bumpdeps/Main.kt#L128
