### PR TITLE
fix(bakery): change exception handling in MonitorBakeTask to use Spinnaker*Exception instead of RetrofitError now that https://github.com/spinnaker/orca/pull/4529 has added SpinnakerRetrofitErrorHandler to BakerySelector

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/MonitorBakeTask.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.bakery.tasks
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
@@ -27,7 +28,6 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import retrofit.RetrofitError
 
 @Slf4j
 @Component
@@ -65,9 +65,9 @@ class MonitorBakeTask implements OverridableTimeoutRetryableTask {
       }
 
       TaskResult.builder(mapStatus(newStatus)).context([status: newStatus]).build()
-    } catch (RetrofitError e) {
+    } catch (SpinnakerHttpException e) {
       log.error("Monitor Error {}", e.getMessage())
-      if (e.response?.status == 404) {
+      if (e.responseCode == 404) {
         return TaskResult.ofStatus(ExecutionStatus.RUNNING)
       }
       throw e


### PR DESCRIPTION
bug fix:

- As part of the PR : https://github.com/spinnaker/orca/pull/4529 the BakeryService was already modified to handle exceptions using SpinnakerRetrofitErrorHandler
- The exception handling was missed out in one class i.e : MonitorBakeTask.
- So this PR is basically a bug fix to cover it.