### PR TITLE
fix(errors): throw a useful error for invalid manifest configuration

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluator.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluator.java
@@ -50,6 +50,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import retrofit.client.Response;
@@ -167,6 +168,12 @@ public class ManifestEvaluator implements CloudProviderAware {
   }
 
   private Artifact getManifestArtifact(StageExecution stage, ManifestContext context) {
+    if (StringUtils.hasText(context.getManifestArtifactId())
+        && StringUtils.hasText(context.getManifestArtifactAccount())) {
+      throw new IllegalArgumentException(
+          "Artifact account must not be set if referencing an artifact produced by a previous stage.");
+    }
+
     Artifact manifestArtifact =
         Optional.ofNullable(
                 artifactUtils.getBoundArtifactForStage(

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
@@ -277,6 +277,23 @@ final class ManifestEvaluatorTest {
   }
 
   @Test
+  void shouldThrowExceptionWhenArtifactIdAndAccountBothSet() {
+    StageExecutionImpl stage = new StageExecutionImpl();
+
+    DeployManifestContext context =
+        DeployManifestContext.builder()
+            .manifestArtifactId("my-manifest-artifact-id")
+            .manifestArtifactAccount("some-other-account")
+            .skipExpressionEvaluation(false)
+            .source(Source.Artifact)
+            .build();
+
+    assertThatThrownBy(() -> manifestEvaluator.evaluate(stage, context))
+        .isInstanceOf(IllegalArgumentException.class);
+    verifyNoInteractions(oortService);
+  }
+
+  @Test
   void shouldThrowExceptionWhenFailedEvaluatingManifestExpressions() {
     StageExecutionImpl stage = new StageExecutionImpl();
     stage.getContext().put("failOnFailedExpressions", true);


### PR DESCRIPTION
Throw a useful error message (and short circuit) if a stage context has both `manifestArtifactId` and `manifestArtifactAccount` set, rather than a generic 404 from Clouddriver.