### PR TITLE
fix(artifacts): Expected Artifacts should be trigger specific

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtils.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtils.java
@@ -197,11 +197,14 @@ public class ArtifactUtils {
 
   public void resolveArtifacts(Map pipeline) {
     Map<String, Object> trigger = (Map<String, Object>) pipeline.get("trigger");
+    List<?> expectedArtifactIds =
+        (List<?>) trigger.getOrDefault("expectedArtifactIds", emptyList());
     ImmutableList<ExpectedArtifact> expectedArtifacts =
         Optional.ofNullable((List<?>) pipeline.get("expectedArtifacts"))
             .map(Collection::stream)
             .orElse(Stream.empty())
             .map(it -> objectMapper.convertValue(it, ExpectedArtifact.class))
+            .filter(artifact -> expectedArtifactIds.contains(artifact.getId()))
             .collect(toImmutableList());
 
     ImmutableSet<Artifact> receivedArtifacts =

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -79,6 +79,12 @@ class DependentPipelineStarter implements ApplicationContextAware {
           objectMapper.writeValueAsString(pipelineConfig))
     }
 
+    def expectedArtifactsIds = pipelineConfig.get("triggers", []).findAll {
+      it.type == "pipeline" && it.pipeline == parentPipeline.pipelineConfigId
+    } collectMany {
+      it.expectedArtifactIds ?: []
+    }
+
     pipelineConfig.trigger = [
       type                 : "pipeline",
       user                 : authenticationDetails?.user ?: user ?: "[anonymous]",
@@ -86,7 +92,8 @@ class DependentPipelineStarter implements ApplicationContextAware {
       parentPipelineStageId: parentPipelineStageId,
       parameters           : [:],
       strategy             : suppliedParameters.strategy == true,
-      correlationId        : "${parentPipeline.id}_${parentPipelineStageId}_${pipelineConfig.id}_${parentPipeline.startTime}".toString()
+      correlationId        : "${parentPipeline.id}_${parentPipelineStageId}_${pipelineConfig.id}_${parentPipeline.startTime}".toString(),
+      expectedArtifactIds  : expectedArtifactsIds
     ]
     /* correlationId is added so that two pipelines aren't triggered when a pipeline is canceled.
      * parentPipelineStageId is added so that a child pipeline (via pipeline stage)

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -79,7 +79,7 @@ class DependentPipelineStarter implements ApplicationContextAware {
           objectMapper.writeValueAsString(pipelineConfig))
     }
 
-    def expectedArtifactsIds = pipelineConfig.get("triggers", []).findAll {
+    def expectedArtifactIds = pipelineConfig.get("triggers", []).findAll {
       it.type == "pipeline" && it.pipeline == parentPipeline.pipelineConfigId
     } collectMany {
       it.expectedArtifactIds ?: []
@@ -93,7 +93,7 @@ class DependentPipelineStarter implements ApplicationContextAware {
       parameters           : [:],
       strategy             : suppliedParameters.strategy == true,
       correlationId        : "${parentPipeline.id}_${parentPipelineStageId}_${pipelineConfig.id}_${parentPipeline.startTime}".toString(),
-      expectedArtifactIds  : expectedArtifactsIds
+      expectedArtifactIds  : expectedArtifactIds
     ]
     /* correlationId is added so that two pipelines aren't triggered when a pipeline is canceled.
      * parentPipelineStageId is added so that a child pipeline (via pipeline stage)


### PR DESCRIPTION
When setting up multiple triggers with different expected artifacts, triggering the pipeline fails if _any_ defined expected artifact is missing, even if it is defined on another trigger. This fix filters the list of expected artifacts to make sure only the artifacts that are relevant for the current trigger is evaluated.

Example:

If you create two triggers like this, with different artifact constraints:
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/155558/199847220-b5b3da16-2bec-4778-8387-72c037db0067.png">

This would result in a pipeline config like this:

```json
{
  "expectedArtifacts": [
    {
      "defaultArtifact": {
        "customKind": true,
        "id": "3c55a698-aa57-4f38-9326-a99511b8e7b0"
      },
      "displayName": "my-artifact",
      "id": "89709fb4-4ad1-4267-ba14-77befa93b58d",
      "matchArtifact": {
        "artifactAccount": "custom-artifact",
        "customKind": true,
        "id": "dfa2e113-eb4f-4d20-adec-db0756ec4f44",
        "name": "s3://my-bucket/myfile",
        "type": "s3/object"
      },
      "useDefaultArtifact": false,
      "usePriorArtifact": false
    },
    {
      "defaultArtifact": {
        "customKind": true,
        "id": "26023c36-8257-4adb-a764-485e5ddb8462"
      },
      "displayName": "another-artifact",
      "id": "5d35f6ed-1336-4bc6-8c46-2c18df238163",
      "matchArtifact": {
        "artifactAccount": "custom-artifact",
        "customKind": true,
        "id": "0ea9e8b6-94e1-4df6-9004-88efade8cf67",
        "type": "custom/object"
      },
      "useDefaultArtifact": false,
      "usePriorArtifact": false
    }
  ],
  "keepWaitingPipelines": false,
  "limitConcurrent": true,
  "schema": "1",
  "spelEvaluator": "v4",
  "stages": [ ... ],
  "triggers": [
    {
      "enabled": true,
      "expectedArtifactIds": [
        "89709fb4-4ad1-4267-ba14-77befa93b58d"
      ],
      "pubsubSystem": "amazon",
      "subscriptionName": "pulse-routing-configurations-dev",
      "type": "pubsub"
    },
    {
      "application": "jervi",
      "enabled": true,
      "expectedArtifactIds": [
        "5d35f6ed-1336-4bc6-8c46-2c18df238163"
      ],
      "pipeline": "cee145ad-21b5-42a8-9894-b34d3f1cfed8",
      "status": [
        "successful"
      ],
      "type": "pipeline"
    }
  ]
}
```

Before the fix, the defined triggers would not trigger unless _all_ the defined artifacts were present. Here I have tried to start the pipeline using the pipeline trigger, but it won't start because it can't find the artifact that is defined for the pubsub trigger:
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/155558/199850048-4ca3b92a-5ca8-41be-87bd-f9e2c17e2440.png">


_As you can see in the [original PR for this feature](https://github.com/spinnaker/orca/pull/1763/files#diff-0655407bbf69c6b474c022ee0bdac3cf852dcf3e22a051483af3e533a7f3f1c5R31), it actually used to filter the expected artifacts correctly._