### PR TITLE
fix(stageExecution): Extend MJ auth propagate logic for exhaustive cases

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
@@ -56,7 +56,7 @@ class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage 
   @Override
   Optional<PipelineExecution.AuthenticationDetails> authenticatedUser(StageExecution stage) {
     def stageData = stage.mapTo(StageData)
-    if (stageData.state != StageData.State.CONTINUE || !stage.lastModified?.user || !stageData.propagateAuthenticationContext) {
+    if (stageData.state != StageData.State.CONTINUE || !stage.lastModified?.user) {
       return Optional.empty()
     }
 

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
@@ -242,7 +242,7 @@ class ManualJudgmentStageSpec extends Specification {
     judgmentStatus | propagateAuthenticationContext || isPresent
     "continue"     | true                           || true
     "ContinuE"     | true                           || true
-    "continue"     | false                          || false
+    "continue"     | false                          || true
     "stop"         | true                           || false
     "stop"         | false                          || false
     ""             | true                           || false

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AuthenticationAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AuthenticationAware.kt
@@ -78,7 +78,7 @@ interface AuthenticationAware {
   //auth propagated are considerated as candidates
   fun solveSkippedStages(stage: StageExecution): StageExecution {
     if (stage.isManualJudgmentType() &&
-      stage.status.isSkipped) {
+      (stage.status.isSkipped || !stage.withPropagateAuthentication())) {
       val result = backtrackSkippedStages(stage)
       stage.lastModified = result.lastModified
       return result

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AuthenticationAware.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AuthenticationAware.kt
@@ -56,30 +56,29 @@ interface AuthenticationAware {
     return stageNavigator
       .ancestors(stage)
       .firstOrNull { it.stageBuilder is AuthenticatedStage } ?.let{
-        (it.stageBuilder as AuthenticatedStage).authenticatedUser(solveSkippedStages(it.stage)).orElse(null)
+        (it.stageBuilder as AuthenticatedStage).authenticatedUser(solveAuthStages(it.stage)).orElse(null)
       }
   }
 
 
   // When a first valid candidate is found in the ancestors chain is returned
   // until the ancestor chain was iterated completely at the pipeline beginning
-  fun backtrackSkippedStages(stage: StageExecution): StageExecution {
+  fun backtrackStages(stage: StageExecution): StageExecution {
     if (stage.isManualJudgmentType &&
       !stage.status.isSkipped &&
       stage.withPropagateAuthentication()) {
       return stage;
     }
     val previousStage = if (stageNavigator.ancestors(stage).size > 1) stageNavigator.ancestors(stage).get(1).stage else null
-    return if (previousStage == null) stage else backtrackSkippedStages(previousStage)
+    return if (previousStage == null) stage else backtrackStages(previousStage)
   }
 
   //Next method will look by a possible stage with authentication propagated in case that previous
-  //stage was skipped, iterating the stage ancestors. By the moment only MJ stages approved with
+  //stage brokes the auth chain, iterating the stage ancestors. By the moment only MJ stages approved with
   //auth propagated are considerated as candidates
-  fun solveSkippedStages(stage: StageExecution): StageExecution {
-    if (stage.isManualJudgmentType() &&
-      (stage.status.isSkipped || !stage.withPropagateAuthentication())) {
-      val result = backtrackSkippedStages(stage)
+  fun solveAuthStages(stage: StageExecution): StageExecution {
+    if (stage.isManualJudgmentType()) {
+      val result = backtrackStages(stage)
       stage.lastModified = result.lastModified
       return result
     }


### PR DESCRIPTION
When Manual Judgment without propagate authentication enabled appear in a pipeline, next stages ignore the last user interaction in propagated stages, and is retrieving the executor user by default when the expected case is consider the last MJ with propagate authentication enabled.

Similar fix was applied in https://github.com/spinnaker/orca/pull/4289 but only considering skipped stages, now we extend the logic for sub cases

Requirements:
-AuthZ system enabled
-Roles properly configured to restrict and allow desired users

Ex:
Roles used:

-----------
    permissions:
      CREATE:
      - "admin" # group members that CAN create applications if enabled
      READ:
      - "admin"
      - "restricted"
      WRITE:
      - "admin"
      EXECUTE:
      - "admin"
      - "restricted"
Users:
OscarMichelH as `admin`
oscar4armory as `restricted`

The wrong behaviour is the next:
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/21283264/208499782-ae4a7d39-1f63-4eee-840d-a099270f3621.png">
<img width="1161" alt="image" src="https://user-images.githubusercontent.com/21283264/208499863-40ea4fb0-82e6-4fe7-b7a5-fce7d9c93697.png">

The restricted user executed the pipeline, but before to deploy in the first stage we have an approval with authentication propagate enabled and the last stage, the MJ was judged by the authorized user, and deployment stage looking by the Authenticated user, is just ignoring the MJ and retrieving the executor user by default, and the expected behaviour is take in consideration the previous MJ with propagate authentication.

With the fix applied the last stage is taking the previous judge from a propagated auth MJ stage even if the propagate authentication is disabled, and acting as expected
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/21283264/208501216-a14ee551-daa4-4934-a217-3a535c479226.png">
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/21283264/208501274-282654f6-0675-4098-bd70-b340bbe953f4.png">
