### PR TITLE
refactor(igor): OortService - Cleaned up the RetrofitError catch block in GitCommitsTask as it is no more relevant

### DIFF
--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTask.groovy
@@ -34,7 +34,6 @@ import com.netflix.spinnaker.orca.pipeline.model.PipelineTrigger
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import retrofit.RetrofitError
 
 @Slf4j
 @Component
@@ -122,32 +121,13 @@ class GetCommitsTask implements DiffTask {
       }
 
       return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).build()
-    } catch (RetrofitError e) {
-      if (e.kind == RetrofitError.Kind.UNEXPECTED) {
-        // give up on internal errors
-        return giveUpOnException(repoInfo, sourceInfo, targetInfo, e)
-      } else if (e.response?.status == 404) {
-        // just give up on 404
-        return handle404(repoInfo, sourceInfo, targetInfo, e)
-      } else { // retry on other status codes
-        return retryOnException("retrofit error (${e.message})", repoInfo, sourceInfo, targetInfo, retriesRemaining, e)
-      }
     } catch (SpinnakerHttpException e) {
-      // Some retrofit objects (e.g. cloudDriverService) use
-      // SpinnakerRetrofitErrorHandler and so throw Spinnaker*Exception
-      // exceptions, while other retrofit objects throw RetrofitErrors.  One day
-      // perhaps everything will use SpinnakerRetrofitErrorHandler.  Until then,
-      // duplicate the logic for handling RetrofitError also for
-      // Spinnaker*Exception.
       if (e.getResponseCode() == 404) {
-        // just give up on 404
         return handle404(repoInfo, sourceInfo, targetInfo, e)
       } else { // retry on other status codes
         return retryOnException("SpinnakerHttpException (${e.message})", repoInfo, sourceInfo, targetInfo, retriesRemaining, e)
       }
     } catch (SpinnakerServerException e) {
-      // give up on internal errors.  Note that this includes network errors
-      // which the above RetrofitError handling swallows.
       return giveUpOnException(repoInfo, sourceInfo, targetInfo, e)
     } catch (Exception f) { // retry on everything else
       return retryOnException("unexpected exception", repoInfo, sourceInfo, targetInfo, retriesRemaining, f)

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/GetCommitsTaskSpec.groovy
@@ -450,7 +450,7 @@ class GetCommitsTaskSpec extends Specification {
     and:
     task.scmService = Stub(ScmService) {
       compareCommits("stash", "projectKey", "repositorySlug", ['to': '186605b', 'from': 'a86305d', 'limit': 100]) >> {
-        throw new RetrofitError(null, null, new Response("http://stash.com", 404, "test reason", [], null), null, null, null, null)
+        throw new SpinnakerHttpException(new RetrofitError(null, null, new Response("http://stash.com", 404, "test reason", [], null), null, null, null, null))
       }
     }
 


### PR DESCRIPTION
As part of this PR , the target is to cleanup the usage of RetrofitError in GitCommitsTask. 

- The Retrofit configuration in ClouddriverConfiguration class is already set with the error handler : SpinnakerRetrofitErrorHandler for the OortService client as part of this commit : https://github.com/spinnaker/orca/blob/7e1e74f90b5d9ab786d2a5efd18100a4a9a794c7/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.java#L212
- As part of the commit : https://github.com/spinnaker/orca/pull/4528/commits/781ad44998b4da43139f807ca5e4f53229f49345 the OortService client exception handling is implemented in GitCommitsTask class and will use SpinnakerRetrofitErrorHandler if any exceptions happen.

The catch block with RetrofitError in GitCommitsTask class will now be irrelevant from the above 2 commits , hence its cleaned up.
