### PR TITLE
chore(dependencies): bump spinnakerGradleVersion to 8.22.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ fiatVersion=1.30.0
 korkVersion=7.132.0
 kotlinVersion=1.4.32
 org.gradle.parallel=true
-spinnakerGradleVersion=8.21.0
+spinnakerGradleVersion=8.22.0
 targetJava11=true
 
 # To enable a composite reference to a project, set the


### PR DESCRIPTION
The autobump PR didn't happen due to rate limit violations.  From https://github.com/spinnaker/spinnaker-gradle-project/runs/5426168051?check_suite_focus=true:
```
[main] ERROR io.spinnaker.bumpdeps.BumpDeps - Exception updating repository orca
org.kohsuke.github.HttpException: {"message":"You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later.","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#secondary-rate-limits"}
	at org.kohsuke.github.GitHubClient.interpretApiError(GitHubClient.java:483)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:407)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:355)
	at org.kohsuke.github.Requester.fetch(Requester.java:76)
	at org.kohsuke.github.GHRepository.createPullRequest(GHRepository.java:1607)
	at org.kohsuke.github.GHRepository.createPullRequest(GHRepository.java:1567)
	at org.kohsuke.github.GHRepository.createPullRequest(GHRepository.java:1540)
	at io.spinnaker.bumpdeps.BumpDeps.createPullRequest(Main.kt:228)
	at io.spinnaker.bumpdeps.BumpDeps.run(Main.kt:114)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:168)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:16)
	at com.github.ajalt.clikt.core.CliktCommand.parse(CliktCommand.kt:258)
	at com.github.ajalt.clikt.core.CliktCommand.parse$default(CliktCommand.kt:255)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:273)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:298)
	at io.spinnaker.bumpdeps.MainKt.main(Main.kt:269)
Caused by: java.io.IOException: Server returned HTTP response code: 403 for URL: https://api.github.com/repos/spinnaker/orca/pulls
	at java.base/jdk.internal.reflect.GeneratedConstructorAccessor24.newInstance(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at java.base/sun.net.www.protocol.http.HttpURLConnection$10.run(HttpURLConnection.java:1974)
	at java.base/sun.net.www.protocol.http.HttpURLConnection$10.run(HttpURLConnection.java:1969)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getChainedException(HttpURLConnection.java:1968)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1536)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1520)
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:250)
	at org.kohsuke.github.GitHubHttpUrlConnectionClient$HttpURLConnectionResponseInfo.bodyStream(GitHubHttpUrlConnectionClient.java:174)
	at org.kohsuke.github.GitHubResponse$ResponseInfo.getBodyAsString(GitHubResponse.java:314)
	at org.kohsuke.github.GitHubResponse.parseBody(GitHubResponse.java:92)
	at org.kohsuke.github.Requester.lambda$fetch$1(Requester.java:76)
	at org.kohsuke.github.GitHubClient.createResponse(GitHubClient.java:449)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:399)
	... 14 more
Caused by: java.io.IOException: Server returned HTTP response code: 403 for URL: https://api.github.com/repos/spinnaker/orca/pulls
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1924)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1520)
	at java.base/java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:527)
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:334)
	at org.kohsuke.github.GitHubHttpUrlConnectionClient.getResponseInfo(GitHubHttpUrlConnectionClient.java:63)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:387)
	... 14 more
```