### PR TITLE
chore(dependency): add explicit dependency of groovy-json in orca-web and orca-webhook during upgrade of groovy 3.x

### DIFF
--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -92,6 +92,7 @@ dependencies {
   testImplementation("dev.minutest:minutest")
   testImplementation("io.strikt:strikt-core")
   testImplementation("io.mockk:mockk")
+  testImplementation("org.codehaus.groovy:groovy-json")
 }
 
 test {

--- a/orca-webhook/orca-webhook.gradle
+++ b/orca-webhook/orca-webhook.gradle
@@ -30,6 +30,7 @@ dependencies {
   implementation("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
 //  testImplementation project(':orca-test')
   testImplementation("org.springframework:spring-test")
+  testImplementation("org.codehaus.groovy:groovy-json")
 
   implementation("io.spinnaker.fiat:fiat-api:$fiatVersion")
   implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, groovy-json is not part of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/2.0-groovy-3.0) and encounter below error during test compilation:
```
startup failed:
/orca/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy: 45: unable to resolve class groovy.json.JsonSlurper
 @ line 45, column 1.
   import groovy.json.JsonSlurper
   ^
/orca/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy: 32: unable to resolve class groovy.json.JsonSlurper
 @ line 32, column 1.
   import groovy.json.JsonSlurper
   ^
2 errors
> Task :orca-web:compileTestGroovy FAILED

```

```
> Task :orca-webhook:compileTestGroovy FAILED
startup failed:
/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStageSpec.groovy: 27: unable to resolve class groovy.json.JsonOutput
 @ line 27, column 1.
   import groovy.json.JsonOutput
   ^
1 error
FAILURE: Build failed with an exception.

```
So, adding explicit dependency of groovy-json in orca-web.gradle and orca-webhook.gradle

With groovy 2.5.15 and spockframework 1.3-groovy-2.5, groovy-json appear as transitive dependency of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/1.3-groovy-2.5) as shown below:
```
$ ./gradlew orca-web:dI --dependency groovy-json --configuration testCompileClasspath

> Task :orca-web:dependencyInsight
org.codehaus.groovy:groovy-json:2.5.15
  Variant compile:
    | Attribute Name                     | Provided | Requested         |
    |------------------------------------|----------|-------------------|
    | org.gradle.status                  | release  |                   |
    | org.gradle.category                | library  | library           |
    | org.gradle.libraryelements         | jar      | classes+resources |
    | org.gradle.usage                   | java-api | java-api          |
    | org.gradle.dependency.bundling     |          | external          |
    | org.gradle.jvm.environment         |          | standard-jvm      |
    | org.gradle.jvm.version             |          | 11                |
    | org.jetbrains.kotlin.platform.type |          | jvm               |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy-json:2.5.15
\--- io.spinnaker.kork:kork-bom:7.190.0
     \--- testCompileClasspath

org.codehaus.groovy:groovy-json:2.5.4 -> 2.5.15
+--- org.spockframework:spock-core:1.3-groovy-2.5
|    +--- testCompileClasspath (requested org.spockframework:spock-core)
|    +--- io.spinnaker.kork:kork-bom:7.190.0
|    |    \--- testCompileClasspath
|    \--- org.spockframework:spock-spring:1.3-groovy-2.5
|         +--- testCompileClasspath (requested org.spockframework:spock-spring)
|         \--- io.spinnaker.kork:kork-bom:7.190.0 (*)
\--- org.spockframework:spock-spring:1.3-groovy-2.5 (*)

```

```
$ ./gradlew orca-webhook:dI --dependency groovy-json --configuration testCompileClasspath

> Task :orca-webhook:dependencyInsight
org.codehaus.groovy:groovy-json:2.5.15
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy-json:2.5.15
\--- io.spinnaker.kork:kork-bom:7.190.0
     \--- testCompileClasspath

org.codehaus.groovy:groovy-json:2.5.4 -> 2.5.15
\--- org.spockframework:spock-core:1.3-groovy-2.5
     +--- testCompileClasspath (requested org.spockframework:spock-core)
     \--- io.spinnaker.kork:kork-bom:7.190.0
          \--- testCompileClasspath

```