### PR TITLE
refactor(web): Clean up redundant spring property in gradle file

### DIFF
--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -18,14 +18,6 @@ apply from: "$rootDir/gradle/groovy.gradle"
 apply from: "$rootDir/gradle/kotlin.gradle"
 apply plugin: 'io.spinnaker.package'
 
-ext {
-  springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/".toString())
-}
-
-run {
-  systemProperty('spring.config.additional-location', project.springConfigLocation)
-}
-
 mainClassName = 'com.netflix.spinnaker.orca.Main'
 
 dependencies {


### PR DESCRIPTION
The property spring.config.additional-location is redundant in orca-web.gradle file. This property is set by class com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder in com.netflix.spinnaker.orca.Main. So removing it from gradle file.