### PR TITLE
chore(kubernetes): stop specifying the version of io.kubernetes:client-java

### DIFF
--- a/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca-clouddriver/orca-clouddriver.gradle
@@ -33,7 +33,7 @@ dependencies {
   implementation(project(":orca-deploymentmonitor"))
   implementation("io.spinnaker.kork:kork-moniker")
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
-  implementation("io.kubernetes:client-java:11.0.2")
+  implementation("io.kubernetes:client-java")
   implementation("javax.validation:validation-api")
   implementation("org.jetbrains:annotations")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava")


### PR DESCRIPTION
since spring 2.4.13 brings it in (transitively).  The version from spring boot takes precedence, so the value we specify here is ignored.

Another approach would be to make the version here match what spring boot brings in (currently 11.0.3), but then future changes could again invalidate what's here.  If some future version of spring boot stops bringing in io.kubernetes:client-java, builds will fail with unspecified version, at which point we can specify the version once again.

Snippets of ./gradlew orca-web:dependencies

before:
```
+--- project :orca-applications
|    +--- project :orca-core
|    |    +--- io.kubernetes:client-java:11.0.2 -> 11.0.3
```
after:
```
+--- project :orca-applications
|    +--- project :orca-core
|    |    +--- io.kubernetes:client-java -> 11.0.3
```

Related clouddriver PR: https://github.com/spinnaker/clouddriver/pull/5797