### PR TITLE
feat(retrofit): add SpinnakerServerExceptionHandler

### DIFF
--- a/orca-queue/orca-queue.gradle
+++ b/orca-queue/orca-queue.gradle
@@ -34,6 +34,7 @@ dependencies {
   implementation("com.github.ben-manes.caffeine:guava")
 
   testImplementation("io.spinnaker.kork:kork-jedis-test")
+  testImplementation("io.spinnaker.kork:kork-retrofit")
   testImplementation(project(":orca-api-tck"))
   testImplementation(project(":orca-retrofit"))
   testImplementation(project(":orca-test-kotlin"))

--- a/orca-queue/orca-queue.gradle
+++ b/orca-queue/orca-queue.gradle
@@ -35,6 +35,7 @@ dependencies {
 
   testImplementation("io.spinnaker.kork:kork-jedis-test")
   testImplementation(project(":orca-api-tck"))
+  testImplementation(project(":orca-retrofit"))
   testImplementation(project(":orca-test-kotlin"))
   testImplementation(project(":orca-queue-tck"))
   testImplementation(project(":orca-queue-redis"))

--- a/orca-queue/src/test/java/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerExceptionHandlerTest.java
+++ b/orca-queue/src/test/java/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerExceptionHandlerTest.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.q.handler;
+
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPELINE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.orca.TaskResolver;
+import com.netflix.spinnaker.orca.api.pipeline.Task;
+import com.netflix.spinnaker.orca.api.pipeline.TaskExecutionInterceptor;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.api.pipeline.models.TaskExecution;
+import com.netflix.spinnaker.orca.exceptions.DefaultExceptionHandler;
+import com.netflix.spinnaker.orca.exceptions.ExceptionHandler;
+import com.netflix.spinnaker.orca.lock.RetriableLock;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory;
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.model.TaskExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import com.netflix.spinnaker.orca.pipeline.util.StageNavigator;
+import com.netflix.spinnaker.orca.q.DummyTask;
+import com.netflix.spinnaker.orca.q.RunTask;
+import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler;
+import com.netflix.spinnaker.q.Queue;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+import retrofit.converter.GsonConverter;
+import retrofit.mime.TypedByteArray;
+import retrofit.mime.TypedString;
+
+/**
+ * It's potentially a better test to use spring to configure all available ExceptionHandlers. To be
+ * the most future proof would involve bringing in the entire context via Main to make sure we
+ * really get all of them. Since there are only a small number of ExceptionHandlers, let's speed up
+ * / simplify the test and explicitly list them.
+ */
+class RunTaskHandlerExceptionHandlerTest {
+  private static final String URL = "https://some-url";
+
+  private static final Response response =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString("{ message: \"arbitrary message\" }"));
+
+  private static final Response response503 =
+      new Response(
+          URL,
+          503,
+          "arbitrary reason",
+          List.of(),
+          new TypedString("{ message: \"arbitrary message\" }"));
+
+  private static final Response responseWithError =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString("{ message: \"arbitrary message\", error: \"error property\" }"));
+
+  private static final Response responseWithException =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString("{ message: \"arbitrary message\", exception: \"exception property\" }"));
+
+  private static final Response responseWithErrors =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString(
+              "{ message: \"arbitrary message\", errors: [\"error one\", \"error two\"] }"));
+
+  private static final Response responseWithErrorAndErrors =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString(
+              "{ message: \"arbitrary message\", error: \"error property\", errors: [\"error one\", \"error two\"] }"));
+
+  private static final Response responseWithErrorAndErrorsAndMessages =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString(
+              "{ message: \"arbitrary message\", error: \"error property\", errors: [\"error one\", \"error two\"], messages: [\"message one\", \"message two\"] }"));
+
+  private RetrofitExceptionHandler retrofitExceptionHandler = new RetrofitExceptionHandler();
+  private DefaultExceptionHandler defaultExceptionHandler = new DefaultExceptionHandler();
+
+  /** Put RetrofitExceptionHandler first since its bean is marked as highest precedence */
+  private List<ExceptionHandler> exceptionHandlers =
+      List.of(retrofitExceptionHandler, defaultExceptionHandler);
+
+  private Queue queue = mock(Queue.class);
+
+  private ExecutionRepository executionRepository = mock(ExecutionRepository.class);
+
+  private DummyTask dummyTask = mock(DummyTask.class);
+
+  private Collection<Task> tasks = List.of(dummyTask);
+
+  private TasksProvider tasksProvider = new TasksProvider(tasks);
+
+  private TaskResolver taskResolver;
+
+  private Clock clock =
+      Clock.fixed(Instant.now().truncatedTo(ChronoUnit.MILLIS), ZoneId.systemDefault());
+
+  private List<TaskExecutionInterceptor> taskExecutionInterceptors = List.of();
+
+  private RunTaskHandler runTaskHandler;
+
+  StageExecution stageExecution;
+
+  private RunTask runTaskMessage;
+
+  RetriableLock retriableLock = mock(RetriableLock.class);
+
+  @BeforeEach
+  void setup() {
+    // Set up enough scaffolding so it's possible for individual tests to mock
+    // the behavior of our dummy task
+
+    // Without this, the TaskResolver constructor throws an exception
+    doReturn(dummyTask.getClass()).when(dummyTask).getExtensionClass();
+    taskResolver = new TaskResolver(tasksProvider);
+
+    DynamicConfigService dynamicConfigService = mock(DynamicConfigService.class);
+    doReturn(0)
+        .when(dynamicConfigService)
+        .getConfig(any(), eq("tasks.warningInvocationTimeMs"), any());
+    doReturn(0L)
+        .when(dynamicConfigService)
+        .getConfig(any(), eq("tasks.global.backOffPeriod"), any());
+
+    // Always get the lock
+    doAnswer(
+            invocation -> {
+              Runnable runnable = invocation.getArgument(1);
+              runnable.run();
+              return true;
+            })
+        .when(retriableLock)
+        .lock(any(RetriableLock.RetriableLockOptions.class), any(Runnable.class));
+
+    runTaskHandler =
+        new RunTaskHandler(
+            queue,
+            executionRepository,
+            mock(StageNavigator.class),
+            mock(StageDefinitionBuilderFactory.class),
+            mock(ContextParameterProcessor.class),
+            taskResolver,
+            clock,
+            exceptionHandlers,
+            taskExecutionInterceptors,
+            new NoopRegistry(),
+            dynamicConfigService,
+            retriableLock);
+
+    PipelineExecutionImpl pipeline = new PipelineExecutionImpl(PIPELINE, "test-application");
+
+    // StageExecutionImpl requires a mutable map
+    Map<String, Object> stageContext = new HashMap<>();
+    TaskExecution taskExecution = new TaskExecutionImpl();
+    String taskId = "1";
+    taskExecution.setId(taskId);
+    taskExecution.setStartTime(clock.instant().toEpochMilli());
+    taskExecution.setImplementingClass("");
+
+    stageExecution = new StageExecutionImpl(pipeline, "stage-type", "stage-name", stageContext);
+    stageExecution.setTasks(List.of(taskExecution));
+    pipeline.getStages().add(stageExecution);
+
+    runTaskMessage =
+        new RunTask(
+            pipeline.getType(),
+            pipeline.getId(),
+            "foo",
+            stageExecution.getId(),
+            taskId,
+            DummyTask.class);
+
+    when(executionRepository.retrieve(PIPELINE, runTaskMessage.getExecutionId()))
+        .thenReturn(pipeline);
+  }
+
+  @ParameterizedTest(name = "{index} => taskThrowsRetrofitErrorNoRetry {0}")
+  @MethodSource("nonRetryableRetrofitErrors")
+  void taskThrowsRetrofitErrorNoRetry(RetrofitError retrofitError) {
+    // given an arbitrary RetrofitError that RetrofitExceptionHandler doesn't consider retryable
+    doThrow(retrofitError).when(dummyTask).execute(any());
+
+    // when
+    runTaskHandler.handle(runTaskMessage);
+
+    // verify that the exception wasn't retried
+    verify(queue, never()).push(eq(runTaskMessage), any());
+
+    // verify that exception handling has populated the stage context as
+    // expected.  This duplicates some logic in RetrofitExceptionHandler, but at
+    // least it helps detect future changes.
+    Map<String, Object> responseBody = (Map<String, Object>) retrofitError.getBodyAs(Map.class);
+    Response response = retrofitError.getResponse();
+    String responseBodyString = new String(((TypedByteArray) response.getBody()).getBytes());
+    String error = (String) responseBody.getOrDefault("error", response.getReason());
+    List<String> errors =
+        (List<String>)
+            responseBody.getOrDefault("errors", responseBody.getOrDefault("messages", List.of()));
+    String message = (String) responseBody.get("message");
+    if (errors.isEmpty() && (message != null)) {
+      errors = List.of(message);
+    }
+
+    ImmutableMap.Builder<String, Object> builder =
+        ImmutableMap.<String, Object>builder()
+            .put("responseBody", responseBodyString)
+            .put("kind", RetrofitError.Kind.HTTP)
+            .put("error", error)
+            .put("errors", errors)
+            .put("url", response.getUrl())
+            .put("status", response.getStatus());
+
+    Object exception = responseBody.get("exception");
+    if (exception != null) {
+      builder.put("rootException", exception);
+    }
+
+    Map<String, Object> responseDetails = builder.build();
+
+    ExceptionHandler.Response expectedResponse =
+        new ExceptionHandler.Response(
+            "RetrofitError", "unspecified", responseDetails, false /* shouldRetry */);
+
+    compareResponse(
+        expectedResponse, (ExceptionHandler.Response) stageExecution.getContext().get("exception"));
+  }
+
+  private static Stream<RetrofitError> nonRetryableRetrofitErrors() {
+    return Stream.of(
+        makeRetrofitError(response),
+        makeRetrofitError(responseWithError),
+        makeRetrofitError(responseWithException),
+        makeRetrofitError(responseWithErrors),
+        makeRetrofitError(responseWithErrorAndErrors),
+        makeRetrofitError(responseWithErrorAndErrorsAndMessages));
+  }
+
+  @Test
+  void taskThrowsRetrofitErrorRetryable() {
+    // given an arbitrary RetrofitError that RetrofitExceptionHandler considers retryable
+    RetrofitError retrofitError = makeRetrofitError(response503);
+    doThrow(retrofitError).when(dummyTask).execute(any());
+
+    // when
+    runTaskHandler.handle(runTaskMessage);
+
+    // verify that the exception was retried
+    verify(queue).push(eq(runTaskMessage), any());
+
+    // On retry, expect no exception info in the context
+    assertThat(stageExecution.getContext().get("exception")).isNull();
+  }
+
+  @Test
+  void taskThrowsRetrofitErrorNonJsonResponse() {
+    // given an arbitrary RetrofitError that RetrofitExceptionHandler doesn't consider retryable
+    Response response =
+        new Response(URL, 500, "arbitrary reason", List.of(), new TypedString("non-json response"));
+    RetrofitError retrofitError = makeRetrofitError(response);
+    doThrow(retrofitError).when(dummyTask).execute(any());
+
+    // when
+    runTaskHandler.handle(runTaskMessage);
+
+    // verify that the exception wasn't retried
+    verify(queue, never()).push(eq(runTaskMessage), any());
+
+    // verify that exception handling has populated the stage context as
+    // expected.  This duplicates some logic in RetrofitExceptionHandler, but at
+    // least it helps detect future changes.
+    Map<String, Object> responseDetails =
+        Map.of(
+            "error", response.getReason(),
+            "errors", List.of(),
+            "responseBody", "non-json response",
+            "kind", RetrofitError.Kind.HTTP,
+            "url", response.getUrl(),
+            "status", response.getStatus());
+
+    ExceptionHandler.Response expectedResponse =
+        new ExceptionHandler.Response(
+            "RetrofitError", "unspecified", responseDetails, false /* shouldRetry */);
+
+    compareResponse(
+        expectedResponse, (ExceptionHandler.Response) stageExecution.getContext().get("exception"));
+  }
+
+  private void compareResponse(
+      ExceptionHandler.Response expectedResponse, ExceptionHandler.Response actualResponse) {
+    assertThat(actualResponse).isNotNull();
+    // Don't look at overall equality since that includes a date
+    assertThat(actualResponse.getExceptionType()).isEqualTo(expectedResponse.getExceptionType());
+    assertThat(actualResponse.getOperation()).isEqualTo(expectedResponse.getOperation());
+    assertThat(actualResponse.getDetails()).isEqualTo(expectedResponse.getDetails());
+    assertThat(actualResponse.isShouldRetry()).isEqualTo(expectedResponse.isShouldRetry());
+  }
+
+  private static RetrofitError makeRetrofitError(Response response) {
+    return RetrofitError.httpError(URL, response, new GsonConverter(new Gson()), String.class);
+  }
+
+  static class TasksProvider implements ObjectProvider<Collection<Task>> {
+
+    final Collection<Task> tasks;
+
+    TasksProvider(Collection<Task> tasks) {
+      this.tasks = tasks;
+    }
+
+    @Override
+    public @NotNull Collection<Task> getObject(Object... args) throws BeansException {
+      return tasks;
+    }
+
+    @Override
+    public Collection<Task> getIfAvailable() throws BeansException {
+      return tasks;
+    }
+
+    @Override
+    public Collection<Task> getIfUnique() throws BeansException {
+      return tasks;
+    }
+
+    @Override
+    public @NotNull Collection<Task> getObject() throws BeansException {
+      return tasks;
+    }
+  }
+}

