### PR TITLE
fix(orca-core): Added unimplemeted methods of ApplicationEventMulticaster class

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/DelegatingApplicationEventMulticaster.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/DelegatingApplicationEventMulticaster.kt
@@ -23,6 +23,7 @@ import org.springframework.context.ApplicationEvent
 import org.springframework.context.ApplicationListener
 import org.springframework.context.event.ApplicationEventMulticaster
 import org.springframework.core.ResolvableType
+import java.util.function.Predicate
 
 /**
  * Supports sync & async event listeners. Listeners are treated as asynchronous unless
@@ -81,6 +82,16 @@ class DelegatingApplicationEventMulticaster(
   override fun removeApplicationListenerBean(listenerBeanName: String) {
     // Bean-name based listeners are async-only.
     asyncApplicationEventMulticaster.removeApplicationListenerBean(listenerBeanName)
+  }
+
+  override fun removeApplicationListeners(predicate: Predicate<ApplicationListener<*>>) {
+    asyncApplicationEventMulticaster.removeApplicationListeners(predicate)
+    syncApplicationEventMulticaster.removeApplicationListeners(predicate)
+  }
+
+  override fun removeApplicationListenerBeans(predicate: Predicate<String>) {
+    asyncApplicationEventMulticaster.removeApplicationListenerBeans(predicate)
+    syncApplicationEventMulticaster.removeApplicationListenerBeans(predicate)
   }
 
   override fun setBeanFactory(beanFactory: BeanFactory) {


### PR DESCRIPTION
There are two unimplemented methods as per latest release of spring framework from [5.3.5](https://docs.spring.io/spring-framework/docs/5.3.5/javadoc-api/org/springframework/context/event/ApplicationEventMulticaster.html) version onwards.

While building orca with spring boot upgrade, faced errors like:
```
> Task :orca-core:compileKotlin
e: /home/opsmx/spinnakerforkcodebase/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/listeners/DelegatingApplicationEventMulticaster.kt: (31, 1): Class 'DelegatingApplicationEventMulticaster' is not abstract and does not implement abstract member public abstract fun removeApplicationListeners(p0: Predicate<ApplicationListener<*>!>!): Unit defined in org.springframework.context.event.ApplicationEventMulticaster
```