### PR TITLE
fix(expressions): fetch labels from actually deployed manfiest

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/ManifestLabelValueExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/ManifestLabelValueExpressionFunctionProvider.java
@@ -87,7 +87,11 @@ public class ManifestLabelValueExpressionFunctionProvider implements ExpressionF
           "A valid Deploy Manifest stage name is required for this function");
     }
 
-    List<Map> manifests = (List<Map>) stage.get().getContext().get("manifests");
+    // using outputs.manifests to give access to labels added by Spinnaker itself during the
+    // deployment
+    // this is safe as we assert above that we're only using successful deploy stages, so this key
+    // should always exist
+    List<Map> manifests = (List<Map>) stage.get().getContext().get("outputs.manifests");
 
     if (manifests == null || manifests.size() == 0) {
       throw new SpelHelperFunctionException(

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/ManifestLabelValueExpressionFunctionProvider.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/functions/ManifestLabelValueExpressionFunctionProvider.java
@@ -108,7 +108,7 @@ public class ManifestLabelValueExpressionFunctionProvider implements ExpressionF
     }
 
     Map manifest = manifestOpt.get();
-    String labelPath = format("$.spec.template.metadata.labels.%s", labelKey);
+    String labelPath = format("$.spec.template.metadata.labels['%s']", labelKey);
     String labelValue;
 
     try {

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/ManifestLabelValueExpressionFunctionProviderSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/functions/ManifestLabelValueExpressionFunctionProviderSpec.groovy
@@ -47,6 +47,22 @@ class ManifestLabelValueExpressionFunctionProviderSpec extends Specification {
               ]
             ]
           ]
+        ],
+        "outputs.manifests": [
+          [
+            "kind": "ReplicaSet",
+            "spec": [
+              "template": [
+                "metadata": [
+                  "labels": [
+                    "my-label-key": "my-label-value",
+                    "my-other-label-key": "my-other-label-value",
+                    "moniker.spinnaker.io/sequence": "0"
+                  ]
+                ]
+              ]
+            ]
+          ]
         ]
       )
       status = SUCCEEDED
@@ -60,9 +76,10 @@ class ManifestLabelValueExpressionFunctionProviderSpec extends Specification {
     manifestLabelValue(deployManifestPipeline, "Deploy ReplicaSet", "ReplicaSet", labelKey) == expectedLabelValue
 
     where:
-    labelKey             || expectedLabelValue
-    "my-label-key"       || "my-label-value"
-    "my-other-label-key" || "my-other-label-value"
+    labelKey                        || expectedLabelValue
+    "my-label-key"                  || "my-label-value"
+    "my-other-label-key"            || "my-other-label-value"
+    "moniker.spinnaker.io/sequence" || "0"
   }
 
   def "manifestLabelValue should raise exception if stage, manifest, or label not found"() {


### PR DESCRIPTION
We have a use case where we want to make a stage conditional based on the value of the sequence label. This label isn't present in the `manifests` field of the context, because it's only applied during deployment by Clouddriver.

The `outputs.manfiests` field contains the full Kubernetes manifests that were deployed by Clouddriver, including labels added by Spinnaker during deployment. This should be a backwards compatible change, as the labels in the `manifests` field are obviously also included in the `outputs.manfiests` field.

I would have preferred to make this change optional using a default function argument of false, but it seems the `FunctionParameter` [class](https://github.com/spinnaker/kork/blob/1d5d80b2b9618bc801e012bf5bf29c97041ac8ec/kork-api/src/main/java/com/netflix/spinnaker/kork/api/expressions/ExpressionFunctionProvider.java#L154) has no concept of a default value.