--- a/orca-queue/src/test/java/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerExceptionHandlerTest.java
+++ b/orca-queue/src/test/java/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerExceptionHandlerTest.java
@@ -28,10 +28,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
 import com.netflix.spinnaker.orca.TaskResolver;
 import com.netflix.spinnaker.orca.api.pipeline.Task;
 import com.netflix.spinnaker.orca.api.pipeline.TaskExecutionInterceptor;
@@ -50,6 +53,7 @@ import com.netflix.spinnaker.orca.pipeline.util.StageNavigator;
 import com.netflix.spinnaker.orca.q.DummyTask;
 import com.netflix.spinnaker.orca.q.RunTask;
 import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler;
+import com.netflix.spinnaker.orca.retrofit.exceptions.SpinnakerServerExceptionHandler;
 import com.netflix.spinnaker.q.Queue;
 import java.time.Clock;
 import java.time.Instant;
@@ -62,6 +66,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -142,11 +147,13 @@ class RunTaskHandlerExceptionHandlerTest {
               "{ message: \"arbitrary message\", error: \"error property\", errors: [\"error one\", \"error two\"], messages: [\"message one\", \"message two\"] }"));
 
   private RetrofitExceptionHandler retrofitExceptionHandler = new RetrofitExceptionHandler();
+  private SpinnakerServerExceptionHandler spinnakerServerExceptionHandler =
+      new SpinnakerServerExceptionHandler();
   private DefaultExceptionHandler defaultExceptionHandler = new DefaultExceptionHandler();
 
   /** Put RetrofitExceptionHandler first since its bean is marked as highest precedence */
   private List<ExceptionHandler> exceptionHandlers =
