### PR TITLE
fix(dependency): To enable controlled conflict resolution of direct and transitive dependencies version using kork-bom for upgrading the spring-boot 2.3.x.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ subprojects {
     apply plugin: "java-library"
 
     dependencies {
-      implementation(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
+      implementation(enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion"))
       annotationProcessor(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
       testAnnotationProcessor(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
       implementation("org.slf4j:slf4j-api")


### PR DESCRIPTION
While upgrading the spring-boot 2.2.x to 2.3.x, encountered issue of uncontrolled conflict resolution of jackson and kotlin dependencies in gate (https://github.com/spinnaker/gate/pull/1505). In order to avoid any such issue with other components for upgrades to spring-boot 2.3.x as well as for any future spring-boot upgrades, we can introduce strict adherence of imported maven kork-bom by replacing platform to enforcedPlatform closure.