### PR TITLE
chore(dependencies): remove dependency on groovy-all where straightforward

### DIFF
--- a/gradle/groovy.gradle
+++ b/gradle/groovy.gradle
@@ -21,7 +21,7 @@
 apply plugin: "groovy"
 
 dependencies {
-  implementation("org.codehaus.groovy:groovy-all")
+  implementation("org.codehaus.groovy:groovy")
   testImplementation("org.spockframework:spock-core")
   testImplementation("cglib:cglib-nodep")
   testImplementation("org.objenesis:objenesis")

--- a/orca-integrations-cloudfoundry/orca-integrations-cloudfoundry.gradle
+++ b/orca-integrations-cloudfoundry/orca-integrations-cloudfoundry.gradle
@@ -12,6 +12,7 @@ dependencies {
   implementation(project(":orca-core"))
 
   implementation("org.jetbrains:annotations")
+  testImplementation("org.codehaus.groovy:groovy-all")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core:2.25.0")

--- a/orca-keel/orca-keel.gradle
+++ b/orca-keel/orca-keel.gradle
@@ -30,6 +30,7 @@ dependencies {
   testImplementation("io.mockk:mockk")
   testImplementation("io.strikt:strikt-jackson")
   testImplementation("org.assertj:assertj-core")
+  testImplementation("org.codehaus.groovy:groovy-all")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
 }


### PR DESCRIPTION
with a specific goal to get `org.testng:testng:7.4.0` out of shipping code, since it's vulnerable to CVE-2022-4065.
