### PR TITLE
fix(bakery): Use DateTimeFormatter instead of String

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -41,6 +41,7 @@ import org.springframework.stereotype.Component
 
 import javax.annotation.Nonnull
 import java.time.Clock
+import java.time.format.DateTimeFormatter
 import java.util.stream.Collectors
 
 import static com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner.STAGE_BEFORE
@@ -115,7 +116,7 @@ class BakeStage implements StageDefinitionBuilder {
 
     log.info("Preparing package `${stage.context.package}` for bake in ${deployRegions.join(", ")}")
     if (!stage.context.amiSuffix) {
-      stage.context.amiSuffix = clock.instant().atZone(UTC).format("yyyyMMddHHmmss")
+      stage.context.amiSuffix = clock.instant().atZone(UTC).format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
     }
     return deployRegions.collect {
       stage.context - ["regions": stage.context.regions, "skipRegionDetection": stage.context.skipRegionDetection] + ([


### PR DESCRIPTION
After `groovy-all` was removed in https://github.com/spinnaker/orca/pull/4364. Orca throws an error when Baking:

```
groovy.lang.MissingMethodException: No signature of method: java.time.ZonedDateTime.format() is applicable for argument types: (String) values: [yyyyMMddHHmmss]
Possible solutions: format(java.time.format.DateTimeFormatter), from(java.time.temporal.TemporalAccessor), getAt(java.lang.String), print(java.lang.Object), print(java.io.PrintWriter)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:70)
	at org.codehaus.groovy.runtime.callsite.PojoMetaClassSite.call(PojoMetaClassSite.java:46)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:127)
	at com.netflix.spinnaker.orca.bakery.pipeline.BakeStage.parallelContexts(BakeStage.groovy:118)
	at com.netflix.spinnaker.orca.bakery.pipeline.BakeStage.beforeStages(BakeStage.groovy:92)
	at com.netflix.spinnaker.orca.q.StageDefinitionBuildersKt.buildBeforeStages(StageDefinitionBuilders.kt:103)
	at com.netflix.spinnaker.orca.q.handler.StartStageHandler.plan(StartStageHandler.kt:178)
	at com.netflix.spinnaker.orca.q.handler.StartStageHandler.access$plan(StartStageHandler.kt:61)
	at com.netflix.spinnaker.orca.q.handler.StartStageHandler$handle$1$1.invoke(StartStageHandler.kt:99)
```

This went unnoticed because `groovy-all` is still a dependency in the tests.