### PR TITLE
refactor(retrofit): use SpinnakerRetrofitErrorHandler as a step towards simplifying exception handling

### DIFF
--- a/orca-bakery/orca-bakery.gradle
+++ b/orca-bakery/orca-bakery.gradle
@@ -26,6 +26,7 @@ dependencies {
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava")
   implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
   implementation("org.codehaus.groovy:groovy-datetime")
+  implementation("io.spinnaker.kork:kork-retrofit")
 
   api("io.spinnaker.kork:kork-web")
 

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfiguration.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfiguration.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.bakery.config
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
 import com.netflix.spinnaker.orca.bakery.BakerySelector
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -80,6 +81,7 @@ class BakeryConfiguration {
       .setClient(retrofitClient)
       .setLogLevel(retrofitLogLevel)
       .setLog(new RetrofitSlf4jLog(BakeryService))
+      .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .build()
       .create(BakeryService)
   }

--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryServiceSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryServiceSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.bakery.api
 
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.bakery.config.BakeryConfiguration
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import retrofit.RequestInterceptor
@@ -105,6 +106,7 @@ class BakeryServiceSpec extends Specification {
         .willReturn(
         aResponse()
           .withStatus(HTTP_NOT_FOUND)
+          .withBody("{\"message\": \"error\"}")
       )
     )
 
@@ -112,7 +114,7 @@ class BakeryServiceSpec extends Specification {
     bakery.lookupStatus(region, statusId)
 
     then:
-    def ex = thrown(RetrofitError)
+    def ex = thrown(SpinnakerHttpException)
     ex.response.status == HTTP_NOT_FOUND
   }
 


### PR DESCRIPTION
- add SpinnakerRetrofitErrorHandler while creating BakeryService
- add retry support to createBake() method in CreateBakeTask
- add retry support to bakeManifest() method in CreateBakeManifestTask

