### PR TITLE
refactor(tests): convert junit4 based test cases to junit5, clean up and unpin mockito in orca

### DIFF
--- a/orca-api-tck/orca-api-tck.gradle
+++ b/orca-api-tck/orca-api-tck.gradle
@@ -25,7 +25,6 @@ dependencies {
 
   // Test framework dependencies
   api("org.junit.jupiter:junit-jupiter-api")
-  api("org.junit.platform:junit-platform-runner")
 //  testImplementation "org.assertj:assertj-core"
   api("io.strikt:strikt-core")
   api("dev.minutest:minutest")
@@ -36,7 +35,6 @@ dependencies {
   api("org.springframework.security:spring-security-config")
   api("com.ninja-squad:springmockk")
 
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 

--- a/orca-api/orca-api.gradle
+++ b/orca-api/orca-api.gradle
@@ -41,9 +41,6 @@ dependencies {
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")
 
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
-
   dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.4.32")
 
   sampleImplementation(sourceSets.main.runtimeClasspath)
@@ -58,7 +55,5 @@ tasks.withType(JavaCompile) {
 }
 
 test {
-  useJUnitPlatform {
-    includeEngines "junit-vintage", "junit-jupiter"
-  }
+  useJUnitPlatform()
 }

--- a/orca-bakery/orca-bakery.gradle
+++ b/orca-bakery/orca-bakery.gradle
@@ -36,9 +36,12 @@ dependencies {
   testImplementation("com.github.tomakehurst:wiremock:2.15.0")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.assertj:assertj-core")
-  testImplementation("org.mockito:mockito-core:2.25.0")
+  testImplementation("org.mockito:mockito-core")
 
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+}
+test {
+  useJUnitPlatform()
 }
 
 sourceSets {

--- a/orca-bakery/src/test/java/com/netflix/spinnaker/orca/bakery/tasks/manifests/cf/BakeCloudFoundryManifestTaskTest.java
+++ b/orca-bakery/src/test/java/com/netflix/spinnaker/orca/bakery/tasks/manifests/cf/BakeCloudFoundryManifestTaskTest.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BakeCloudFoundryManifestTaskTest {
 

--- a/orca-clouddriver-provider-titus/orca-clouddriver-provider-titus.gradle
+++ b/orca-clouddriver-provider-titus/orca-clouddriver-provider-titus.gradle
@@ -17,9 +17,7 @@
 apply from: "$rootDir/gradle/groovy.gradle"
 
 test {
-  useJUnitPlatform {
-    includeEngines "junit-vintage", "junit-jupiter"
-  }
+  useJUnitPlatform()
 }
 
 dependencies {
@@ -30,6 +28,5 @@ dependencies {
   testImplementation(project(":orca-test"))
   testImplementation(project(":orca-test-groovy"))
 
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }

--- a/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca-clouddriver/orca-clouddriver.gradle
@@ -18,9 +18,7 @@ apply from: "$rootDir/gradle/groovy.gradle"
 apply from: "$rootDir/gradle/kotlin.gradle"
 
 test {
-  useJUnitPlatform {
-    includeEngines "junit-vintage", "junit-jupiter"
-  }
+  useJUnitPlatform()
 }
 
 dependencies {
@@ -53,9 +51,7 @@ dependencies {
   testImplementation("com.github.tomakehurst:wiremock:2.15.0")
   testImplementation("org.springframework:spring-test")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
-  testImplementation("org.junit.platform:junit-platform-runner")
   testImplementation("org.assertj:assertj-core")
-  testImplementation("org.mockito:mockito-core:2.25.0")
   testImplementation("org.mockito:mockito-junit-jupiter")
   testImplementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
   testImplementation("dev.minutest:minutest")
@@ -66,8 +62,7 @@ dependencies {
   testCompileOnly("org.projectlombok:lombok")
   testAnnotationProcessor("org.projectlombok:lombok")
 
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 
 sourceSets {

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/model/ManifestTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/model/ManifestTest.java
@@ -25,10 +25,7 @@ import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
 import java.io.IOException;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class ManifestTest {
   private static final ObjectMapper objectMapper = OrcaObjectMapper.newInstance();
 

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ShrinkClusterStageTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/ShrinkClusterStageTest.java
@@ -30,10 +30,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class ShrinkClusterStageTest {
 
   private PipelineExecutionImpl pipeline;

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletionTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletionTest.java
@@ -19,7 +19,9 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.job;
 import static com.netflix.spinnaker.orca.TestUtils.getResource;
 import static com.netflix.spinnaker.orca.TestUtils.getResourceAsStream;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -51,12 +53,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import retrofit.client.Response;
 import retrofit.mime.TypedByteArray;
 
-@RunWith(JUnitPlatform.class)
 public final class WaitOnJobCompletionTest {
   private ObjectMapper objectMapper;
   private RetrySupport retrySupport;

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolveDeploySourceManifestTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolveDeploySourceManifestTaskTest.java
@@ -28,10 +28,7 @@ import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import java.util.*;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class ResolveDeploySourceManifestTaskTest {
 
   private static final Map<Object, Object> MANIFEST_1 =

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskTest.java
@@ -34,10 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class WaitForManifestStableTaskTest {
   private static final String UNSTABLE_MESSAGE = "manifest is unstable";
   private static final String FAILED_MESSAGE = "manifest failed";

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/DeployAppEngineConfigurationTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/appengine/DeployAppEngineConfigurationTaskTest.java
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.providers.appengine;
 
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPELINE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -36,7 +36,7 @@ import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DeployAppEngineConfigurationTaskTest {
   private final String CLOUD_OPERATION_TYPE = "deployAppengineConfiguration";

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/tasks/artifacts/FindArtifactFromPipelineExecutionTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/tasks/artifacts/FindArtifactFromPipelineExecutionTaskTest.java
@@ -33,10 +33,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class FindArtifactFromPipelineExecutionTaskTest {
   private static final String PIPELINE = "my pipeline";
   private static final Artifact ARTIFACT_A =

--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -64,12 +64,10 @@ dependencies {
   testImplementation(project(":orca-test-groovy"))
   testImplementation("com.github.tomakehurst:wiremock:2.15.0")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
-  testImplementation("org.junit.platform:junit-platform-runner")
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core")
   testImplementation("org.mockito:mockito-junit-jupiter")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
 
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
-  testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
 }

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorTest.java
@@ -35,10 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class CompoundExecutionOperatorTest {
   private static final String APPLICATION = "myapp";
   private static final String PIPELINE = "mypipeline";

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/persistence/PipelineExecutionRepositoryTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/persistence/PipelineExecutionRepositoryTest.java
@@ -23,10 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class PipelineExecutionRepositoryTest {
   private static final String APPLICATION = "myapp";
 

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverTest.java
@@ -25,10 +25,7 @@ import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver.ResolveResult;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class ArtifactResolverTest {
   private static final Artifact DOCKER_ARTIFACT =
       Artifact.builder().name("my-docker-image").type("docker/image").build();

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtilsTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtilsTest.java
@@ -31,10 +31,7 @@ import com.netflix.spinnaker.orca.pipeline.persistence.InMemoryExecutionReposito
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class ArtifactUtilsTest {
   @Test
   void withAccountNonNullAccount() {

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtilsTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/HttpClientUtilsTest.java
@@ -21,17 +21,12 @@ import static org.assertj.core.api.Fail.fail;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.http.Fault;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
 import java.io.IOException;
-import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class HttpClientUtilsTest {
 
   private final String host = "localhost";
@@ -41,8 +36,6 @@ public class HttpClientUtilsTest {
       new UserConfiguredUrlRestrictions.Builder();
 
   WireMockServer wireMockServer = new WireMockServer();
-
-  @Rule public WireMockRule wireMockRule = new WireMockRule(port);
 
   @BeforeEach
   public void setup() {

--- a/orca-kayenta/src/test/java/com/netflix/spinnaker/orca/kayenta/pipeline/functions/KayentaConfigExpressionFunctionProviderTest.java
+++ b/orca-kayenta/src/test/java/com/netflix/spinnaker/orca/kayenta/pipeline/functions/KayentaConfigExpressionFunctionProviderTest.java
@@ -1,5 +1,7 @@
 package com.netflix.spinnaker.orca.kayenta.pipeline.functions;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
@@ -8,24 +10,25 @@ import com.netflix.spinnaker.orca.kayenta.KayentaCanaryConfig;
 import com.netflix.spinnaker.orca.kayenta.KayentaService;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class KayentaConfigExpressionFunctionProviderTest {
 
-  @Test(expected = SpelHelperFunctionException.class)
+  @Test
   public void missingName() {
     KayentaConfigExpressionFunctionProvider provider =
         new KayentaConfigExpressionFunctionProvider(Mockito.mock(KayentaService.class));
-    provider.canaryConfigNameToId(null, "myapp");
+    assertThrows(
+        SpelHelperFunctionException.class, () -> provider.canaryConfigNameToId(null, "myapp"));
   }
 
-  @Test(expected = SpelHelperFunctionException.class)
+  @Test
   public void missingApp() {
     KayentaConfigExpressionFunctionProvider provider =
         new KayentaConfigExpressionFunctionProvider(Mockito.mock(KayentaService.class));
-    provider.canaryConfigNameToId("myname", null);
+    assertThrows(
+        SpelHelperFunctionException.class, () -> provider.canaryConfigNameToId("myname", null));
   }
 
   @Test
@@ -41,10 +44,10 @@ public class KayentaConfigExpressionFunctionProviderTest {
         new KayentaConfigExpressionFunctionProvider(kayentaService);
     String configId = provider.canaryConfigNameToId("myname", "myapp");
 
-    Assert.assertEquals("myconfig", configId);
+    assertEquals("myconfig", configId);
   }
 
-  @Test(expected = SpelHelperFunctionException.class)
+  @Test
   public void nothingFound() {
     KayentaService kayentaService = Mockito.mock(KayentaService.class);
     List<KayentaCanaryConfig> canaryConfigs = Lists.newArrayList();
@@ -55,6 +58,8 @@ public class KayentaConfigExpressionFunctionProviderTest {
 
     KayentaConfigExpressionFunctionProvider provider =
         new KayentaConfigExpressionFunctionProvider(kayentaService);
-    provider.canaryConfigNameToId("someothername", "myapp");
+    assertThrows(
+        SpelHelperFunctionException.class,
+        () -> provider.canaryConfigNameToId("someothername", "myapp"));
   }
 }

--- a/orca-plugins-test/orca-plugins-test.gradle
+++ b/orca-plugins-test/orca-plugins-test.gradle
@@ -30,7 +30,6 @@ dependencies {
   testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-properties")
   testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin"
 
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 
@@ -39,7 +38,5 @@ test {
     includeTestsMatching "com.netflix.spinnaker.orca.plugins.test.OrcaPluginsTest"
   }
 
-  useJUnitPlatform {
-    includeEngines("junit-jupiter", "junit-vintage")
-  }
+  useJUnitPlatform()
 }

--- a/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueIntegrationTest.kt
+++ b/orca-queue-redis/src/test/kotlin/com/netflix/spinnaker/orca/q/redis/RedisQueueIntegrationTest.kt
@@ -27,11 +27,11 @@ import com.netflix.spinnaker.orca.q.QueueIntegrationTest
 import com.netflix.spinnaker.orca.q.TestConfig
 import com.netflix.spinnaker.orca.q.redis.pending.RedisPendingExecutionService
 import com.netflix.spinnaker.orca.test.redis.EmbeddedRedisConfiguration
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import redis.clients.jedis.Jedis
 import redis.clients.jedis.util.Pool
 
@@ -52,7 +52,7 @@ class RedisTestConfig {
 /**
  * This just runs [QueueIntegrationTest] with a [com.netflix.spinnaker.q.redis.RedisQueue].
  */
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @SpringBootTest(
   classes = [
     EmbeddedRedisConfiguration::class,

--- a/orca-queue-sql/src/test/kotlin/com/netflix/spinnaker/orca/q/sql/SqlQueueIntegrationTest.kt
+++ b/orca-queue-sql/src/test/kotlin/com/netflix/spinnaker/orca/q/sql/SqlQueueIntegrationTest.kt
@@ -52,12 +52,12 @@ import java.time.Clock
 import java.time.Duration
 import java.util.Optional
 import org.jooq.DSLContext
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @Configuration
 class SqlTestConfig {
@@ -163,7 +163,7 @@ class SqlTestConfig {
     RedisClientSelector(redisClientDelegates)
 }
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @SpringBootTest(
   classes = [
     SqlTestConfig::class,

--- a/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
+++ b/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/QueueIntegrationTest.kt
@@ -73,10 +73,11 @@ import java.time.Instant.now
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit.HOURS
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -90,7 +91,7 @@ import org.springframework.context.annotation.Import
 import org.springframework.context.event.ApplicationEventMulticaster
 import org.springframework.context.event.SimpleApplicationEventMulticaster
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.util.concurrent.TimeUnit
 import java.util.function.Predicate
 
@@ -98,7 +99,7 @@ import java.util.function.Predicate
   classes = [TestConfig::class],
   properties = ["queue.retry.delay.ms=10"]
 )
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 abstract class QueueIntegrationTest {
 
   @Autowired
@@ -116,17 +117,17 @@ abstract class QueueIntegrationTest {
   lateinit var timeZoneId: String
   private val timeZone by lazy { ZoneId.of(timeZoneId) }
 
-  @Before
+  @BeforeEach
   fun discoveryUp() {
     context.publishEvent(RemoteStatusChangedEvent(DiscoveryStatusChangeEvent(InstanceStatus.STARTING, InstanceStatus.UP)))
   }
 
-  @After
+  @AfterEach
   fun discoveryDown() {
     context.publishEvent(RemoteStatusChangedEvent(DiscoveryStatusChangeEvent(InstanceStatus.UP, InstanceStatus.OUT_OF_SERVICE)))
   }
 
-  @After
+  @AfterEach
   fun resetMocks() {
     reset(dummyTask)
     whenever(dummyTask.extensionClass) doReturn dummyTask::class.java

--- a/orca-sql/orca-sql.gradle
+++ b/orca-sql/orca-sql.gradle
@@ -53,12 +53,8 @@ dependencies {
   testRuntimeOnly("mysql:mysql-connector-java")
   testRuntimeOnly("org.postgresql:postgresql")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }
 
 test {
-  useJUnitPlatform {
-    includeEngines "junit-vintage", "junit-jupiter"
-  }
+  useJUnitPlatform()
 }

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -110,7 +110,5 @@ test {
       }
     }
   }
-  useJUnitPlatform {
-    includeEngines("junit-jupiter", "junit-vintage")
-  }
+  useJUnitPlatform()
 }

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/MainSpec.java
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/MainSpec.java
@@ -18,15 +18,15 @@ package com.netflix.spinnaker.orca;
 
 import com.netflix.spinnaker.orca.notifications.NotificationClusterLock;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {Main.class})
 @ContextConfiguration(classes = {StartupTestConfiguration.class})
 @TestPropertySource(properties = {"spring.config.location=classpath:orca-test.yml"})

--- a/orca-web/src/test/java/com/netflix/spinnaker/orca/MeterRegistryProcessorIntTest.java
+++ b/orca-web/src/test/java/com/netflix/spinnaker/orca/MeterRegistryProcessorIntTest.java
@@ -19,17 +19,17 @@ package com.netflix.spinnaker.orca;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {Main.class})
 @ContextConfiguration(classes = {MeterRegistryProcessorTestConfiguration.class})
 @TestPropertySource(


### PR DESCRIPTION
Before refactor, total test cases executed were 4230. 
After refactor, total test cases executed are 4233.