### PR TITLE
refactor(peering): replace deprecated method during upgrade to Kotlin 1.5.32

### DIFF
--- a/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
+++ b/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt
@@ -194,7 +194,7 @@ class PeeringAgent(
       val succeeded = !(orchestrationDeletionResult.hadFailures || pipelinesDeletionResult.hadFailures)
 
       if (succeeded) {
-        deletedExecutionCursor = (deletedExecutionIds.maxBy { it.id })
+        deletedExecutionCursor = (deletedExecutionIds.maxByOrNull { it.id })
           ?.id
           ?: deletedExecutionCursor
 
@@ -255,7 +255,7 @@ class PeeringAgent(
       .map { it.id }
 
     fun getLatestCompletedUpdatedTime() =
-      (completedPipelineKeys.map { it.updated_at }.max() ?: updatedAfter)
+      (completedPipelineKeys.map { it.updated_at }.maxOrNull() ?: updatedAfter)
 
     if (pipelineIdsToDelete.isEmpty() && pipelineIdsToMigrate.isEmpty()) {
       log.debug("No completed $executionType executions to copy for peering")


### PR DESCRIPTION
While upgrading Kotlin 1.5.32, encounter below error in orca-peering module:
```
> Task :orca-peering:compileKotlin FAILED
e: /orca/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt: (197, 55): Using 'maxBy((T) -> R): T?' is an error. Use maxByOrNull instead.
e: /orca/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/PeeringAgent.kt: (258, 52): Using 'max(): T?' is an error. Use maxOrNull instead.
```
To fix this error, replaced the deprecated method.