### PR TITLE
test(clouddriver): Test Suite Refinement: MonitoredDeployTask and getRetrofitLogMessage() Behaviour

### DIFF
--- a/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca-clouddriver/orca-clouddriver.gradle
@@ -59,6 +59,7 @@ dependencies {
   testImplementation("io.strikt:strikt-core")
   testImplementation("io.mockk:mockk")
   testImplementation("ru.lanwen.wiremock:wiremock-junit5:1.3.1")
+  testImplementation("org.mockito:mockito-inline")
 
   testCompileOnly("org.projectlombok:lombok")
   testAnnotationProcessor("org.projectlombok:lombok")


### PR DESCRIPTION
This pull request aims to enhance the testing suite for the MonitoredDeployTask and the getRetrofitLogMessage() method, demonstrating their behavior and preparing for upcoming modifications, which are currently a work in progress under PR : https://github.com/spinnaker/orca/pull/4614.

### Key Changes:

- Test Cases for MonitoredDeployTask: Added test cases to illustrate the behaviour of the MonitoredDeployTask when encountering various RetrofitErrors, including networkError, httpError, unexpectedError, and conversionError.

- Test Cases for getRetrofitLogMessage(): Introduced test cases to validate the behaviour of the getRetrofitLogMessage() method, specifically during the parsing of HTTP error response details such as http headers, http status codes, reason, and http error body. These test cases cover scenarios where exceptions occur during the reading or parsing of these HTTP error details.

### Dependency Addition:

- Included the Mockito dependency ('org.mockito:mockito-inline') to enable spying/mocking on the final class retrofit.client.Response. This resolves an issue encountered during testing where Mockito could not mock/spy the final class, leading to the following error:

	
org.mockito.exceptions.base.MockitoException: 
Cannot mock/spy class retrofit.client.Response
Mockito cannot mock/spy because :
      final class
	    at 
    com.netflix.spinnaker.orca.clouddriver.tasks.monitoreddeploy.MonitoredDeployBaseTaskTest.shouldReturnOnlyStatusWhenExceptionThrownWhileParsingHttpErrorBody(MonitoredDeployBaseTaskTest.java:217)
	    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)