### PR TITLE
fix wrong indentation for rollback in database changeLog

### DIFF
--- a/keiko-sql/src/main/resources/db/changelog/20190822-initial-schema.yml
+++ b/keiko-sql/src/main/resources/db/changelog/20190822-initial-schema.yml
@@ -243,19 +243,19 @@ databaseChangeLog:
         # Original changeset checksum
         - 8:53370973bc79095573dfe46d41cffae7
       changes:
-      - addColumn:
-          tableName: keiko_v1_messages_template
-          columns:
-            - column:
-                name: updated_at
-                type: bigint
-                defaultValue: 0
-                constraints:
-                  nullable: false
-    rollback:
-      - dropColumn:
-          tableName: keiko_v1_messages_template
-          columnName: updated_at
+        - addColumn:
+            tableName: keiko_v1_messages_template
+            columns:
+              - column:
+                  name: updated_at
+                  type: bigint
+                  defaultValue: 0
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: keiko_v1_messages_template
+            columnName: updated_at
 
   - changeSet:
       id: add-keiko-queue-messages-updated-idx

--- a/orca-sql/src/main/resources/db/changelog/20200221-partition-name-table.yml
+++ b/orca-sql/src/main/resources/db/changelog/20200221-partition-name-table.yml
@@ -17,6 +17,6 @@ databaseChangeLog:
                   type: varchar(255)
                   constraints:
                     nullable: true
-    rollback:
-      - dropTable:
-          tableName: partition_name
+      rollback:
+        - dropTable:
+            tableName: partition_name

--- a/orca-sql/src/main/resources/db/changelog/20200327-deleted-executions-table.yml
+++ b/orca-sql/src/main/resources/db/changelog/20200327-deleted-executions-table.yml
@@ -34,6 +34,6 @@ databaseChangeLog:
         - sql:
             dbms: mysql
             sql: ALTER TABLE `deleted_executions` MODIFY COLUMN `execution_type` ENUM("pipeline", "orchestration") NOT NULL
-    rollback:
-      - dropTable:
-          tableName: deleted_executions
+      rollback:
+        - dropTable:
+            tableName: deleted_executions

--- a/orca-sql/src/main/resources/db/changelog/20200424-index-deleted-executions-table.yml
+++ b/orca-sql/src/main/resources/db/changelog/20200424-index-deleted-executions-table.yml
@@ -10,7 +10,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: deleted_at
-    rollback:
-      - dropIndex:
-          indexName: deleted_at_idx
-          tableName: deleted_executions
+      rollback:
+        - dropIndex:
+            indexName: deleted_at_idx
+            tableName: deleted_executions

--- a/orca-sql/src/main/resources/db/changelog/20200603-deleted-executions-table-not-mysql.yml
+++ b/orca-sql/src/main/resources/db/changelog/20200603-deleted-executions-table-not-mysql.yml
@@ -55,7 +55,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: deleted_at
-    rollback:
-      - dropIndex:
-          indexName: deleted_at_idx
-          tableName: deleted_executions
+      rollback:
+        - dropIndex:
+            indexName: deleted_at_idx
+            tableName: deleted_executions


### PR DESCRIPTION
Indentations for rollback are wrong in some files of database changeLog, which raises the following exception:

```log
liquibase.exception.ChangeLogParseException: Error parsing db/changelog/20200221-partition-name-table.yml
	at liquibase.parser.core.yaml.YamlChangeLogParser.parse(YamlChangeLogParser.java:89)
	at liquibase.changelog.DatabaseChangeLog.include(DatabaseChangeLog.java:587)
	at liquibase.changelog.DatabaseChangeLog.handleChildNode(DatabaseChangeLog.java:363)
	... 113 common frames omitted
Caused by: liquibase.parser.core.ParsedNodeException: Unexpected node found under databaseChangeLog: rollback
	at liquibase.changelog.DatabaseChangeLog.handleChildNode(DatabaseChangeLog.java:483)
	at liquibase.changelog.DatabaseChangeLog.load(DatabaseChangeLog.java:318)
	at liquibase.parser.core.yaml.YamlChangeLogParser.parse(YamlChangeLogParser.java:83)
	... 115 common frames omitted
```

This PR corrects those indentations.
