### PR TITLE
refactor(clouddriver): fix scope resolution of static method explictly calling by class name during upgrade to groovy 3.x

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/loadbalancer/UpsertLoadBalancerStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/loadbalancer/UpsertLoadBalancerStage.groovy
@@ -31,8 +31,7 @@ import javax.annotation.Nonnull
 @Component
 @CompileStatic
 class UpsertLoadBalancerStage implements StageDefinitionBuilder {
-  public static
-  final String PIPELINE_CONFIG_TYPE = getType(UpsertLoadBalancerStage)
+  public static final String PIPELINE_CONFIG_TYPE = StageDefinitionBuilder.getType(UpsertLoadBalancerStage)
 
   @Override
   void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.scalingprocess.ResumeAwsScalingProcessTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.scalingprocess.SuspendAwsScalingProcessTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
@@ -38,7 +39,7 @@ import org.springframework.stereotype.Component
 @CompileStatic
 class ModifyAwsScalingProcessStage extends TargetServerGroupLinearStageSupport implements ForceCacheRefreshAware {
 
-  public static final String TYPE = getType(ModifyAwsScalingProcessStage)
+  public static final String TYPE = StageDefinitionBuilder.getType(ModifyAwsScalingProcessStage)
 
   private final DynamicConfigService dynamicConfigService
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/DetermineTargetServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/DetermineTargetServerGroupStage.groovy
@@ -29,7 +29,7 @@ import javax.annotation.Nonnull
 @CompileStatic
 class DetermineTargetServerGroupStage implements StageDefinitionBuilder {
   public static
-  final String PIPELINE_CONFIG_TYPE = getType(DetermineTargetServerGroupStage)
+  final String PIPELINE_CONFIG_TYPE = StageDefinitionBuilder.getType(DetermineTargetServerGroupStage)
 
   @Override
   void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/DetermineTargetReferenceStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/DetermineTargetReferenceStage.groovy
@@ -30,7 +30,7 @@ import javax.annotation.Nonnull
 @Deprecated
 class DetermineTargetReferenceStage implements StageDefinitionBuilder {
   public static
-  final String PIPELINE_CONFIG_TYPE = getType(DetermineTargetReferenceStage)
+  final String PIPELINE_CONFIG_TYPE = StageDefinitionBuilder.getType(DetermineTargetReferenceStage)
 
   @Override
   void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encountered the following errors in orca-clouddriver module:
```
> Task :orca-clouddriver:compileGroovy
startup failed:
/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/loadbalancer/UpsertLoadBalancerStage.groovy: 35: [Static type checking] - Cannot find matching method com.netflix.spinnaker.orca.clouddriver.pipeline.loadbalancer.UpsertLoadBalancerStage#getType(java.lang.Class <com.netflix.spinnaker.orca.clouddriver.pipeline.loadbalancer.UpsertLoadBalancerStage>). Please check if the declared type is correct and if the method exists.
 @ line 35, column 39.
     final String PIPELINE_CONFIG_TYPE = getType(UpsertLoadBalancerStage)
                                         ^

1 error

> Task :orca-clouddriver:compileGroovy FAILED
```

```
> Task :orca-clouddriver:compileGroovy
startup failed:
/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/ModifyAwsScalingProcessStage.groovy: 41: [Static type checking] - Cannot find matching method com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ModifyAwsScalingProcessStage#getType(java.lang.Class <com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ModifyAwsScalingProcessStage>). Please check if the declared type is correct and if the method exists.
 @ line 41, column 37.
     public static final String TYPE = getType(ModifyAwsScalingProcessStage)
                                       ^

1 error

> Task :orca-clouddriver:compileGroovy FAILED
```

```
startup failed:
/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/DetermineTargetServerGroupStage.groovy: 32: [Static type checking] - Cannot find matching method com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.DetermineTargetServerGroupStage#getType(java.lang.Class <com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.DetermineTargetServerGroupStage>). Please check if the declared type is correct and if the method exists.
 @ line 32, column 39.
     final String PIPELINE_CONFIG_TYPE = getType(DetermineTargetServerGroupStage)
                                         ^

1 error

> Task :orca-clouddriver:compileGroovy FAILED
```

```
startup failed:
/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/DetermineTargetReferenceStage.groovy: 33: [Static type checking] - Cannot find matching method com.netflix.spinnaker.orca.kato.pipeline.DetermineTargetReferenceStage#getType(java.lang.Class <com.netflix.spinnaker.orca.kato.pipeline.DetermineTargetReferenceStage>). Please check if the declared type is correct and if the method exists.
 @ line 33, column 39.
     final String PIPELINE_CONFIG_TYPE = getType(DetermineTargetReferenceStage)
                                         ^

1 error

> Task :orca-clouddriver:compileGroovy FAILED
```
To fix this issue explicitly called the static function with class name.