### PR TITLE
fix(test): fix intermittent issue of port binding by using dynamic port for WireMockServer

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
@@ -37,7 +37,7 @@ import static retrofit.RestAdapter.LogLevel.FULL
 
 class KatoRestServiceSpec extends Specification {
 
-  public WireMockServer wireMockServer = new WireMockServer()
+  public WireMockServer wireMockServer = new WireMockServer(0)
 
   @Subject
   KatoRestService service
@@ -59,6 +59,7 @@ class KatoRestServiceSpec extends Specification {
   @BeforeAll
   def setup() {
     wireMockServer.start()
+    configureFor(wireMockServer.port())
     def cfg = new CloudDriverConfiguration()
     def builder = cfg.clouddriverRetrofitBuilder(
       mapper,


### PR DESCRIPTION
While running complete test as `./gradlew --no-build-cache cleanTest test`, encountered below error in orca-clouddriver module with `KatoRestServiceSpec` intermittently:
```
java.lang.RuntimeException: java.io.IOException: Failed to bind to /0.0.0.0:8080
com.github.tomakehurst.wiremock.common.FatalStartupException: java.lang.RuntimeException: java.io.IOException: Failed to bind to /0.0.0.0:8080
	at app//com.github.tomakehurst.wiremock.WireMockServer.start(WireMockServer.java:146)
	at app//com.netflix.spinnaker.orca.clouddriver.KatoRestServiceSpec.setup(KatoRestServiceSpec.groovy:61)
Caused by: java.lang.RuntimeException: java.io.IOException: Failed to bind to /0.0.0.0:8080
	at com.github.tomakehurst.wiremock.jetty9.JettyHttpServer.start(JettyHttpServer.java:137)
	at com.github.tomakehurst.wiremock.WireMockServer.start(WireMockServer.java:144)
	... 1 more
Caused by: java.io.IOException: Failed to bind to /0.0.0.0:8080
	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:349)
	at org.eclipse.jetty.server.ServerConnector.open(ServerConnector.java:310)
	at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:80)
	at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:234)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.eclipse.jetty.server.Server.doStart(Server.java:401)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at com.github.tomakehurst.wiremock.jetty9.JettyHttpServer.start(JettyHttpServer.java:135)
	... 2 more
Caused by: java.net.BindException: Address already in use
	at java.base/sun.nio.ch.Net.bind(Net.java:461)
	at java.base/sun.nio.ch.Net.bind(Net.java:453)
	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:227)
	at java.base/sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:80)
	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:344)
	... 9 more
```
The root cause of the issue seems multifold:
1. depends on machine capacity to run parallel tests.
2. use of WireMockServer in multiple modules.
3. default port used by WireMockServer is 8080. https://wiremock.org/docs/standalone/java-jar/#command-line-options

To fix this issue updating the default port to dynamic port.