### PR TITLE
feat(bakery): Clean up cached data created by Rosco.

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryService.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryService.groovy
@@ -38,6 +38,9 @@ interface BakeryService {
   @GET("/api/v1/{region}/bake/{bakeId}")
   Bake lookupBake(@Path("region") String region, @Path("bakeId") String bakeId)
 
+  @POST("/api/v1/bakes/delete-requests")
+  Void createDeleteBakesRequest(@Body DeleteBakesRequest deleteBakesRequest)
+
   //
   // Methods below this line are not supported by the Netflix Bakery, and are only available
   // iff bakery.roscoApisEnabled is true.

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/DeleteBakesRequest.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/DeleteBakesRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.bakery.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class DeleteBakesRequest {
+
+  @JsonProperty("pipelineExecutionIds")
+  private List<String> pipelineExecutionIds = new ArrayList<>();
+}

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeryPipelineDependencyCleanupOperator.java
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeryPipelineDependencyCleanupOperator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.bakery.pipeline;
+
+import com.netflix.spinnaker.orca.bakery.api.BakeryService;
+import com.netflix.spinnaker.orca.bakery.api.DeleteBakesRequest;
+import com.netflix.spinnaker.orca.notifications.scheduling.PipelineDependencyCleanupOperator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnExpression("${bakery-pipeline-dependency-cleanup.enabled:false}")
+@RequiredArgsConstructor
+public class BakeryPipelineDependencyCleanupOperator implements PipelineDependencyCleanupOperator {
+
+  private final BakeryService bakeryService;
+
+  @Override
+  public void cleanup(List<String> pipelineExecutionIds) {
+    DeleteBakesRequest deleteBakesRequest = new DeleteBakesRequest();
+    deleteBakesRequest.setPipelineExecutionIds(pipelineExecutionIds);
+
+    bakeryService.createDeleteBakesRequest(deleteBakesRequest);
+  }
+}

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/BakerySelectorSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/BakerySelectorSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.bakery.api.Bake
 import com.netflix.spinnaker.orca.bakery.api.BakeRequest
 import com.netflix.spinnaker.orca.bakery.api.BakeStatus
 import com.netflix.spinnaker.orca.bakery.api.BakeryService
+import com.netflix.spinnaker.orca.bakery.api.DeleteBakesRequest
 import com.netflix.spinnaker.orca.bakery.api.BaseImage
 import com.netflix.spinnaker.orca.bakery.api.manifests.BakeManifestRequest
 import com.netflix.spinnaker.orca.bakery.config.BakeryConfigurationProperties
@@ -142,6 +143,11 @@ class BakerySelectorSpec extends Specification {
 
     @Override
     Bake lookupBake(@Path("region") String region, @Path("bakeId") String bakeId) {
+      return null
+    }
+
+    @Override
+    Void createDeleteBakesRequest(@Body DeleteBakesRequest deleteBakesRequest) {
       return null
     }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/PipelineDependencyCleanupOperator.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/notifications/scheduling/PipelineDependencyCleanupOperator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.notifications.scheduling;
+
+import java.util.List;
+
+/** This interface is responsible for the pipeline execution dependencies cleanup. */
+public interface PipelineDependencyCleanupOperator {
+
+  void cleanup(List<String> pipelineExecutionIds);
+}

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -45,7 +45,8 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
       new NoopRegistry(),
       5000,
       1,
-      5
+      5,
+      []
     ).filter
 
     expect:
@@ -82,7 +83,8 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
       new NoopRegistry(),
       5000,
       1,
-      5
+      5,
+      []
     ).mapper
 
     expect:
@@ -122,6 +124,7 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
       1 * retrieveAllApplicationNames(PIPELINE) >> ["orca"]
       1 * retrievePipelinesForApplication("orca") >> rx.Observable.from(pipelines)
     }
+    def pipelineDependencyCleanupOperator = Mock(PipelineDependencyCleanupOperator)
     def agent = new OldPipelineCleanupPollingNotificationAgent(
       Mock(NotificationClusterLock),
       executionRepository,
@@ -129,7 +132,8 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
       new NoopRegistry(),
       5000,
       thresholdDays,
-      retain
+      retain,
+      [pipelineDependencyCleanupOperator]
     )
 
     when:
@@ -140,6 +144,7 @@ class OldPipelineCleanupPollingNotificationAgentSpec extends Specification {
     // expect D1-5 to be too old, but for the most recent 3 to be retained
     1 * executionRepository.delete(PIPELINE, '1')
     1 * executionRepository.delete(PIPELINE, '2')
+    1 * pipelineDependencyCleanupOperator.cleanup(['1', '2'])
   }
 
   private

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationPipelineExecutionCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/notifications/scheduling/TopApplicationPipelineExecutionCleanupPollingNotificationAgentSpec.groovy
@@ -40,7 +40,8 @@ class TopApplicationPipelineExecutionCleanupPollingNotificationAgentSpec extends
       Mock(ExecutionRepository),
       new NoopRegistry(),
       5000,
-      2500
+      2500,
+      []
     ).filter
 
     expect:
@@ -70,7 +71,8 @@ class TopApplicationPipelineExecutionCleanupPollingNotificationAgentSpec extends
       Mock(ExecutionRepository),
       new NoopRegistry(),
       5000,
-      2500
+      2500,
+      []
     ).mapper
 
     expect:
@@ -92,12 +94,14 @@ class TopApplicationPipelineExecutionCleanupPollingNotificationAgentSpec extends
       1 * retrieveAllApplicationNames(_, _) >> ["app1"]
       1 * retrieveOrchestrationsForApplication("app1", _) >> rx.Observable.from(orchestrations)
     }
+    def pipelineDependencyCleanupOperator = Mock(PipelineDependencyCleanupOperator)
     def agent = new TopApplicationExecutionCleanupPollingNotificationAgent(
       Mock(NotificationClusterLock),
       executionRepository,
       new NoopRegistry(),
       5000,
-      2
+      2,
+      [pipelineDependencyCleanupOperator]
     )
 
     when:
@@ -105,6 +109,7 @@ class TopApplicationPipelineExecutionCleanupPollingNotificationAgentSpec extends
 
     then:
     1 * executionRepository.delete(ORCHESTRATION, orchestrations[0].id)
+    1 * pipelineDependencyCleanupOperator.cleanup([orchestrations[0].id])
   }
 
   private static Collection<PipelineExecutionImpl> buildExecutions(AtomicInteger stageStartTime,

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -73,7 +73,8 @@ abstract class OldPipelineCleanupPollingNotificationAgentSpec extends Specificat
         ["exceptionalApp"],
         50
     ),
-    new OrcaSqlProperties()
+    new OrcaSqlProperties(),
+    []
   )
 
   def setupSpec() {

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
@@ -74,7 +74,8 @@ abstract class TopApplicationExecutionCleanupPollingNotificationAgentSpec extend
             exceptionApp2 : 5
         ]
     ),
-    new OrcaSqlProperties()
+    new OrcaSqlProperties(),
+    []
   )
 
   def setupSpec() {


### PR DESCRIPTION
**Description**

Rosco service uses Redis for caching purposes. The records created in Redis can be up to 50MB size and will never be removed. As a result, Redis can become quite expensive. This pull request changes solve this issue. 