### PR TITLE
fix(config): add back public visibility for ClouddriverRetrofitBuilde…

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.java
@@ -80,7 +80,7 @@ public class CloudDriverConfiguration {
         cloudDriverConfigurationProperties);
   }
 
-  static class ClouddriverRetrofitBuilder {
+  public static class ClouddriverRetrofitBuilder {
     ObjectMapper objectMapper;
     OkHttpClientProvider clientProvider;
     RestAdapter.LogLevel retrofitLogLevel;
@@ -100,7 +100,7 @@ public class CloudDriverConfiguration {
       this.cloudDriverConfigurationProperties = cloudDriverConfigurationProperties;
     }
 
-    <T> T buildWriteableService(Class<T> type) {
+    public <T> T buildWriteableService(Class<T> type) {
       return buildService(type, cloudDriverConfigurationProperties.getCloudDriverBaseUrl());
     }
 


### PR DESCRIPTION
When this class was migrated from groovy to java the visibility of the class went from public to package-private, so adding back public access