### PR TITLE
fix(bakery/test): use dynamic port in BakeryServiceSpec

### DIFF
--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryServiceSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryServiceSpec.groovy
@@ -32,7 +32,7 @@ import static retrofit.RestAdapter.LogLevel.FULL
 
 class BakeryServiceSpec extends Specification {
 
-  static WireMockServer wireMockServer = new WireMockServer()
+  static WireMockServer wireMockServer = new WireMockServer(0)
 
   @Subject BakeryService bakery
 
@@ -50,6 +50,7 @@ class BakeryServiceSpec extends Specification {
 
   def setupSpec() {
     wireMockServer.start()
+    configureFor(wireMockServer.port())
     bakeURI = wireMockServer.url(bakePath)
     statusURI = wireMockServer.url(statusPath)
   }


### PR DESCRIPTION
to reduce intermittent port conflict failures

similar to https://github.com/spinnaker/orca/pull/4600.