### PR TITLE
refactor(flex/test): fix conflict of variable scope by renaming local variables during upgrade of groovy 3.x

### DIFF
--- a/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/AssociateElasticIpTaskSpec.groovy
+++ b/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/AssociateElasticIpTaskSpec.groovy
@@ -27,7 +27,7 @@ class AssociateElasticIpTaskSpec extends Specification {
   def "should delegate Elastic Ip association to `flexService` and include result in outputs"() {
     given:
     def flexService = Mock(FlexService) {
-      1 * associateElasticIp(application, account, cluster, region, _) >> { application, account, cluster, region, elasticIp ->
+      1 * associateElasticIp(application, account, cluster, region, _) >> { application_local, account_local, cluster_local, region_local, elasticIp ->
         assert elasticIp.type == elasticIpType
         assert elasticIp.address == elasticIpAddress
         return elasticIpResult


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encountered the following errors in groovy test compilation of orca-flex module:
```
> Task :orca-flex:compileTestGroovy FAILED
startup failed:
/orca/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/AssociateElasticIpTaskSpec.groovy: 30: The current scope already contains a variable of the name application
 @ line 30, column 75.
   count, cluster, region, _) >> { applicat
                                 ^
/orca/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/AssociateElasticIpTaskSpec.groovy: 30: The current scope already contains a variable of the name account
 @ line 30, column 75.
   count, cluster, region, _) >> { applicat
                                 ^
/orca/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/AssociateElasticIpTaskSpec.groovy: 30: The current scope already contains a variable of the name cluster
 @ line 30, column 75.
   count, cluster, region, _) >> { applicat
                                 ^
/orca/orca-flex/src/test/groovy/com/netflix/spinnaker/orca/flex/tasks/AssociateElasticIpTaskSpec.groovy: 30: The current scope already contains a variable of the name region
 @ line 30, column 75.
   count, cluster, region, _) >> { applicat
                                 ^
4 errors
FAILURE: Build failed with an exception.
```
To fix this issue renamed the local variables to avoid the scope confilct with global variables.
