### PR TITLE
feat(retrofit2): orca-bakery - Eliminated the usage of RetrofitError by replacing the error handling logic with spinnaker customised exceptions

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.bakery.tasks
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
@@ -65,9 +66,9 @@ class MonitorBakeTask implements OverridableTimeoutRetryableTask {
       }
 
       TaskResult.builder(mapStatus(newStatus)).context([status: newStatus]).build()
-    } catch (RetrofitError e) {
+    } catch (SpinnakerHttpException e) {
       log.error("Monitor Error {}", e.getMessage())
-      if (e.response?.status == 404) {
+      if (e.responseCode == 404) {
         return TaskResult.ofStatus(ExecutionStatus.RUNNING)
       }
       throw e

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -28,7 +28,6 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import retrofit.RetrofitError
 
 @Slf4j
 @Component


### PR DESCRIPTION
We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/docs/community/contributing/code/submitting/#commit-and-pr-message-conventions).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Bakery Service Retrofit client :

As part of this PR, the target is to eliminate the usage of RetrofitError in the module orca-bakery.
The error handling logic which was earlier added for the BakeryService client , will now be replaced with the spinnaker customised exceptions.
