### PR TITLE
fix(clouddriver): fix property binding for Clouddriver

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.java
@@ -57,7 +57,7 @@ import retrofit.converter.JacksonConverter;
   PollerConfigurationProperties.class
 })
 @Slf4j
-class CloudDriverConfiguration {
+public class CloudDriverConfiguration {
 
   @ConditionalOnMissingBean(ObjectMapper.class)
   @Bean

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationProperties.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationProperties.java
@@ -18,14 +18,24 @@ package com.netflix.spinnaker.orca.clouddriver.config;
 
 import java.util.List;
 import java.util.Map;
+
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * NB: The explicit @Getter, @Setter and @NoArgsConstructor on some of these inner classes is required. Some
+ * weird behaviour going on when using @Data prevented fields from being populated. See spinnaker/#6704.
+ */
 @Data
 @ConfigurationProperties
 public class CloudDriverConfigurationProperties {
 
-  @Data
+  @Getter
+  @Setter
+  @NoArgsConstructor
   public static class BaseUrl {
     private String baseUrl;
     private int priority = 1;
@@ -42,7 +52,9 @@ public class CloudDriverConfigurationProperties {
     private List<BaseUrl> baseUrls;
   }
 
-  @Data
+  @Getter
+  @Setter
+  @NoArgsConstructor
   public static class CloudDriver {
     private String baseUrl;
     private MultiBaseUrl readonly;

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationProperties.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationProperties.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.clouddriver.config;
 
 import java.util.List;
 import java.util.Map;
-
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,8 +25,9 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * NB: The explicit @Getter, @Setter and @NoArgsConstructor on some of these inner classes is required. Some
- * weird behaviour going on when using @Data prevented fields from being populated. See spinnaker/#6704.
+ * NB: The explicit @Getter, @Setter and @NoArgsConstructor on some of these inner classes is
+ * required. Some weird behaviour going on when using @Data prevented fields from being populated.
+ * See spinnaker/#6704.
  */
 @Data
 @ConfigurationProperties


### PR DESCRIPTION
I have no idea why this is necessary, since `@Data` includes `@RequiredArgsConstructor`, which in this case is equivalent to `@NoArgsConstructor`. Regardless, it doesn't work using `@Data`. Must be some weird interaction between Lombok and nested classes.

Fixes https://github.com/spinnaker/spinnaker/issues/6704