### PR TITLE
feat(artifacts): Add ArtifactStore to orca

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jakewharton.retrofit.Ok3Client;
 import com.netflix.spinnaker.config.DefaultServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfiguration;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.web.selector.DefaultServiceSelector;
 import com.netflix.spinnaker.kork.web.selector.SelectableService;
@@ -47,7 +48,7 @@ import retrofit.RestAdapter;
 import retrofit.converter.JacksonConverter;
 
 @Configuration
-@Import(RetrofitConfiguration.class)
+@Import({RetrofitConfiguration.class, ArtifactStoreConfiguration.class})
 @ComponentScan({
   "com.netflix.spinnaker.orca.clouddriver",
   "com.netflix.spinnaker.orca.kato.pipeline",

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/DeploymentManifest.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/DeploymentManifest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.artifacts.ArtifactTypes;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.Base64;
 import java.util.Collections;
@@ -47,7 +48,7 @@ public class DeploymentManifest {
     if (direct != null) {
       return Artifact.builder()
           .name("manifest")
-          .type("embedded/base64")
+          .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
           .artifactAccount("embedded-artifact")
           .reference(Base64.getEncoder().encodeToString(direct.toManifestYml().getBytes()))
           .build();

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/ServiceManifest.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/cf/ServiceManifest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.netflix.spinnaker.kork.artifacts.ArtifactTypes;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.IOException;
 import java.util.Base64;
@@ -53,7 +54,7 @@ public class ServiceManifest {
     if (direct != null) {
       return Artifact.builder()
           .name("manifest")
-          .type("embedded/base64")
+          .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
           .artifactAccount("embedded-artifact")
           .reference(Base64.getEncoder().encodeToString(direct.toManifestYml().getBytes()))
           .build();

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ManifestEvaluatorTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.artifacts.ArtifactTypes;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
@@ -108,7 +109,7 @@ final class ManifestEvaluatorTest {
     Artifact manifestArtifact =
         Artifact.builder()
             .artifactAccount("my-artifact-account")
-            .type("embedded/base64")
+            .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
             .customKind(false)
             .name("somename")
             .reference(

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.config.PluginsAutoConfiguration;
 import com.netflix.spinnaker.kork.api.expressions.ExpressionFunctionProvider;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfiguration;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.kork.expressions.config.ExpressionProperties;
@@ -84,11 +85,13 @@ import rx.schedulers.Schedulers;
   "com.netflix.spinnaker.orca.preprocessors",
   "com.netflix.spinnaker.orca.telemetry",
   "com.netflix.spinnaker.orca.notifications.scheduling",
-  "com.netflix.spinnaker.orca.lock"
+  "com.netflix.spinnaker.orca.lock",
+  "com.netflix.spinnaker.kork.artifacts.model",
 })
 @Import({
   PreprocessorConfiguration.class,
   PluginsAutoConfiguration.class,
+  ArtifactStoreConfiguration.class,
 })
 @EnableConfigurationProperties({
   TaskOverrideConfigurationProperties.class,

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.front50
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.kork.artifacts.ArtifactTypes
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
@@ -848,7 +849,7 @@ class DependentPipelineStarterSpec extends Specification {
                                          matchArtifact: [
                                            kind: "base64",
                                            name: "baked-manifest",
-                                           type: "embedded/base64"
+                                           type: ArtifactTypes.EMBEDDED_BASE64.getMimeType()
                                          ],
                                          useDefaultArtifact: false
                                        ]],


### PR DESCRIPTION
This commit adds artifact storage to orca. The new artifact type
remote/base64 is completely compatible with SpEL and users can use the
same SpEL expressions. Meaning that this change should be completely
transparent to users

Signed-off-by: benjamin-j-powell <benjamin_j_powell@apple.com>

Co-authored-by: Nicolas Favre-Felix <nff@apple.com>
Signed-off-by: benjamin-j-powell <benjamin_j_powell@apple.com>