-      List.of(retrofitExceptionHandler, defaultExceptionHandler);
+      List.of(retrofitExceptionHandler, spinnakerServerExceptionHandler, defaultExceptionHandler);
 
   private Queue queue = mock(Queue.class);
 
@@ -353,6 +360,119 @@ class RunTaskHandlerExceptionHandlerTest {
         expectedResponse, (ExceptionHandler.Response) stageExecution.getContext().get("exception"));
   }
 
+  @ParameterizedTest(name = "{index} => taskThrowsSpinnakerHttpExceptionNoRetry {0}")
+  @MethodSource("nonRetryableSpinnakerHttpExceptions")
+  void taskThrowsSpinnakerHttpExceptionNoRetry(SpinnakerHttpException spinnakerHttpException) {
+    // given an arbitrary SpinnakerHttpException that SpinnakerServerExceptionHandler doesn't
+    // consider retryable
+    doThrow(spinnakerHttpException).when(dummyTask).execute(any());
+
+    // when
+    runTaskHandler.handle(runTaskMessage);
+
+    // verify that the exception wasn't retried
+    verify(queue, never()).push(eq(runTaskMessage), any());
+
+    // verify that exception handling has populated the stage context as
+    // expected.  This duplicates some logic in SpinnakerServerExceptionHandler,
+    // but at least it helps detect future changes.
+    Map<String, Object> responseBody = spinnakerHttpException.getResponseBody();
+    String error = (String) responseBody.getOrDefault("error", spinnakerHttpException.getReason());
+    List<String> errors =
+        (List<String>)
+            responseBody.getOrDefault("errors", responseBody.getOrDefault("messages", List.of()));
+    String message = (String) responseBody.get("message");
+    if (errors.isEmpty()) {
+      errors = List.of(spinnakerHttpException.getMessage());
+    }
+
+    ImmutableMap.Builder<String, Object> builder =
+        ImmutableMap.<String, Object>builder()
+            .put("kind", "HTTP")
+            .put("error", error)
+            .put("errors", errors)
+            .put("url", spinnakerHttpException.getUrl())
+            .put("status", spinnakerHttpException.getResponseCode());
+
+    Object exception = responseBody.get("exception");
+    if (exception != null) {
+      builder.put("rootException", exception);
+    } else {
+      builder.put("stackTrace", Throwables.getStackTraceAsString(spinnakerHttpException));
+    }
+
+    Map<String, Object> responseDetails = builder.build();
+
+    ExceptionHandler.Response expectedResponse =
+        new ExceptionHandler.Response(
+            "SpinnakerHttpException", "unspecified", responseDetails, false /* shouldRetry */);
+
+    compareResponse(
+        expectedResponse, (ExceptionHandler.Response) stageExecution.getContext().get("exception"));
+  }
+
+  private static Stream<SpinnakerHttpException> nonRetryableSpinnakerHttpExceptions() {
+    return nonRetryableRetrofitErrors()
+        .map(retrofitError -> makeSpinnakerHttpException(retrofitError));
+  }
+
+  @Test
+  void taskThrowsSpinnakerServerExceptionRetryable() {
+    // given an arbitrary SpinnakerServerException that SpinnakerServerExceptionHandler considers
+    // retryable
+    SpinnakerServerException spinnakerServerException =
+        makeSpinnakerHttpException(makeRetrofitError(response503));
+    doThrow(spinnakerServerException).when(dummyTask).execute(any());
+
+    // when
+    runTaskHandler.handle(runTaskMessage);
+
+    // verify that the exception was retried
+    verify(queue).push(eq(runTaskMessage), any());
+
+    // On retry, expect no exception info in the context
+    assertThat(stageExecution.getContext().get("exception")).isNull();
+  }
+
+  @Disabled("until the SpinnakerHttpException constructor can handle non-json responses")
+  @Test
+  void taskThrowsSpinnakerHttpExceptionNonJsonResponse() {
+    // given an arbitrary SpinnakerHttpException that SpinnakerServerExceptionHandler doesn't
+    // consider retryable
+    Response response =
+        new Response(URL, 500, "arbitrary reason", List.of(), new TypedString("non-json response"));
+    SpinnakerHttpException spinnakerHttpException =
+        makeSpinnakerHttpException(makeRetrofitError(response));
+    doThrow(spinnakerHttpException).when(dummyTask).execute(any());
+
+    // when
+    runTaskHandler.handle(runTaskMessage);
+
+    // verify that the exception wasn't retried
+    verify(queue, never()).push(eq(runTaskMessage), any());
+
+    // verify that exception handling has populated the stage context as
+    // expected.  There's no implementation for this yet in
+    // SpinnakerServerExceptionHandler since SpinnakerHttpException can't handle
+    // non-json responses yet.  The expected details here matches the current
+    // behavior of RetrofitExceptionHandler.
+    Map<String, Object> responseDetails =
+        Map.of(
+            "error", spinnakerHttpException.getReason(),
+            "errors", List.of(),
+            "responseBody", "non-json response",
+            "kind", "HTTP",
+            "url", spinnakerHttpException.getUrl(),
+            "status", spinnakerHttpException.getResponseCode());
+
+    ExceptionHandler.Response expectedResponse =
+        new ExceptionHandler.Response(
+            "SpinnakerHttpException", "unspecified", responseDetails, false /* shouldRetry */);
+
+    compareResponse(
+        expectedResponse, (ExceptionHandler.Response) stageExecution.getContext().get("exception"));
+  }
+
   private void compareResponse(
       ExceptionHandler.Response expectedResponse, ExceptionHandler.Response actualResponse) {
     assertThat(actualResponse).isNotNull();
@@ -361,6 +481,10 @@ class RunTaskHandlerExceptionHandlerTest {
     assertThat(actualResponse.getOperation()).isEqualTo(expectedResponse.getOperation());
     assertThat(actualResponse.getDetails()).isEqualTo(expectedResponse.getDetails());
     assertThat(actualResponse.isShouldRetry()).isEqualTo(expectedResponse.isShouldRetry());
+  }
+
+  private static SpinnakerHttpException makeSpinnakerHttpException(RetrofitError retrofitError) {
+    return new SpinnakerHttpException(retrofitError);
   }
 
   private static RetrofitError makeRetrofitError(Response response) {

--- a/orca-retrofit/orca-retrofit.gradle
+++ b/orca-retrofit/orca-retrofit.gradle
@@ -28,7 +28,30 @@ dependencies {
   implementation("com.squareup.okhttp:okhttp-urlconnection")
   implementation("com.squareup.okhttp:okhttp-apache")
   implementation("io.reactivex:rxjava")
+  implementation("io.spinnaker.kork:kork-retrofit")
   implementation("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
+  implementation "com.google.guava:guava"
 
   testImplementation("com.squareup.retrofit:retrofit-mock")
+  testImplementation("org.assertj:assertj-core")
+  testImplementation("org.junit.jupiter:junit-jupiter-params")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  testRuntimeOnly("org.springframework:spring-test")
+
+  test {
+    useJUnitPlatform()
+  }
+}
+
+sourceSets {
+  main {
+    java { srcDirs = [] } // no source dirs for the java compiler
+    groovy { srcDirs = ["src/main/java", "src/main/groovy"] }  // compile everything in src/main with groovy
+  }
+
+  test {
+    java { srcDirs = [] } // no source dirs for the java compiler
+    groovy { srcDirs = ["src/test/java", "src/test/groovy"] }  // compile everything in src/test with groovy
+  }
+
 }

--- a/orca-retrofit/orca-retrofit.gradle
+++ b/orca-retrofit/orca-retrofit.gradle
@@ -35,6 +35,8 @@ dependencies {
   testImplementation("com.squareup.retrofit:retrofit-mock")
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
+  testImplementation("org.mockito:mockito-core")
+  testImplementation("org.springframework.boot:spring-boot-test")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
   testRuntimeOnly("org.springframework:spring-test")
 

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.config.OkHttpClientConfiguration
 import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler
+import com.netflix.spinnaker.orca.retrofit.exceptions.SpinnakerServerExceptionHandler
 import groovy.transform.CompileStatic
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -98,9 +99,27 @@ class RetrofitConfiguration {
     return LogLevel.valueOf(retrofitLogLevel)
   }
 
+  /**
+   * Set the order such that this has higher precedence than the
+   * DefaultExceptionHandler bean.  The order relative to the
+   * SpinnakerServerExceptionHandler bean isn't important since they
+   * handle different types.
+   */
   @Bean
   @Order(Ordered.HIGHEST_PRECEDENCE)
   RetrofitExceptionHandler retrofitExceptionHandler() {
     new RetrofitExceptionHandler()
+  }
+
+  /**
+   * Set the order such that this has higher precedence than the
+   * DefaultExceptionHandler bean.  The order relative to the
+   * RetrofitExceptionHandler bean isn't important since they handle different
+   * types.
+   */
+  @Bean
+  @Order(Ordered.HIGHEST_PRECEDENCE)
+  SpinnakerServerExceptionHandler spinnakerServerExceptionHandler() {
+    new SpinnakerServerExceptionHandler()
   }
 }

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/BaseRetrofitExceptionHandler.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/BaseRetrofitExceptionHandler.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.retrofit.exceptions
+
+import java.lang.annotation.Annotation
+import java.lang.reflect.Method
+import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
+import retrofit.RetrofitError
+import retrofit.http.RestMethod
+import static java.net.HttpURLConnection.*
+import static retrofit.RetrofitError.Kind.HTTP
+import static retrofit.RetrofitError.Kind.NETWORK
+import static retrofit.RetrofitError.Kind.UNEXPECTED
+
+abstract class BaseRetrofitExceptionHandler implements ExceptionHandler {
+  boolean shouldRetry(RetrofitError e) {
+    if (isMalformedRequest(e)) {
+      return false
+    }
+
+    // retry on 503 even for non-idempotent requests
+    if (e.kind == HTTP && e.response?.status == HTTP_UNAVAILABLE) {
+      return true
+    }
+
+    return isIdempotentRequest(e) && (isNetworkError(e) || isGatewayErrorCode(e) || isThrottle(e))
+  }
+
+  private boolean isGatewayErrorCode(RetrofitError e) {
+    e.kind == HTTP && e.response?.status in [HTTP_BAD_GATEWAY, HTTP_UNAVAILABLE, HTTP_GATEWAY_TIMEOUT]
+  }
+
+  private static final int HTTP_TOO_MANY_REQUESTS = 429
+
+  boolean isThrottle(RetrofitError e) {
+    e.kind == HTTP && e.response?.status == HTTP_TOO_MANY_REQUESTS
+  }
+
+  private boolean isNetworkError(RetrofitError e) {
+    e.kind == NETWORK
+  }
+
+  private boolean isMalformedRequest(RetrofitError e) {
+    // We never want to retry errors like "Path parameter "blah" value must not be null.
+    return e.kind == UNEXPECTED && e.message?.contains("Path parameter")
+  }
+
+  private static boolean isIdempotentRequest(RetrofitError e) {
+    findHttpMethodAnnotation(e) in ["GET", "HEAD", "DELETE", "PUT"]
+  }
+
+  private static String findHttpMethodAnnotation(RetrofitError exception) {
+    exception.stackTrace.findResult { StackTraceElement frame ->
+      try {
+        Class.forName(frame.className)
+          .interfaces
+          .findResult { Class<?> iface ->
+          iface.declaredMethods.findAll { Method m ->
+            m.name == frame.methodName
+          }.findResult { Method m ->
+            m.declaredAnnotations.findResult { Annotation annotation ->
+              annotation
+                .annotationType()
+                .getAnnotation(RestMethod)?.value()
+            }
+          }
+        }
+      } catch (ClassNotFoundException e) {
+        // inner class or something non-accessible
+        return null
+      } catch (MissingMethodException e) {
+        // While testing with RunTaskHandler, there's some case where this code fails with
+        //
+        // groovy.lang.MissingMethodException: No signature of method:
+        // com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler$_findHttpMethodAnnotation_closure2$_closure3.doCall()
+        // is applicable for argument types: (Optional) values: [Optional.empty]
+        //
+        // so treat this as having no annotation
+        return null
+      }
+    }
+  }
+}

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
@@ -126,6 +126,15 @@ class RetrofitExceptionHandler implements ExceptionHandler {
       } catch (ClassNotFoundException e) {
         // inner class or something non-accessible
         return null
+      } catch (MissingMethodException e) {
+        // While testing with RunTaskHandler, there's some case where this code fails with
+        //
+        // groovy.lang.MissingMethodException: No signature of method:
+        // com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler$_findHttpMethodAnnotation_closure2$_closure3.doCall()
+        // is applicable for argument types: (Optional) values: [Optional.empty]
+        //
+        // so treat this as having no annotation
+        return null
       }
     }
   }

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
@@ -60,7 +60,7 @@ class RetrofitExceptionHandler extends BaseRetrofitExceptionHandler {
       responseDetails.status = properties.status ?: null
       responseDetails.url = properties.url ?: null
 
-      return new ExceptionHandler.Response(e.class.simpleName, stepName, responseDetails, shouldRetry(e, e.kind, e.response?.status))
+      return new ExceptionHandler.Response(e.class.simpleName, stepName, responseDetails, shouldRetry(e, e.kind.toString(), e.response?.status))
     }
   }
 }

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
@@ -16,21 +16,14 @@
 
 package com.netflix.spinnaker.orca.retrofit.exceptions
 
