### PR TITLE
refactor(core/test): fix cardinality issue by replacing Stub to Mock during upgrade to groovy 3.x

### DIFF
--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtilsSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtilsSpec.groovy
@@ -42,7 +42,7 @@ class ArtifactUtilsSpec extends Specification {
     return criteria
   }()
 
-  def executionRepository = Stub(ExecutionRepository) {
+  def executionRepository = Mock(ExecutionRepository) {
     // only a call to retrievePipelinesForPipelineConfigId() with these argument values is expected
     retrievePipelinesForPipelineConfigId(pipelineId, expectedExecutionCriteria) >> Observable.empty()
     // any other interaction is unexpected
@@ -336,7 +336,7 @@ class ArtifactUtilsSpec extends Specification {
     def executionTerminalCriteria = new ExecutionRepository.ExecutionCriteria()
     executionTerminalCriteria.setStatuses(ExecutionStatus.TERMINAL)
 
-    def executionRepositoryStub = Stub(ExecutionRepository) {
+    def executionRepositoryStub = Mock(ExecutionRepository) {
       // only a call to retrievePipelinesForPipelineConfigId() with these argument values is expected
       retrievePipelinesForPipelineConfigId(pipelineId, executionCriteria) >> Observable.just(execution)
       retrievePipelinesForPipelineConfigId(pipelineId, executionTerminalCriteria) >> Observable.empty()
@@ -375,7 +375,7 @@ class ArtifactUtilsSpec extends Specification {
     }
     execution.trigger = new DefaultTrigger("webhook", null, "user", [:], [Artifact.builder().type("trigger").build()])
 
-    def executionRepositoryStub = Stub(ExecutionRepository) {
+    def executionRepositoryStub = Mock(ExecutionRepository) {
       // only a call to retrievePipelinesForPipelineConfigId() with these argument values is expected
       retrievePipelinesForPipelineConfigId(pipelineId, expectedExecutionCriteria) >> Observable.just(execution)
       // any other interaction is unexpected


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encountered the following errors in groovy test orca-core module:
```
Stub 'executionRepository' matches the following required interaction:

0 * _   (0 invocations)

Remove the cardinality (e.g. '1 *'), or turn the stub into a mock.

org.spockframework.runtime.InvalidSpecException: Stub 'executionRepository' matches the following required interaction:

0 * _   (0 invocations)

Remove the cardinality (e.g. '1 *'), or turn the stub into a mock.

	at app//org.spockframework.mock.constraint.TargetConstraint.setInteraction(TargetConstraint.java:57)
	at app//org.spockframework.mock.runtime.MockInteraction.<init>(MockInteraction.java:53)
	at app//org.spockframework.mock.runtime.InteractionBuilder.build(InteractionBuilder.java:187)
	at com.netflix.spinnaker.orca.pipeline.util.ArtifactUtilsSpec.$spock_initializeFields_closure2(ArtifactUtilsSpec.groovy:49)
	at app//groovy.lang.Closure.call(Closure.java:412)
	at app//org.spockframework.lang.SpecInternals.createMock(SpecInternals.java:50)
	at app//org.spockframework.lang.SpecInternals.createMockImpl(SpecInternals.java:302)
	at app//org.spockframework.lang.SpecInternals.createMockImpl(SpecInternals.java:292)
	at app//org.spockframework.lang.SpecInternals.StubImpl(SpecInternals.java:137)
	at app//com.netflix.spinnaker.orca.pipeline.util.ArtifactUtilsSpec.$spock_initializeFields(ArtifactUtilsSpec.groovy:45)
```

```
ArtifactUtilsSpec > should find artifacts from a specific pipeline FAILED
    org.spockframework.runtime.InvalidSpecException: Stub 'executionRepositoryStub' matches the following required interaction:
    0 * _   (0 invocations)
    Remove the cardinality (e.g. '1 *'), or turn the stub into a mock.
        at app//org.spockframework.mock.constraint.TargetConstraint.setInteraction(TargetConstraint.java:57)
        at app//org.spockframework.mock.runtime.MockInteraction.<init>(MockInteraction.java:53)
        at app//org.spockframework.mock.runtime.InteractionBuilder.build(InteractionBuilder.java:187)
        at com.netflix.spinnaker.orca.pipeline.util.ArtifactUtilsSpec.should find artifacts from a specific pipeline_closure25(ArtifactUtilsSpec.groovy:344)
        at app//groovy.lang.Closure.call(Closure.java:412)
        at app//org.spockframework.lang.SpecInternals.createMock(SpecInternals.java:50)
        at app//org.spockframework.lang.SpecInternals.createMockImpl(SpecInternals.java:302)
        at app//org.spockframework.lang.SpecInternals.createMockImpl(SpecInternals.java:292)
        at app//org.spockframework.lang.SpecInternals.StubImpl(SpecInternals.java:137)
        at com.netflix.spinnaker.orca.pipeline.util.ArtifactUtilsSpec.should find artifacts from a specific pipeline(ArtifactUtilsSpec.groovy:339)
1 test completed, 1 failed
> Task :orca-core:test FAILED
```

```
ArtifactUtilsSpec > should find artifacts without a specific stage ref FAILED
    org.spockframework.runtime.InvalidSpecException: Stub 'executionRepositoryStub' matches the following required interaction:
    0 * _   (0 invocations)
    Remove the cardinality (e.g. '1 *'), or turn the stub into a mock.
        at app//org.spockframework.mock.constraint.TargetConstraint.setInteraction(TargetConstraint.java:57)
        at app//org.spockframework.mock.runtime.MockInteraction.<init>(MockInteraction.java:53)
        at app//org.spockframework.mock.runtime.InteractionBuilder.build(InteractionBuilder.java:187)
        at com.netflix.spinnaker.orca.pipeline.util.ArtifactUtilsSpec.should find artifacts without a specific stage ref_closure27(ArtifactUtilsSpec.groovy:382)
        at app//groovy.lang.Closure.call(Closure.java:412)
        at app//org.spockframework.lang.SpecInternals.createMock(SpecInternals.java:50)
        at app//org.spockframework.lang.SpecInternals.createMockImpl(SpecInternals.java:302)
        at app//org.spockframework.lang.SpecInternals.createMockImpl(SpecInternals.java:292)
        at app//org.spockframework.lang.SpecInternals.StubImpl(SpecInternals.java:137)
        at com.netflix.spinnaker.orca.pipeline.util.ArtifactUtilsSpec.should find artifacts without a specific stage ref(ArtifactUtilsSpec.groovy:378)
1 test completed, 1 failed
> Task :orca-core:test FAILED
```
To fix this issue replaced Stub() with Mock().