### PR TITLE
fix(artifacts): Ignoring the artifacts filter for pipeline stage

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtils.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtils.java
@@ -237,10 +237,14 @@ public class ArtifactUtils {
             .orElse(Stream.empty())
             .map(it -> objectMapper.convertValue(it, ExpectedArtifact.class))
             .filter(
-                artifact ->
-                    expectedArtifactIds.contains(artifact.getId())
-                        || artifact.isUseDefaultArtifact()
-                        || artifact.isUsePriorArtifact())
+                // artifacts coming from a parent pipeline are always expected
+                trigger.get("parentPipelineStageId") != null
+                    ? artifact -> true
+                    // artifacts coming from an automated trigger should be constrained
+                    : artifact ->
+                        (expectedArtifactIds.contains(artifact.getId()))
+                            || artifact.isUseDefaultArtifact()
+                            || artifact.isUsePriorArtifact())
             .collect(toImmutableList());
 
     ImmutableSet<Artifact> receivedArtifacts =


### PR DESCRIPTION
fixes [spinnaker/#6850](https://github.com/spinnaker/spinnaker/issues/6850)

There are two main ways to trigger a pipeline
using a trigger and using the [Pipeline Stage](https://github.com/spinnaker/orca/blob/master/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java)

Seems like the field `expectedArtifacts` has 2 use cases:

1. `Artifact Constraints` in `Automated Triggers`
2. Use the artifact in a stage in the pipeline(e.g. `Deploy (Manifest)` in `Required Artifacts to Bind` )

Triggering a Pipeline using the `Pipeline Stage` or the `Trigger Type Pipeline` are using the same mechanism,
the only way to know if the trigger comes from the Pipeline Stage is if the trigger has the field `parentPipelineStageId`

If we always filter the `expectedArtifactIds` the `ArtifactUtils` is not populating the field `resolvedExpectedArtifacts` which could be used later for example in [ResolveDeploySourceManifestTask](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/ResolveDeploySourceManifestTask.java)
