### PR TITLE
fix(cfn): Fix detection of empty CloudFormation changesets

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTask.java
@@ -160,7 +160,8 @@ public class WaitForCloudFormationCompletionTask implements OverridableTimeoutRe
       String status = getChangeSetInfo(stack, stage.getContext(), "status");
       String statusReason = getChangeSetInfo(stack, stage.getContext(), "statusReason");
       return status.equals(CloudFormationStates.FAILED.toString())
-          && statusReason.startsWith("The submitted information didn't contain changes");
+          && (statusReason.startsWith("The submitted information didn't contain changes")
+              || statusReason.equals("No updates are to be performed."));
     } else {
       return false;
     }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTaskSpec.groovy
@@ -73,6 +73,7 @@ class WaitForCloudFormationCompletionTaskSpec extends Specification {
     false       | 'UPDATE_COMPLETE' | 'ignored'                                           | false                 || ExecutionStatus.SUCCEEDED
     false       | 'DELETE_COMPLETE' | 'ignored'                                           | false                 || ExecutionStatus.SUCCEEDED
     true        | 'FAILED'          | 'The submitted information didn\'t contain changes' | true                  || ExecutionStatus.SUCCEEDED
+    true        | 'FAILED'          | 'No updates are to be performed.'                   | true                  || ExecutionStatus.SUCCEEDED
     true        | 'CREATE_COMPLETE' | 'ignored'                                           | false                 || ExecutionStatus.SUCCEEDED
   }
 


### PR DESCRIPTION
It seems that the status message from AWS has changed or could potentially differ. Updating to check for what I'm getting as output.
