### PR TITLE
feat(clouddriver): use SpinnakerRetrofitErrorHandler for retrofit client beans in CloudDriverConfiguration

### DIFF
--- a/orca-applications/orca-applications.gradle
+++ b/orca-applications/orca-applications.gradle
@@ -23,6 +23,7 @@ dependencies {
   implementation(project(":orca-keel"))
   implementation(project(":orca-retrofit"))
   implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
+  implementation("io.spinnaker.kork:kork-retrofit")
 
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")

--- a/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca-clouddriver/orca-clouddriver.gradle
@@ -30,6 +30,7 @@ dependencies {
   implementation(project(":orca-bakery"))
   implementation(project(":orca-deploymentmonitor"))
   implementation("io.spinnaker.kork:kork-moniker")
+  implementation("io.spinnaker.kork:kork-retrofit")
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   implementation("io.kubernetes:client-java")
   implementation("com.amazonaws:aws-java-sdk-lambda")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/instance/TerminatingInstanceSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/instance/TerminatingInstanceSupport.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.instance
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
 import com.netflix.spinnaker.orca.clouddriver.model.SearchResultSet
@@ -24,7 +25,6 @@ import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import retrofit.RetrofitError
 
 @Slf4j
 @Component
@@ -116,7 +116,7 @@ class TerminatingInstanceSupport implements CloudProviderAware {
       List<SearchResultSet> searchResult
       try {
         searchResult = cloudDriverService.getSearchResults(terminatingInstance.id, "instances", cloudProvider)
-      } catch (RetrofitError e) {
+      } catch (SpinnakerServerException e) {
         log.warn e.message
       }
       return !(searchResult?.getAt(0)?.totalMatches == 0)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolver.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/TargetServerGroupResolver.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.kork.annotations.VisibleForTesting
 import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup
@@ -153,11 +154,11 @@ class TargetServerGroupResolver {
     return retrySupport.retry({
       try {
         return fetchClosure.call()
-      } catch (RetrofitError re) {
-        if (re.kind == RetrofitError.Kind.HTTP && re.response.status == 404) {
+      } catch (SpinnakerHttpException spinnakerHttpException) {
+        if (spinnakerHttpException.getResponseCode() == 404) {
           return null
         }
-        throw re
+        throw spinnakerHttpException
       }
     }, NUM_RETRIES, Duration.ofMillis(1000), false)
   }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTask.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.cluster
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.kork.exceptions.ConfigurationException
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
@@ -96,11 +97,11 @@ class ClusterSizePreconditionTask implements CloudProviderAware, RetryableTask, 
     def response
     try {
       response = oortService.getCluster(config.application, credentials, config.cluster, cloudProvider)
-    } catch (RetrofitError re) {
-      if (re.kind == RetrofitError.Kind.HTTP && re.response.status == 404) {
+    } catch (SpinnakerHttpException spinnakerHttpException) {
+      if (spinnakerHttpException.getResponseCode() == 404) {
         return [:]
       }
-      throw re
+      throw spinnakerHttpException
     }
 
     JacksonConverter converter = new JacksonConverter(objectMapper)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonSecurityGroupUpserter.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonSecurityGroupUpserter.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.MortService
 import com.netflix.spinnaker.orca.clouddriver.tasks.securitygroup.SecurityGroupUpserter
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import retrofit.RetrofitError
 
 import static com.netflix.spinnaker.orca.clouddriver.MortService.SecurityGroup.filterForSecurityGroupIngress
 
@@ -102,8 +102,8 @@ class AmazonSecurityGroupUpserter implements SecurityGroupUpserter, CloudProvide
         return mortSecurityGroupIngress.containsAll(targetSecurityGroupIngress)
       }
       return mortSecurityGroupIngress == targetSecurityGroupIngress
-    } catch (RetrofitError e) {
-      if (e.response?.status != 404) {
+    } catch (SpinnakerHttpException e) {
+      if (e.getResponseCode() != 404) {
         throw e
       }
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureSecurityGroupUpserter.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureSecurityGroupUpserter.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.azure
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.MortService
 import com.netflix.spinnaker.orca.clouddriver.tasks.securitygroup.SecurityGroupUpserter
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import retrofit.RetrofitError
 
 @Component
 class AzureSecurityGroupUpserter implements SecurityGroupUpserter, CloudProviderAware {
@@ -51,8 +51,8 @@ class AzureSecurityGroupUpserter implements SecurityGroupUpserter, CloudProvider
         cloudProvider,
         upsertedSecurityGroup.name,
         upsertedSecurityGroup.region)
-    } catch (RetrofitError e) {
-      if (e.response?.status != 404) {
+    } catch (SpinnakerHttpException e) {
+      if (e.getResponseCode() != 404) {
         throw e
       }
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleSecurityGroupUpserter.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleSecurityGroupUpserter.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.gce
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.MortService
@@ -23,7 +24,6 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.securitygroup.SecurityGroupU
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import retrofit.RetrofitError
 
 import static com.netflix.spinnaker.orca.clouddriver.MortService.SecurityGroup.SecurityGroupIngress
 
@@ -103,8 +103,8 @@ class GoogleSecurityGroupUpserter implements SecurityGroupUpserter, CloudProvide
       boolean ingressMatches = existingSecurityGroupIngress == targetSecurityGroupIngress
 
       return ingressMatches
-    } catch (RetrofitError e) {
-      if (e.response?.status != 404) {
+    } catch (SpinnakerHttpException e) {
+      if (e.getResponseCode() != 404) {
         throw e
       }
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolver.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolver.groovy
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
-import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
@@ -38,7 +37,6 @@ import retrofit.RetrofitError
 class SourceResolver {
 
   @Autowired CloudDriverService cloudDriverService
-  @Autowired OortService oortService
   @Autowired ObjectMapper mapper
 
   @Autowired

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolver.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolver.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.kato.pipeline.support
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
 import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup
@@ -29,7 +30,6 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import retrofit.RetrofitError
 
 @Component
 @CompileStatic
@@ -42,7 +42,7 @@ class SourceResolver {
   @Autowired
   TargetServerGroupResolver resolver
 
-  StageData.Source getSource(StageExecution stage) throws RetrofitError, JsonParseException, JsonMappingException {
+  StageData.Source getSource(StageExecution stage) throws JsonParseException, JsonMappingException {
     def stageData = stage.mapTo(StageData)
     if (stageData.source) {
       // targeting a source in a different account and region
@@ -123,15 +123,15 @@ class SourceResolver {
     )
   }
 
-  List<ServerGroup> getExistingAsgs(String app, String account, String cluster, String cloudProvider) throws RetrofitError, JsonParseException, JsonMappingException {
+  List<ServerGroup> getExistingAsgs(String app, String account, String cluster, String cloudProvider) throws JsonParseException, JsonMappingException {
     try {
       def map = cloudDriverService.getCluster(app, account, cluster, cloudProvider)
       map.serverGroups.sort { it.createdTime }
-    } catch (RetrofitError re) {
-      if (re.kind == RetrofitError.Kind.HTTP && re.response.status == 404) {
+    } catch (SpinnakerHttpException e) {
+      if (e.getResponseCode() == 404) {
         return []
       }
-      throw re
+      throw e
     }
   }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceSupport.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceSupport.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.kato.pipeline.support
 
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
 import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup
@@ -24,7 +25,6 @@ import com.netflix.spinnaker.orca.kato.pipeline.DetermineTargetReferenceStage
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import retrofit.RetrofitError
 
 @Deprecated
 @Component
@@ -188,8 +188,8 @@ class TargetReferenceSupport {
     try {
       def map = cloudDriverService.getCluster(app, account, cluster, cloudProvider)
       map.serverGroups
-    } catch (RetrofitError e) {
-      if (e.response.status == 404) {
+    } catch (SpinnakerHttpException e) {
+      if (e.getResponseCode() == 404) {
         return null
       }
       throw e

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTask.groovy
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.InstanceService
-import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.utils.OortHelper
 import com.netflix.spinnaker.orca.libdiffs.ComparableLooseVersion
 import com.netflix.spinnaker.orca.libdiffs.Library
@@ -59,9 +58,6 @@ class JarDiffsTask implements DiffTask {
 
   @Autowired
   ObjectMapper objectMapper
-
-  @Autowired
-  OortService oortService
 
   @Autowired
   OortHelper oortHelper

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/VerifyQuipTask.groovy
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
-import com.netflix.spinnaker.orca.clouddriver.OortService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
@@ -32,9 +31,6 @@ import javax.annotation.Nonnull
 @Deprecated
 @Component
 class VerifyQuipTask extends AbstractQuipTask implements Task {
-
-  @Autowired
-  OortService oortService
 
   @Autowired
   ObjectMapper objectMapper

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/CloudDriverService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/CloudDriverService.java
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.orca.clouddriver;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.orca.clouddriver.model.*;
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup;
 import com.netflix.spinnaker.orca.clouddriver.utils.ServerGroupDescriptor;
@@ -12,7 +13,6 @@ import java.util.function.Supplier;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 @Component
@@ -109,11 +109,11 @@ public class CloudDriverService {
     try {
       T result = supplier.get();
       return Optional.ofNullable(result);
-    } catch (RetrofitError re) {
-      if (re.getKind() == RetrofitError.Kind.HTTP && re.getResponse().getStatus() == 404) {
+    } catch (SpinnakerHttpException spinnakerHttpException) {
+      if (spinnakerHttpException.getResponseCode() == 404) {
         return Optional.empty();
       }
-      throw re;
+      throw spinnakerHttpException;
     }
   }
 

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.config.DefaultServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfiguration;
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
 import com.netflix.spinnaker.kork.web.selector.DefaultServiceSelector;
 import com.netflix.spinnaker.kork.web.selector.SelectableService;
 import com.netflix.spinnaker.kork.web.selector.ServiceSelector;
@@ -208,6 +209,7 @@ public class CloudDriverConfiguration {
           .setLogLevel(retrofitLogLevel)
           .setLog(new RetrofitSlf4jLog(type))
           .setConverter(new JacksonConverter(objectMapper))
+          .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
           .build()
           .create(type);
     }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pollers/PollerSupport.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pollers/PollerSupport.java
@@ -19,10 +19,10 @@ package com.netflix.spinnaker.orca.clouddriver.pollers;
 import static java.lang.String.format;
 
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService;
 import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup;
 import java.util.Optional;
-import retrofit.RetrofitError;
 
 public class PollerSupport {
   private final RetrySupport retrySupport;
@@ -40,9 +40,9 @@ public class PollerSupport {
             ServerGroup response = cloudDriverService.getServerGroup(account, region, name);
             return Optional.of(response);
           } catch (Exception e) {
-            if (e instanceof RetrofitError) {
-              RetrofitError re = (RetrofitError) e;
-              if (re.getResponse() != null && re.getResponse().getStatus() == 404) {
+            if (e instanceof SpinnakerHttpException) {
+              SpinnakerHttpException spinnakerHttpException = (SpinnakerHttpException) e;
+              if (spinnakerHttpException.getResponseCode() == 404) {
                 return Optional.empty();
               }
             }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/image/UpsertImageTagsTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/image/UpsertImageTagsTask.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.image;
 
 import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
@@ -33,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import retrofit.RetrofitError;
 
 @Component
 public class UpsertImageTagsTask implements CloudProviderAware, RetryableTask {
@@ -85,7 +85,7 @@ public class UpsertImageTagsTask implements CloudProviderAware, RetryableTask {
       }
 
       throw e;
-    } catch (RetrofitError e) {
+    } catch (SpinnakerServerException e) {
       log.error(
           "Failed creating clouddriver upsertimagetags task, cloudprovider: {}, operations: {}",
           cloudProvider,

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTask.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
 import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
@@ -34,7 +35,6 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import retrofit.RetrofitError;
 
 @Component
 @RequiredArgsConstructor
@@ -89,7 +89,7 @@ public class WaitForManifestStableTask
         Manifest manifest;
         try {
           manifest = oortService.getManifest(account, location, name, includeEvents);
-        } catch (RetrofitError e) {
+        } catch (SpinnakerServerException e) {
           log.warn("Unable to read manifest {}", identifier, e);
           return TaskResult.builder(ExecutionStatus.RUNNING)
               .context(new HashMap<>())

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTask.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.cloudformation;
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
@@ -31,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import retrofit.RetrofitError;
 
 @Slf4j
 @Component
@@ -87,8 +87,8 @@ public class WaitForCloudFormationCompletionTask implements OverridableTimeoutRe
         throw new RuntimeException(statusReason);
       }
       throw new RuntimeException("Unexpected stack status: " + stack.get("stackStatus"));
-    } catch (RetrofitError e) {
-      if (e.getResponse().getStatus() == HttpStatus.NOT_FOUND.value()) {
+    } catch (SpinnakerHttpException e) {
+      if (e.getResponseCode() == HttpStatus.NOT_FOUND.value()) {
         // The cache might not be up to date, try in the next iteration.
         return TaskResult.RUNNING;
       } else {

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/huaweicloud/HuaweiCloudSecurityGroupUpserter.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/huaweicloud/HuaweiCloudSecurityGroupUpserter.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.huaweicloud;
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.MortService;
 import com.netflix.spinnaker.orca.clouddriver.tasks.securitygroup.SecurityGroupUpserter;
@@ -26,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import retrofit.RetrofitError;
 
 @Component
 public class HuaweiCloudSecurityGroupUpserter implements SecurityGroupUpserter, CloudProviderAware {
@@ -94,8 +94,8 @@ public class HuaweiCloudSecurityGroupUpserter implements SecurityGroupUpserter, 
               upsertedSecurityGroup.getRegion());
 
       return securityGroup != null;
-    } catch (RetrofitError e) {
-      if (404 != e.getResponse().getStatus()) {
+    } catch (SpinnakerHttpException e) {
+      if (404 != e.getResponseCode()) {
         throw e;
       }
     }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/tencentcloud/TencentCloudSecurityGroupUpserter.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/tencentcloud/TencentCloudSecurityGroupUpserter.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.tencentcloud;
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.MortService;
 import com.netflix.spinnaker.orca.clouddriver.MortService.SecurityGroup;
@@ -29,8 +30,6 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import retrofit.RetrofitError;
-import retrofit.client.Response;
 
 @Slf4j
 @Component
@@ -78,9 +77,8 @@ public class TencentCloudSecurityGroupUpserter
               upsertedSecurityGroup.getVpcId());
 
       return upsertedSecurityGroup.getName().equals(securityGroup.getName());
-    } catch (RetrofitError e) {
-      final Response response = e.getResponse();
-      if ((response == null ? null : response.getStatus()) != 404) {
+    } catch (SpinnakerHttpException e) {
+      if (e.getResponseCode() != 404) {
         throw e;
       }
     }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGenerator.java
@@ -21,6 +21,7 @@ import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPEL
 
 import com.netflix.frigga.Names;
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
@@ -31,7 +32,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import retrofit.RetrofitError;
 
 @Component
 public class SpinnakerMetadataServerGroupTagGenerator implements ServerGroupEntityTagGenerator {
@@ -177,8 +177,8 @@ public class SpinnakerMetadataServerGroupTagGenerator implements ServerGroupEnti
       }
 
       return previousServerGroup;
-    } catch (RetrofitError e) {
-      if (e.getKind() == RetrofitError.Kind.HTTP && e.getResponse().getStatus() == 404) {
+    } catch (SpinnakerHttpException e) {
+      if (e.getResponseCode() == 404) {
         // it's ok if the previous server group does not exist
         return null;
       }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/CloudDriverServiceSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/CloudDriverServiceSpec.groovy
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.orca.clouddriver
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import retrofit.RetrofitError
 import retrofit.client.Response
@@ -32,12 +33,12 @@ class CloudDriverServiceSpec extends Specification {
         return new Response("http://clouddriver", statusCode, "OK", [], new TypedString("""{"name": "${serverGroupName}"}"""))
       }
 
-      throw RetrofitError.httpError(
+      throw new SpinnakerHttpException(RetrofitError.httpError(
           null,
           new Response("http://clouddriver", statusCode, "", [], null),
           null,
           null
-      )
+      ))
     }
 
     optionalTargetServerGroup.isPresent() == shouldExist

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.cluster
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.gson.Gson
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
@@ -214,7 +215,7 @@ class FindImageFromClusterTaskSpec extends Specification {
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse1
     findCalls * oortService.getServerGroupSummary("foo", "test", "foo-test", cloudProvider, location2.value,
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> {
-      throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), gsonConverter, Map)
+      throw new SpinnakerHttpException(RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), gsonConverter, Map))
     }
     findCalls * oortService.findImage(cloudProvider, "ami-012-name-ebs*", "test", null, null) >> imageSearchResult
     findCalls * regionCollector.getRegionsFromChildStages(stage) >> regionCollectorResponse
@@ -293,7 +294,7 @@ class FindImageFromClusterTaskSpec extends Specification {
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse1
     1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location2.value,
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> {
-      throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), gsonConverter, Map)
+      throw new SpinnakerHttpException(RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), gsonConverter, Map))
     }
     1 * oortService.findImage("cloudProvider", "ami-012-name-ebs*", "test", null, null) >> imageSearchResult
     assertNorth(result.outputs?.deploymentDetails?.find {
@@ -356,7 +357,7 @@ class FindImageFromClusterTaskSpec extends Specification {
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse1
     1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "aws", location2.value,
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> {
-      throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), gsonConverter, Map)
+      throw new SpinnakerHttpException(RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), gsonConverter, Map))
     }
     1 * oortService.findImage("aws", "ami-012-name-ebs*", "test", null, null) >> null
     1 * oortService.findImage("aws", "ami-012-name-ebs*", "bakery", null, null) >> imageSearchResult
@@ -420,7 +421,7 @@ class FindImageFromClusterTaskSpec extends Specification {
     then:
     1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location.value,
       "FAIL", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> {
-      throw RetrofitError.httpError("http://oort", response, gsonConverter, String.class)
+      throw new SpinnakerHttpException(RetrofitError.httpError("http://oort", response, gsonConverter, String.class))
     }
     IllegalStateException ise = thrown()
     ise.message == "Multiple possible server groups present in ${location.value}".toString()

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/FindImageFromClusterTaskSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.cluster
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.gson.Gson
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
@@ -24,6 +25,7 @@ import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.util.RegionCollector
 import retrofit.RetrofitError
 import retrofit.client.Response
+import retrofit.converter.GsonConverter
 import retrofit.mime.TypedString
 import spock.lang.Specification
 import spock.lang.Subject
@@ -31,6 +33,8 @@ import spock.lang.Unroll
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 
 class FindImageFromClusterTaskSpec extends Specification {
+
+  private static final GsonConverter gsonConverter = new GsonConverter(new Gson())
 
   @Subject
   task = new FindImageFromClusterTask()
@@ -210,7 +214,7 @@ class FindImageFromClusterTaskSpec extends Specification {
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse1
     findCalls * oortService.getServerGroupSummary("foo", "test", "foo-test", cloudProvider, location2.value,
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> {
-      throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), null, Map)
+      throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), gsonConverter, Map)
     }
     findCalls * oortService.findImage(cloudProvider, "ami-012-name-ebs*", "test", null, null) >> imageSearchResult
     findCalls * regionCollector.getRegionsFromChildStages(stage) >> regionCollectorResponse
@@ -289,7 +293,7 @@ class FindImageFromClusterTaskSpec extends Specification {
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse1
     1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location2.value,
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> {
-      throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), null, Map)
+      throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), gsonConverter, Map)
     }
     1 * oortService.findImage("cloudProvider", "ami-012-name-ebs*", "test", null, null) >> imageSearchResult
     assertNorth(result.outputs?.deploymentDetails?.find {
@@ -352,7 +356,7 @@ class FindImageFromClusterTaskSpec extends Specification {
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> oortResponse1
     1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "aws", location2.value,
       "LARGEST", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> {
-      throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), null, Map)
+      throw RetrofitError.httpError("http://clouddriver", new Response("http://clouddriver", 404, 'Not Found', [], new TypedString("{}")), gsonConverter, Map)
     }
     1 * oortService.findImage("aws", "ami-012-name-ebs*", "test", null, null) >> null
     1 * oortService.findImage("aws", "ami-012-name-ebs*", "bakery", null, null) >> imageSearchResult
@@ -416,7 +420,7 @@ class FindImageFromClusterTaskSpec extends Specification {
     then:
     1 * oortService.getServerGroupSummary("foo", "test", "foo-test", "cloudProvider", location.value,
       "FAIL", FindImageFromClusterTask.SUMMARY_TYPE, false.toString()) >> {
-      throw new RetrofitError(null, null, response, null, null, null, null)
+      throw RetrofitError.httpError("http://oort", response, gsonConverter, String.class)
     }
     IllegalStateException ise = thrown()
     ise.message == "Multiple possible server groups present in ${location.value}".toString()

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterShrinkTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterShrinkTaskSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.cluster
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
@@ -135,7 +136,7 @@ class WaitForClusterShrinkTaskSpec extends Specification {
     ])
 
     and:
-    oortService.getCluster(*_) >> { throw httpError("http://cloudriver", emptyClusterResponse(), null, null) }
+    oortService.getCluster(*_) >> { throw new SpinnakerHttpException(httpError("http://cloudriver", emptyClusterResponse(), null, null)) }
 
     when:
     def result = task.execute(stage)

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/instance/AbstractInstancesCheckTaskSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.instance
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
@@ -227,12 +228,12 @@ ModelUtils.serverGroup([
         return new ServerGroup("name": serverGroupName)
       }
 
-      throw RetrofitError.httpError(
+      throw new SpinnakerHttpException(RetrofitError.httpError(
         null,
         new Response("http://clouddriver", statusCode, "", [], null),
         null,
         null
-      )
+      ))
     }
 
     serverGroups.size() == expectedServerGroupCount

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonSecurityGroupUpserterSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/AmazonSecurityGroupUpserterSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.clouddriver.MortService
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
@@ -39,6 +40,9 @@ class AmazonSecurityGroupUpserterSpec extends Specification {
 
   @Shared
   def error404 = RetrofitError.httpError(null, new Response("", HTTP_NOT_FOUND, "Not Found", [], null), null, null)
+
+  @Shared
+  def notFoundException = new SpinnakerHttpException(error404)
 
   def "should throw exception on missing region"() {
     given:
@@ -116,7 +120,7 @@ class AmazonSecurityGroupUpserterSpec extends Specification {
     where:
       expectedSecurityGroup                 | currentSecurityGroupProvider              || isUpdated
       null                                  | { bSG(bIR("S1", 7000)) }                  || false
-      bSG(bIR("S2", 7000))                  | { throw error404 }                        || false
+      bSG(bIR("S2", 7000))                  | { throw notFoundException }               || false
       bSG(bIR("S2", 7000))                  | { bSG(bIR("S1", 7000)) }                  || false
       bSG(bIR("S1", 7000, 7001))            | { bSG(bIR("S1", 7000)) }                  || false
       bSG(bIR("S1", 7000), bIR("S2", 7001)) | { bSG(bIR("S1", 7000)) }                  || false

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTaskSpec.groovy
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.cloudformation
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
@@ -114,7 +115,7 @@ class WaitForCloudFormationCompletionTaskSpec extends Specification {
       'kato.tasks': [[resultObjects: [[stackId: 'stackId']]]]
     ]
     def stage = new StageExecutionImpl(pipeline, 'test', 'test', context)
-    def error404 = RetrofitError.httpError("url", new Response("url", 404, "reason", [], null), null, null)
+    def error404 = new SpinnakerHttpException(RetrofitError.httpError("url", new Response("url", 404, "reason", [], null), null, null))
 
     when:
     def result = waitForCloudFormationCompletionTask.execute(stage)

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleSecurityGroupUpserterSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/gce/GoogleSecurityGroupUpserterSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.providers.gce
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.clouddriver.MortService
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
@@ -103,7 +104,7 @@ class GoogleSecurityGroupUpserterSpec extends Specification {
 
     then:
       1 * mortService.getSecurityGroup("abc", "gce", "test-security-group", "global") >> {
-        throw RetrofitError.httpError("/", new Response("", 404, "", [], null), null, null)
+        throw new SpinnakerHttpException(RetrofitError.httpError("/", new Response("", 404, "", [], null), null, null))
       }
     !result
 
@@ -112,9 +113,9 @@ class GoogleSecurityGroupUpserterSpec extends Specification {
 
     then:
       1 * mortService.getSecurityGroup("abc", "gce", "test-security-group", "global") >> {
-        throw RetrofitError.httpError("/", new Response("", 400, "", [], null), null, null)
+        throw new SpinnakerHttpException(RetrofitError.httpError("/", new Response("", 400, "", [], null), null, null))
       }
-      thrown(RetrofitError)
+      thrown(SpinnakerHttpException)
   }
 
   @Unroll

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGeneratorSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/SpinnakerMetadataServerGroupTagGeneratorSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup
 
 import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import retrofit.RetrofitError
 import retrofit.client.Response
@@ -43,12 +44,12 @@ class SpinnakerMetadataServerGroupTagGeneratorSpec extends Specification {
   }
 
   @Shared
-  def notFoundError = RetrofitError.httpError(
+  def notFoundError = new SpinnakerHttpException(RetrofitError.httpError(
     null,
     new Response("http://google.com", HTTP_NOT_FOUND, "Not Found", [], null),
     null,
     null
-  )
+  ))
 
 //  @Unroll
 //  def "should build spinnaker:metadata tag for pipeline"() {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolverSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolverSpec.groovy
@@ -105,7 +105,6 @@ class SourceResolverSpec extends Specification {
     }
 
     SourceResolver resolver = new SourceResolver(
-      oortService: oort,
       mapper: mapper,
       resolver: new TargetServerGroupResolver(oortService: oort, mapper: mapper, retrySupport: retrySupport)
     )
@@ -153,7 +152,6 @@ class SourceResolverSpec extends Specification {
     }
 
     SourceResolver resolver = new SourceResolver(
-      oortService: oort,
       mapper: mapper,
       resolver: new TargetServerGroupResolver(oortService: oort, mapper: mapper, retrySupport: retrySupport)
     )

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceSupportSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/TargetReferenceSupportSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.kato.pipeline.support
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
 import com.netflix.spinnaker.orca.clouddriver.ModelUtils
 import com.netflix.spinnaker.orca.clouddriver.model.Cluster
@@ -270,12 +271,12 @@ class TargetReferenceSupportSpec extends Specification {
 
     then:
     1 * cloudDriverService.getCluster("kato", "prod", "kato-main", "aws") >> {
-      throw new RetrofitError(null, null, new Response("http://clouddriver", 404, "null", [], null), null, null, null, null)
+      throw new SpinnakerHttpException(new RetrofitError(null, null, new Response("http://clouddriver", 404, "null", [], null), null, null, null, null))
     }
     thrown TargetReferenceNotFoundException
   }
 
-  void "should throw RetrofitError when status is not 404"() {
+  void "should throw SpinnakerHttpException when status is not 404"() {
     setup:
     def config = [
       regions    : ["us-west-1", "us-east-1"],
@@ -289,8 +290,8 @@ class TargetReferenceSupportSpec extends Specification {
 
     then:
     1 * cloudDriverService.getCluster("kato", "prod", "kato-main", "aws") >> {
-      throw new RetrofitError(null, null, new Response("http://clouddriver", 429, "null", [], null), null, null, null, null)
+      throw new SpinnakerHttpException(new RetrofitError(null, null, new Response("http://clouddriver", 429, "null", [], null), null, null, null, null))
     }
-    thrown RetrofitError
+    thrown SpinnakerHttpException
   }
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDestroyedAsgTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDestroyedAsgTaskSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.kato.tasks
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.gson.Gson
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForDestroyedServerGroupTask
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
@@ -49,12 +50,12 @@ class WaitForDestroyedAsgTaskSpec extends Specification {
     task.oortService = Mock(OortService) {
       1 * getCluster(*_) >> {
         if (status >= 400) {
-          throw RetrofitError.httpError(
+          throw new SpinnakerHttpException(RetrofitError.httpError(
             null,
             new Response("http://...", status, "...", [], null),
             gsonConverter,
             null
-          )
+          ))
         }
         new Response('..', status, 'ok', [], new TypedString(
           objectMapper.writeValueAsString(body)

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDestroyedAsgTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/kato/tasks/WaitForDestroyedAsgTaskSpec.groovy
@@ -17,12 +17,14 @@
 package com.netflix.spinnaker.orca.kato.tasks
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.gson.Gson
 import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForDestroyedServerGroupTask
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import retrofit.RetrofitError
 import retrofit.client.Response
+import retrofit.converter.GsonConverter
 import retrofit.mime.TypedString
 import spock.lang.Shared
 import spock.lang.Specification
@@ -32,6 +34,9 @@ import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.RUN
 import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.SUCCEEDED
 
 class WaitForDestroyedAsgTaskSpec extends Specification {
+
+  private static final GsonConverter gsonConverter = new GsonConverter(new Gson())
+
   @Subject
   def task = new WaitForDestroyedServerGroupTask()
 
@@ -47,7 +52,7 @@ class WaitForDestroyedAsgTaskSpec extends Specification {
           throw RetrofitError.httpError(
             null,
             new Response("http://...", status, "...", [], null),
-            null,
+            gsonConverter,
             null
           )
         }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/tasks/image/MonitorDeleteImageTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/tasks/image/MonitorDeleteImageTaskSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.tasks.image
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
 import com.netflix.spinnaker.orca.clouddriver.OortService
@@ -69,11 +70,11 @@ class MonitorDeleteImageTaskSpec extends Specification {
   }
 
   private void error(int status) {
-    throw RetrofitError.httpError(
+    throw new SpinnakerHttpException(RetrofitError.httpError(
       null,
       new Response("http://...", status, "...", [], null),
       null,
       null
-    )
+    ))
   }
 }

--- a/orca-igor/orca-igor.gradle
+++ b/orca-igor/orca-igor.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation(project(":orca-clouddriver"))
   implementation(project(":orca-front50"))
   implementation("io.spinnaker.kork:kork-core")
+  implementation("io.spinnaker.kork:kork-retrofit")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("org.yaml:snakeyaml")
 

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
@@ -123,23 +123,33 @@ class GetCommitsTask implements DiffTask {
     } catch (RetrofitError e) {
       if (e.kind == RetrofitError.Kind.UNEXPECTED) {
         // give up on internal errors
-        log.warn("internal error while talking to igor : [repoType: ${repoInfo?.repoType} projectKey:${repoInfo?.projectKey} repositorySlug:${repoInfo?.repositorySlug} sourceCommit:$sourceInfo targetCommit: $targetInfo]", e)
-        return TaskResult.builder(ExecutionStatus.SUCCEEDED).context([commits: []]).build()
+        return giveUpOnException(repoInfo, sourceInfo, targetInfo, e)
       } else if (e.response?.status == 404) {
         // just give up on 404
-        log.warn("got a 404 from igor for : [repoType: ${repoInfo?.repoType} projectKey:${repoInfo?.projectKey} repositorySlug:${repoInfo?.repositorySlug} sourceCommit:${sourceInfo} targetCommit: ${targetInfo}]", e)
-        return TaskResult.builder(ExecutionStatus.SUCCEEDED).context([commits: []]).build()
+        return handle404(repoInfo, sourceInfo, targetInfo, e)
       } else { // retry on other status codes
-        log.warn("retrofit error (${e.message}) for : [repoType: ${repoInfo?.repoType} projectKey:${repoInfo?.projectKey} repositorySlug:${repoInfo?.repositorySlug} sourceCommit:${sourceInfo} targetCommit: ${targetInfo}], retrying", e)
-        return TaskResult.builder(ExecutionStatus.RUNNING).context([getCommitsRetriesRemaining: retriesRemaining - 1]).build()
+        return retryOnException("retrofit error (${e.message})", repoInfo, sourceInfo, targetInfo, retriesRemaining, e)
       }
     } catch (Exception f) { // retry on everything else
-      log.warn("unexpected exception for : [repoType: ${repoInfo?.repoType} projectKey:${repoInfo?.projectKey} repositorySlug:${repoInfo?.repositorySlug} sourceCommit:${sourceInfo} targetCommit: ${targetInfo}], retrying", f)
-      return TaskResult.builder(ExecutionStatus.RUNNING).context([getCommitsRetriesRemaining: retriesRemaining - 1]).build()
+      return retryOnException("unexpected exception", repoInfo, sourceInfo, targetInfo, retriesRemaining, f)
     } catch (Throwable g) {
-      log.warn("unexpected throwable for : [repoType: ${repoInfo?.repoType} projectKey:${repoInfo?.projectKey} repositorySlug:${repoInfo?.repositorySlug} sourceCommit:${sourceInfo} targetCommit: ${targetInfo}], retrying", g)
-      return TaskResult.builder(ExecutionStatus.RUNNING).context([getCommitsRetriesRemaining: retriesRemaining - 1]).build()
+      return retryOnException("unexpected throwable", repoInfo, sourceInfo, targetInfo, retriesRemaining, g)
     }
+  }
+
+  TaskResult giveUpOnException(Map repoInfo, Map sourceInfo, Map targetInfo, Exception e) {
+    log.warn("internal error while talking to igor : [repoType: ${repoInfo?.repoType} projectKey:${repoInfo?.projectKey} repositorySlug:${repoInfo?.repositorySlug} sourceCommit:$sourceInfo targetCommit: $targetInfo]", e)
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context([commits: []]).build()
+  }
+
+  TaskResult handle404(Map repoInfo, Map sourceInfo, Map targetInfo, Exception e) {
+    log.warn("got a 404 from igor for : [repoType: ${repoInfo?.repoType} projectKey:${repoInfo?.projectKey} repositorySlug:${repoInfo?.repositorySlug} sourceCommit:${sourceInfo} targetCommit: ${targetInfo}]", e)
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context([commits: []]).build()
+  }
+
+  TaskResult retryOnException(String description, Map repoInfo, Map sourceInfo, Map targetInfo, int retriesRemaining, Throwable t) {
+      log.warn("$description for : [repoType: ${repoInfo?.repoType} projectKey:${repoInfo?.projectKey} repositorySlug:${repoInfo?.repositorySlug} sourceCommit:${sourceInfo} targetCommit: ${targetInfo}], retrying", t)
+      return TaskResult.builder(ExecutionStatus.RUNNING).context([getCommitsRetriesRemaining: retriesRemaining - 1]).build()
   }
 
   List getCommitsList(String repoType, String projectKey, String repositorySlug, String sourceCommit, String targetCommit) {

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
@@ -402,14 +402,14 @@ class GetCommitsTaskSpec extends Specification {
     1 * cloudDriverService.getServerGroupFromCluster(app, account, cluster, serverGroup, region, "aws") >> response
 
     1 * cloudDriverService.getByAmiId("aws", account, region, sourceImage) >> {
-      if (sourceThrowRetrofitError) {
+      if (sourceThrowException) {
         throw new RetrofitError(null, null, new Response("http://stash.com", 404, "test reason", [], null), null, null, null, null)
       }
       return sourceResponse
     }
 
-    (sourceThrowRetrofitError ? 0 : 1) * cloudDriverService.getByAmiId("aws", account, region, targetImage) >> {
-      if (targetThrowRetrofitError) {
+    (sourceThrowException ? 0 : 1) * cloudDriverService.getByAmiId("aws", account, region, targetImage) >> {
+      if (targetThrowException) {
         throw new RetrofitError(null, null, new Response("http://stash.com", 404, "test reason", [], null), null, null, null, null)
       }
       return targetResponse
@@ -432,9 +432,9 @@ class GetCommitsTaskSpec extends Specification {
     jobState = 'SUCCESS'
     taskStatus = SUCCEEDED
 
-    cluster | serverGroup | targetServerGroup | sourceThrowRetrofitError | targetThrowRetrofitError
-    "myapp" | "myapp" | "myapp-v000" | true | false
-    "myapp" | "myapp" | "myapp-v000" | false | true
+    cluster | serverGroup | targetServerGroup | sourceThrowException | targetThrowException
+    "myapp" | "myapp"     | "myapp-v000"      | true                 | false
+    "myapp" | "myapp"     | "myapp-v000"      | false                | true
   }
 
   def "igor service 404 results in success"() {

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.igor.tasks
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
@@ -403,14 +404,14 @@ class GetCommitsTaskSpec extends Specification {
 
     1 * cloudDriverService.getByAmiId("aws", account, region, sourceImage) >> {
       if (sourceThrowException) {
-        throw new RetrofitError(null, null, new Response("http://stash.com", 404, "test reason", [], null), null, null, null, null)
+        throw new SpinnakerHttpException(new RetrofitError(null, null, new Response("http://stash.com", 404, "test reason", [], null), null, null, null, null))
       }
       return sourceResponse
     }
 
     (sourceThrowException ? 0 : 1) * cloudDriverService.getByAmiId("aws", account, region, targetImage) >> {
       if (targetThrowException) {
-        throw new RetrofitError(null, null, new Response("http://stash.com", 404, "test reason", [], null), null, null, null, null)
+        throw new SpinnakerHttpException(new RetrofitError(null, null, new Response("http://stash.com", 404, "test reason", [], null), null, null, null, null))
       }
       return targetResponse
     }


### PR DESCRIPTION
to improve the behavior of RetrySupport, to improve error messages in the UI, and to pave
the way to move to retrofit2 by reducing dependencies on retrofit1 classes
(e.g. RetrofitError).  The main consequence of this is that code that previously checked
for RetrofitError now checks for Spinnaker*Exception.

Specifically, the beans for these classes now use SpinnakerRetrofitErrorHandler:

* KatoRestService
* FeaturesRestService
* MortService
* CloudDriverCacheStatusService
* OortService
* CloudDriverTaskStatusService

and then as well

* KatoService since it wraps KatoRestService
* CloudDriverService since it wraps OortService

There are a bunch of refactor commits that could be in their own PR, but they're connected enough with the exception handling changes that I kept them here.  All the individual commits to keep up with the addition of SpinnakerRetrofitErrorHandler could all be together in one, but it seemed easier to make incremental progress as I was doing it to commit each change.