### PR TITLE
feat(igor): Stop Jenkins job when job name has slashes in the job name

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/BuildServiceConfiguration.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/BuildServiceConfiguration.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.config
+
+import com.netflix.spinnaker.orca.igor.BuildService
+import com.netflix.spinnaker.orca.igor.IgorFeatureFlagProperties
+import com.netflix.spinnaker.orca.igor.IgorService
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(IgorFeatureFlagProperties.class)
+class BuildServiceConfiguration {
+
+  @Bean
+  BuildService buildService(IgorService igorService, IgorFeatureFlagProperties igorFeatureFlagProperties) {
+    return new BuildService(igorService, igorFeatureFlagProperties);
+  }
+}

--- a/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/BuildService.java
+++ b/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/BuildService.java
@@ -18,15 +18,22 @@ package com.netflix.spinnaker.orca.igor;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.List;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriUtils;
 import retrofit.client.Response;
 
 @Component
-@RequiredArgsConstructor
 public class BuildService {
   private final IgorService igorService;
+  private final boolean jobNameAsQueryParameter;
+
+  public BuildService(IgorService igorService, @Value("${jobName.queryParameter:false}") boolean jobNameAsQueryParameter) {
+    this.igorService = igorService;
+    this.jobNameAsQueryParameter = jobNameAsQueryParameter;
+  }
+
 
   private String encode(String uri) {
     return UriUtils.encodeFragment(uri, "UTF-8");
@@ -42,6 +49,9 @@ public class BuildService {
   }
 
   public String stop(String master, String jobName, String queuedBuild, Integer buildNumber) {
+    if(this.jobNameAsQueryParameter) {
+      return igorService.stopWithJobNameAsQueryParameter(master, jobName, queuedBuild, buildNumber, "");
+    }
     return igorService.stop(master, jobName, queuedBuild, buildNumber, "");
   }
 

--- a/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/BuildService.java
+++ b/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/BuildService.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.orca.igor;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.List;
 import java.util.Map;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriUtils;
@@ -29,11 +28,12 @@ public class BuildService {
   private final IgorService igorService;
   private final boolean jobNameAsQueryParameter;
 
-  public BuildService(IgorService igorService, @Value("${jobName.queryParameter:false}") boolean jobNameAsQueryParameter) {
+  public BuildService(
+      IgorService igorService,
+      @Value("${jobName.queryParameter:false}") boolean jobNameAsQueryParameter) {
     this.igorService = igorService;
     this.jobNameAsQueryParameter = jobNameAsQueryParameter;
   }
-
 
   private String encode(String uri) {
     return UriUtils.encodeFragment(uri, "UTF-8");
@@ -49,8 +49,9 @@ public class BuildService {
   }
 
   public String stop(String master, String jobName, String queuedBuild, Integer buildNumber) {
-    if(this.jobNameAsQueryParameter) {
-      return igorService.stopWithJobNameAsQueryParameter(master, jobName, queuedBuild, buildNumber, "");
+    if (this.jobNameAsQueryParameter) {
+      return igorService.stopWithJobNameAsQueryParameter(
+          master, jobName, queuedBuild, buildNumber, "");
     }
     return igorService.stop(master, jobName, queuedBuild, buildNumber, "");
   }

--- a/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/BuildService.java
+++ b/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/BuildService.java
@@ -18,21 +18,17 @@ package com.netflix.spinnaker.orca.igor;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriUtils;
 import retrofit.client.Response;
 
-@Component
 public class BuildService {
   private final IgorService igorService;
-  private final boolean jobNameAsQueryParameter;
+  private final IgorFeatureFlagProperties igorFeatureFlagProperties;
 
   public BuildService(
-      IgorService igorService,
-      @Value("${jobName.queryParameter:false}") boolean jobNameAsQueryParameter) {
+      IgorService igorService, IgorFeatureFlagProperties igorFeatureFlagProperties) {
     this.igorService = igorService;
-    this.jobNameAsQueryParameter = jobNameAsQueryParameter;
+    this.igorFeatureFlagProperties = igorFeatureFlagProperties;
   }
 
   private String encode(String uri) {
@@ -49,7 +45,7 @@ public class BuildService {
   }
 
   public String stop(String master, String jobName, String queuedBuild, Integer buildNumber) {
-    if (this.jobNameAsQueryParameter) {
+    if (this.igorFeatureFlagProperties.isJobNameAsQueryParameter()) {
       return igorService.stopWithJobNameAsQueryParameter(
           master, jobName, queuedBuild, buildNumber, "");
     }

--- a/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/IgorFeatureFlagProperties.java
+++ b/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/IgorFeatureFlagProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "feature.igor")
+public class IgorFeatureFlagProperties {
+  private boolean jobNameAsQueryParameter = false;
+
+  public boolean isJobNameAsQueryParameter() {
+    return jobNameAsQueryParameter;
+  }
+
+  public void setJobNameAsQueryParameter(boolean jobNameAsQueryParameter) {
+    this.jobNameAsQueryParameter = jobNameAsQueryParameter;
+  }
+}

--- a/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -42,6 +42,14 @@ public interface IgorService {
       @Path(encode = false, value = "buildNumber") Integer buildNumber,
       @Body String ignored);
 
+  @PUT("/masters/{name}/jobs/stop/{queuedBuild}/{buildNumber}")
+  String stopWithJobNameAsQueryParameter(
+      @Path("name") String master,
+      @Query(value = "jobName") String jobName,
+      @Path(encode = false, value = "queuedBuild") String queuedBuild,
+      @Path(encode = false, value = "buildNumber") Integer buildNumber,
+      @Body String ignored);
+
   @PATCH("/masters/{name}/jobs/{jobName}/update/{buildNumber}")
   Response update(
       @Path("name") String master,

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
@@ -29,7 +29,7 @@ class BuildServiceSpec extends Specification {
   private static final JOB_NAME_ENCODED = "name/with/slashes%20and%20spaces"
   private static final PARAMS = ['key': 'value']
   private static final FILENAME = 'file.txt'
-  private static final QUEUE_BUILD = ''
+  private static final QUEUE_BUILD = '12'
 
   void setup() {
     igorService = Mock(IgorService)

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
@@ -33,7 +33,7 @@ class BuildServiceSpec extends Specification {
 
   void setup() {
     igorService = Mock(IgorService)
-    buildService = new BuildService(igorService, false)
+    buildService = new BuildService(igorService, new IgorFeatureFlagProperties())
   }
 
   void 'build method encodes the job name'() {
@@ -69,7 +69,9 @@ class BuildServiceSpec extends Specification {
   }
 
   void 'stop method sends job name in query when flag is true'() {
-    buildService = new BuildService(igorService, true)
+    IgorFeatureFlagProperties igorFeatureFlagProperties = new IgorFeatureFlagProperties()
+    igorFeatureFlagProperties.setJobNameAsQueryParameter(true)
+    buildService = new BuildService(igorService, igorFeatureFlagProperties)
 
     when:
     buildService.stop(MASTER, JOB_NAME, QUEUE_BUILD, BUILD_NUMBER )

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
@@ -29,7 +29,7 @@ class BuildServiceSpec extends Specification {
   private static final JOB_NAME_ENCODED = "name/with/slashes%20and%20spaces"
   private static final PARAMS = ['key': 'value']
   private static final FILENAME = 'file.txt'
-  private static final QUEUE_BUILD = '12'
+  private static final QUEUED_BUILD = '12'
 
   void setup() {
     igorService = Mock(IgorService)
@@ -62,10 +62,10 @@ class BuildServiceSpec extends Specification {
 
   void 'stop method sends job name in path when flag is false'() {
     when:
-    buildService.stop(MASTER, JOB_NAME, QUEUE_BUILD, BUILD_NUMBER )
+    buildService.stop(MASTER, JOB_NAME, QUEUED_BUILD, BUILD_NUMBER )
 
     then:
-    1 * igorService.stop(MASTER, JOB_NAME, QUEUE_BUILD, BUILD_NUMBER, '')
+    1 * igorService.stop(MASTER, JOB_NAME, QUEUED_BUILD, BUILD_NUMBER, '')
   }
 
   void 'stop method sends job name in query when flag is true'() {
@@ -74,9 +74,9 @@ class BuildServiceSpec extends Specification {
     buildService = new BuildService(igorService, igorFeatureFlagProperties)
 
     when:
-    buildService.stop(MASTER, JOB_NAME, QUEUE_BUILD, BUILD_NUMBER )
+    buildService.stop(MASTER, JOB_NAME, QUEUED_BUILD, BUILD_NUMBER )
 
     then:
-    1 * igorService.stopWithJobNameAsQueryParameter(MASTER, JOB_NAME, QUEUE_BUILD, BUILD_NUMBER, '')
+    1 * igorService.stopWithJobNameAsQueryParameter(MASTER, JOB_NAME, QUEUED_BUILD, BUILD_NUMBER, '')
   }
 }

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
@@ -29,10 +29,11 @@ class BuildServiceSpec extends Specification {
   private static final JOB_NAME_ENCODED = "name/with/slashes%20and%20spaces"
   private static final PARAMS = ['key': 'value']
   private static final FILENAME = 'file.txt'
+  private static final QUEUE_BUILD = ''
 
   void setup() {
     igorService = Mock(IgorService)
-    buildService = new BuildService(igorService)
+    buildService = new BuildService(igorService, false)
   }
 
   void 'build method encodes the job name'() {
@@ -57,5 +58,23 @@ class BuildServiceSpec extends Specification {
 
     then:
     1 * igorService.getPropertyFile(BUILD_NUMBER, FILENAME, MASTER, JOB_NAME_ENCODED)
+  }
+
+  void 'stop method sends job name in path when flag is false'() {
+    when:
+    buildService.stop(MASTER, JOB_NAME, QUEUE_BUILD, BUILD_NUMBER )
+
+    then:
+    1 * igorService.stop(MASTER, JOB_NAME, QUEUE_BUILD, BUILD_NUMBER, '')
+  }
+
+  void 'stop method sends job name in query when flag is true'() {
+    buildService = new BuildService(igorService, true)
+
+    when:
+    buildService.stop(MASTER, JOB_NAME, QUEUE_BUILD, BUILD_NUMBER )
+
+    then:
+    1 * igorService.stopWithJobNameAsQueryParameter(MASTER, JOB_NAME, QUEUE_BUILD, BUILD_NUMBER, '')
   }
 }


### PR DESCRIPTION
When defining a Jenkins job inside folders, the name contains slashes. Because of that instead of matching the request to the IGOR STOP endpoint (/masters/{name}/jobs/{jobName}/stop/{queuedBuild}/{buildNumber}), Spring is matching the request to the BUILD one  (/masters/{name}/jobs/**)

The stop request is failing because it is trying to start a job that does not exist.

Feature flag added to call the existing endpoint (which accepts the job name as path variable) or the new one (which accepts  the job name as a query parameter)

Related Igor PR https://github.com/spinnaker/igor/pull/1038