-import java.lang.annotation.Annotation
-import java.lang.reflect.Method
 import com.netflix.spinnaker.orca.exceptions.ExceptionHandler
 import org.springframework.core.annotation.Order
 import retrofit.RetrofitError
-import retrofit.http.RestMethod
 import retrofit.mime.TypedByteArray
-import static java.net.HttpURLConnection.*
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE
-import static retrofit.RetrofitError.Kind.HTTP
-import static retrofit.RetrofitError.Kind.NETWORK
-import static retrofit.RetrofitError.Kind.UNEXPECTED
 
 @Order(HIGHEST_PRECEDENCE)
-class RetrofitExceptionHandler implements ExceptionHandler {
+class RetrofitExceptionHandler extends BaseRetrofitExceptionHandler {
   @Override
   boolean handles(Exception e) {
     return e.class == RetrofitError
@@ -68,74 +61,6 @@ class RetrofitExceptionHandler implements ExceptionHandler {
       responseDetails.url = properties.url ?: null
 
       return new ExceptionHandler.Response(e.class.simpleName, stepName, responseDetails, shouldRetry(e))
-    }
-  }
-
-  boolean shouldRetry(RetrofitError e) {
-    if (isMalformedRequest(e)) {
-      return false
-    }
-
-    // retry on 503 even for non-idempotent requests
-    if (e.kind == HTTP && e.response?.status == HTTP_UNAVAILABLE) {
-      return true
-    }
-
-    return isIdempotentRequest(e) && (isNetworkError(e) || isGatewayErrorCode(e) || isThrottle(e))
-  }
-
-  boolean isGatewayErrorCode(RetrofitError e) {
-    e.kind == HTTP && e.response?.status in [HTTP_BAD_GATEWAY, HTTP_UNAVAILABLE, HTTP_GATEWAY_TIMEOUT]
-  }
-
-  private static final int HTTP_TOO_MANY_REQUESTS = 429
-
-  boolean isThrottle(RetrofitError e) {
-    e.kind == HTTP && e.response?.status == HTTP_TOO_MANY_REQUESTS
-  }
-
-  private boolean isNetworkError(RetrofitError e) {
-    e.kind == NETWORK
-  }
-
-  private boolean isMalformedRequest(RetrofitError e) {
-    // We never want to retry errors like "Path parameter "blah" value must not be null.
-    return e.kind == UNEXPECTED && e.message?.contains("Path parameter")
-  }
-
-  private static boolean isIdempotentRequest(RetrofitError e) {
-    findHttpMethodAnnotation(e) in ["GET", "HEAD", "DELETE", "PUT"]
-  }
-
-  private static String findHttpMethodAnnotation(RetrofitError exception) {
-    exception.stackTrace.findResult { StackTraceElement frame ->
-      try {
-        Class.forName(frame.className)
-          .interfaces
-          .findResult { Class<?> iface ->
-          iface.declaredMethods.findAll { Method m ->
-            m.name == frame.methodName
-          }.findResult { Method m ->
-            m.declaredAnnotations.findResult { Annotation annotation ->
-              annotation
-                .annotationType()
-                .getAnnotation(RestMethod)?.value()
-            }
-          }
-        }
-      } catch (ClassNotFoundException e) {
-        // inner class or something non-accessible
-        return null
-      } catch (MissingMethodException e) {
-        // While testing with RunTaskHandler, there's some case where this code fails with
-        //
-        // groovy.lang.MissingMethodException: No signature of method:
-        // com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler$_findHttpMethodAnnotation_closure2$_closure3.doCall()
-        // is applicable for argument types: (Optional) values: [Optional.empty]
-        //
-        // so treat this as having no annotation
-        return null
-      }
     }
   }
 }

--- a/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
+++ b/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy
@@ -60,7 +60,7 @@ class RetrofitExceptionHandler extends BaseRetrofitExceptionHandler {
       responseDetails.status = properties.status ?: null
       responseDetails.url = properties.url ?: null
 
-      return new ExceptionHandler.Response(e.class.simpleName, stepName, responseDetails, shouldRetry(e))
+      return new ExceptionHandler.Response(e.class.simpleName, stepName, responseDetails, shouldRetry(e, e.kind, e.response?.status))
     }
   }
 }

