### PR TITLE
refactor(cloudriver): fix enum constructor modifier as private during upgrade to groovy 3.x

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTask.groovy
@@ -153,7 +153,7 @@ class ClusterSizePreconditionTask implements CloudProviderAware, RetryableTask, 
     private final String value
     private final Closure<Boolean> closure
 
-    public Operator(String value, Closure<Boolean> closure) {
+    private Operator(String value, Closure<Boolean> closure) {
       this.value = value
       this.closure = closure
     }


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encountered the below error:
```
> Task :orca-clouddriver:compileGroovy FAILED
startup failed:
/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ClusterSizePreconditionTask.groovy: 156: Illegal modifier for the enum constructor; only private is permitted.
 @ line 156, column 5.
       public Operator(String value, Closure<Boolean> closure) {
       ^
1 error
FAILURE: Build failed with an exception.
```
To fix this issue replaced the public modifier to private in ClusterSizePreconditionTask.groovy

For reference https://stackoverflow.com/questions/7113363/private-enum-constructor