### PR TITLE
refactor(deploymentmonitor): Configure SpinnakerRetrofitErrorHandler for DeploymentMonitorService

### DIFF
--- a/orca-deploymentmonitor/orca-deploymentmonitor.gradle
+++ b/orca-deploymentmonitor/orca-deploymentmonitor.gradle
@@ -19,6 +19,7 @@ apply from: "$rootDir/gradle/spock.gradle"
 dependencies {
   implementation(project(":orca-core"))
   implementation(project(":orca-retrofit"))
+  implementation("io.spinnaker.kork:kork-retrofit")
 
   implementation("org.springframework.boot:spring-boot-autoconfigure")
 

--- a/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/orca/deploymentmonitor/DeploymentMonitorServiceProvider.java
+++ b/orca-deploymentmonitor/src/main/java/com/netflix/spinnaker/orca/deploymentmonitor/DeploymentMonitorServiceProvider.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.deploymentmonitor;
 
 import com.netflix.spinnaker.config.DeploymentMonitorDefinition;
 import com.netflix.spinnaker.kork.exceptions.UserException;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
 import com.netflix.spinnaker.orca.retrofit.logging.RetrofitSlf4jLog;
 import java.util.HashMap;
 import java.util.List;
@@ -81,6 +82,7 @@ public class DeploymentMonitorServiceProvider {
               .setLogLevel(retrofitLogLevel)
               .setLog(new RetrofitSlf4jLog(DeploymentMonitorService.class))
               .setConverter(new JacksonConverter())
+              .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
               .build()
               .create(DeploymentMonitorService.class);
 


### PR DESCRIPTION
### Changes Made

- 	Configured the error handler for the Retrofit client, DeploymentMonitorService, with SpinnakerRetrofitErrorHandler.
- 	Modified catch blocks with RetrofitError to use Spinnaker*Exception, aligning with the upcoming Retrofit version upgrade to retrofit2.x.

### Purpose
This PR represents foundational work for upgrading the Retrofit version to retrofit2.x, paving the way for future improvements and compatibility.
### Behavioural Changes

- The significant modification involves updating catch blocks, resulting in a change in the format of logger messages. This aligns with the anticipated modifications discussed in the related PR: https://github.com/spinnaker/orca/pull/4608 , which talks about the broader context related to this change.
- Additionally, when the error response body is null, an appropriate error message will be printed in the logger.
