### PR TITLE
fix(plugins-test): try harder for the version of versionNotSupportedP…

### DIFF
--- a/orca-plugins-test/src/test/kotlin/com/netflix/spinnaker/orca/plugins/test/OrcaPluginsFixture.kt
+++ b/orca-plugins-test/src/test/kotlin/com/netflix/spinnaker/orca/plugins/test/OrcaPluginsFixture.kt
@@ -97,7 +97,8 @@ class OrcaPluginsFixture : PluginsTckFixture, OrcaTestService() {
     plugins.mkdir()
     enabledPlugin = buildPlugin("com.netflix.orca.enabled.plugin", ">=1.0.0")
     disabledPlugin = buildPlugin("com.netflix.orca.disabled.plugin", ">=1.0.0")
-    versionNotSupportedPlugin = buildPlugin("com.netflix.orca.version.not.supported.plugin", ">=2.0.0")
+    // Make it very unlikely that the version of orca satisfies this requirement
+    versionNotSupportedPlugin = buildPlugin("com.netflix.orca.version.not.supported.plugin", "=0.0.9")
   }
 }
 


### PR DESCRIPTION
…lugin to actually not be supported

Before this, an orca version >= 2.0.0 would cause versionNotSupportedPlugin to get used,
causing tests to fail, and making it impossible to e.g. release orca.
