### PR TITLE
feat(tasks): Capture task output data from clouddriver

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy
@@ -165,7 +165,8 @@ class MonitorKatoTask implements RetryableTask, CloudProviderAware {
         id           : katoTask.id,
         status       : katoTask.status,
         history      : katoTask.history,
-        resultObjects: katoTask.resultObjects
+        resultObjects: katoTask.resultObjects,
+        outputs      : katoTask.outputs
       ]
       if (katoTask.resultObjects?.find { it.type == "EXCEPTION" }) {
         def exception = katoTask.resultObjects.find { it.type == "EXCEPTION" }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/model/Task.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/model/Task.java
@@ -15,6 +15,7 @@ public class Task {
   private Status status;
   private List<Map> resultObjects;
   private List<StatusLine> history;
+  private List<Output> outputs;
 
   @Data
   @AllArgsConstructor
@@ -31,5 +32,15 @@ public class Task {
   public static class StatusLine implements Serializable {
     private String phase;
     private String status;
+  }
+
+  @Data
+  @AllArgsConstructor
+  @NoArgsConstructor
+  static class Output implements Serializable {
+    private String manifest;
+    private String phase;
+    private String stdOut;
+    private String stdError;
   }
 }

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/CloudFoundryMonitorKatoServicesTaskTest.java
@@ -52,6 +52,7 @@ class CloudFoundryMonitorKatoServicesTaskTest {
                 taskIdString,
                 new Task.Status(completed, failed, false),
                 resultObjects,
+                Collections.emptyList(),
                 Collections.emptyList()));
 
     CloudFoundryMonitorKatoServicesTask task = new CloudFoundryMonitorKatoServicesTask(katoService);


### PR DESCRIPTION
This adds context.kato.tasks[].outputs to the pipeline execution context for each stage that uses MonitorKatoTask.  It's empty unless clouddriver provides it via its GET /task/{id} endpoint.

Depends on https://github.com/spinnaker/clouddriver/pull/5846.