--- a/orca-retrofit/src/main/java/com/netflix/spinnaker/orca/retrofit/exceptions/SpinnakerServerExceptionHandler.java
+++ b/orca-retrofit/src/main/java/com/netflix/spinnaker/orca/retrofit/exceptions/SpinnakerServerExceptionHandler.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.retrofit.exceptions;
+
+import com.google.common.base.Throwables;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerNetworkException;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
+import com.netflix.spinnaker.orca.exceptions.ExceptionHandler;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SpinnakerServerExceptionHandler extends BaseRetrofitExceptionHandler {
+
+  private final Logger log = LoggerFactory.getLogger(SpinnakerServerExceptionHandler.class);
+
+  @Override
+  public boolean handles(Exception e) {
+    return e instanceof SpinnakerServerException;
+  }
+
+  @Override
+  public Response handle(String taskName, Exception exception) {
+    SpinnakerServerException ex = (SpinnakerServerException) exception;
+
+    Map<String, Object> responseDetails;
+
+    String kind;
+    Integer responseCode = null;
+
+    if (ex instanceof SpinnakerNetworkException) {
+      kind = "NETWORK";
+      responseDetails = ExceptionHandler.responseDetails(ex.getMessage());
+      responseDetails.put("stackTrace", Throwables.getStackTraceAsString(ex));
+    } else if (ex instanceof SpinnakerHttpException) {
+      SpinnakerHttpException spinnakerHttpException = (SpinnakerHttpException) ex;
+      kind = "HTTP";
+      responseCode = spinnakerHttpException.getResponseCode();
+
+      Map<String, Object> body = spinnakerHttpException.getResponseBody();
+
+      // It's not only non-json responses that have null response bodies.  It's
+      // possible that other responses have null bodies too, according to
+      // https://github.com/square/retrofit/blob/parent-1.9.0/retrofit/src/main/java/retrofit/client/Response.java#L78,
+      // so handle it.
+      if (body == null) {
+        responseDetails = ExceptionHandler.responseDetails(spinnakerHttpException.getMessage());
+      } else {
+        String error = (String) body.getOrDefault("error", spinnakerHttpException.getReason());
+        List<String> errors =
+            (List<String>) body.getOrDefault("errors", body.getOrDefault("messages", List.of()));
+
+        // SpinnakerHttpException includes the message property from the response
+        // body along with other useful info into its "regular" exception message.
+        // So, use that if there's no errors nor messages property.  Note that
+        // this is what appears in the spinnaker UI.
+        if (errors.isEmpty()) {
+          errors = List.of(spinnakerHttpException.getMessage());
+        }
+
+        responseDetails = ExceptionHandler.responseDetails(error, errors);
+
+        Object exceptionProperty = body.get("exception");
+        if (exceptionProperty != null) {
+          // Mirror what RetrofitExceptionHandler does.
+          responseDetails.put("rootException", exceptionProperty);
+        } else {
+          // If there's no explicit exception property, include the stack trace in
+          // the same way DefaultExceptionHandler does to get a stack trace in the
+          // execution context.  It is tempting to leave this out to reduce the
+          // size of the execution context, and assume that the info is available
+          // in the log.
+          responseDetails.put(
+              "stackTrace", Throwables.getStackTraceAsString(spinnakerHttpException));
+        }
+
+        // RetrofitExceptionHandler includes the entire response body as a string.
+        // This seems a bit much, as, in theory, SpinnakerHttpException extracts
+        // all the relevant information already.  As well, the response could be
+        // huge so it's likely not a good idea to try to include all of it.  As
+        // well, by the time we get here, we likely no longer have access to the
+        // response body.
+      }
+
+      responseDetails.put("status", spinnakerHttpException.getResponseCode());
+      responseDetails.put("url", spinnakerHttpException.getUrl());
+    } else {
+      kind = "UNEXPECTED";
+      responseDetails = ExceptionHandler.responseDetails(ex.getMessage());
+      responseDetails.put("stackTrace", Throwables.getStackTraceAsString(ex));
+    }
+
+    responseDetails.put("kind", kind);
+
+    // Although Spinnaker*Exception has a retryable property that other parts of
+    // spinnaker use, ignore it here for compatibility with
+    // RetrofitExceptionHandler, specifically because that doesn't retry (most)
+    // POST requests which could be dangerous.
+    return new ExceptionHandler.Response(
+        ex.getClass().getSimpleName(),
+        taskName,
+        responseDetails,
+        shouldRetry(ex, kind, responseCode));
+  }
+}

--- a/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/BaseRetrofitExceptionHandlerSpec.groovy
+++ b/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/BaseRetrofitExceptionHandlerSpec.groovy
@@ -36,7 +36,13 @@ class BaseRetrofitExceptionHandlerSpec extends Specification {
 
     @Override
     Response handle(String taskName, Exception e) {
-      boolean retry = e instanceof RetrofitError ? shouldRetry(e) : false
+      RetrofitError.Kind kind = null
+      Integer responseCode = null
+      if (e instanceof RetrofitError) {
+        kind = e.kind
+        responseCode = e.response?.status
+      }
+      boolean retry = shouldRetry(e, kind, responseCode)
       new Response(e.class.simpleName, taskName, responseDetails("test"), retry)
     }
   }

