### PR TITLE
fix(sql): No offset for retrievePipelinesForPipelineConfigId and retr…

### DIFF
--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -396,7 +396,7 @@ class SqlExecutionRepository(
           it.orderBy(field("id").desc())
             .run {
               if (criteria.pageSize > 0) {
-                limit(criteria.pageSize)
+                offset((criteria.page - 1) * criteria.pageSize).limit(criteria.pageSize)
               } else {
                 this
               }
@@ -436,7 +436,7 @@ class SqlExecutionRepository(
               .statusIn(criteria.statuses)
           },
           seek = {
-            it.orderBy(field("id").desc()).limit(criteria.pageSize)
+            it.orderBy(field("id").desc()).offset((criteria.page - 1) * criteria.pageSize).limit(criteria.pageSize)
           }
         )
       } else {
@@ -449,7 +449,7 @@ class SqlExecutionRepository(
               .statusIn(criteria.statuses)
           },
           seek = {
-            it.orderBy(field("id").desc()).limit(criteria.pageSize)
+            it.orderBy(field("id").desc()).offset((criteria.page - 1) * criteria.pageSize).limit(criteria.pageSize)
           }
         )
       }


### PR DESCRIPTION
Currently, param page is ignored by retrieve and retrievePipelinesForPipelineConfigId methods (although they are used by other methods), resulting in always returning the content of the first page.

This PR add page support for these 2 methods.