### PR TITLE
fix(artifacts): Be more lenient when filtering expected artifacts

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -84,6 +84,11 @@ class DependentPipelineStarter implements ApplicationContextAware {
     } collectMany {
       it.expectedArtifactIds ?: []
     }
+    if (!expectedArtifactIds && parentPipelineStageId) {
+      expectedArtifactIds = parentPipeline.trigger.resolvedExpectedArtifacts.collect {
+        it.id
+      }
+    }
 
     pipelineConfig.trigger = [
       type                 : "pipeline",
@@ -117,6 +122,9 @@ class DependentPipelineStarter implements ApplicationContextAware {
 
     if (parentPipelineStageId != null) {
       pipelineConfig.receivedArtifacts = artifactUtils?.getArtifacts(parentPipeline.stageById(parentPipelineStageId))
+      if (!pipelineConfig.expectedArtifacts) {
+        pipelineConfig.expectedArtifacts = parentPipeline.trigger.getOther().getOrDefault("expectedArtifacts", [])
+      }
     } else {
       pipelineConfig.receivedArtifacts = artifactUtils?.getAllArtifacts(parentPipeline)
     }


### PR DESCRIPTION
It is currently hard/impossible to resolve artifacts in pipelines that doesn't have any triggers defined by themselves, and are triggered by a pipeline stage in another pipeline. Previously it was possible to get it to work by editing the json of the pipeline or in the UI by adding artifacts in a temp trigger and then removing it (this would keep the expected artifacts around). When I introduced trigger specific artifact constraints in #4322, I made it a lot harder (if not impossible) to do this because no triggers are used and thus all expected artifacts are filtered out.

This PR will fix this by copying expected artifacts from the parent execution (only if triggered by a pipeline stage), thus avoiding the whole situation altogether. It will also not filter away any expected artifacts where `useDefaultArtifact` or `usePriorArtifact` is set to `true`, and it will bind artifacts defined inline in stages (so that you can match artifacts using regex and not only SpEL).