### PR TITLE
fix(deployment): fixed missing namespace while fetching manifest deta…

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
@@ -158,7 +158,7 @@ public class DeployManifestStage extends ExpressionAwareStageDefinitionBuilder {
           (name, manifest) -> {
             var oldManifestIsUnstable =
                 this.manifestOperationsHelper.previousDeploymentNeitherStableNorFailed(
-                    manifest.getAccount(), name);
+                    manifest.getAccount(), manifest.getNamespace(), name);
             var nextStageType =
                 oldManifestIsUnstable
                     ? DeleteManifestStage.PIPELINE_CONFIG_TYPE
@@ -254,8 +254,8 @@ public class DeployManifestStage extends ExpressionAwareStageDefinitionBuilder {
      * @param name of the manifest
      * @return true, if manifest was not deployed correctly and waits to get stable, false otherwise
      */
-    boolean previousDeploymentNeitherStableNorFailed(String account, String name) {
-      var oldManifest = this.oortService.getManifest(account, name, false);
+    boolean previousDeploymentNeitherStableNorFailed(String account, String location, String name) {
+      var oldManifest = this.oortService.getManifest(account, location, name, false);
 
       var status = oldManifest.getStatus();
       var notStable = !status.getStable().isState();

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStageTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStageTest.java
@@ -401,6 +401,7 @@ final class DeployManifestStageTest {
   }
 
   private void givenManifestIs(Manifest manifest) {
-    when(oortService.getManifest(anyString(), anyString(), anyBoolean())).thenReturn(manifest);
+    when(oortService.getManifest(anyString(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(manifest);
   }
 }


### PR DESCRIPTION
This fix addresses a problem of missing “namespace” attribute in a HTTP call, that’s being sent while fetching manifest details from clouddriver. Without it clouddriver cannot find correct manifest and returns 404.