### PR TITLE
fix(orca): fail the stage as soon as a task fails.

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandler.kt
@@ -94,9 +94,9 @@ class CompleteTaskHandler(
       return true
     }
 
-    if (originalStatus == FAILED_CONTINUE) {
-      // the task explicitly returned FAILED_CONTINUE and _should_ run subsequent tasks
-      return false
+    if (status == FAILED_CONTINUE) {
+      // the task explicitly returned FAILED_CONTINUE and _should_ not run subsequent tasks
+      return true
     }
 
     // the task _should not_ run subsequent tasks


### PR DESCRIPTION
When a stage marked with "continuePipeline==true" has one of the tasks(except last task) failed then the stage need not execute remaining tasks. This change has been added in this PR. The pipeline continues to execute next stage. 
This PR addresses the issue [#6615](https://github.com/spinnaker/spinnaker/issues/6615)