### PR TITLE
fix: Deadlock in PostgreSQL.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 fiatVersion=1.39.0
-korkVersion=7.171.2
+korkVersion=7.172.0
 kotlinVersion=1.4.32
 org.gradle.parallel=true
 spinnakerGradleVersion=8.26.0

--- a/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
+++ b/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
@@ -263,6 +263,7 @@ class SqlQueue(
       return
     }
 
+    // Must use one query per id to avoid Dead Lock in PostgreSQL
     candidates.parallelStream().forEach {
       changed.addAndGet(jooq.update(queueTable)
         .set(lockedField, "$lockId:$now")

--- a/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
+++ b/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
@@ -281,6 +281,7 @@ class SqlQueue(
       return
     }
 
+    // Ordering is essential to prevent Deadlock in PostgreSQL datasource.
     candidates = candidates.sorted()
 
     var position = 0

--- a/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
+++ b/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
@@ -61,6 +61,7 @@ import org.jooq.impl.DSL.table
 import org.jooq.util.mysql.MySQLDSL
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
+import java.util.concurrent.atomic.AtomicInteger
 
 @KotlinOpen
 class SqlQueue(
@@ -233,30 +234,11 @@ class SqlQueue(
    */
   private fun doPoll(maxMessages: Int, callback: (Message, () -> Unit) -> Unit) {
     val now = clock.instant().toEpochMilli()
-    var changed = 0
+    val changed = AtomicInteger()
 
     /**
      * Selects the primary key ulid's of up to ([maxMessages] * 3) ready and unlocked messages,
      * sorted by delivery time.
-     *
-     * To minimize lock contention, this is a non-locking read. The id's returned may be
-     * locked or removed by another instance before we can acquire them. We read more id's
-     * than [maxMessages] and shuffle them to decrease the likelihood that multiple instances
-     * polling concurrently are all competing for the oldest ready messages when many more
-     * than [maxMessages] are read.
-     *
-     * Candidate rows are locked via an autocommit update query by primary key that will
-     * only modify unlocked rows. When (candidates > maxMessages), a sliding window is used
-     * to traverse the shuffled candidates, sized to (maxMessages - changed) with up-to 3
-     * attempts (and update queries) to grab [maxMessages].
-     *
-     * I.e. if maxMessage == 5 and
-     * candidates == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].shuffle() == [9, 3, 7, 1, 10, 8, 5, 2, 6, 4]
-     *
-     * - pass1: attempts to claim [9, 3, 7, 1, 10], locks 3 messages
-     * - pass2: attempts to claim [8, 5], locks 1 message
-     * - pass3: attempt to claim [2], succeeds but if not, there are no further attempts
-     * - proceeds to process 5 messages locked via 3 update queries.
      *
      * This makes a trade-off between grabbing the maximum number of ready messages per poll cycle
      * vs. minimizing [poll] runtime which is also critical to throughput. In testing a scenario
@@ -269,7 +251,7 @@ class SqlQueue(
      * [MaxAttemptsAttribute] has been set to a positive integer. Otherwise,
      * [AttemptsAttribute] is unused.
      */
-    var candidates = jooq.select(idField)
+    val candidates = jooq.select(idField)
       .from(queueTable)
       .where(deliveryField.le(now), lockedField.eq("0"))
       .orderBy(deliveryField.asc())
@@ -281,27 +263,14 @@ class SqlQueue(
       return
     }
 
-    // Ordering is essential to prevent Deadlock in PostgreSQL datasource.
-    candidates = candidates.sorted()
-
-    var position = 0
-    var passes = 0
-    while (changed < maxMessages && position < candidates.size && passes < 3) {
-      passes++
-      val sliceNext = min(maxMessages - 1 - changed, candidates.size - 1 - position)
-      val ids = candidates.slice(IntRange(position, position + sliceNext))
-      when (sliceNext) {
-        0 -> position++
-        else -> position += sliceNext
-      }
-
-      changed += jooq.update(queueTable)
+    candidates.parallelStream().forEach {
+      changed.addAndGet(jooq.update(queueTable)
         .set(lockedField, "$lockId:$now")
-        .where(idField.`in`(*ids.toTypedArray()), lockedField.eq("0"))
-        .execute()
+        .where(idField.eq(it), lockedField.eq("0"))
+        .execute())
     }
 
-    if (changed > 0) {
+    if (changed.get() > 0) {
       val rs = withRetry(READ) {
         jooq.select(
           field("q.id").`as`("id"),

--- a/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
+++ b/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
@@ -269,7 +269,7 @@ class SqlQueue(
      * [MaxAttemptsAttribute] has been set to a positive integer. Otherwise,
      * [AttemptsAttribute] is unused.
      */
-    val candidates = jooq.select(idField)
+    var candidates = jooq.select(idField)
       .from(queueTable)
       .where(deliveryField.le(now), lockedField.eq("0"))
       .orderBy(deliveryField.asc())
@@ -281,7 +281,7 @@ class SqlQueue(
       return
     }
 
-    candidates.shuffle()
+    candidates = candidates.sorted()
 
     var position = 0
     var passes = 0

--- a/orca-queue-sql/src/test/kotlin/com/netflix/spinnaker/orca/q/sql/SqlQueueIntegrationTest.kt
+++ b/orca-queue-sql/src/test/kotlin/com/netflix/spinnaker/orca/q/sql/SqlQueueIntegrationTest.kt
@@ -47,23 +47,29 @@ import com.netflix.spinnaker.q.Queue
 import com.netflix.spinnaker.q.metrics.EventPublisher
 import com.netflix.spinnaker.q.metrics.MonitorableQueue
 import com.netflix.spinnaker.q.sql.SqlQueue
+import com.zaxxer.hikari.HikariConfig
 import de.huxhorn.sulky.ulid.ULID
-import java.time.Clock
-import java.time.Duration
-import java.util.Optional
 import org.jooq.DSLContext
+import org.jooq.SQLDialect
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.junit4.SpringRunner
+import java.time.Clock
+import java.time.Duration
+import java.util.*
 
 @Configuration
 class SqlTestConfig {
   @Bean
   fun jooq(): DSLContext {
-    val testDatabase = SqlTestUtil.initTcMysqlDatabase()
+    val hikariConfig = HikariConfig()
+    hikariConfig.jdbcUrl = SqlTestUtil.tcJdbcUrl
+    hikariConfig.maximumPoolSize = 10
+
+    val testDatabase = SqlTestUtil.initDatabase(hikariConfig, SQLDialect.MYSQL, "test")
     return testDatabase.context
   }
 


### PR DESCRIPTION
In PostgreSQL the rows will be locked as they are updated - in fact, the way this actually works is that each tuple (version of a row) has a system field called `xmin` to indicate which transaction made that tuple current (by insert or update) and a system field called `xmax` to indicate which transaction expired that tuple (by update or delete). When we access data, it checks each tuple to determine whether it is visible to our transaction, by checking our active "snapshot" against these values.

If we are executing an UPDATE and a tuple which matches our search conditions has an `xmin` which would make it visible to our snapshot and an `xmax` of an active transaction, it blocks, waiting for that transaction to complete. If the transaction which first updated the tuple rolls back, our transaction wakes up and processes the row; if the first transaction commits, our transaction wakes up and takes action depending on the current transaction isolation level.

Obviously, a deadlock is the result of this happening to rows in different order. There is no row-level lock in RAM which can be obtained for all rows at the same time, but if rows are updated in the same order we can't have the circular locking. Unfortunately, the suggested IN(1, 2) syntax doesn't guarantee that. Different sessions may have different costing factors active, a background "analyze" task may change statistics for the table between the generation of one plan and the other, or it may be using a `seqscan` and be affected by the PostgreSQL optimization which causes a new `seqscan` to join one already in progress and "loop around" to reduce disk I/O.