### PR TITLE
feat(Azure): Update createBakeTask for managed and custom images.

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
@@ -46,6 +46,7 @@ class BakeRequest {
 
   String user
   @JsonProperty("package") String packageName
+  String packageType
   List<Artifact> packageArtifacts
   String buildHost
   String job

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
@@ -62,7 +62,7 @@ class BakeRequest {
   StoreType storeType
   Boolean enhancedNetworking
   String amiName
-  String account
+  String accountName
   String sku
   String offer
   String publisher

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/api/BakeRequest.groovy
@@ -61,6 +61,12 @@ class BakeRequest {
   StoreType storeType
   Boolean enhancedNetworking
   String amiName
+  String account
+  String sku
+  String offer
+  String publisher
+  String osType
+  String custom_managed_image_name
   private String amiSuffix
 
   public void setAmiSuffix(String amiSuffix) {

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -166,6 +166,10 @@ class CreateBakeTask implements RetryableTask {
 
     Map requestMap = packageInfo.findTargetPackage(bakery.config.allowMissingPackageInstallation as Boolean)
 
+    if (stage.context.account) {
+      requestMap.accountName = stage.context.account as String
+    }
+
     // if the field "packageArtifactIds" is present in the context, because it was set in the UI,
     // this will resolve those ids into real artifacts and then put them in List<Artifact> packageArtifacts
     requestMap.packageArtifacts = stage.context.packageArtifactIds.collect { String artifactId ->

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy
@@ -153,7 +153,7 @@ class CreateBakeTask implements RetryableTask {
   private BakeRequest bakeFromContext(StageExecution stage, SelectedService<BakeryService> bakery) {
     PackageType packageType
     packageType = stage.context.baseOs != null ? getBaseOsPackageType(bakery, stage) : getCustomPackageType(stage)
-
+    stage.context.packageType = packageType
     List<Artifact> artifacts = artifactUtils.getAllArtifacts(stage.getExecution())
 
     PackageInfo packageInfo = new PackageInfo(stage,
@@ -184,7 +184,7 @@ class CreateBakeTask implements RetryableTask {
 
     if (stage.context.baseOs == null) {
       requestMap.custom_managed_image_name = stage.context.managedImage as String
-      if (stage.context.managedImage as String == null) {
+      if (stage.context.managedImage == null) {
         requestMap.sku = stage.context.sku as String
         requestMap.offer = stage.context.offer as String
         requestMap.publisher = stage.context.publisher as String
@@ -200,14 +200,13 @@ class CreateBakeTask implements RetryableTask {
   }
 
   private static PackageType getCustomPackageType(StageExecution stage) {
-    PackageType type
     if(stage.context.osType != "linux") {
-      type = PackageType.NUPKG
-    } else {
-      type = stage.context.packageType as PackageType
-      if (type == null) {
-        type = new OperatingSystem(stage.context.managedImage as String).getPackageType()
-      }
+      return PackageType.NUPKG
+    }
+
+    PackageType type = stage.context.packageType as PackageType
+    if (type == null) {
+      type = new OperatingSystem(stage.context.managedImage as String).getPackageType()
     }
 
     type

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -63,6 +63,7 @@ class MonitorBakeTask implements OverridableTimeoutRetryableTask {
 
       TaskResult.builder(mapStatus(newStatus)).context([status: newStatus]).build()
     } catch (RetrofitError e) {
+      log.error("Monitor Error {}", e.getMessage())
       if (e.response?.status == 404) {
         return TaskResult.ofStatus(ExecutionStatus.RUNNING)
       }

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -93,9 +93,9 @@ class CreateBakeTaskSpec extends Specification {
     cloudProviderType: "azure",
     baseLabel        : "release",
     osType           : "linux",
-    packageType      : "DEB",
-    managedImage     : "managed"
-
+    packageType      : "RPM",
+    managedImage     : "managed",
+    account          : "splat-azure"
   ]
 
   @Shared
@@ -105,7 +105,8 @@ class CreateBakeTaskSpec extends Specification {
     user             : "bran",
     cloudProviderType: "azure",
     baseOs           : "ubuntu",
-    baseLabel        : "release"
+    baseLabel        : "release",
+    account          : "splat-azure"
   ]
 
   @Shared
@@ -118,7 +119,8 @@ class CreateBakeTaskSpec extends Specification {
     sku              : "sky",
     offer            : "offer",
     publisher        : "pub",
-    baseLabel        : "release"
+    baseLabel        : "release",
+    account          : "splat-azure"
   ]
 
   @Shared
@@ -1061,6 +1063,7 @@ class CreateBakeTaskSpec extends Specification {
     bake.custom_managed_image_name == bakeConfigWithAzureManagedImage.managedImage
     bake.osType == bakeConfigWithAzureManagedImage.osType
     bake.packageType == bakeConfigWithAzureManagedImage.packageType as String
+    bake.accountName == bakeConfigWithAzureManagedImage.account
   }
 
   def "Azure defaultImage is propagated"() {
@@ -1103,6 +1106,7 @@ class CreateBakeTaskSpec extends Specification {
     bake.baseOs == bakeConfigWithAzureDefaultImage.baseOs
     bake.baseLabel == bakeConfigWithAzureDefaultImage.baseLabel
     bake.packageType == PackageType.DEB as String
+    bake.accountName == bakeConfigWithAzureManagedImage.account
   }
 
   def "Azure customImage is propagated"() {
@@ -1148,6 +1152,7 @@ class CreateBakeTaskSpec extends Specification {
     bake.publisher == bakeConfigWithAzureCustomImage.publisher
     bake.osType == bakeConfigWithAzureCustomImage.osType
     bake.packageType == PackageType.NUPKG as String
+    bake.accountName == bakeConfigWithAzureManagedImage.account
   }
 
   @Unroll

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTaskSpec.groovy
@@ -86,6 +86,42 @@ class CreateBakeTaskSpec extends Specification {
   ]
 
   @Shared
+  def bakeConfigWithAzureManagedImage = [
+    region           : "us-west-1",
+    package          : "hodor",
+    user             : "bran",
+    cloudProviderType: "azure",
+    baseLabel        : "release",
+    osType           : "linux",
+    packageType      : "DEB",
+    managedImage     : "managed"
+
+  ]
+
+  @Shared
+  def bakeConfigWithAzureDefaultImage = [
+    region           : "us-west-1",
+    package          : "hodor",
+    user             : "bran",
+    cloudProviderType: "azure",
+    baseOs           : "ubuntu",
+    baseLabel        : "release"
+  ]
+
+  @Shared
+  def bakeConfigWithAzureCustomImage = [
+    region           : "us-west-1",
+    package          : "hodor",
+    user             : "bran",
+    cloudProviderType: "azure",
+    osType           : "windows",
+    sku              : "sky",
+    offer            : "offer",
+    publisher        : "pub",
+    baseLabel        : "release"
+  ]
+
+  @Shared
   def bakeConfigWithRebake = [
     region           : "us-west-1",
     package          : "hodor",
@@ -982,6 +1018,136 @@ class CreateBakeTaskSpec extends Specification {
     bake.packageName == bakeConfigWithCloudProviderType.package
     bake.baseOs == bakeConfigWithCloudProviderType.baseOs
     bake.baseLabel == bakeConfigWithCloudProviderType.baseLabel
+  }
+
+  def "Azure managedImage is propagated"() {
+    given:
+    def pipeline = pipeline {
+      stage {
+        type = "bake"
+        context = bakeConfigWithAzureManagedImage
+      }
+    }
+    def bake
+    def bakery = Mock(BakeryService) {
+      1 * createBake(*_) >> {
+        bake = it[1]
+        runningStatus
+      }
+    }
+
+    and:
+    def selectedBakeryService = Stub(SelectableService.SelectedService) {
+      getService() >> bakery
+      getConfig() >> [
+        extractBuildDetails: false,
+        allowMissingPackageInstallation: false,
+        roscoApisEnabled: false
+      ]
+    }
+
+    task.bakerySelector = Mock(BakerySelector) {
+      select(_) >> selectedBakeryService
+    }
+
+    when:
+    task.execute(pipeline.stages.first())
+
+    then:
+    bake.cloudProviderType == BakeRequest.CloudProviderType.azure
+    bake.user == bakeConfigWithAzureManagedImage.user
+    bake.packageName == bakeConfigWithAzureManagedImage.package
+    bake.baseLabel == bakeConfigWithAzureManagedImage.baseLabel
+    bake.custom_managed_image_name == bakeConfigWithAzureManagedImage.managedImage
+    bake.osType == bakeConfigWithAzureManagedImage.osType
+    bake.packageType == bakeConfigWithAzureManagedImage.packageType as String
+  }
+
+  def "Azure defaultImage is propagated"() {
+    given:
+    def pipeline = pipeline {
+      stage {
+        type = "bake"
+        context = bakeConfigWithAzureDefaultImage
+      }
+    }
+    def bake
+    def bakery = Mock(BakeryService) {
+      1 * createBake(*_) >> {
+        bake = it[1]
+        runningStatus
+      }
+    }
+
+    and:
+    def selectedBakeryService = Stub(SelectableService.SelectedService) {
+      getService() >> bakery
+      getConfig() >> [
+        extractBuildDetails: false,
+        allowMissingPackageInstallation: false,
+        roscoApisEnabled: false
+      ]
+    }
+
+    task.bakerySelector = Mock(BakerySelector) {
+      select(_) >> selectedBakeryService
+    }
+
+    when:
+    task.execute(pipeline.stages.first())
+
+    then:
+    bake.cloudProviderType == BakeRequest.CloudProviderType.azure
+    bake.user == bakeConfigWithAzureDefaultImage.user
+    bake.packageName == bakeConfigWithAzureDefaultImage.package
+    bake.baseOs == bakeConfigWithAzureDefaultImage.baseOs
+    bake.baseLabel == bakeConfigWithAzureDefaultImage.baseLabel
+    bake.packageType == PackageType.DEB as String
+  }
+
+  def "Azure customImage is propagated"() {
+    given:
+    def pipeline = pipeline {
+      stage {
+        type = "bake"
+        context = bakeConfigWithAzureCustomImage
+      }
+    }
+    def bake
+    def bakery = Mock(BakeryService) {
+      1 * createBake(*_) >> {
+        bake = it[1]
+        runningStatus
+      }
+    }
+
+    and:
+    def selectedBakeryService = Stub(SelectableService.SelectedService) {
+      getService() >> bakery
+      getConfig() >> [
+        extractBuildDetails: false,
+        allowMissingPackageInstallation: false,
+        roscoApisEnabled: false
+      ]
+    }
+
+    task.bakerySelector = Mock(BakerySelector) {
+      select(_) >> selectedBakeryService
+    }
+
+    when:
+    task.execute(pipeline.stages.first())
+
+    then:
+    bake.cloudProviderType == BakeRequest.CloudProviderType.azure
+    bake.user == bakeConfigWithAzureCustomImage.user
+    bake.packageName == bakeConfigWithAzureCustomImage.package
+    bake.baseLabel == bakeConfigWithAzureCustomImage.baseLabel
+    bake.sku == bakeConfigWithAzureCustomImage.sku
+    bake.offer == bakeConfigWithAzureCustomImage.offer
+    bake.publisher == bakeConfigWithAzureCustomImage.publisher
+    bake.osType == bakeConfigWithAzureCustomImage.osType
+    bake.packageType == PackageType.NUPKG as String
   }
 
   @Unroll


### PR DESCRIPTION
Add support for handling the bake of managed and custom images for Azure.

Tested the feature manually.

To be pushed after the rosco packer templates have been validated and the entire workflow was tested.