### PR TITLE
fix(config): restore prior visibility of methods on CloudDriverConfigurationProperties class

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationProperties.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationProperties.java
@@ -65,7 +65,7 @@ public class CloudDriverConfigurationProperties {
   private BaseUrl kato;
   private CloudDriver clouddriver;
 
-  String getCloudDriverBaseUrl() {
+  public String getCloudDriverBaseUrl() {
     if (clouddriver != null && clouddriver.baseUrl != null) {
       return clouddriver.baseUrl;
     } else if (kato != null && kato.baseUrl != null) {
@@ -79,7 +79,7 @@ public class CloudDriverConfigurationProperties {
     return null;
   }
 
-  List<BaseUrl> getCloudDriverReadOnlyBaseUrls() {
+  public List<BaseUrl> getCloudDriverReadOnlyBaseUrls() {
     if (clouddriver != null
         && clouddriver.readonly != null
         && clouddriver.readonly.baseUrl != null) {


### PR DESCRIPTION
when this class was refactored from groovy into java, the visibility of these two methods was (inadvertently?) changed, causing downstream plugins to break with illegal access.

https://github.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/issues/125
