### PR TITLE
fix(tasks): Fix MonitorPipelineTask regression

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
@@ -125,7 +125,7 @@ class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
       result.executionStatuses = pipelineStatuses
     }
 
-    if (pipelineIds.size() == 1) {
+    if (pipelineIds.size() == 1 && allPipelinesCompleted) {
       result.insertPipelineContext(firstPipeline.getContext())
     }
 

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
@@ -222,6 +222,32 @@ class MonitorPipelineTaskSpec extends Specification {
     ]
   }
 
+  def "do not propagate running child pipeline outputs"() {
+    def pipeline = pipeline {
+      application = "orca"
+      name = "a pipeline"
+      stage {
+        type = PipelineStage.PIPELINE_CONFIG_TYPE
+        name = "running stage with outputs"
+        outputs = [
+            "myVar1": "myValue1",
+            "myVar2": "myValue2"
+        ]
+        status = ExecutionStatus.RUNNING
+      }
+      status = ExecutionStatus.RUNNING
+    }
+
+    repo.retrieve(*_) >> pipeline
+
+    when:
+    def result = task.execute(stage)
+    def outputs = result.outputs
+
+    then:
+    outputs == [:]
+  }
+
   @Unroll
   def "respect #behavior behavior when monitoring multiple pipelines"() {
     ObjectMapper objectMapper = new ObjectMapper()


### PR DESCRIPTION
The way that the monitor pipeline task worked before was that it only
stored the _status_ of the child pipeline when the child was running
(see file before the commit
[here](https://github.com/spinnaker/orca/pull/3902/files#diff-4c694b67271c7d9436d5af695f160f0b60c7ad7753a0ba1eb9aea76d7ba4e851R128-R130)).
After the commit was merged, the MonitorPipelineTask was storing the
context of the child pipeline on every update regardless of the child
pipeline’s status ([see line in
commit](https://github.com/spinnaker/orca/blob/20e2b9ea61037e7fc8eb59c817dc5d33f4718af3/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy#L96)).

This should address the issue seen where large nested pipelines
especially those child pipelines that generate a lot of outputs (Deploy
Manifest) negatively impact the performance of Spinnaker.

See: https://github.com/spinnaker/spinnaker/issues/6159