### PR TITLE
fix(dependencies): Break cycling beans.

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtils.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtils.java
@@ -46,6 +46,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import rx.schedulers.Schedulers;
 
@@ -62,7 +63,7 @@ public class ArtifactUtils {
   @Autowired
   public ArtifactUtils(
       ObjectMapper objectMapper,
-      ExecutionRepository executionRepository,
+      @Lazy ExecutionRepository executionRepository,
       ContextParameterProcessor contextParameterProcessor) {
     this.objectMapper = objectMapper;
     this.executionRepository = executionRepository;

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -33,6 +33,7 @@ import org.springframework.beans.BeansException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
+import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Component
 
 import java.util.concurrent.Callable
@@ -46,7 +47,7 @@ class DependentPipelineStarter implements ApplicationContextAware {
   ObjectMapper objectMapper
   ContextParameterProcessor contextParameterProcessor
   List<ExecutionPreprocessor> executionPreprocessors
-  ArtifactUtils artifactUtils
+  @Lazy ArtifactUtils artifactUtils
   Registry registry
 
   @Autowired

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/v2/V2Handlers.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/v2/V2Handlers.kt
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.orca.pipelinetemplate.loader.v2.V2TemplateLoader
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.graph.v2.V2GraphMutator
 import com.netflix.spinnaker.orca.pipelinetemplate.v2schema.V2SchemaExecutionGenerator
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Component
 
 @Component
@@ -36,7 +37,7 @@ class V2SchemaHandlerGroup
   private val templateLoader: V2TemplateLoader,
   private val objectMapper: ObjectMapper,
   private val contextParameterProcessor: ContextParameterProcessor,
-  private val artifactUtils: ArtifactUtils
+  @Lazy private val artifactUtils: ArtifactUtils
 ) : HandlerGroup {
 
   override fun getHandlers(): List<Handler> =


### PR DESCRIPTION
Break cycling beans by adding lazy annotation.  

Tested on 2.28.x with the Multiple  Pipelines plugin enabled and disabled.
