### PR TITLE
fix(clouddriver): change exception handling in ClouddriverClearAltTablespaceTask

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/cache/ClouddriverClearAltTablespaceTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/cache/ClouddriverClearAltTablespaceTask.java
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.cache;
 
 import static java.util.Collections.emptyList;
 
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
 import com.netflix.spinnaker.orca.api.pipeline.Task;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
@@ -17,8 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import retrofit.RetrofitError;
-import retrofit.mime.TypedByteArray;
 
 @Component
 public class ClouddriverClearAltTablespaceTask implements Task {
@@ -48,17 +47,11 @@ public class ClouddriverClearAltTablespaceTask implements Task {
           result.getOrDefault("tables", emptyList()));
 
       return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(result).build();
-    } catch (RetrofitError e) {
+    } catch (SpinnakerServerException e) {
       Map<String, Object> output = new HashMap<>();
       List<String> errors = new ArrayList<>();
 
-      if (e.getResponse() != null && e.getResponse().getBody() != null) {
-        String error = new String(((TypedByteArray) e.getResponse().getBody()).getBytes());
-        log.error("Failed clearing clouddriver table namespace: {}", error, e);
-        errors.add(error);
-      } else {
-        errors.add(e.getMessage());
-      }
+      errors.add(e.getMessage());
       output.put("errors", errors);
       return TaskResult.builder(ExecutionStatus.TERMINAL).context(output).build();
     }

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/cache/ClouddriverClearAltTablespaceTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/cache/ClouddriverClearAltTablespaceTaskTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
+import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverCacheService;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+
+public class ClouddriverClearAltTablespaceTaskTest {
+
+  private CloudDriverCacheService cloudDriverCacheService;
+
+  private ClouddriverClearAltTablespaceTask clouddriverClearAltTablespaceTask;
+
+  @BeforeEach
+  public void setup() {
+    cloudDriverCacheService = mock(CloudDriverCacheService.class);
+    clouddriverClearAltTablespaceTask =
+        new ClouddriverClearAltTablespaceTask(cloudDriverCacheService);
+  }
+
+  @Test
+  void testSpinnakerServerExceptionHandling() {
+
+    String namespace = "test-namespace";
+    StageExecution stageExecution = new StageExecutionImpl();
+    Map<String, Object> context = new HashMap<>();
+    List<String> errors = new ArrayList<>();
+
+    context.put("namespace", namespace);
+    stageExecution.setContext(context);
+    Response mockResponse =
+        new Response(
+            "http://foo.com/admin/db/truncate/" + namespace,
+            400,
+            "bad-request",
+            Collections.emptyList(),
+            null);
+
+    RetrofitError retrofitError =
+        RetrofitError.httpError(
+            "https://foo.com/admin/db/truncate/" + namespace, mockResponse, null, null);
+    SpinnakerServerException spinnakerServerException = new SpinnakerServerException(retrofitError);
+    errors.add(spinnakerServerException.getMessage());
+
+    when(cloudDriverCacheService.clearNamespace(namespace)).thenThrow(spinnakerServerException);
+    TaskResult taskResult = clouddriverClearAltTablespaceTask.execute(stageExecution);
+
+    assertEquals(taskResult.getStatus(), ExecutionStatus.TERMINAL);
+    assertTrue(taskResult.getContext().containsKey("errors"));
+    assertEquals(errors.toString(), taskResult.getContext().get("errors").toString());
+  }
+}


### PR DESCRIPTION
change exception handling in ClouddriverClearAltTablespaceTask to check for Spinnaker*Exception since, as of https://github.com/spinnaker/orca/pull/4528, CloudDriverCacheService uses SpinnakerRetrofitErrorHandler.
