### PR TITLE
fix(waiting-executions) : Waiting executions doesn't follow FIFO

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandler.kt
@@ -84,11 +84,21 @@ class CompleteExecutionHandler(
           }
         }
       }
-      execution.pipelineConfigId?.let {
-        queue.push(StartWaitingExecutions(it, purgeQueue = !execution.isKeepWaitingPipelines))
+      log.info("Execution ${execution.id} is with ${execution.status} status and  Disabled concurrent executions is ${execution.isLimitConcurrent}")
+        if (execution.isLimitConcurrent){
+          if (execution.status != RUNNING) {
+            execution.pipelineConfigId?.let {
+              queue.push(StartWaitingExecutions(it, purgeQueue = !execution.isKeepWaitingPipelines))
+            }
+          }else {
+            log.info("Not starting waiting executions as execution ${execution.id} is currently RUNNING with Disabled concurrent executions.")
+          }
+        } else{
+            log.info("Execution ${execution.id} is not Disabled for concurrent executions, no need to run waiting executions")
+        }
       }
     }
-  }
+
 
   private fun CompleteExecution.determineFinalStatus(
     execution: PipelineExecution,


### PR DESCRIPTION
This PR has changes to fix the issue https://github.com/spinnaker/spinnaker/issues/6373

** Root Cause: **
Currently `StartWaitingExecutions` is getting pushed to the queue every time it receives `CompleteExecution` for all the execution status. 
But this is causing an issue when pipeline execution with branches is running with Disabled concurrent executions and trying to `StartWaitingExecutions`, which leads to remove the oldest execution from the waiting queue to start and re-insert the execution at the top of the queue as the current execution is still running.

** Fix: **
Changes to push `StartWaitingExecutions` to the queue only when execution status is not running and disabled concurrent executions, in all other cases no need to push `StartWaitingExecutions` to the queue.
