### PR TITLE
TargetServerGroupResolver cleanup

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolver.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolver.groovy
@@ -67,7 +67,7 @@ class TargetServerGroupResolver {
   private TargetServerGroup resolveByTarget(TargetServerGroup.Params params, Location location) {
     try {
       ServerGroup tsg = fetchWithRetries {
-        oortService.getTargetServerGroupTyped(params.app,
+        oortService.getTargetServerGroup(params.app,
           params.credentials,
           params.cluster,
           params.cloudProvider,

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolver.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolver.groovy
@@ -17,20 +17,23 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.annotations.VisibleForTesting
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
-import retrofit.client.Response
-import retrofit.converter.ConversionException
-import retrofit.converter.JacksonConverter
+
+import java.time.Duration
 
 @Component
 @Slf4j
 class TargetServerGroupResolver {
+
+  public static final int NUM_RETRIES = 15;
 
   @Autowired
   OortService oortService
@@ -63,18 +66,18 @@ class TargetServerGroupResolver {
 
   private TargetServerGroup resolveByTarget(TargetServerGroup.Params params, Location location) {
     try {
-      Map tsgMap = fetchWithRetries(Map) {
-        oortService.getTargetServerGroup(params.app,
+      ServerGroup tsg = fetchWithRetries {
+        oortService.getTargetServerGroupTyped(params.app,
           params.credentials,
           params.cluster,
           params.cloudProvider,
           location.value,
           params.target.name())
       }
-      if (!tsgMap) {
+      if (!tsg) {
         throw new TargetServerGroup.NotFoundException("Unable to locate ${params.target.name()} in $params.credentials/$location.value/$params.cluster")
       }
-      return new TargetServerGroup(tsgMap)
+      return new TargetServerGroup(tsg)
     } catch (Exception e) {
       log.error("Unable to locate ${params.target.name()} in $params.credentials/$location.value/$params.cluster", e)
       throw e
@@ -82,18 +85,18 @@ class TargetServerGroupResolver {
   }
 
   private TargetServerGroup resolveByServerGroupName(TargetServerGroup.Params params, Location location) {
-    List<Map> tsgList = fetchWithRetries(List) {
-      oortService.getServerGroupFromCluster(
+    // TODO(ttomsu): Add zonal support to this op. (e.g. the region param).  Note that adding a region changes the response type from a List to a singleServerGroup
+    List<ServerGroup> tsgList = fetchWithRetries {
+      oortService.getServerGroupsFromClusterTyped(
         params.app,
         params.credentials,
         params.cluster,
         params.serverGroupName,
-        null /* region */, // TODO(ttomsu): Add zonal support to this op.
         params.cloudProvider
       )
     }
     // Without zonal support in the getServerGroup call above, we have to do the filtering here.
-    def tsg = tsgList?.find { Map tsg -> tsg.region == location.value || tsg.zones?.contains(location.value) || tsg.namespace == location.value }
+    def tsg = tsgList?.find { ServerGroup tsg -> tsg.region == location.value || tsg.zones?.contains(location.value) || tsg.namespace == location.value }
     if (!tsg) {
       throw new TargetServerGroup.NotFoundException("Unable to locate $params.serverGroupName in $params.credentials/$location.value/$params.cluster")
     }
@@ -145,28 +148,17 @@ class TargetServerGroupResolver {
     return stage.type == DetermineTargetServerGroupStage.PIPELINE_CONFIG_TYPE
   }
 
-  private <T> T fetchWithRetries(Class<T> responseType, Closure<Response> fetchClosure) {
-    return fetchWithRetries(responseType, 15, 1000, fetchClosure)
-  }
-
-  private <T> T fetchWithRetries(Class<T> responseType, int maxRetries, long retryBackoff, Closure<Response> fetchClosure) {
+  @VisibleForTesting
+  <T> T fetchWithRetries(Closure<T> fetchClosure) {
     return retrySupport.retry({
-      def converter = new JacksonConverter(mapper)
-
-      Response response
       try {
-        response = fetchClosure.call()
+        return fetchClosure.call()
       } catch (RetrofitError re) {
         if (re.kind == RetrofitError.Kind.HTTP && re.response.status == 404) {
           return null
         }
         throw re
       }
-      try {
-        return (T) converter.fromBody(response.body, responseType)
-      } catch (ConversionException ce) {
-        throw RetrofitError.conversionError(response.url, response, converter, responseType, ce)
-      }
-    }, maxRetries, retryBackoff, false)
+    }, NUM_RETRIES, Duration.ofMillis(1000), false)
   }
 }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -99,17 +99,6 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   }
 
   @Override
-  public Response getTargetServerGroup(
-      String app,
-      String account,
-      String cluster,
-      String cloudProvider,
-      String scope,
-      String target) {
-    return getService().getTargetServerGroup(app, account, cluster, cloudProvider, scope, target);
-  }
-
-  @Override
   public ServerGroup getTargetServerGroupTyped(
       String app,
       String account,

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -99,15 +99,14 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   }
 
   @Override
-  public ServerGroup getTargetServerGroupTyped(
+  public ServerGroup getTargetServerGroup(
       String app,
       String account,
       String cluster,
       String cloudProvider,
       String scope,
       String target) {
-    return getService()
-        .getTargetServerGroupTyped(app, account, cluster, cloudProvider, scope, target);
+    return getService().getTargetServerGroup(app, account, cluster, cloudProvider, scope, target);
   }
 
   @Override

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.kork.web.selector.SelectableService;
 import com.netflix.spinnaker.orca.clouddriver.model.Ami;
 import com.netflix.spinnaker.orca.clouddriver.model.Manifest;
 import com.netflix.spinnaker.orca.clouddriver.model.ManifestCoordinates;
+import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
@@ -75,6 +76,13 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   }
 
   @Override
+  public List<ServerGroup> getServerGroupsFromClusterTyped(
+      String app, String account, String cluster, String serverGroup, String cloudProvider) {
+    return getService()
+        .getServerGroupsFromClusterTyped(app, account, cluster, serverGroup, cloudProvider);
+  }
+
+  @Override
   public Response getServerGroups(String app) {
     return getService().getServerGroups(app);
   }
@@ -99,6 +107,18 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
       String scope,
       String target) {
     return getService().getTargetServerGroup(app, account, cluster, cloudProvider, scope, target);
+  }
+
+  @Override
+  public ServerGroup getTargetServerGroupTyped(
+      String app,
+      String account,
+      String cluster,
+      String cloudProvider,
+      String scope,
+      String target) {
+    return getService()
+        .getTargetServerGroupTyped(app, account, cluster, cloudProvider, scope, target);
   }
 
   @Override

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
@@ -107,7 +107,7 @@ public interface OortService {
 
   @GET(
       "/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/{scope}/serverGroups/target/{target}")
-  ServerGroup getTargetServerGroupTyped(
+  ServerGroup getTargetServerGroup(
       @Path("app") String app,
       @Path("account") String account,
       @Path("cluster") String cluster,

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
@@ -107,16 +107,6 @@ public interface OortService {
 
   @GET(
       "/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/{scope}/serverGroups/target/{target}")
-  Response getTargetServerGroup(
-      @Path("app") String app,
-      @Path("account") String account,
-      @Path("cluster") String cluster,
-      @Path("cloudProvider") String cloudProvider,
-      @Path("scope") String scope,
-      @Path("target") String target);
-
-  @GET(
-      "/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/{scope}/serverGroups/target/{target}")
   ServerGroup getTargetServerGroupTyped(
       @Path("app") String app,
       @Path("account") String account,

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.orca.clouddriver.model.Ami;
 import com.netflix.spinnaker.orca.clouddriver.model.Manifest;
 import com.netflix.spinnaker.orca.clouddriver.model.ManifestCoordinates;
+import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup;
 import java.util.List;
 import java.util.Map;
 import retrofit.client.Response;
@@ -49,6 +50,15 @@ public interface OortService {
       @Path("cluster") String cluster,
       @Path("serverGroup") String serverGroup,
       @Query("region") String region,
+      @Path("cloudProvider") String cloudProvider);
+
+  @GET(
+      "/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/serverGroups/{serverGroup}")
+  List<ServerGroup> getServerGroupsFromClusterTyped(
+      @Path("app") String app,
+      @Path("account") String account,
+      @Path("cluster") String cluster,
+      @Path("serverGroup") String serverGroup,
       @Path("cloudProvider") String cloudProvider);
 
   @GET("/manifests/{account}/_/{manifest}")
@@ -98,6 +108,16 @@ public interface OortService {
   @GET(
       "/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/{scope}/serverGroups/target/{target}")
   Response getTargetServerGroup(
+      @Path("app") String app,
+      @Path("account") String account,
+      @Path("cluster") String cluster,
+      @Path("cloudProvider") String cloudProvider,
+      @Path("scope") String scope,
+      @Path("target") String target);
+
+  @GET(
+      "/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/{scope}/serverGroups/target/{target}")
+  ServerGroup getTargetServerGroupTyped(
       @Path("app") String app,
       @Path("account") String account,
       @Path("cluster") String cluster,

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolverSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolverSpec.groovy
@@ -144,7 +144,7 @@ class TargetServerGroupResolverSpec extends Specification {
     ))
 
     then:
-    1 * oort.getTargetServerGroupTyped("test", "testCreds", "test-app", "abc", "north-pole", "current_asg") >>
+    1 * oort.getTargetServerGroup("test", "testCreds", "test-app", "abc", "north-pole", "current_asg") >>
       new ServerGroup([
         name  : "test-app-v010",
         region: "north-pole"

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolverSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolverSpec.groovy
@@ -21,11 +21,10 @@ import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
 import com.netflix.spinnaker.orca.clouddriver.ModelUtils
 import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupResolver
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
-import retrofit.client.Response
-import retrofit.mime.TypedString
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -126,18 +125,18 @@ class SourceResolverSpec extends Specification {
     def source = resolver.getSource(stage)
 
     then:
-    1 * oort.getTargetServerGroup(
+    1 * oort.getTargetServerGroupTyped(
       'app',
       'test',
       'app-test',
       'aws',
       'us-west-1',
-      'current_asg_dynamic') >> new Response('http://oort.com', 200, 'Okay', [], new TypedString('''\
-    {
+      'current_asg_dynamic') >> new ServerGroup(
+    [
       "name": "app-test-v009",
       "region": "us-west-1",
       "createdTime": 1
-    }'''.stripIndent()))
+    ])
 
     source?.account == 'test'
     source?.region == 'us-west-1'
@@ -175,18 +174,18 @@ class SourceResolverSpec extends Specification {
     def source = resolver.getSource(stage)
 
     then:
-    1 * oort.getTargetServerGroup(
+    1 * oort.getTargetServerGroupTyped(
       'app',
       'test2',
       'app-test',
       'cloudfoundry',
       'org2 > space2',
-      'current_asg_dynamic') >> new Response('http://oort.com', 200, 'Okay', [], new TypedString('''\
-    {
+      'current_asg_dynamic') >> new ServerGroup(
+    [
       "name": "app-test-v009",
       "region": "org2 > space2",
       "createdTime": 1
-    }'''.stripIndent()))
+    ])
 
     source?.account == 'test2'
     source?.region == 'org2 > space2'

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolverSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolverSpec.groovy
@@ -125,7 +125,7 @@ class SourceResolverSpec extends Specification {
     def source = resolver.getSource(stage)
 
     then:
-    1 * oort.getTargetServerGroupTyped(
+    1 * oort.getTargetServerGroup(
       'app',
       'test',
       'app-test',
@@ -174,7 +174,7 @@ class SourceResolverSpec extends Specification {
     def source = resolver.getSource(stage)
 
     then:
-    1 * oort.getTargetServerGroupTyped(
+    1 * oort.getTargetServerGroup(
       'app',
       'test2',
       'app-test',


### PR DESCRIPTION
A bit of cleanup that makes it easier/possible to start using SpinnakerRetrofitErrorHandler in more places.