### PR TITLE
fix(artifacts): Stop copying expectedArtifactIds to child pipelines

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarter.groovy
@@ -84,11 +84,6 @@ class DependentPipelineStarter implements ApplicationContextAware {
     } collectMany {
       it.expectedArtifactIds ?: []
     }
-    if (!expectedArtifactIds && parentPipelineStageId) {
-      expectedArtifactIds = parentPipeline.trigger.resolvedExpectedArtifacts.collect {
-        it.id
-      }
-    }
 
     pipelineConfig.trigger = [
       type                 : "pipeline",
@@ -122,9 +117,6 @@ class DependentPipelineStarter implements ApplicationContextAware {
 
     if (parentPipelineStageId != null) {
       pipelineConfig.receivedArtifacts = artifactUtils?.getArtifacts(parentPipeline.stageById(parentPipelineStageId))
-      if (!pipelineConfig.expectedArtifacts) {
-        pipelineConfig.expectedArtifacts = parentPipeline.trigger.getOther().getOrDefault("expectedArtifacts", [])
-      }
     } else {
       pipelineConfig.receivedArtifacts = artifactUtils?.getAllArtifacts(parentPipeline)
     }


### PR DESCRIPTION
This commit partially reverts #4397. It broke some pipelines for a team that had a CI stage that created more artifacts with the same name as the expected artifact from the original trigger, and then had a pipeline stage. The result was that the child pipeline was triggered with multiple artifacts with the same name (but different version numbers), and then failed to start because the artifact resolver matched multiple artifacts instead of exactly one. Turns out the changes in DependentPipelineStarter wasn't really needed to fix the issue that #4397 tried to solve, so I'm reverting them.