### PR TITLE
feat(retrofit2): orca-bakery - Eliminated the usage of RetrofitError by replacing the error handling logic with spinnaker customised exceptions

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.bakery.tasks
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
@@ -65,9 +66,9 @@ class MonitorBakeTask implements OverridableTimeoutRetryableTask {
       }
 
       TaskResult.builder(mapStatus(newStatus)).context([status: newStatus]).build()
-    } catch (RetrofitError e) {
+    } catch (SpinnakerHttpException e) {
       log.error("Monitor Error {}", e.getMessage())
-      if (e.response?.status == 404) {
+      if (e.responseCode == 404) {
         return TaskResult.ofStatus(ExecutionStatus.RUNNING)
       }
       throw e

--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -28,7 +28,6 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import retrofit.RetrofitError
 
 @Slf4j
 @Component


### PR DESCRIPTION
Bakery Service Retrofit client :

As part of this PR, the target is to eliminate the usage of RetrofitError in the module orca-bakery.
The error handling logic which was earlier added for the BakeryService client , will now be replaced with the spinnaker customised exceptions.