### PR TITLE
fix(artifacts): separate resolve artifacts for trigger of type pipeline

### DIFF
--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtilsSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtilsSpec.groovy
@@ -82,29 +82,6 @@ class ArtifactUtilsSpec extends Specification {
     artifact.name == 'build/libs/my-jar-100.jar'
   }
 
-  def "should bind stage-inlined artifacts to trigger artifacts"() {
-    setup:
-    def execution = pipeline {
-      stage {
-        name = "upstream stage"
-        type = "stage1"
-        refId = "1"
-      }
-    }
-
-    execution.trigger = new DefaultTrigger('manual')
-    execution.trigger.artifacts.add(Artifact.builder().type('http/file').name('build/libs/my-jar-100.jar').build())
-
-    when:
-    def artifact = makeArtifactUtils().getBoundArtifactForStage(execution.stages[0], null, Artifact.builder()
-        .type('http/file')
-        .name('build/libs/my-jar-\\d+.jar')
-        .build())
-
-    then:
-    artifact.name == 'build/libs/my-jar-100.jar'
-  }
-
   def "should find upstream artifacts in small pipeline"() {
     when:
     def desired = execution.getStages().find { it.name == "desired" }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtilsSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtilsSpec.groovy
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.orca.pipeline.util
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.kork.artifacts.ArtifactTypes
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
@@ -491,83 +490,6 @@ class ArtifactUtilsSpec extends Specification {
 
     then:
     initialArtifacts == finalArtifacts
-  }
-
-  def "should find artifact if triggers is present in pipeline"() {
-    given:
-    def defaultArtifact = Artifact.builder()
-        .customKind(true)
-        .build()
-
-    def matchArtifact = Artifact.builder()
-        .name("my-pipeline-artifact")
-        .type("embedded/base64")
-        .reference("aGVsbG8gd29ybGQK")
-        .build()
-
-    def expectedArtifact = ExpectedArtifact.builder()
-        .usePriorArtifact(false)
-        .useDefaultArtifact(false)
-        .id("my-id")
-        .defaultArtifact(defaultArtifact)
-        .matchArtifact(matchArtifact)
-        .build()
-
-    def expectedArtifact2 = ExpectedArtifact.builder()
-        .usePriorArtifact(false)
-        .useDefaultArtifact(false)
-        .id("my-id-2")
-        .defaultArtifact(defaultArtifact)
-        .matchArtifact(matchArtifact)
-        .build()
-
-    def pipeline = [
-        "id": "abc",
-        "stages": [
-            stage {
-              expectedArtifacts: [expectedArtifact]
-              inputArtifacts: [
-                  "id": "my-id"
-              ]
-            }
-        ],
-        expectedArtifacts: [
-          expectedArtifact
-        ],
-        trigger: [
-            artifacts: [
-               Artifact.builder()
-                .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
-                .name(matchArtifact.getName())
-                .reference(matchArtifact.getReference())
-                .build()
-            ],
-            type: "some-type"
-        ],
-        triggers: [
-            [
-                enabled: true,
-                expectedArtifactIds: [
-                    expectedArtifact.getId()
-                ],
-                type: "some-type"
-            ],
-            [
-                enabled: true,
-                expectedArtifactIds: [
-                    expectedArtifact2.getId()
-                ],
-                type: "some-other-type"
-            ]
-        ]
-    ]
-
-    def pipelineMap = getObjectMapper().convertValue(pipeline, Map.class)
-    when:
-     makeArtifactUtils().resolveArtifacts(pipelineMap)
-
-    then:
-    pipelineMap.trigger.resolvedExpectedArtifacts.size() == 1
   }
 
   private List<Artifact> extractTriggerArtifacts(Map<String, Object> trigger) {

--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.kork.artifacts.ArtifactTypes
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor
@@ -355,7 +356,7 @@ class DependentPipelineStarterSpec extends Specification {
     result.trigger.artifacts.size() == 2
     result.trigger.artifacts*.name.contains(testArtifact1.name)
     result.trigger.artifacts*.name.contains(testArtifact2.name)
-    result.trigger.resolvedExpectedArtifacts.size() == 0
+    result.trigger.resolvedExpectedArtifacts.size() == 1
   }
 
   def "should find expected artifacts from pipeline trigger"() {
@@ -496,7 +497,7 @@ class DependentPipelineStarterSpec extends Specification {
     result.trigger.artifacts.size() == 2
     result.trigger.artifacts*.name.contains(testArtifact1.name)
     result.trigger.artifacts*.name.contains(testArtifact2.name)
-    result.trigger.resolvedExpectedArtifacts.size() == 0
+    result.trigger.resolvedExpectedArtifacts.size() == 1
   }
 
   def "should find expected artifacts from parent pipeline trigger if triggered by pipeline stage"() {
@@ -576,40 +577,47 @@ class DependentPipelineStarterSpec extends Specification {
     result.trigger.artifacts.findAll { it.name == "gcr.io/project/image" }.version.containsAll(["42", "1337"])
   }
 
-  def "should find expected artifacts when pipeline has requiredArtifactIds and triggered by pipeline stage"() {
+  def "should fail pipeline when parent pipeline does not provide expected artifacts"() {
     given:
-    def requiredArtifactId = "docker-artifact-id"
-    def expectedImage = Artifact.builder().type("docker/image").name("docker.io/org/image").build()
-    ArrayList<ExpectedArtifact> expectedArtifacts = [
-        ExpectedArtifact.builder().id(requiredArtifactId).matchArtifact(expectedImage).build()
-    ]
+    def artifact = Artifact.builder().type("embedded/base64").name("baked-manifest").build()
+    def expectedArtifactId = "826018cd-e278-4493-a6a5-4b0a0166a843"
+    def expectedArtifact = ExpectedArtifact
+        .builder()
+        .id(expectedArtifactId)
+        .matchArtifact(artifact)
+        .build()
+
+    def parentPipeline = pipeline {
+      name = "my-parent-pipeline"
+      authentication = new PipelineExecution.AuthenticationDetails("username", "account1")
+      pipelineConfigId = "fe0b3537-3101-46a1-8e08-ab57cf65a207"
+      stage {
+        id = "my-stage-1"
+        refId = "1"
+        // not passing artifacts
+      }
+    }
 
     def triggeredPipelineConfig = [
         name             : "triggered-by-stage",
         id               : "triggered-id",
         stages           : [
             [
-                name               : "Deploy (Manifest)",
-                type               : "deployManifest",
-                requiredArtifactIds: [requiredArtifactId]
+                name: "My Stage",
+                type: "bakeManifest",
             ]
         ],
-        expectedArtifacts: expectedArtifacts,
-        triggers         : [],
+        expectedArtifacts: [
+            expectedArtifact
+        ],
+        triggers         : [
+            [
+                type               : "pipeline",
+                pipeline           : parentPipeline.pipelineConfigId,
+                expectedArtifactIds: [expectedArtifactId]
+            ]
+        ],
     ]
-
-    Artifact testArtifact = Artifact.builder().type("docker/image").name("docker.io/org/image").version("alpine").build()
-
-    def parentPipeline = pipeline {
-      name = "parent-pipeline"
-      authentication = new PipelineExecution.AuthenticationDetails("username", "account1")
-      pipelineConfigId = "f837d603-bcc8-41c4-8ebc-bf0b23f59108"
-      stage {
-        id = "stage1"
-        refId = "1"
-        outputs = [artifacts: [testArtifact]]
-      }
-    }
 
     def executionLauncher = Mock(ExecutionLauncher)
     def applicationContext = new StaticApplicationContext()
@@ -624,15 +632,14 @@ class DependentPipelineStarterSpec extends Specification {
     )
 
     and:
-    executionLauncher.start(*_) >> { _, p ->
+    def error
+    executionLauncher.fail(_, _, _) >> { PIPELINE, processedPipeline, artifactError ->
+      error = artifactError
       return pipeline {
-        name = p.name
-        id = p.name
-        trigger = mapper.convertValue(p.trigger, Trigger)
+        name = processedPipeline.name
+        id = processedPipeline.name
+        trigger = mapper.convertValue(processedPipeline.trigger, Trigger)
       }
-    }
-    artifactUtils.getArtifactsForPipelineId(*_) >> {
-      return new ArrayList<Artifact>();
     }
 
     when:
@@ -641,14 +648,17 @@ class DependentPipelineStarterSpec extends Specification {
         null,
         parentPipeline,
         [:],
-        "stage1",
+        "my-stage-1",
         buildAuthenticatedUser("username", [])
     )
 
     then:
-    result.trigger.artifacts.size() == 1
-    result.trigger.artifacts*.name.contains(testArtifact.name)
-    result.trigger.artifacts.findAll { it.name == "docker.io/org/image" }.version.containsAll(["alpine"])
+    1 * artifactUtils.validateArtifactConstraintsFromTrigger(_)
+    0 * artifactUtils.resolveArtifactsFromTrigger(_) // should not be called
+    error != null
+    error instanceof InvalidRequestException
+    error.message == "Unmatched expected artifact " + expectedArtifact + " could not be resolved."
+    result.trigger.artifacts.size() == 0
   }
 
   def "should resolve expressions in trigger"() {
@@ -846,7 +856,7 @@ class DependentPipelineStarterSpec extends Specification {
       }
     }
     1 * templateLoader.load(_ as TemplateConfiguration.TemplateSource, _, _) >> [triggeredPipelineTemplate]
-    1 * executionRepository.retrievePipelinesForPipelineConfigId("triggered", _ as ExecutionRepository.ExecutionCriteria) >>
+    2 * executionRepository.retrievePipelinesForPipelineConfigId("triggered", _ as ExecutionRepository.ExecutionCriteria) >>
       Observable.just(priorExecution)
 
     when:


### PR DESCRIPTION
Follow up to
* https://github.com/spinnaker/orca/pull/4489
* https://github.com/spinnaker/orca/pull/4568

Triggering a pipeline from Pipeline A using the [pipeline stage](https://spinnaker.io/docs/reference/pipeline/stages/#pipeline) where Pipeline B uses BakeManifestStage or DeployManifestStage which rely on expectedArtifacts is broken. [ArtifactUtils](https://github.com/spinnaker/orca/blob/master/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtils.java#L264-L275) is filtering the `expectedArtifacts` needed in stages.

In 1.28, you were able to define expectedArtifacts in Pipeline B, and when you triggered from Pipeline A, Pipeline B was able to resolve the artifacts from Pipeline A. [Passing artifacts between pipelines](https://spinnaker.io/docs/reference/ref-artifacts/in-pipelines/#passing-artifacts-between-pipelines)

We are partially reverting some changes from:
* https://github.com/spinnaker/orca/pull/4397
* https://github.com/spinnaker/orca/pull/4489
* https://github.com/spinnaker/orca/pull/4526

because they are not needed anymore. 

Fixes https://github.com/spinnaker/spinnaker/issues/6897
