### PR TITLE
fix(ci): fetch previous tag from git instead of API

### DIFF
--- a/.github/workflows/release_info.sh
+++ b/.github/workflows/release_info.sh
@@ -1,20 +1,24 @@
 #!/bin/bash -x
 
-# Only look to the latest release to determine the previous tag -- this allows us to skip unsupported tag formats (like `version-1.0.0`)
-export PREVIOUS_TAG=`curl --silent "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'`
-echo "PREVIOUS_TAG=$PREVIOUS_TAG"
-export NEW_TAG=${GITHUB_REF/refs\/tags\//}
+NEW_TAG=${GITHUB_REF/refs\/tags\//}
+export NEW_TAG
 echo "NEW_TAG=$NEW_TAG"
-export CHANGELOG=`git log $NEW_TAG...$PREVIOUS_TAG --oneline`
+# Glob match previous tags which should be format v1.2.3. Avoids Deck's npm tagging.
+PREVIOUS_TAG=$(git describe --abbrev=0 --tags "${NEW_TAG}"^ --match 'v[0-9]*')
+export PREVIOUS_TAG
+echo "PREVIOUS_TAG=$PREVIOUS_TAG"
+CHANGELOG=$(git log "$NEW_TAG"..."$PREVIOUS_TAG" --oneline)
+export CHANGELOG
 echo "CHANGELOG=$CHANGELOG"
 
-#Format the changelog so it's markdown compatible
+# Format the changelog so it's markdown compatible
 CHANGELOG="${CHANGELOG//$'%'/%25}"
 CHANGELOG="${CHANGELOG//$'\n'/%0A}"
 CHANGELOG="${CHANGELOG//$'\r'/%0D}"
 
 # If the previous release tag is the same as this tag the user likely cut a release (and in the process created a tag), which means we can skip the need to create a release
-export SKIP_RELEASE=`[[ "$PREVIOUS_TAG" = "$NEW_TAG" ]] && echo "true" || echo "false"`
+SKIP_RELEASE=$([[ "$PREVIOUS_TAG" = "$NEW_TAG" ]] && echo "true" || echo "false")
+export SKIP_RELEASE
 
 # https://github.com/fsaintjacques/semver-tool/blob/master/src/semver#L5-L14
 NAT='0|[1-9][0-9]*'
@@ -28,8 +32,10 @@ SEMVER_REGEX="\
 (\\+${FIELD}(\\.${FIELD})*)?$"
 
 # Used in downstream steps to determine if the release should be marked as a "prerelease" and if the build should build candidate release artifacts
-export IS_CANDIDATE=`[[ $NEW_TAG =~ $SEMVER_REGEX && ! -z ${BASH_REMATCH[4]} ]] && echo "true" || echo "false"`
+IS_CANDIDATE=$([[ $NEW_TAG =~ $SEMVER_REGEX && -n ${BASH_REMATCH[4]} ]] && echo "true" || echo "false")
+export IS_CANDIDATE
 
 # This is the version string we will pass to the build, trim off leading 'v' if present
-export RELEASE_VERSION=`[[ $NEW_TAG =~ $SEMVER_REGEX ]] && echo "${NEW_TAG:1}" || echo "${NEW_TAG}"`
+RELEASE_VERSION=$([[ $NEW_TAG =~ $SEMVER_REGEX ]] && echo "${NEW_TAG:1}" || echo "${NEW_TAG}")
+export RELEASE_VERSION
 echo "RELEASE_VERSION=$RELEASE_VERSION"


### PR DESCRIPTION
Previously the release info script would query the GitHub HTTP API and retrieve
the latest "Release" (git tag) published.
The latest "Release" could (likely) be for a different `release-*` branch or
even `master` rather than the previous tag on the same branch as the new
tag.
This resulted in "Release" changelogs containing commits that dont
exist in the tags history.

By instead querying git itself we can fetch the previous tag in history
and then generate an accurate changelog, eg: between `v1.7.4` and
`v1.7.3` rather than potentially `v1.7.4` and `v1.10.0`.

Run script through `shellcheck` and `shfmt`.