--- a/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/BaseRetrofitExceptionHandlerSpec.groovy
+++ b/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/BaseRetrofitExceptionHandlerSpec.groovy
@@ -36,10 +36,10 @@ class BaseRetrofitExceptionHandlerSpec extends Specification {
 
     @Override
     Response handle(String taskName, Exception e) {
-      RetrofitError.Kind kind = null
+      String kind = null
       Integer responseCode = null
       if (e instanceof RetrofitError) {
-        kind = e.kind
+        kind = e.kind.toString()
         responseCode = e.response?.status
       }
       boolean retry = shouldRetry(e, kind, responseCode)

--- a/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/BaseRetrofitExceptionHandlerSpec.groovy
+++ b/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/BaseRetrofitExceptionHandlerSpec.groovy
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.retrofit.exceptions
+
+import retrofit.RestAdapter
+import retrofit.RetrofitError
+import retrofit.client.Client
+import retrofit.client.Response
+import retrofit.mime.TypedString
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE
+
+class BaseRetrofitExceptionHandlerSpec extends Specification {
+  class TestBaseRetrofitExceptionHandler extends BaseRetrofitExceptionHandler {
+    @Override
+    boolean handles(Exception e) {
+      true
+    }
+
+    @Override
+    Response handle(String taskName, Exception e) {
+      boolean retry = e instanceof RetrofitError ? shouldRetry(e) : false
+      new Response(e.class.simpleName, taskName, responseDetails("test"), retry)
+    }
+  }
+
+  @Subject
+  def handler = new TestBaseRetrofitExceptionHandler()
+
+  def "should not retry an internal error"() {
+    given:
+    def client = Stub(Client) {
+      execute(_) >> { throw new IllegalArgumentException("Path parameter is null") }
+    }
+
+    and:
+    def api = new RestAdapter.Builder()
+      .setEndpoint("http://localhost:1337")
+      .setClient(client)
+      .build()
+      .create(DummyRetrofitApi)
+
+    when:
+    def ex = expectingException {
+      api.getWithArg(null)
+    }
+
+    then:
+    with(handler.handle("whatever", ex)) {
+      !shouldRetry
+    }
+  }
+
+  @Unroll
+  def "should not retry a network error on a #httpMethod request"() {
+    given:
+    def client = Stub(Client) {
+      execute(_) >> { throw new IOException("network error") }
+    }
+
+    and:
+    def api = new RestAdapter.Builder()
+      .setEndpoint("http://localhost:1337")
+      .setClient(client)
+      .build()
+      .create(DummyRetrofitApi)
+
+    when:
+    def ex = expectingException {
+      api."$methodName"("whatever")
+    }
+
+    then:
+    with(handler.handle("whatever", ex)) {
+      !shouldRetry
+    }
+
+    where:
+    httpMethod << ["POST", "PATCH"]
+    methodName = httpMethod.toLowerCase()
+  }
+
+  @Unroll
+  def "should retry a network error on a #httpMethod request"() {
+    given:
+    def client = Stub(Client) {
+      execute(_) >> { throw new IOException("network error") }
+    }
+
+    and:
+    def api = new RestAdapter.Builder()
+      .setEndpoint("http://localhost:1337")
+      .setClient(client)
+      .build()
+      .create(DummyRetrofitApi)
+
+    when:
+    def ex = expectingException {
+      api."$methodName"()
+    }
+
+    then:
+    with(handler.handle("whatever", ex)) {
+      shouldRetry
+    }
+
+    where:
+    httpMethod << ["GET", "HEAD", "DELETE", "PUT"]
+    methodName = httpMethod.toLowerCase()
+  }
+
+  @Unroll
+  def "shouldRetry=#expectedShouldRetry an HTTP #statusCode on a #httpMethod request"() {
+    given:
+    def client = Stub(Client) {
+      execute(_) >> new Response("http://localhost:1337", statusCode, "bad gateway", [], new TypedString(""))
+    }
+
+    and:
+    def api = new RestAdapter.Builder()
+      .setEndpoint("http://localhost:1337")
+      .setClient(client)
+      .build()
+      .create(DummyRetrofitApi)
+
+    and:
+    def ex = expectingException {
+      if (httpMethod in ["POST", "PATCH"]) {
+        api."$methodName"("body")
+      } else {
+        api."$methodName"()
+      }
+    }
+
+    expect:
+    with(handler.handle("whatever", ex)) {
+      shouldRetry == expectedShouldRetry
+    }
+
+    where:
+    httpMethod | statusCode       || expectedShouldRetry
+    "POST"     | HTTP_BAD_GATEWAY || false
+    "PATCH"    | HTTP_BAD_GATEWAY || false
+    "POST"     | HTTP_UNAVAILABLE || true
+
+    "GET"      | HTTP_BAD_GATEWAY || true
+    "HEAD"     | HTTP_BAD_GATEWAY || true
+    "DELETE"   | HTTP_BAD_GATEWAY || true
+    "PUT"      | HTTP_BAD_GATEWAY || true
+
+
+    methodName = httpMethod.toLowerCase()
+  }
+
+  private static RetrofitError expectingException(Closure action) {
+    try {
+      action()
+      throw new IllegalStateException("Closure did not throw an exception")
+    } catch (RetrofitError e) {
+      return e
+    }
+  }
+}

--- a/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/DummyRetrofitApi.java
+++ b/orca-retrofit/src/test/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/DummyRetrofitApi.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.retrofit.exceptions;
+
+import retrofit.client.Response;
+import retrofit.http.Body;
+import retrofit.http.DELETE;
+import retrofit.http.GET;
+import retrofit.http.HEAD;
+import retrofit.http.PATCH;
+import retrofit.http.POST;
+import retrofit.http.PUT;
+import retrofit.http.Path;
+
+interface DummyRetrofitApi {
+  @GET("/whatever")
+  Response get();
+
+  @HEAD("/whatever")
+  Response head();
+
+  @POST("/whatever")
+  Response post(@Body String data);
+
+  @PUT("/whatever")
+  Response put();
+
+  @PATCH("/whatever")
+  Response patch(@Body String data);
+
+  @DELETE("/whatever")
+  Response delete();
+
+  @GET("/whatever/{stuff}")
+  Response getWithArg(@Path("stuff") String stuff);
+}

--- a/orca-retrofit/src/test/java/com/netflix/spinnaker/orca/retrofit/RetrofitConfigurationTest.java
+++ b/orca-retrofit/src/test/java/com/netflix/spinnaker/orca/retrofit/RetrofitConfigurationTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.retrofit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+import static org.mockito.Mockito.mock;
+
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.config.OkHttpClientComponents;
+import com.netflix.spinnaker.orca.config.OrcaConfiguration;
+import com.netflix.spinnaker.orca.exceptions.DefaultExceptionHandler;
+import com.netflix.spinnaker.orca.exceptions.ExceptionHandler;
+import com.netflix.spinnaker.orca.pipeline.ExecutionRunner;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
+import com.netflix.spinnaker.orca.retrofit.exceptions.RetrofitExceptionHandler;
+import com.netflix.spinnaker.orca.retrofit.exceptions.SpinnakerServerExceptionHandler;
+import java.util.List;
+import okhttp3.logging.HttpLoggingInterceptor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.annotation.UserConfigurations;
+import org.springframework.boot.task.TaskExecutorBuilder;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+class RetrofitConfigurationTest {
+
+  private final ApplicationContextRunner runner =
+      new ApplicationContextRunner()
+          .withBean(NoopRegistry.class)
+          .withBean(TaskExecutorBuilder.class)
+          .withAllowBeanDefinitionOverriding(true)
+          .withConfiguration(
+              UserConfigurations.of(
+                  OrcaConfiguration.class,
+                  RetrofitConfiguration.class,
+                  OkHttpClientComponents.class,
+                  TestDependencyConfiguration.class));
+
+  @Test
+  void testExceptionHandlerPrecedence() {
+    runner
+        .withPropertyValues("spring.application.name=orca")
+        .run(
+            ctx -> {
+              AllExceptionHandlers allExceptionHandlers =
+                  ctx.getBean("allExceptionHandlers", AllExceptionHandlers.class);
+              List<ExceptionHandler> exceptionHandlers =
+                  allExceptionHandlers.getExceptionHandlers();
+
+              assertThat(exceptionHandlers).hasSize(3);
+
+              Integer retrofitExceptionHandlerIndex = null;
+              Integer spinnakerServerExceptionHandlerIndex = null;
+              Integer defaultExceptionHandlerIndex = null;
+
+              // Figure out where each handler is in the list
+              for (ExceptionHandler exceptionHandler : exceptionHandlers) {
+                int thisIndex = exceptionHandlers.indexOf(exceptionHandler);
+                if (exceptionHandler instanceof RetrofitExceptionHandler) {
+                  // Make sure there's exactly one RetrofitExceptionHandler
+                  assertThat(retrofitExceptionHandlerIndex).isNull();
+                  retrofitExceptionHandlerIndex = thisIndex;
+                } else if (exceptionHandler instanceof SpinnakerServerExceptionHandler) {
+                  // Make sure there's exactly one SpinnakerServerExceptionHandler
+                  assertThat(spinnakerServerExceptionHandlerIndex).isNull();
+                  spinnakerServerExceptionHandlerIndex = thisIndex;
+                } else if (exceptionHandler instanceof DefaultExceptionHandler) {
+                  // Make sure there's exactly one DefaultExceptionHandler
+                  assertThat(defaultExceptionHandlerIndex).isNull();
+                  defaultExceptionHandlerIndex = thisIndex;
+                } else {
+                  fail("Unknown exception handler class: " + exceptionHandler.getClass());
+                }
+              }
+
+              // Make sure we found each handler
+              assertThat(retrofitExceptionHandlerIndex).isNotNull();
+              assertThat(spinnakerServerExceptionHandlerIndex).isNotNull();
+              assertThat(defaultExceptionHandlerIndex).isNotNull();
+
+              // Verify that the position of RetrofitExceptionHandler is before
+              // DefaultExceptionHandler
+              assertThat(retrofitExceptionHandlerIndex).isLessThan(defaultExceptionHandlerIndex);
+
+              // Verify that the position of SpinnakerServerExceptionHandler is before
+              // DefaultExceptionHandler
+              assertThat(spinnakerServerExceptionHandlerIndex)
+                  .isLessThan(defaultExceptionHandlerIndex);
+            });
+  }
+
+  @TestConfiguration
+  static class TestDependencyConfiguration {
+    @Bean
+    ExecutionRepository executionRepository() {
+      return mock(ExecutionRepository.class);
+    }
+
+    @Bean
+    ExecutionRunner executionRunner() {
+      return mock(ExecutionRunner.class);
+    }
+
+    @Bean
+    HttpLoggingInterceptor.Level logLevel() {
+      return HttpLoggingInterceptor.Level.NONE;
+    }
+
+    @Bean
+    AllExceptionHandlers allExceptionHandlers(List<ExceptionHandler> exceptionHandlers) {
+      // Store the ExceptionHandler beans in a container object
+      return new AllExceptionHandlers(exceptionHandlers);
+    }
+  }
+
+  /** A place to store the ExceptionHandlers beans */
+  static class AllExceptionHandlers {
+    private final List<ExceptionHandler> exceptionHandlers;
+
+    public AllExceptionHandlers(List<ExceptionHandler> exceptionHandlers) {
+      this.exceptionHandlers = exceptionHandlers;
+    }
+
+    public List<ExceptionHandler> getExceptionHandlers() {
+      return exceptionHandlers;
+    }
+  }
+}

--- a/orca-retrofit/src/test/java/com/netflix/spinnaker/orca/retrofit/exceptions/SpinnakerServerExceptionHandlerTest.java
+++ b/orca-retrofit/src/test/java/com/netflix/spinnaker/orca/retrofit/exceptions/SpinnakerServerExceptionHandlerTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.retrofit.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerNetworkException;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
+import com.netflix.spinnaker.orca.exceptions.ExceptionHandler;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import retrofit.RestAdapter;
+import retrofit.RetrofitError;
+import retrofit.client.Client;
+import retrofit.client.Request;
+import retrofit.client.Response;
+import retrofit.converter.GsonConverter;
+import retrofit.mime.TypedString;
+
+class SpinnakerServerExceptionHandlerTest {
+  private static final String URL = "https://some-url";
+
+  private static final String TASK_NAME = "task name";
+
+  private static final Response response =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString("{ message: \"arbitrary message\" }"));
+
+  private static final Response responseWithNullBody =
+      new Response(URL, 500, "arbitrary reason", List.of(), null);
+
+  private static final Response response429 =
+      new Response(
+          URL,
+          429,
+          "arbitrary reason",
+          List.of(),
+          new TypedString("{ message: \"arbitrary message\" }"));
+
+  private static final Response response503 =
+      new Response(
+          URL,
+          503,
+          "arbitrary reason",
+          List.of(),
+          new TypedString("{ message: \"arbitrary message\" }"));
+
+  private static final Response response504 =
+      new Response(
+          URL,
+          504,
+          "arbitrary reason",
+          List.of(),
+          new TypedString("{ message: \"arbitrary message\" }"));
+
+  private static final Response responseWithError =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString("{ message: \"arbitrary message\", error: \"error property\" }"));
+
+  private static final Response responseWithException =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString("{ message: \"arbitrary message\", exception: \"exception property\" }"));
+
+  private static final Response responseWithErrors =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString(
+              "{ message: \"arbitrary message\", errors: [\"error one\", \"error two\"] }"));
+
+  private static final Response responseWithErrorAndErrors =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString(
+              "{ message: \"arbitrary message\", error: \"error property\", errors: [\"error one\", \"error two\"] }"));
+
+  private static final Response responseWithErrorAndErrorsAndMessages =
+      new Response(
+          URL,
+          500,
+          "arbitrary reason",
+          List.of(),
+          new TypedString(
+              "{ message: \"arbitrary message\", error: \"error property\", errors: [\"error one\", \"error two\"], messages: [\"message one\", \"message two\"] }"));
+
+  private static final GsonConverter gsonConverter = new GsonConverter(new Gson());
+  private static final IOException io = new IOException("an IOException");
+
+  SpinnakerServerExceptionHandler spinnakerServerExceptionHandler =
+      new SpinnakerServerExceptionHandler();
+
+  @ParameterizedTest(name = "{index} => onlyHandlesSpinnakerServerExceptionAndSubclasses {0}")
+  @MethodSource("exceptionsForHandlesTest")
+  void onlyHandlesSpinnakerServerExceptionAndSubclasses(Exception ex, boolean supported) {
+    assertThat(spinnakerServerExceptionHandler.handles(ex)).isEqualTo(supported);
+  }
+
+  private static Stream<Arguments> exceptionsForHandlesTest() {
+    RetrofitError retrofitError = makeRetrofitError(response);
+    return Stream.of(
+        Arguments.of(new SpinnakerHttpException(retrofitError), true),
+        Arguments.of(new SpinnakerServerException(io), true),
+        Arguments.of(new SpinnakerNetworkException(io), true),
+        Arguments.of(new RuntimeException(), false),
+        Arguments.of(new IllegalArgumentException(), false));
+  }
+
+  @ParameterizedTest(name = "{index} => testRetryable {0}")
+  @MethodSource("exceptionsForRetryTest")
+  void testRetryable(SpinnakerServerException ex, boolean expectedRetryable) {
+    ExceptionHandler.Response response = spinnakerServerExceptionHandler.handle(TASK_NAME, ex);
+    assertThat(response.isShouldRetry()).isEqualTo(expectedRetryable);
+  }
+
+  private static Stream<Arguments> exceptionsForRetryTest() throws Exception {
+    // This isn't retryable because it's not considered an idempotent request
+    // since there's no retrofit http method annotation in the exception's stack
+    // trace.
+    RetrofitError notRetryableRetrofitError = makeRetrofitError(response504);
+    SpinnakerServerException notRetryable = new SpinnakerHttpException(notRetryableRetrofitError);
+
+    // This is retryable because HTTP 503 is retryable, regardless of request method
+    RetrofitError retryableRetrofitError = makeRetrofitError(response503);
+    SpinnakerServerException retryable = new SpinnakerHttpException(retryableRetrofitError);
+
+    // Exceptions generated via "real" retrofit API calls (aka via interface
+    // methods annotated with e.g. @GET/HEAD/DELETE/PUT are considered
+    // idempotent and so have a chance of being retryable.  The only other
+    // retryable exceptions are HTTP 503 independent of the http method.
+    //
+    // So, generate some of these exceptions, in combination with
+    // SpinnakerRetrofitErrorHandler.  We don't need to exercise all of
+    // BaseRetrofitExceptionHandler.shouldRetry, only enough to ensure that the
+    // way SpinnakerHttpRetrofitHandler generates exceptions, and the way
+    // SpinnakerServerExceptionHandler invokes shouldRetry, results in the
+    // expected behavior as far as picking up retrofit annotations.
+    Client client = mock(Client.class);
+
+    DummyRetrofitApi api =
+        new RestAdapter.Builder()
+            .setEndpoint(URL)
+            .setClient(client)
+            .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
+            .build()
+            .create(DummyRetrofitApi.class);
+
+    // Retryable since it's a network error from an idempotent request
+    when(client.execute(any(Request.class))).thenThrow(RetrofitError.networkError(URL, io));
+    SpinnakerServerException idempotentNetworkException = expectingException(api::get);
+
+    // Retryable since it's one of the allowed gateway error codes from an
+    // idempotent request (502/bad gateway or 504/gateway timeout)
+    when(client.execute(any(Request.class))).thenThrow(makeRetrofitError(response504));
+    SpinnakerServerException idempotentGatewayException = expectingException(api::head);
+
+    // Throttling of an idempotent request is retryable
+    when(client.execute(any(Request.class))).thenThrow(makeRetrofitError(response429));
+    SpinnakerServerException idempotentThrottlingException = expectingException(api::delete);
+
+    // Throttling of a non-idempotent request isn't retryable
+    when(client.execute(any(Request.class))).thenThrow(makeRetrofitError(response429));
+    SpinnakerServerException nonIdempotentThrottlingException =
+        expectingException(() -> api.post("whatever"));
+
+    return Stream.of(
+        Arguments.of(notRetryable, false),
+        Arguments.of(retryable, true),
+        Arguments.of(idempotentNetworkException, true),
+        Arguments.of(idempotentGatewayException, true),
+        Arguments.of(idempotentThrottlingException, true),
+        Arguments.of(nonIdempotentThrottlingException, false));
+  }
+
+  @ParameterizedTest(name = "{index} => verifyResponseDetails {0}")
+  @MethodSource("exceptionsForResponseDetailsTest")
+  void verifyResponseDetails(SpinnakerHttpException spinnakerHttpException) {
+    ExceptionHandler.Response response =
+        spinnakerServerExceptionHandler.handle(TASK_NAME, spinnakerHttpException);
+
+    // verify that exception handling has populated the stage context as
+    // expected.  This duplicates some logic in SpinnakerServerExceptionHandler,
+    // but at least it helps detect future changes.
+    Map<String, Object> responseBody = spinnakerHttpException.getResponseBody();
+    String error = null;
+    List<String> errors = null;
+
+    ImmutableMap.Builder<String, Object> builder =
+        ImmutableMap.<String, Object>builder()
+            .put("kind", "HTTP")
+            .put("url", spinnakerHttpException.getUrl())
+            .put("status", spinnakerHttpException.getResponseCode());
+
+    if (responseBody == null) {
+      error = spinnakerHttpException.getMessage();
+      errors = List.of();
+    } else {
+      error = (String) responseBody.getOrDefault("error", spinnakerHttpException.getReason());
+      errors =
+          (List<String>)
+              responseBody.getOrDefault("errors", responseBody.getOrDefault("messages", List.of()));
+      String message = (String) responseBody.get("message");
+      if (errors.isEmpty()) {
+        errors = List.of(spinnakerHttpException.getMessage());
+      }
+
+      Object exception = responseBody.get("exception");
+      if (exception != null) {
+        builder.put("rootException", exception);
+      } else {
+        builder.put("stackTrace", Throwables.getStackTraceAsString(spinnakerHttpException));
+      }
+    }
+
+    if (error != null) {
+      builder.put("error", error);
+    }
+    builder.put("errors", errors);
+
+    Map<String, Object> responseDetails = builder.build();
+
+    ExceptionHandler.Response expectedResponse =
+        new ExceptionHandler.Response(
+            "SpinnakerHttpException", TASK_NAME, responseDetails, false /* shouldRetry */);
+
+    compareResponse(expectedResponse, response);
+  }
+
+  private static Stream<SpinnakerHttpException> exceptionsForResponseDetailsTest() {
+    return Stream.of(
+            makeRetrofitError(response),
+            makeRetrofitError(responseWithNullBody),
+            makeRetrofitError(responseWithError),
+            makeRetrofitError(responseWithException),
+            makeRetrofitError(responseWithErrors),
+            makeRetrofitError(responseWithErrorAndErrors),
+            makeRetrofitError(responseWithErrorAndErrorsAndMessages))
+        .map(SpinnakerServerExceptionHandlerTest::makeSpinnakerHttpException);
+  }
+
+  private void compareResponse(
+      ExceptionHandler.Response expectedResponse, ExceptionHandler.Response actualResponse) {
+    assertThat(actualResponse).isNotNull();
+    // Don't look at overall equality since that includes a date
+    assertThat(actualResponse.getExceptionType()).isEqualTo(expectedResponse.getExceptionType());
+    assertThat(actualResponse.getOperation()).isEqualTo(expectedResponse.getOperation());
+    assertThat(actualResponse.getDetails()).isEqualTo(expectedResponse.getDetails());
+    assertThat(actualResponse.isShouldRetry()).isEqualTo(expectedResponse.isShouldRetry());
+  }
+
+  private static SpinnakerHttpException makeSpinnakerHttpException(RetrofitError retrofitError) {
+    return new SpinnakerHttpException(retrofitError);
+  }
+
+  private static RetrofitError makeRetrofitError(Response response) {
+    return RetrofitError.httpError(URL, response, gsonConverter, String.class);
+  }
+
+  private static <V> SpinnakerServerException expectingException(Callable<V> action)
+      throws Exception {
+    try {
+      action.call();
+      throw new IllegalStateException("Callable did not throw an exception");
+    } catch (SpinnakerServerException e) {
+      return e;
+    }
+  }
+}


### PR DESCRIPTION
Not used yet, since orca doesn't use SpinnakerRetrofitErrorHandler, and doesn't explicitly throw SpinnakerServerException, nor its children.  Once we do use it, we'll get similar information present in the execution context if a SpinnakerServerException happens as we get today if a RetrofitError happens, and the same retry behavior.