### PR TITLE
refactor(bakery): fix incompatible generic type issue faced during upgrade to springboot 2.5.15

### DIFF
--- a/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
+++ b/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy
@@ -155,7 +155,7 @@ class BakeStage implements StageDefinitionBuilder {
 
     @Nonnull
     TaskResult execute(@Nonnull StageExecution stage) {
-      def relatedBakeStages = stage.execution.stages.findAll {
+      List<StageExecution> relatedBakeStages = stage.execution.stages.findAll {
         it.type == PIPELINE_CONFIG_TYPE && stage.id == it.parentStageId
       }
 
@@ -174,7 +174,7 @@ class BakeStage implements StageDefinitionBuilder {
 
       if (failOnImageNameMismatchEnabled()) {
         // find distinct image names in bake stages that are actually related to the stage passed into the task
-        List<String> distinctImageNames = relatedBakeStages
+        List<Object> distinctImageNames = relatedBakeStages
           .findAll { childStage -> childStage.parentStageId == stage.id && childStage.context.imageName }
           .stream()
           .map { childStage -> childStage.context.imageName }


### PR DESCRIPTION
While upgrading springboot 2.5.15, encounter below error in orca-bakery module:
```
startup failed:
/orca/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/pipeline/BakeStage.groovy: 177: [Static type checking] - Incompatible generic argument types. Cannot assign java.util.List <java.lang.Object> to: java.util.List <String>
 @ line 177, column 43.
   <String> distinctImageNames = relatedBak
                                 ^

1 error

> Task :orca-bakery:compileGroovy FAILED
```
To fix this issue use explicit object reference of `List<StageExecution>` to hold and operate on the object stream, and `List` to capture the filtered generic objects.