### PR TITLE
fix(artifacts): Parent and child pipeline artifact resolution

### DIFF
--- a/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
+++ b/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/DependentPipelineStarterSpec.groovy
@@ -355,7 +355,8 @@ class DependentPipelineStarterSpec extends Specification {
     result.trigger.artifacts.size() == 2
     result.trigger.artifacts*.name.contains(testArtifact1.name)
     result.trigger.artifacts*.name.contains(testArtifact2.name)
-    result.trigger.resolvedExpectedArtifacts.size() == 0
+    result.trigger.resolvedExpectedArtifacts.size() == 1
+    result.trigger.resolvedExpectedArtifacts.get(0).id.equals("id1")
   }
 
   def "should find expected artifacts from pipeline trigger"() {
@@ -496,7 +497,8 @@ class DependentPipelineStarterSpec extends Specification {
     result.trigger.artifacts.size() == 2
     result.trigger.artifacts*.name.contains(testArtifact1.name)
     result.trigger.artifacts*.name.contains(testArtifact2.name)
-    result.trigger.resolvedExpectedArtifacts.size() == 0
+    result.trigger.resolvedExpectedArtifacts.size() == 1
+    result.trigger.resolvedExpectedArtifacts.get(0).id.equals("id1")
   }
 
   def "should find expected artifacts from parent pipeline trigger if triggered by pipeline stage"() {


### PR DESCRIPTION
This fix allows us to revert https://github.com/spinnaker/orca/pull/4397
since that makes retrieving bound artifacts actually more strict for
most use cases. So this commit addresses the root cause that that PR was
trying to implement.

When a parent pipeline triggers a child pipeline, the child pipeline should be able to
resolve incoming artifacts properly. Right now that does not happen
because `expectedArtifactIds` is needed in the trigger section,
otherwise no resolution will occur.

This change fixes the parent payload to include `expectedArtifactIds` by
viewing the child pipeline's top level expected artifacts and finding
the intersection between expected artifacts and artifacts to be sent.
With that intersection we can grab the expected artifact ids and
properly set the the necessary field to allow for child pipelines to
ingest the artifact.

@nemesisOsorio

Also, we can probably still utilize some of https://github.com/spinnaker/orca/pull/4570 and still revert the changes that were introduced due to not properly handling the root cause
