### PR TITLE
Fix/blue green deploy

### DIFF
--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStageTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStageTest.java
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.orca.clouddriver.model.Manifest;
 import com.netflix.spinnaker.orca.clouddriver.model.ManifestCoordinates;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.manifest.DeployManifestStage.GetDeployedManifests;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.manifest.DeployManifestStage.ManifestOperationsHelper;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.manifest.DeployManifestStage.OldManifestActionAppender;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestContext;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestContext.TrafficManagement.ManifestStrategyType;
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
@@ -57,6 +58,7 @@ final class DeployManifestStageTest {
   private ManifestOperationsHelper manifestOperationsHelper;
   private GetDeployedManifests getDeployedManifests;
   private DeployManifestStage deployManifestStage;
+  private OldManifestActionAppender oldManifestActionAppender;
 
   private static Map<String, Object> getContext(DeployManifestContext deployManifestContext) {
     Map<String, Object> context =
@@ -86,7 +88,11 @@ final class DeployManifestStageTest {
     oortService = mock(OortService.class);
     manifestOperationsHelper = new ManifestOperationsHelper(oortService);
     getDeployedManifests = new GetDeployedManifests(manifestOperationsHelper);
-    deployManifestStage = new DeployManifestStage(manifestOperationsHelper, getDeployedManifests);
+    oldManifestActionAppender =
+        new OldManifestActionAppender(getDeployedManifests, manifestOperationsHelper);
+    deployManifestStage =
+        new DeployManifestStage(
+            manifestOperationsHelper, getDeployedManifests, oldManifestActionAppender);
   }
 
   @Test
@@ -203,7 +209,6 @@ final class DeployManifestStageTest {
 
   @Test
   void rolloutStrategyHighlander() {
-    givenManifestIsStable();
     when(oortService.getClusterManifests(ACCOUNT, NAMESAPCE, "replicaSet", APPLICATION, CLUSTER))
         .thenReturn(
             ImmutableList.of(

--- a/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestExpressionEvaluationTest.kt
+++ b/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestExpressionEvaluationTest.kt
@@ -143,7 +143,7 @@ class DeployManifestExpressionEvaluationTest : JUnit5Minutests {
     override val contextParameterProcessor = ContextParameterProcessor()
     override val stageDefinitionBuilderFactory = StageDefinitionBuilderFactory { execution ->
       when (execution.type) {
-        "deployManifest" -> DeployManifestStage(mockk())
+        "deployManifest" -> DeployManifestStage(mockk(), mockk())
         else -> throw IllegalArgumentException("Test factory can't make \"${execution.type}\" stages.")
       }
     }

--- a/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestExpressionEvaluationTest.kt
+++ b/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestExpressionEvaluationTest.kt
@@ -143,7 +143,7 @@ class DeployManifestExpressionEvaluationTest : JUnit5Minutests {
     override val contextParameterProcessor = ContextParameterProcessor()
     override val stageDefinitionBuilderFactory = StageDefinitionBuilderFactory { execution ->
       when (execution.type) {
-        "deployManifest" -> DeployManifestStage(mockk(), mockk())
+        "deployManifest" -> DeployManifestStage(mockk(), mockk(), mockk())
         else -> throw IllegalArgumentException("Test factory can't make \"${execution.type}\" stages.")
       }
     }

--- a/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestExpressionEvaluationTest.kt
+++ b/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestExpressionEvaluationTest.kt
@@ -143,7 +143,7 @@ class DeployManifestExpressionEvaluationTest : JUnit5Minutests {
     override val contextParameterProcessor = ContextParameterProcessor()
     override val stageDefinitionBuilderFactory = StageDefinitionBuilderFactory { execution ->
       when (execution.type) {
-        "deployManifest" -> DeployManifestStage(mockk(), mockk(), mockk())
+        "deployManifest" -> DeployManifestStage(mockk())
         else -> throw IllegalArgumentException("Test factory can't make \"${execution.type}\" stages.")
       }
     }


### PR DESCRIPTION
This PR addresses an interesting bug observed while using Blue/Green (Red/Black) deployment.

If the first replica set deployment fails (e.g. due to an incorrect image), a consecutive deployment with a fixed image name would also fail. This was due to one of the new deployment stages disabling the previous deployment. The DisableManifestStage waits for the manifest to stabilize, which never happens since the original pods were not running in the first place.

In this PR, I attempt to tackle the problem by verifying the old manifest status. When it is not stable but not failed, we are dealing with the situation described above.

I also made slight refactoring to the existing code. The primary focus of the refactoring was to extract new helper classes that encapsulate some parts of the existing logic.