### PR TITLE
fix(databaseChangeLog): fix for 'addAfterColumn is not allowed on postgresql'

### DIFF
--- a/orca-sql/src/main/resources/db/changelog/20180510-add-legacy-id-fields.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180510-add-legacy-id-fields.yml
@@ -1,4 +1,8 @@
 databaseChangeLog:
+- removeChangeSetProperty:
+    change: addColumn
+    dbms: postgresql
+    remove: afterColumn
 - changeSet:
     id: add-legacy-id-fields
     author: cthielen

--- a/orca-sql/src/main/resources/db/changelog/20180515-execution-canceled-column.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180515-execution-canceled-column.yml
@@ -1,4 +1,8 @@
 databaseChangeLog:
+- removeChangeSetProperty:
+    change: addColumn
+    dbms: postgresql
+    remove: afterColumn
 - changeSet:
     id: add-canceled-column
     author: robzienert

--- a/orca-sql/src/main/resources/db/changelog/20180724-partitions.yml
+++ b/orca-sql/src/main/resources/db/changelog/20180724-partitions.yml
@@ -1,4 +1,8 @@
 databaseChangeLog:
+- removeChangeSetProperty:
+    change: addColumn
+    dbms: postgresql
+    remove: afterColumn
 - changeSet:
     id: partition-updated-executions
     author: rzienert

--- a/orca-sql/src/main/resources/db/changelog/20181016-add-start-time.yml
+++ b/orca-sql/src/main/resources/db/changelog/20181016-add-start-time.yml
@@ -1,4 +1,8 @@
 databaseChangeLog:
+- removeChangeSetProperty:
+    change: addColumn
+    dbms: postgresql
+    remove: afterColumn
 - changeSet:
     id: 20181016-add-start-time
     author: robzienert


### PR DESCRIPTION
Liquibase 4.13.0 introduced a change which breaks processing orca's changelog files. Liquibase 4.24.0 has a workaround for this issue.

Check the following kork PR for the background: https://github.com/spinnaker/kork/pull/1117 - upgrade liquibase to 4.24.0

This PR requires above kork PR to be merged first.

The following snippet is needed under `databaseChangeLog` for liquibase to ignore the `afterColumn` construct for postgresql which doesn't support the feature. 
```yaml
- removeChangeSetProperty:
    change: addColumn
    dbms: postgresql
    remove: afterColumn
```