### PR TITLE
feat(bakery): add includeCRDs in Helm Bake request

### DIFF
--- a/orca-bakery/src/main/java/com/netflix/spinnaker/orca/bakery/api/manifests/helm/HelmBakeManifestRequest.java
+++ b/orca-bakery/src/main/java/com/netflix/spinnaker/orca/bakery/api/manifests/helm/HelmBakeManifestRequest.java
@@ -43,6 +43,9 @@ public class HelmBakeManifestRequest extends BakeManifestRequest {
   @JsonProperty("rawOverrides")
   private Boolean rawOverrides;
 
+  @JsonProperty("includeCRDs")
+  private Boolean includeCRDs;
+
   @JsonProperty("helmChartFilePath")
   private String helmChartFilePath;
 
@@ -59,6 +62,7 @@ public class HelmBakeManifestRequest extends BakeManifestRequest {
     this.setNamespace(bakeManifestContext.getNamespace());
     this.setInputArtifacts(inputArtifacts);
     this.setRawOverrides(bakeManifestContext.getRawOverrides());
+    this.setIncludeCRDs(bakeManifestContext.getIncludeCRDs());
     this.setHelmChartFilePath(bakeManifestContext.getHelmChartFilePath());
   }
 }

--- a/orca-bakery/src/main/java/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
+++ b/orca-bakery/src/main/java/com/netflix/spinnaker/orca/bakery/tasks/manifests/BakeManifestContext.java
@@ -35,6 +35,7 @@ public class BakeManifestContext {
   private final String outputName;
   private final String namespace;
   private final Boolean rawOverrides;
+  private final Boolean includeCRDs;
   @Nullable private final String kustomizeFilePath;
   @Nullable private final String helmChartFilePath;
   // There does not seem to be a way to auto-generate a constructor using our current version of
@@ -52,7 +53,8 @@ public class BakeManifestContext {
       @Nullable @JsonProperty("inputArtifact") CreateBakeManifestTask.InputArtifact inputArtifact,
       @Nullable @JsonProperty("kustomizeFilePath") String kustomizeFilePath,
       @Nullable @JsonProperty("helmChartFilePath") String helmChartFilePath,
-      @JsonProperty("rawOverrides") Boolean rawOverrides) {
+      @JsonProperty("rawOverrides") Boolean rawOverrides,
+      @JsonProperty("includeCRDs") Boolean includeCRDs) {
     this.inputArtifacts = Optional.ofNullable(inputArtifacts).orElse(new ArrayList<>());
     // Kustomize stage configs provide a single input artifact
     if (this.inputArtifacts.isEmpty() && inputArtifact != null) {
@@ -67,5 +69,6 @@ public class BakeManifestContext {
     this.kustomizeFilePath = kustomizeFilePath;
     this.helmChartFilePath = helmChartFilePath;
     this.rawOverrides = rawOverrides;
+    this.includeCRDs = includeCRDs;
   }
 }


### PR DESCRIPTION
This is part of https://github.com/spinnaker/spinnaker/issues/6518

Add new field `includeCRDs` in request to rosco in order to include custom resource definitions manifests in templated output.
