### PR TITLE
feat(AWS): Get the rollback timeout value from stage data.

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
@@ -107,8 +107,8 @@ public class DetermineRollbackCandidatesTask implements CloudProviderAware, Retr
   }
 
   public long getDynamicTimeout(StageExecution stage) {
-    if (stage.getContext().containsKey("timeout")) {
-      return TimeUnit.MINUTES.toMillis((int) stage.getContext().get("timeout"));
+    if (stage.getContext().containsKey("rollbackTimeout")) {
+      return TimeUnit.MINUTES.toMillis((int) stage.getContext().get("rollbackTimeout"));
     }
 
     return getTimeout();

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
@@ -73,6 +73,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class DetermineRollbackCandidatesTask implements CloudProviderAware, RetryableTask {
+  private Integer timeout;
+
   private static final Logger logger =
       LoggerFactory.getLogger(DetermineRollbackCandidatesTask.class);
 
@@ -103,13 +105,14 @@ public class DetermineRollbackCandidatesTask implements CloudProviderAware, Retr
 
   @Override
   public long getTimeout() {
-    return TimeUnit.MINUTES.toMillis(5);
+    return TimeUnit.MINUTES.toMillis(timeout == null ? 5 : timeout);
   }
 
   @Nonnull
   @Override
   public TaskResult execute(@Nonnull StageExecution stage) {
     StageData stageData = stage.mapTo(StageData.class);
+    timeout = stageData.timeout;
     Moniker moniker =
         populateMonikerWithServerGroupInfo(
             stageData.moniker,
@@ -527,6 +530,7 @@ public class DetermineRollbackCandidatesTask implements CloudProviderAware, Retr
     public String credentials;
     public String cloudProvider;
     public String serverGroup;
+    public Integer timeout;
 
     public Integer targetHealthyRollbackPercentage;
 


### PR DESCRIPTION
Get the rollback timeout value from stage data. The value is now configurable from the UI. If the value is not set in the UI the hardcoded value is used.

Testing:
The rollback failed after 20 min and 8 sec with a timeout of 20min.

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/111055962/203998075-df1849bf-2224-4c4a-9243-f714d9bc598a.png">
