### PR TITLE
feat(bakery): add tasks.monitor-bake.timeout-millis configuration property

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.orca.bakery.api.BakeStatus
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 
@@ -34,7 +35,9 @@ import retrofit.RetrofitError
 class MonitorBakeTask implements OverridableTimeoutRetryableTask {
 
   long backoffPeriod = 30000
-  long timeout = 3600000 // 1hr
+
+  @Value('${tasks.monitor-bake.timeout-millis:3600000}')
+  long timeout
 
   @Autowired(required = false)
   BakerySelector bakerySelector


### PR DESCRIPTION
for MonitorBakeTask timeout

The default value is unchanged -- 3600000 milliseconds, or 1 hour.

See https://github.com/spinnaker/orca/pull/4347 which does a similar thing for MonitorPipelineTask.