### PR TITLE
fix(dependency): Issue with keiko-redis-spring module while upgrading the spring boot 2.5.x

### DIFF
--- a/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
+++ b/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
@@ -55,7 +55,7 @@ class RedisQueueConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(GenericObjectPoolConfig::class)
-  fun redisPoolConfig() = GenericObjectPoolConfig<Any>().apply {
+  fun redisPoolConfig() = GenericObjectPoolConfig<Jedis>().apply {
     blockWhenExhausted = false
     maxWaitMillis = 2000
   }
@@ -70,7 +70,7 @@ class RedisQueueConfiguration {
   fun queueRedisPool(
     @Value("\${redis.connection:redis://localhost:6379}") connection: String,
     @Value("\${redis.timeout:2000}") timeout: Int,
-    redisPoolConfig: GenericObjectPoolConfig<Any>
+    redisPoolConfig: GenericObjectPoolConfig<Jedis>
   ) =
     URI.create(connection).let { cx ->
       val port = if (cx.port == -1) Protocol.DEFAULT_PORT else cx.port
@@ -138,7 +138,7 @@ class RedisQueueConfiguration {
     @Value("\${redis.connection:redis://localhost:6379}") connection: String,
     @Value("\${redis.timeout:2000}") timeout: Int,
     @Value("\${redis.maxattempts:4}") maxAttempts: Int,
-    redisPoolConfig: GenericObjectPoolConfig<Any>
+    redisPoolConfig: GenericObjectPoolConfig<Jedis>
   ): JedisCluster {
     URI.create(connection).let { cx ->
       val port = if (cx.port == -1) Protocol.DEFAULT_PORT else cx.port

--- a/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueShovelConfiguration.kt
+++ b/orca-queue-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueShovelConfiguration.kt
@@ -58,7 +58,7 @@ class RedisQueueShovelConfiguration {
     @Value("\${redis.connection:redis://localhost:6379}") mainConnection: String,
     @Value("\${redis.connection-previous:#{null}}") previousConnection: String?,
     @Value("\${redis.timeout:2000}") timeout: Int,
-    redisPoolConfig: GenericObjectPoolConfig<*>,
+    redisPoolConfig: GenericObjectPoolConfig<Jedis>,
     registry: Registry
   ): Pool<Jedis> {
     if (mainConnection == previousConnection) {
@@ -84,7 +84,7 @@ class RedisQueueShovelConfiguration {
     @Value("\${redis.connection-previous}") previousConnection: String,
     @Value("\${redis.timeout:2000}") timeout: Int,
     @Value("\${redis.maxattempts:4}") maxAttempts: Int,
-    redisPoolConfig: GenericObjectPoolConfig<*>,
+    redisPoolConfig: GenericObjectPoolConfig<Jedis>,
     registry: Registry
   ): JedisCluster {
     if (mainConnection == previousConnection) {


### PR DESCRIPTION
During upgrade of spring boot from 2.4.x to 2.5.x, encountered the below build error in orca

```
> Task :keiko-redis-spring:compileKotlin FAILED
e: /spinnaker-comp/oss/sb-upgrade-2-5-14/orca/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt: (86, 7): None of the following functions can be called with the arguments supplied:
public constructor JedisPool(p0: GenericObjectPoolConfig<Jedis!>!, p1: URI!, p2: Int, p3: Int, p4: SSLSocketFactory!, p5: SSLParameters!, p6: HostnameVerifier!) defined in redis.clients.jedis.JedisPool
public constructor JedisPool(p0: GenericObjectPoolConfig<Jedis!>!, p1: String!, p2: Int, p3: Boolean, p4: SSLSocketFactory!, p5: SSLParameters!, p6: HostnameVerifier!) defined in redis.clients.jedis.JedisPool
public constructor JedisPool(p0: GenericObjectPoolConfig<Jedis!>!, p1: String!, p2: Int, p3: Int, p4: String!, p5: Int, p6: Boolean) defined in redis.clients.jedis.JedisPool
public constructor JedisPool(p0: GenericObjectPoolConfig<Jedis!>!, p1: String!, p2: Int, p3: Int, p4: String!, p5: Int, p6: String!) defined in redis.clients.jedis.JedisPool
public constructor JedisPool(p0: GenericObjectPoolConfig<Jedis!>!, p1: String!, p2: Int, p3: Int, p4: String!, p5: String!, p6: Boolean) defined in redis.clients.jedis.JedisPool
public constructor JedisPool(p0: GenericObjectPoolConfig<Jedis!>!, p1: String!, p2: Int, p3: Int, p4: String!, p5: String!, p6: Int) defined in redis.clients.jedis.JedisPool
e: /spinnaker-comp/oss/sb-upgrade-2-5-14/orca/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt: (146, 14): None of the following functions can be called with the arguments supplied:
public constructor JedisCluster(p0: (Mutable)Set<HostAndPort!>!, p1: Int, p2: Int, p3: Int, p4: String!, p5: GenericObjectPoolConfig<Jedis!>!) defined in redis.clients.jedis.JedisCluster
public constructor JedisCluster(p0: HostAndPort!, p1: Int, p2: Int, p3: Int, p4: String!, p5: GenericObjectPoolConfig<Jedis!>!) defined in redis.clients.jedis.JedisCluster

FAILURE: Build failed with an exception.
```

The root cause of this issue is change in JedisPool constructor parameters due to transitive upgrade of redis.clients:jedis. With upgrade of spring boot 2.5.x, redis.clients:jedis gets upgraded from 3.3.0 to 3.6.3 transitively. In 3.3.0 version, constructor of JedisPool [class](https://javadoc.io/static/redis.clients/jedis/3.3.0/redis/clients/jedis/JedisPool.html) expects `org.apache.commons.pool2.impl.GenericObjectPoolConfig` object where as in 3.6.3 version JedisPool [class](https://javadoc.io/static/redis.clients/jedis/3.6.3/redis/clients/jedis/JedisPool.html) expects `org.apache.commons.pool2.impl.GenericObjectPoolConfig<Jedis>`. Fix is to change GenericObjectPoolConfig object template from generic to <Jedis>
