### PR TITLE
feat(mpt-v1): Support for jinja expressions in stages

### DIFF
--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
@@ -769,7 +769,7 @@ class DependentPipelineStarterSpec extends Specification {
         stages.addAll(mapper.convertValue(p.stages, type))
       }
     }
-    1 * templateLoader.load(_ as TemplateConfiguration.TemplateSource) >> [triggeredPipelineTemplate]
+    1 * templateLoader.load(_ as TemplateConfiguration.TemplateSource, _, _) >> [triggeredPipelineTemplate]
     1 * executionRepository.retrievePipelinesForPipelineConfigId("triggered", _ as ExecutionRepository.ExecutionCriteria) >>
       Observable.just(priorExecution)
 
@@ -908,7 +908,7 @@ class DependentPipelineStarterSpec extends Specification {
         stages.addAll(mapper.convertValue(execution.stages, type))
       }
     }
-    1 * templateLoader.load(_ as TemplateConfiguration.TemplateSource) >> [triggeredPipelineTemplate]
+    1 * templateLoader.load(_ as TemplateConfiguration.TemplateSource, _, _) >> [triggeredPipelineTemplate]
 
     artifactUtils.getArtifactsForPipelineId(*_) >> {
       return new ArrayList<>()

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplateService.java
@@ -72,7 +72,7 @@ public class PipelineTemplateService {
         // Do nothing
       }
     }
-    List<PipelineTemplate> templates = templateLoader.load(templateSource);
+    List<PipelineTemplate> templates = templateLoader.load(templateSource, null, null);
     return TemplateMerge.merge(templates);
   }
 

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/FileTemplateSchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/FileTemplateSchemeLoader.java
@@ -16,14 +16,15 @@
 
 package com.netflix.spinnaker.orca.pipelinetemplate.loader;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -49,7 +50,7 @@ public class FileTemplateSchemeLoader implements TemplateSchemeLoader {
   }
 
   @Override
