### PR TITLE
fix(front50): filtering null execution ids for MonitorPipelineTask

### DIFF
--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy
@@ -59,8 +59,14 @@ class MonitorPipelineTask implements OverridableTimeoutRetryableTask {
     if (stage.type == MonitorPipelineStage.PIPELINE_CONFIG_TYPE) {
       pipelineIds = stageData.executionIds
     } else {
-      pipelineIds = Collections.singletonList(stageData.executionId)
+      pipelineIds = [stageData.executionId]
       isLegacyStage = true
+    }
+
+    pipelineIds.removeAll { it == null }
+
+    if (pipelineIds.isEmpty()) {
+      return TaskResult.builder(ExecutionStatus.TERMINAL).context([error: "no execution Ids were provided"]).build()
     }
 
     HashMap<String, MonitorPipelineStage.ChildPipelineStatusDetails> pipelineStatuses = new HashMap<>(pipelineIds.size())

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTaskSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.front50.tasks
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.front50.pipeline.MonitorPipelineStage
 import com.netflix.spinnaker.orca.front50.pipeline.PipelineStage
 import com.netflix.spinnaker.orca.pipeline.WaitStage
@@ -308,5 +309,25 @@ class MonitorPipelineTaskSpec extends Specification {
     behavior                                                    || expectedStatus
     MonitorPipelineStage.MonitorBehavior.FailFast               || ExecutionStatus.TERMINAL
     MonitorPipelineStage.MonitorBehavior.WaitForAllToComplete   || ExecutionStatus.RUNNING
+  }
+
+  def "terminal execution status when no execution Ids were provided"() {
+    def stageNoExecutionId = stage {
+      type = providedType
+      name = "my_stage"
+      status = ExecutionStatus.RUNNING
+    }
+    stageNoExecutionId.context.put("executionIds", [])
+
+    when:
+    def result = task.execute(stageNoExecutionId)
+
+    then:
+    result.status == expectedStatus
+
+    where:
+    providedType                              || expectedStatus
+    "anyOtherType"                            || ExecutionStatus.TERMINAL
+    MonitorPipelineStage.PIPELINE_CONFIG_TYPE || ExecutionStatus.TERMINAL
   }
 }


### PR DESCRIPTION
We have a plugin that implements [ExecutionPreprocessor](https://github.com/spinnaker/orca/blob/master/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/ExecutionPreprocessor.java), the implementation throws an exception given some rules to avoid the execution of [StartPipelineTask](https://github.com/spinnaker/orca/blob/master/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy), if you configure your [PipelineStage](https://github.com/spinnaker/orca/blob/master/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/pipeline/PipelineStage.java) to `ignore the failure` it will continue the execution of [MonitorPipelineTask](https://github.com/spinnaker/orca/blob/master/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy), that scenario throws an error in [executionRepository.retrieve](https://github.com/spinnaker/orca/blob/cd9781f13438fc32aa6149c6adc04feddace3489/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/MonitorPipelineTask.groovy#L70) because the execution Id does not exist.