### PR TITLE
refactor(clouddriver/test): refactor Spy.with{} closure during upgrade to groovy 3.x

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/AbstractDeployStrategyStageSpec.groovy
@@ -47,10 +47,8 @@ class AbstractDeployStrategyStageSpec extends Specification {
     def basicTask = task("basic", Task)
 
     AbstractDeployStrategyStage testStage = Spy(AbstractDeployStrategyStage)
-    testStage.with {
-      strategies = [noStrat, aStrat, bStrat, cStrat]
-      noStrategy = noStrat
-    }
+    testStage.strategies = [noStrat, aStrat, bStrat, cStrat].asList()
+    testStage.noStrategy = noStrat
 
     StageExecutionImpl stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "whatever", [strategy: specifiedStrategy])
 


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encountered the following errors in groovy test orca-clouddriver module:
```
No signature of method: com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage.getNoStrat() is applicable for argument types: () values: []
Possible solutions: getNoStrategy(), setNoStrategy(com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.NoStrategy)
groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage.getNoStrat() is applicable for argument types: () values: []
Possible solutions: getNoStrategy(), setNoStrategy(com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.NoStrategy)
	at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStageSpec.should compose list of steps_closure4(AbstractDeployStrategyStageSpec.groovy:51)
	at app//groovy.lang.Closure.call(Closure.java:412)
	at app//groovy.lang.Closure.call(Closure.java:428)
	at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStageSpec.should compose list of steps(AbstractDeployStrategyStageSpec.groovy:50)

No signature of method: com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage.getNoStrat() is applicable for argument types: () values: []
Possible solutions: getNoStrategy(), setNoStrategy(com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.NoStrategy)
groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage.getNoStrat() is applicable for argument types: () values: []
Possible solutions: getNoStrategy(), setNoStrategy(com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.NoStrategy)
	at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStageSpec.should compose list of steps_closure4(AbstractDeployStrategyStageSpec.groovy:51)
	at app//groovy.lang.Closure.call(Closure.java:412)
	at app//groovy.lang.Closure.call(Closure.java:428)
	at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStageSpec.should compose list of steps(AbstractDeployStrategyStageSpec.groovy:50)

No signature of method: com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage.getNoStrat() is applicable for argument types: () values: []
Possible solutions: getNoStrategy(), setNoStrategy(com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.NoStrategy)
groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage.getNoStrat() is applicable for argument types: () values: []
Possible solutions: getNoStrategy(), setNoStrategy(com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.NoStrategy)
	at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStageSpec.should compose list of steps_closure4(AbstractDeployStrategyStageSpec.groovy:51)
	at app//groovy.lang.Closure.call(Closure.java:412)
	at app//groovy.lang.Closure.call(Closure.java:428)
	at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStageSpec.should compose list of steps(AbstractDeployStrategyStageSpec.groovy:50)

No signature of method: com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage.getNoStrat() is applicable for argument types: () values: []
Possible solutions: getNoStrategy(), setNoStrategy(com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.NoStrategy)
groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage.getNoStrat() is applicable for argument types: () values: []
Possible solutions: getNoStrategy(), setNoStrategy(com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.NoStrategy)
	at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStageSpec.should compose list of steps_closure4(AbstractDeployStrategyStageSpec.groovy:51)
	at app//groovy.lang.Closure.call(Closure.java:412)
	at app//groovy.lang.Closure.call(Closure.java:428)
	at com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStageSpec.should compose list of steps(AbstractDeployStrategyStageSpec.groovy:50)
```
To fix this issue replaced with{} closure with individual properties of Spy object.