-  public PipelineTemplate load(URI uri) {
+  public Map<String, Object> load(URI uri) {
     File templateFile = new File(uri);
 
     if (!templateFile.exists()) {
@@ -58,7 +59,7 @@ public class FileTemplateSchemeLoader implements TemplateSchemeLoader {
 
     try {
       ObjectMapper objectMapper = isJson(uri) ? jsonObjectMapper : yamlObjectMapper;
-      return objectMapper.readValue(templateFile, PipelineTemplate.class);
+      return objectMapper.readValue(templateFile, new TypeReference<>() {});
     } catch (IOException e) {
       throw new TemplateLoaderException(e);
     }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/Front50SchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/Front50SchemeLoader.java
@@ -15,10 +15,10 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.loader;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.net.URI;
 import java.util.Map;
@@ -46,7 +46,7 @@ public class Front50SchemeLoader implements TemplateSchemeLoader {
   }
 
   @Override
-  public PipelineTemplate load(URI uri) {
+  public Map<String, Object> load(URI uri) {
     if (front50Service == null) {
       throw new TemplateLoaderException(
           "Cannot load templates without front50 enabled. Set 'front50.enabled: true' in your orca config.");
@@ -56,7 +56,7 @@ public class Front50SchemeLoader implements TemplateSchemeLoader {
     try {
       Map<String, Object> pipelineTemplate =
           AuthenticatedRequest.allowAnonymous(() -> front50Service.getPipelineTemplate(id));
-      return objectMapper.convertValue(pipelineTemplate, PipelineTemplate.class);
+      return objectMapper.convertValue(pipelineTemplate, new TypeReference<>() {});
     } catch (Exception e) {
       throw new TemplateLoaderException(e);
     }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/HttpTemplateSchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/HttpTemplateSchemeLoader.java
@@ -18,14 +18,15 @@ package com.netflix.spinnaker.orca.pipelinetemplate.loader;
 
 import static java.lang.String.format;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.Map;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -63,7 +64,7 @@ public class HttpTemplateSchemeLoader implements TemplateSchemeLoader {
   }
 
   @Override
-  public PipelineTemplate load(URI uri) {
+  public Map<String, Object> load(URI uri) {
     log.debug("Resolving pipeline template: {}", uri.toString());
 
     Request request = new Request.Builder().url(convertToUrl(uri)).build();
@@ -82,7 +83,7 @@ public class HttpTemplateSchemeLoader implements TemplateSchemeLoader {
       log.debug("Loaded Template ({}):\n{}", uri, strBody);
       ObjectMapper objectMapper = isJson(uri) ? jsonObjectMapper : yamlObjectMapper;
 
-      return objectMapper.readValue(strBody, PipelineTemplate.class);
+      return objectMapper.readValue(strBody, new TypeReference<>() {});
     } catch (Exception e) {
       throw new TemplateLoaderException(e);
     }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/ResourceSchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/ResourceSchemeLoader.java
@@ -15,15 +15,16 @@
  */
 package com.netflix.spinnaker.orca.pipelinetemplate.loader;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException;
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 /** Used strictly for testing, not available as a template loader at runtime. */
 public class ResourceSchemeLoader implements TemplateSchemeLoader {
@@ -50,7 +51,7 @@ public class ResourceSchemeLoader implements TemplateSchemeLoader {
   }
 
   @Override
-  public PipelineTemplate load(URI uri) {
+  public Map<String, Object> load(URI uri) {
     URI u = convertToResourcePath(uri);
 
     File templateFile = new File(u);
@@ -61,7 +62,7 @@ public class ResourceSchemeLoader implements TemplateSchemeLoader {
 
     try {
       ObjectMapper objectMapper = isJson(u) ? jsonObjectMapper : yamlObjectMapper;
-      return objectMapper.readValue(templateFile, PipelineTemplate.class);
+      return objectMapper.readValue(templateFile, new TypeReference<>() {});
     } catch (IOException e) {
       throw new TemplateLoaderException(e);
     }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateLoader.java
@@ -18,58 +18,153 @@ package com.netflix.spinnaker.orca.pipelinetemplate.loader;
 
 import static java.lang.String.format;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateLoaderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.exceptions.TemplateRenderException;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.TemplateMerge;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderContext;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderUtil;
+import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class TemplateLoader {
   private Collection<TemplateSchemeLoader> schemeLoaders;
+  private ObjectMapper objectMapper;
+
+  private Renderer renderer;
 
   @Autowired
-  public TemplateLoader(Collection<TemplateSchemeLoader> schemeLoaders) {
+  public TemplateLoader(
+      Collection<TemplateSchemeLoader> schemeLoaders,
+      ObjectMapper objectMapper,
+      Renderer renderer) {
     this.schemeLoaders = schemeLoaders;
+    this.objectMapper =
+        new ObjectMapper(new YAMLFactory())
+            .setConfig(objectMapper.getSerializationConfig())
+            .setConfig(objectMapper.getDeserializationConfig());
+    this.renderer = renderer;
   }
 
   /** @return a LIFO list of pipeline templates */
-  public List<PipelineTemplate> load(TemplateConfiguration.TemplateSource template) {
-    PipelineTemplate pipelineTemplate = load(template.getSource());
-    return load(pipelineTemplate);
+  public List<PipelineTemplate> load(
+      TemplateConfiguration.TemplateSource template,
+      @Nullable TemplateConfiguration tc,
+      @Nullable Map<String, Object> trigger) {
+    Map<String, Object> pipelineTemplate = load(template.getSource());
+    return load(pipelineTemplate, tc, trigger);
   }
 
-  public List<PipelineTemplate> load(PipelineTemplate pipelineTemplate) {
-    List<PipelineTemplate> pipelineTemplates = new ArrayList<>();
+  public List<PipelineTemplate> load(
+      Map<String, Object> pipelineTemplate,
+      @Nullable TemplateConfiguration tc,
+      @Nullable Map<String, Object> trigger) {
+    List<Map<String, Object>> pipelineTemplates = new ArrayList<>();
 
     pipelineTemplates.add(0, pipelineTemplate);
 
     Set<String> seenTemplateSources = new HashSet<>();
-    while (pipelineTemplate.getSource() != null) {
-      seenTemplateSources.add(pipelineTemplate.getSource());
+    while (pipelineTemplate.get("source") != null) {
+      String source = pipelineTemplate.get("source").toString();
+      seenTemplateSources.add(source);
 
-      pipelineTemplate = load(pipelineTemplate.getSource());
+      pipelineTemplate = load(source);
       pipelineTemplates.add(0, pipelineTemplate);
 
-      if (seenTemplateSources.contains(pipelineTemplate.getSource())) {
+      if (pipelineTemplate.get("source") != null
+          && seenTemplateSources.contains(pipelineTemplate.get("source").toString())) {
         throw new TemplateLoaderException(
             format(
                 "Illegal cycle detected loading pipeline template '%s'",
-                pipelineTemplate.getSource()));
+                pipelineTemplate.get("source")));
       }
     }
 
-    return pipelineTemplates;
+    if (tc != null) {
+      List<PipelineTemplate.Variable> variables =
+          pipelineTemplates.stream()
+              .map(
+                  template ->
+                      objectMapper.convertValue(
+                          template.getOrDefault("variables", Collections.emptyList()),
+                          new TypeReference<List<PipelineTemplate.Variable>>() {}))
+              .reduce(Collections.emptyList(), TemplateMerge::mergeNamedContent);
+      pipelineTemplates = preRenderStagesAndVariables(pipelineTemplates, tc, trigger, variables);
+    }
+
+    return pipelineTemplates.stream()
+        .map(
+            template -> {
+              try {
+                return objectMapper.convertValue(template, PipelineTemplate.class);
+              } catch (IllegalArgumentException e) {
+                throw new TemplateLoaderException(e);
+              }
+            })
+        .collect(Collectors.toList());
   }
 
-  private PipelineTemplate load(String source) {
+  /**
+   * This method will render Jinja expressions present in the stages block of a pipeline template if
+   * (and only if) the entire block is represented as a String. This makes it possible to
+   * dynamically create stages in the templates, e.g. by creating Jinja loops.
+   */
+  private List<Map<String, Object>> preRenderStagesAndVariables(
+      List<Map<String, Object>> pipelineTemplates,
+      TemplateConfiguration tc,
+      Map<String, Object> trigger,
+      List<PipelineTemplate.Variable> variables) {
+    PipelineTemplate contextTemplate = new PipelineTemplate();
+    contextTemplate.setVariables(variables);
+    RenderContext context =
+        RenderUtil.createDefaultRenderContext(
+            contextTemplate, tc, Optional.ofNullable(trigger).orElse(Collections.emptyMap()));
+    renderTemplateVariables(context, variables);
+
+    return pipelineTemplates.stream()
+        .peek(
+            template -> {
+              if (template.get("stages") instanceof String) {
+                try {
+                  String renderedTemplate =
+                      renderer.render((String) template.get("stages"), context);
+                  List<Map<String, Object>> stages =
+                      objectMapper.readValue(renderedTemplate, new TypeReference<>() {});
+                  template.put("stages", stages);
+                } catch (TemplateRenderException | JsonProcessingException e) {
+                  log.warn(
+                      "Tried to pre-render stages for pipeline {}/{}, but an error occurred during parsing.",
+                      tc.getPipeline().getApplication(),
+                      tc.getPipeline().getName(),
+                      e);
+                }
+              }
+            })
+        .collect(Collectors.toList());
+  }
+
+  private Map<String, Object> load(String source) {
     URI uri;
     try {
       uri = new URI(source);
@@ -87,5 +182,22 @@ public class TemplateLoader {
                         format("No TemplateSchemeLoader found for '%s'", uri.getScheme())));
 
     return schemeLoader.load(uri);
+  }
+
+  private void renderTemplateVariables(
+      RenderContext renderContext, List<PipelineTemplate.Variable> variables) {
+    if (variables == null) {
+      return;
+    }
+    variables.forEach(
+        v -> {
+          Object value = v.getDefaultValue();
+          if (v.isNullable() && value == null) {
+            renderContext.getVariables().putIfAbsent(v.getName(), v.getDefaultValue());
+          } else if (value instanceof String) {
+            v.setDefaultValue(renderer.renderGraph(value.toString(), renderContext));
+            renderContext.getVariables().putIfAbsent(v.getName(), v.getDefaultValue());
+          }
+        });
   }
 }

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateLoader.java
@@ -145,6 +145,7 @@ public class TemplateLoader {
     return pipelineTemplates.stream()
         .peek(
             template -> {
+              template.put("variables", variables);
               if (template.get("stages") instanceof String) {
                 try {
                   String renderedTemplate =

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateSchemeLoader.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/loader/TemplateSchemeLoader.java
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.orca.pipelinetemplate.loader;
 
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate;
 import java.net.URI;
+import java.util.Map;
 
 public interface TemplateSchemeLoader {
   boolean supports(URI uri);
 
-  PipelineTemplate load(URI uri);
+  Map<String, Object> load(URI uri);
 
   default boolean isJson(URI uri) {
     String uriName = uri.toString().toLowerCase();

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutator.java
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutator.java
@@ -222,7 +222,8 @@ public class TemplatedPipelineModelMutator implements PipelineModelMutator {
 
   private PipelineTemplate getPipelineTemplate(TemplateConfiguration configuration) {
     try {
-      return TemplateMerge.merge(templateLoader.load(configuration.getPipeline().getTemplate()));
+      return TemplateMerge.merge(
+          templateLoader.load(configuration.getPipeline().getTemplate(), configuration, null));
     } catch (TemplateLoaderException e) {
       log.error("Could not load template: {}", configuration.getPipeline().getTemplate(), e);
       return null;

--- a/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/V1TemplateLoaderHandler.kt
+++ b/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/V1TemplateLoaderHandler.kt
@@ -79,22 +79,6 @@ class V1TemplateLoaderHandler(
     )
   }
 
-  private fun renderTemplateVariables(renderContext: RenderContext, variables: List<PipelineTemplate.Variable>?) {
-    if (variables == null) {
-      return
-    }
-
-    variables.forEach { v ->
-      val value = v.defaultValue
-      if (v.isNullable() && value == null) {
-        renderContext.variables.putIfAbsent(v.name, v.defaultValue)
-      } else if (value != null && value is String) {
-        v.defaultValue = renderer.renderGraph(value.toString(), renderContext)
-        renderContext.variables.putIfAbsent(v.name, v.defaultValue)
-      }
-    }
-  }
-
   private fun setTemplateSourceWithJinja(tc: TemplateConfiguration, trigger: MutableMap<String, Any>?) {
     if (trigger == null || tc.pipeline.template == null) {
       return

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -16,7 +16,11 @@
 package com.netflix.spinnaker.orca.pipelinetemplate
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spectator.api.*
+import com.netflix.spectator.api.Clock
+import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Timer
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
@@ -45,16 +49,16 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
   ObjectMapper objectMapper = new ObjectMapper()
   def oortService = Mock(OortService)
 
-  TemplateLoader templateLoader = new TemplateLoader([new FileTemplateSchemeLoader(objectMapper)])
+  Renderer renderer = new JinjaRenderer(
+      new YamlRenderedValueConverter(), objectMapper, Mock(Front50Service), []
+  )
+
+  TemplateLoader templateLoader = new TemplateLoader([new FileTemplateSchemeLoader(objectMapper)], objectMapper, renderer)
   V2TemplateLoader v2TemplateLoader = new V2TemplateLoader(oortService, objectMapper)
   ContextParameterProcessor contextParameterProcessor = new ContextParameterProcessor()
 
   ExecutionRepository executionRepository = Mock(ExecutionRepository)
   ArtifactUtils artifactUtils = Spy(ArtifactUtils, constructorArgs: [objectMapper, executionRepository, new ContextParameterProcessor()])
-
-  Renderer renderer = new JinjaRenderer(
-    new YamlRenderedValueConverter(), objectMapper, Mock(Front50Service), []
-  )
 
   Registry registry = Mock() {
     clock() >> Mock(Clock) {
@@ -332,6 +336,16 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
 
     then:
     result.limitConcurrent == false
+  }
+
+  def "should render stages dynamically with jinja"() {
+    when:
+    def template =  createTemplateRequest('dynamic-stages-001.yml')
+    def result = subject.process(template)
+
+    then:
+    result.stages.size == 4
+    result.stages*.name.toSet() == ["Wait", "Deploy to cluster-1", "Deploy to cluster-2", "Deploy to cluster-3"].toSet()
   }
 
   Map<String, Object> createTemplateRequest(String templatePath, Map<String, Object> variables = [:], List<Map<String, Object>> stages = [], boolean plan = false) {

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -338,7 +338,7 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
     result.limitConcurrent == false
   }
 
-  def "should render stages dynamically with jinja"() {
+  def "should render stages dynamically with jinja if the stages block is a single string"() {
     when:
     def template =  createTemplateRequest('dynamic-stages-001.yml')
     def result = subject.process(template)

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutatorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/TemplatedPipelineModelMutatorSpec.groovy
@@ -92,7 +92,7 @@ class TemplatedPipelineModelMutatorSpec extends Specification {
     subject.mutate(pipeline)
 
     then:
-    1 * templateLoader.load(_) >> { [new PipelineTemplate(
+    1 * templateLoader.load(_, _, _) >> { [new PipelineTemplate(
       schema: '1',
       configuration: new Configuration(
         expectedArtifacts: [
@@ -125,7 +125,7 @@ class TemplatedPipelineModelMutatorSpec extends Specification {
     subject.mutate(pipeline)
 
     then:
-    1 * templateLoader.load(_) >> { [new PipelineTemplate(
+    1 * templateLoader.load(_, _, _) >> { [new PipelineTemplate(
       schema: '1',
       configuration: new Configuration(
         concurrentExecutions: [
@@ -176,7 +176,7 @@ class TemplatedPipelineModelMutatorSpec extends Specification {
     subject.mutate(pipeline)
 
     then:
-    1 * templateLoader.load(_) >> { [new PipelineTemplate(
+    1 * templateLoader.load(_, _, _) >> { [new PipelineTemplate(
       schema: '1'
     )] }
     pipeline.id == pipeline.config.pipeline.pipelineConfigId
@@ -202,7 +202,7 @@ class TemplatedPipelineModelMutatorSpec extends Specification {
     subject.mutate(pipeline)
 
     then:
-    1 * templateLoader.load(_) >> { [new PipelineTemplate(
+    1 * templateLoader.load(_, _, _) >> { [new PipelineTemplate(
       schema: '1'
     )] }
     pipeline.name == pipeline.config.pipeline.name

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy
@@ -51,7 +51,7 @@ class V1SchemaIntegrationSpec extends Specification {
   ObjectMapper objectMapper = OrcaObjectMapper.newInstance()
   def oortService = Mock(OortService)
 
-  TemplateLoader templateLoader = new TemplateLoader([new ResourceSchemeLoader("/integration/v1schema", objectMapper)])
+  TemplateLoader templateLoader = new TemplateLoader([new ResourceSchemeLoader("/integration/v1schema", objectMapper)], objectMapper, renderer)
   V2TemplateLoader v2TemplateLoader = new V2TemplateLoader(oortService, objectMapper)
   ContextParameterProcessor contextParameterProcessor = new ContextParameterProcessor()
 

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/V1TemplateLoaderHandlerSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/V1TemplateLoaderHandlerSpec.groovy
@@ -37,7 +37,7 @@ class V1TemplateLoaderHandlerSpec extends Specification {
 
   Renderer renderer = new JinjaRenderer(objectMapper, Mock(Front50Service), [])
 
-  TemplateLoader templateLoader = new TemplateLoader([new FileTemplateSchemeLoader(objectMapper)])
+  TemplateLoader templateLoader = new TemplateLoader([new FileTemplateSchemeLoader(objectMapper)], objectMapper, renderer)
 
   @Subject
   def subject = new V1TemplateLoaderHandler(templateLoader, renderer, objectMapper)
@@ -101,7 +101,7 @@ class V1TemplateLoaderHandlerSpec extends Specification {
     ])
 
     when:
-    subject.renderTemplateVariables(renderContext, pipelineTemplate)
+    subject.renderTemplateVariables(renderContext, pipelineTemplate.variables)
 
     then:
     pipelineTemplate.variables*.defaultValue == expectedDefaultValues

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/V1TemplateLoaderHandlerSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/handler/V1TemplateLoaderHandlerSpec.groovy
@@ -22,10 +22,7 @@ import com.netflix.spinnaker.orca.pipelinetemplate.handler.DefaultHandlerChain
 import com.netflix.spinnaker.orca.pipelinetemplate.handler.GlobalPipelineTemplateContext
 import com.netflix.spinnaker.orca.pipelinetemplate.loader.FileTemplateSchemeLoader
 import com.netflix.spinnaker.orca.pipelinetemplate.loader.TemplateLoader
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.PipelineTemplate
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.TemplateConfiguration
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer
-import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.RenderUtil
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer
 import spock.lang.Specification
 import spock.lang.Subject
@@ -83,28 +80,27 @@ class V1TemplateLoaderHandlerSpec extends Specification {
   @Unroll
   def 'should render jinja expressions contained within template variables'() {
     given:
-    def pipelineTemplate = new PipelineTemplate(variables: templateVariables.collect {
-      new PipelineTemplate.Variable(name: it.key, defaultValue: it.value)
-    })
+    def chain = new DefaultHandlerChain()
+    def context = new GlobalPipelineTemplateContext(chain, createInlinedTemplateRequest(true))
 
-    def templateConfig = new TemplateConfiguration(
-      pipeline: new TemplateConfiguration.PipelineDefinition(variables: configVariables)
-    )
-
-    def renderContext = RenderUtil.createDefaultRenderContext(
-      pipelineTemplate, templateConfig, [
-      parameters: [
+    context.request.template.variables = templateVariables.collect {
+      [
+          name        : it.key,
+          defaultValue: it.value
+      ]
+    }
+    context.request.config.pipeline.variables = configVariables
+    context.request.trigger.parameters = [
         "list"   : "us-west-2,us-east-1",
         "boolean": "true",
         "string" : "this is a string"
-      ]
-    ])
+    ]
 
     when:
-    subject.renderTemplateVariables(renderContext, pipelineTemplate.variables)
+    subject.handle(chain, context)
 
     then:
-    pipelineTemplate.variables*.defaultValue == expectedDefaultValues
+    (context.schemaContext as V1PipelineTemplateContext).template.variables*.defaultValue == expectedDefaultValues
 
     where:
     templateVariables                                                     | configVariables       || expectedDefaultValues

--- a/orca-pipelinetemplate/src/test/resources/templates/dynamic-stages-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/dynamic-stages-001.yml
@@ -7,7 +7,7 @@ variables:
       - cluster-1
       - cluster-2
       - cluster-3
-stages: |
+stages: | # Note the pipe here - it makes the block a string, which is needed to render Jinja expressions at the top level
   - id: wait
     name: Wait
     type: wait

--- a/orca-pipelinetemplate/src/test/resources/templates/dynamic-stages-001.yml
+++ b/orca-pipelinetemplate/src/test/resources/templates/dynamic-stages-001.yml
@@ -1,0 +1,35 @@
+schema: "1"
+id: simpleTemplate
+variables:
+  - name: clusters
+    type: list
+    defaultValue:
+      - cluster-1
+      - cluster-2
+      - cluster-3
+stages: |
+  - id: wait
+    name: Wait
+    type: wait
+    config:
+      waitTime: 5
+  {%- for cluster in clusters %}
+  - name: Deploy to {{ cluster }}
+    type: deployManifest
+    id: deploy-{{ cluster }}
+    dependsOn:
+      - wait
+    config:
+      account: "{{ cluster }}"
+      cloudProvider: kubernetes
+      manifestArtifactId: baked-manifest
+      moniker:
+        app: "${ execution['application'] }"
+      skipExpressionEvaluation: false
+      source: artifact
+      trafficManagement:
+        enabled: false
+        options:
+          enableTraffic: false
+          services: []
+  {%- endfor %}


### PR DESCRIPTION
Adds support for using jinja expressions at the top level in the stages block. Because the template file had to be both well-formed YAML and adhering to the schema defined in `PipelineTemplate`, there was no way to use expressions at the top level here, as can be seen in the `dynamic-stages-001.yml` file. With this patch Orca will first load the yaml file as a `Map` instead of directly as a `PipelineTemplate`. Then it will parse any variables to create a context for the Jinja parser, and if the stages section is a single string, it will parse any Jinja expressions in the stages section. Finally it will load the result as `PipelineTemplate`, just as before, and proceed with processing the rest of the handler chain.

This lets you do stuff like this:

```yaml
schema: "1"
id: simpleTemplate
variables:
  - name: myList
    type: list
    defaultValue:
      - item-1
      - item-2
stages: |
  {%- for item in myList %}
  - id: wait-{{ item }}
    name: Wait {{ item }}
    type: wait
    config:
      waitTime: 5
  {%- endfor %}
```

And it will render like this:
```yaml
schema: "1"
id: simpleTemplate
variables:
  - name: myList
    type: list
    defaultValue:
      - item-1
      - item-2
stages:
  - id: wait-item-1
    name: Wait item-1
    type: wait
    config:
      waitTime: 5
  - id: wait-item-2
    name: Wait item-2
    type: wait
    config:
      waitTime: 5
```