### PR TITLE
fix: check manifests types

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunner.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/kubernetes/KubernetesJobRunner.java
@@ -67,7 +67,17 @@ public class KubernetesJobRunner implements JobRunner {
 
     List<Map<Object, Object>> manifests = result.getManifests();
     if (manifests.size() != 1) {
-      throw new IllegalArgumentException("Run Job only supports manifests with a single Job.");
+      int numJobs = 0;
+      for (Map<Object, Object> manifest : manifests) {
+        String manifestKind = (String) manifest.get("kind");
+        if (manifestKind.toLowerCase() == "job") {
+          numJobs += 1;
+          if (numJobs > 1) {
+            throw new IllegalArgumentException(
+                "Run Job only supports manifests with a single Job.");
+          }
+        }
+      }
     }
 
     return ImmutableMap.of(


### PR DESCRIPTION
# Issue
https://github.com/spinnaker/spinnaker/issues/6769

# Description
Allow a manifest file to contain more than one embedded manifest when running a Job. This supports use cases such as a Job manifest bundled with a ConfigMap manifest in the same file. Strictly speaking, it is a manifest file containing more than one _Job_ definition that is the problem. This is solved by checking the `kind` of each manifest in the file, and only throwing an exception if more than one `Job` kind is found.