### PR TITLE
feat(front50): call front50's GET /pipelines/triggeredBy/{pipelineId}/{status} endpoint

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -83,6 +83,9 @@ interface Front50Service {
   @GET("/pipelines?restricted=false")
   List<Map<String, Object>> getAllPipelines()
 
+  @GET("/pipelines/triggeredBy/{pipelineId}/{status}?restricted=false")
+  List<Map<String, Object>> getTriggeredPipelines(@Path("pipelineId") String pipelineId, @Path("status") String status)
+
   @POST('/actions/pipelines/reorder')
   Response reorderPipelines(@Body ReorderPipelinesCommand reorderPipelinesCommand)
 

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
@@ -29,8 +29,8 @@ import com.netflix.spinnaker.orca.retrofit.RetrofitConfiguration
 import com.netflix.spinnaker.orca.retrofit.logging.RetrofitSlf4jLog
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationListener
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
@@ -50,6 +50,7 @@ import static retrofit.Endpoints.newFixedEndpoint
   "com.netflix.spinnaker.orca.front50.tasks",
   "com.netflix.spinnaker.orca.front50"
 ])
+@EnableConfigurationProperties(Front50ConfigurationProperties)
 @CompileStatic
 @ConditionalOnExpression('${front50.enabled:true}')
 class Front50Configuration {
@@ -64,9 +65,8 @@ class Front50Configuration {
   RequestInterceptor spinnakerRequestInterceptor
 
   @Bean
-  Endpoint front50Endpoint(
-    @Value('${front50.base-url}') String front50BaseUrl) {
-    newFixedEndpoint(front50BaseUrl)
+  Endpoint front50Endpoint(Front50ConfigurationProperties front50ConfigurationProperties) {
+    newFixedEndpoint(front50ConfigurationProperties.getBaseUrl())
   }
 
   @Bean

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50ConfigurationProperties.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50ConfigurationProperties.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.front50.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("front50")
+public class Front50ConfigurationProperties {
+  boolean enabled;
+
+  String baseUrl;
+}

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50ConfigurationProperties.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50ConfigurationProperties.java
@@ -25,4 +25,12 @@ public class Front50ConfigurationProperties {
   boolean enabled;
 
   String baseUrl;
+
+  /**
+   * Controls the front50 endpoint that DependentPipelineExecutionListener calls to retrieve
+   * pipelines.
+   *
+   * <p>When true: GET /pipelines/triggeredBy/{pipelineId}/{status} When false: GET /pipelines
+   */
+  boolean useTriggeredByEndpoint;
 }

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListenerSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListenerSpec.groovy
@@ -22,11 +22,13 @@ import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.TaskExecution
 import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
 import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.front50.config.Front50ConfigurationProperties
 import com.netflix.spinnaker.orca.front50.pipeline.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipelinetemplate.V2Util
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
 
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
@@ -39,6 +41,7 @@ class DependentPipelineExecutionListenerSpec extends Specification {
   def v2MptPipelineConfig = buildTemplatedPipelineConfig()
   def pipelineConfigWithRunAsUser = buildPipelineConfig("my_run_as_user")
   def contextParameterProcessor = new ContextParameterProcessor()
+  def front50ConfigurationProperties = new Front50ConfigurationProperties()
   def templatePreprocessor = [process: {}] // Groovy thunk mock since the actual class is Kotlin and makes compliation fail.
 
   def pipeline = pipeline {
@@ -55,7 +58,7 @@ class DependentPipelineExecutionListenerSpec extends Specification {
 
   @Subject
   DependentPipelineExecutionListener listener = new DependentPipelineExecutionListener(
-    front50Service, dependentPipelineStarter, fiatStatus, Optional.of([templatePreprocessor]), contextParameterProcessor
+    front50Service, dependentPipelineStarter, fiatStatus, Optional.of([templatePreprocessor]), contextParameterProcessor, front50ConfigurationProperties
   )
 
   def "should trigger downstream pipeline when status and pipelines match"() {
@@ -217,6 +220,35 @@ class DependentPipelineExecutionListenerSpec extends Specification {
 
     then:
     0 * dependentPipelineStarter._
+  }
+
+  @Unroll
+  def "uses front50's getTriggeredPipelines endpoint when configured to do so (#status)"() {
+    given:
+    def origValue = front50ConfigurationProperties.useTriggeredByEndpoint
+    front50ConfigurationProperties.setUseTriggeredByEndpoint(true)
+
+    // Set the execution status of the entire pipeline, since that's passed to front50
+    pipeline.status = status
+
+    pipeline.pipelineConfigId = "97c435a0-0faf-11e5-a62b-696d38c37faa"
+    front50Service.getTriggeredPipelines(pipeline.pipelineConfigId, DependentPipelineExecutionListener.convertStatus(pipeline)) >> [
+      pipelineConfig, pipelineConfigWithRunAsUser
+    ]
+
+    when:
+    listener.afterExecution(null, pipeline, null, true)
+
+    then:
+    0 * front50Service.getAllPipelines()
+    1 * dependentPipelineStarter.trigger(_, _, _, _, _, null)
+    1 * dependentPipelineStarter.trigger(_, _, _, _, _, { PipelineExecution.AuthenticationDetails user -> user.user == "my_run_as_user" })
+
+    cleanup:
+    front50ConfigurationProperties.setUseTriggeredByEndpoint(origValue)
+
+    where:
+    status << [ExecutionStatus.SUCCEEDED, ExecutionStatus.TERMINAL]
   }
 
   private static Map buildTemplatedPipelineConfig() {


### PR DESCRIPTION
in DependentPipelineExecutionListener when the front50.useTriggeredByEndpoint configuration property is true.  The default value is false.
    
The advantage of the new endpoint is that front50 only returns a (potentially very small) subset of pipelines over the wire to orca, in contrast to the current behavior where front50 returns all pipelines, and leaves it to orca to filter them.

Depends on https://github.com/spinnaker/front50/pull/1251 to add the new endpoint.