### PR TITLE
refactor(queue): replace deprecated method during upgrade to Kotlin 1.5.32

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -352,7 +352,7 @@ class RunTaskHandler(
       }
     }
 
-    return backOffs.max() ?: dynamicBackOffPeriod
+    return backOffs.maxOrNull() ?: dynamicBackOffPeriod
   }
 
   private fun List<TaskExecutionInterceptor>.maxBackoff(): Long =

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartWaitingExecutionsHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartWaitingExecutionsHandlerTest.kt
@@ -133,8 +133,8 @@ object StartWaitingExecutionsHandlerTest : SubjectSpek<StartWaitingExecutionsHan
           }
         }
       }
-      val oldest = waitingPipelines.minBy { it.buildTime!! }!!
-      val newest = waitingPipelines.maxBy { it.buildTime!! }!!
+      val oldest = waitingPipelines.minByOrNull { it.buildTime!! }!!
+      val newest = waitingPipelines.maxByOrNull { it.buildTime!! }!!
 
       given("the queue should not be purged") {
         beforeGroup {


### PR DESCRIPTION
While upgrading Kotlin 1.5.32, encounter below error in orca-queue module:
```
> Task :orca-queue:compileKotlin FAILED
e: /orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt: (355, 21): Using 'max(): T?' is an error. Use maxOrNull instead.
```

```
> Task :orca-queue:compileTestKotlin FAILED
e: /orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartWaitingExecutionsHandlerTest.kt: (136, 37): Using 'minBy((T) -> R): T?' is an error. Use minByOrNull instead.
e: /orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartWaitingExecutionsHandlerTest.kt: (137, 37): Using 'maxBy((T) -> R): T?' is an error. Use maxByOrNull instead.
```
To fix this error, replaced the deprecated method.
