### PR TITLE
fix(tasks): removing context from TaskResult in WaitForManualJudgment…

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStage.groovy
@@ -115,18 +115,18 @@ class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage 
         }
       }
 
-      Map outputs = processNotifications(stage, stageData, notificationState)
+      processNotifications(stage, stageData, notificationState)
 
-      return TaskResult.builder(executionStatus).context(outputs).build()
+      return TaskResult.builder(executionStatus).build()
     }
 
-    Map processNotifications(StageExecution stage, StageData stageData, String notificationState) {
+    void processNotifications(StageExecution stage, StageData stageData, String notificationState) {
       if (echoService) {
         // sendNotifications will be true if using the new scheme for configuration notifications.
         // The new scheme matches the scheme used by the other stages.
         // If the deprecated scheme is in use, only the original 'awaiting judgment' notification is supported.
         if (notificationState != "manualJudgment" && !stage.context.sendNotifications) {
-          return [:]
+          return
         }
 
         stageData.notifications.findAll { it.shouldNotify(notificationState) }.each {
@@ -136,10 +136,6 @@ class ManualJudgmentStage implements StageDefinitionBuilder, AuthenticatedStage 
             log.error("Unable to send notification (executionId: ${stage.execution.id}, address: ${it.address}, type: ${it.type})", e)
           }
         }
-
-        return [notifications: stageData.notifications]
-      } else {
-        return [:]
       }
     }
   }

--- a/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
+++ b/orca-echo/src/test/groovy/com/netflix/spinnaker/orca/echo/pipeline/ManualJudgmentStageSpec.groovy
@@ -110,9 +110,7 @@ class ManualJudgmentStageSpec extends Specification {
 
     then:
     result.status == ExecutionStatus.RUNNING
-    result.context.notifications.findAll {
-      it.lastNotifiedByNotificationState["manualJudgment"]
-    }*.type == ["email", "hipchat", "sms", "pubsub"]
+    4 * echoService.create(_)
   }
 
   @Unroll
@@ -197,7 +195,7 @@ class ManualJudgmentStageSpec extends Specification {
   }
 
   @Unroll
-  void "should retain unknown fields in the notification context"() {
+  void "should not pass context to the task"() {
     given:
     def task = new WaitForManualJudgmentTask(Optional.of(echoService), manualJudgmentAuthorization)
 
@@ -218,8 +216,7 @@ class ManualJudgmentStageSpec extends Specification {
     def result = task.execute(stage)
 
     then:
-    result.context.notifications?.get(0)?.other?.customMessage == "hello slack"
-    result.context.notifications?.get(1)?.other?.customSubject == "hello email"
+    result.context.isEmpty()
   }
 
   @Unroll


### PR DESCRIPTION
This PR fixes an issue of ManualJudgement stage data overwriting, that happens when two threads concurrently process:
1. PATCH request to update the stage in CompoundExecutionOperator,
2. RunTask event by RunTaskHandler,

The diagram below explains what happens
![image](https://user-images.githubusercontent.com/25036832/221223635-9f49fe49-8ed6-411d-8f39-7b9fdcdf75a1.png)

If we don't pass the context, while building the ManualJudgement TaskResult, RunTaskHandler will not make any update calls to the database, hence it will not overwrite the data set in PATCH request.
