### PR TITLE
refactor(test): replace deprecated mockito api verifyZeroInteractions() with verifyNoMoreInteractions() during upgrade to spring boot 2.6.x

### DIFF
--- a/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/MessageHandlerTest.kt
+++ b/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/MessageHandlerTest.kt
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.assertj.isA
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
@@ -58,7 +58,7 @@ object MessageHandlerTest : SubjectSpek<MessageHandler<*>>({
     }
 
     it("does not invoke the handler") {
-      verifyZeroInteractions(handleCallback)
+      verifyNoMoreInteractions(handleCallback)
     }
   }
 

--- a/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/QueueProcessorTest.kt
+++ b/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/QueueProcessorTest.kt
@@ -31,7 +31,7 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
@@ -77,7 +77,7 @@ object QueueProcessorTest : Spek({
       }
 
       it("does not poll the queue") {
-        verifyZeroInteractions(queue)
+        verifyNoMoreInteractions(queue)
       }
     }
 
@@ -112,7 +112,7 @@ object QueueProcessorTest : Spek({
         }
 
         it("does not poll the queue") {
-          verifyZeroInteractions(queue)
+          verifyNoMoreInteractions(queue)
         }
 
         it("fires an event") {

--- a/keiko-tck/src/main/kotlin/com/netflix/spinnaker/q/QueueTest.kt
+++ b/keiko-tck/src/main/kotlin/com/netflix/spinnaker/q/QueueTest.kt
@@ -25,7 +25,6 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import java.io.Closeable
 import java.time.Clock
 import java.time.Duration
@@ -72,7 +71,7 @@ abstract class QueueTest<out Q : Queue>(
       }
 
       it("does not invoke the callback") {
-        verifyZeroInteractions(callback)
+        verifyNoMoreInteractions(callback)
       }
     }
 
@@ -143,7 +142,7 @@ abstract class QueueTest<out Q : Queue>(
         }
 
         it("does not invoke the callback") {
-          verifyZeroInteractions(callback)
+          verifyNoMoreInteractions(callback)
         }
       }
 
@@ -196,7 +195,7 @@ abstract class QueueTest<out Q : Queue>(
       }
 
       it("does not retry the message") {
-        verifyZeroInteractions(callback)
+        verifyNoMoreInteractions(callback)
       }
     }
 
@@ -252,7 +251,7 @@ abstract class QueueTest<out Q : Queue>(
       }
 
       it("does not retry the message") {
-        verifyZeroInteractions(callback)
+        verifyNoMoreInteractions(callback)
       }
 
       on("polling the queue after the message acknowledgment override has timed out") {
@@ -325,7 +324,7 @@ abstract class QueueTest<out Q : Queue>(
       }
 
       it("stops retrying the message") {
-        verifyZeroInteractions(callback)
+        verifyNoMoreInteractions(callback)
       }
 
       it("passes the failed message to the dead letter handler") {
@@ -341,7 +340,7 @@ abstract class QueueTest<out Q : Queue>(
         }
 
         it("it does not get redelivered again") {
-          verifyZeroInteractions(callback)
+          verifyNoMoreInteractions(callback)
         }
 
         it("no longer gets sent to the dead letter handler") {
@@ -473,7 +472,7 @@ abstract class QueueTest<out Q : Queue>(
         }
 
         it("did not enqueue the duplicate message") {
-          verifyZeroInteractions(callback)
+          verifyNoMoreInteractions(callback)
         }
       }
 

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/CFRollingRedBlackStrategyTest.java
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/strategies/CFRollingRedBlackStrategyTest.java
@@ -213,8 +213,8 @@ class CFRollingRedBlackStrategyTest {
     assertThat(deployServerGroupStage.getContext().get("useSourceCapacity")).isNull();
     assertThat(deployServerGroupStage.getContext().get("capacity")).isEqualTo(zeroCapacity);
     assertThat(deployServerGroupStage.getContext().get("manifest")).isEqualTo(expectedManifest);
-    verifyZeroInteractions(artifactUtils);
-    verifyZeroInteractions(oortService);
+    verifyNoMoreInteractions(artifactUtils);
+    verifyNoMoreInteractions(oortService);
   }
 
   @Test
@@ -281,8 +281,8 @@ class CFRollingRedBlackStrategyTest {
     assertThat(deployServerGroupStage.getContext().get("useSourceCapacity")).isNull();
     assertThat(deployServerGroupStage.getContext().get("capacity")).isEqualTo(zeroCapacity);
     assertThat(deployServerGroupStage.getContext().get("manifest")).isEqualTo(expectedManifest);
-    verifyZeroInteractions(artifactUtils);
-    verifyZeroInteractions(oortService);
+    verifyNoMoreInteractions(artifactUtils);
+    verifyNoMoreInteractions(oortService);
   }
 
   @Test

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueShovelTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/QueueShovelTest.kt
@@ -31,7 +31,7 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
@@ -113,10 +113,10 @@ class QueueShovelTest : SubjectSpek<QueueShovel>({
 
       it("leaves the message on the old queue") {
         // not pushed
-        verifyZeroInteractions(queue)
+        verifyNoMoreInteractions(queue)
 
         // not acked
-        verifyZeroInteractions(ackCallback)
+        verifyNoMoreInteractions(ackCallback)
 
         // execution not updated
         verify(executionRepository, never()).handlesPartition(anyString())
@@ -142,10 +142,10 @@ class QueueShovelTest : SubjectSpek<QueueShovel>({
         verify(executionRepository).store(execution)
 
         // not pushed
-        verifyZeroInteractions(queue)
+        verifyNoMoreInteractions(queue)
 
         // not acked
-        verifyZeroInteractions(ackCallback)
+        verifyNoMoreInteractions(ackCallback)
       }
     }
   }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/admin/HydrateQueueCommandTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/admin/HydrateQueueCommandTest.kt
@@ -50,7 +50,6 @@ import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import java.time.Instant
 import org.assertj.core.api.Assertions.assertThat
@@ -85,7 +84,7 @@ object HydrateQueueCommandTest : SubjectSpek<HydrateQueueCommand>({
         subject.invoke(HydrateQueueInput(dryRun = false))
 
         it("does nothing") {
-          verifyZeroInteractions(queue)
+          verifyNoMoreInteractions(queue)
         }
       }
     }
@@ -128,7 +127,7 @@ object HydrateQueueCommandTest : SubjectSpek<HydrateQueueCommand>({
         )
 
         it("does nothing") {
-          verifyZeroInteractions(queue)
+          verifyNoMoreInteractions(queue)
         }
       }
     }
@@ -155,7 +154,7 @@ object HydrateQueueCommandTest : SubjectSpek<HydrateQueueCommand>({
         subject.invoke(HydrateQueueInput(executionId = "2", dryRun = false))
 
         it("does nothing") {
-          verifyZeroInteractions(queue)
+          verifyNoMoreInteractions(queue)
         }
       }
     }
@@ -465,7 +464,7 @@ object HydrateQueueCommandTest : SubjectSpek<HydrateQueueCommand>({
         val output = subject.invoke(HydrateQueueInput(dryRun = true))
 
         it("does not interact with queue") {
-          verifyZeroInteractions(queue)
+          verifyNoMoreInteractions(queue)
         }
 
         it("emits dry run output") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/AbortStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/AbortStageHandlerTest.kt
@@ -38,7 +38,7 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
@@ -88,8 +88,8 @@ object AbortStageHandlerTest : SubjectSpek<AbortStageHandler>({
       }
 
       it("does nothing at all") {
-        verifyZeroInteractions(queue)
-        verifyZeroInteractions(publisher)
+        verifyNoMoreInteractions(queue)
+        verifyNoMoreInteractions(publisher)
         verify(repository, never()).storeStage(any())
       }
     }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelExecutionHandlerTest.kt
@@ -33,7 +33,7 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
@@ -97,7 +97,7 @@ object CancelExecutionHandlerTest : SubjectSpek<CancelExecutionHandler>({
       }
 
       it("does not send any further messages") {
-        verifyZeroInteractions(queue)
+        verifyNoMoreInteractions(queue)
       }
     }
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CancelStageHandlerTest.kt
@@ -42,7 +42,7 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe
@@ -131,7 +131,7 @@ object CancelStageHandlerTest : SubjectSpek<CancelStageHandler>({
         }
 
         it("should not push any messages to the queue") {
-          verifyZeroInteractions(queue)
+          verifyNoMoreInteractions(queue)
         }
       }
     }
@@ -160,7 +160,7 @@ object CancelStageHandlerTest : SubjectSpek<CancelStageHandler>({
         }
 
         it("should not push any messages to the queue") {
-          verifyZeroInteractions(queue)
+          verifyNoMoreInteractions(queue)
         }
       }
     }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteExecutionHandlerTest.kt
@@ -43,7 +43,6 @@ import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import java.time.Duration
 import java.util.UUID
@@ -110,7 +109,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
       }
 
       it("does not queue any other commands") {
-        verifyZeroInteractions(queue)
+        verifyNoMoreInteractions(queue)
       }
     }
 
@@ -175,7 +174,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
       }
 
       it("does not publish any events") {
-        verifyZeroInteractions(publisher)
+        verifyNoMoreInteractions(publisher)
       }
 
       it("re-queues the message for later evaluation") {
@@ -281,7 +280,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
     }
 
     it("does not queue any other commands") {
-      verifyZeroInteractions(queue)
+      verifyNoMoreInteractions(queue)
     }
   }
 
@@ -330,7 +329,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
     }
 
     it("does not queue any other commands") {
-      verifyZeroInteractions(queue)
+      verifyNoMoreInteractions(queue)
     }
   }
 
@@ -375,7 +374,7 @@ object CompleteExecutionHandlerTest : SubjectSpek<CompleteExecutionHandler>({
     }
 
     it("publishes no events") {
-      verifyZeroInteractions(publisher)
+      verifyNoMoreInteractions(publisher)
     }
 
     it("re-queues the message") {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
@@ -82,7 +82,7 @@ import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.spy
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import java.time.Duration.ZERO
 import org.assertj.core.api.Assertions.assertThat
@@ -214,8 +214,8 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
 
           it("ignores the message") {
             verify(repository, never()).storeStage(any())
-            verifyZeroInteractions(queue)
-            verifyZeroInteractions(publisher)
+            verifyNoMoreInteractions(queue)
+            verifyNoMoreInteractions(publisher)
           }
         }
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteTaskHandlerTest.kt
@@ -57,7 +57,7 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
@@ -251,7 +251,7 @@ object CompleteTaskHandlerTest : SubjectSpek<CompleteTaskHandler>({
           }
 
           it("does not publish an event") {
-            verifyZeroInteractions(publisher)
+            verifyNoMoreInteractions(publisher)
           }
         }
       }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ConfigurationErrorHandlerTest.kt
@@ -30,7 +30,7 @@ import com.netflix.spinnaker.q.Queue
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.on
@@ -57,11 +57,11 @@ object ConfigurationErrorHandlerTest : SubjectSpek<ConfigurationErrorHandler>({
       }
 
       it("does not try to update the execution status") {
-        verifyZeroInteractions(repository)
+        verifyNoMoreInteractions(repository)
       }
 
       it("does not push any messages to the queue") {
-        verifyZeroInteractions(queue)
+        verifyNoMoreInteractions(queue)
       }
     }
   }
@@ -84,7 +84,7 @@ object ConfigurationErrorHandlerTest : SubjectSpek<ConfigurationErrorHandler>({
       }
 
       it("does not push any messages to the queue") {
-        verifyZeroInteractions(queue)
+        verifyNoMoreInteractions(queue)
       }
     }
   }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/ContinueParentStageHandlerTest.kt
@@ -43,7 +43,7 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import java.time.Duration
 import org.jetbrains.spek.api.dsl.describe
@@ -121,7 +121,7 @@ object ContinueParentStageHandlerTest : SubjectSpek<ContinueParentStageHandler>(
         }
 
         it("does not re-queue the message") {
-          verifyZeroInteractions(queue)
+          verifyNoMoreInteractions(queue)
         }
       }
 
@@ -170,7 +170,7 @@ object ContinueParentStageHandlerTest : SubjectSpek<ContinueParentStageHandler>(
           }
 
           it("ignores the message") {
-            verifyZeroInteractions(queue)
+            verifyNoMoreInteractions(queue)
           }
         }
       }

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/DeadMessageHandlerTest.kt
@@ -29,7 +29,7 @@ import com.netflix.spinnaker.q.Queue
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.on
@@ -100,7 +100,7 @@ object DeadMessageHandlerTest : SubjectSpek<DeadMessageHandler>({
     }
 
     it("does nothing") {
-      verifyZeroInteractions(queue)
+      verifyNoMoreInteractions(queue)
     }
   }
 })

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/PauseStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/PauseStageHandlerTest.kt
@@ -32,7 +32,6 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.context
@@ -87,7 +86,7 @@ object PauseStageHandlerTest : SubjectSpek<PauseStageHandler>({
     }
 
     it("does not take any further action") {
-      verifyZeroInteractions(queue)
+      verifyNoMoreInteractions(queue)
     }
   }
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/SkipStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/SkipStageHandlerTest.kt
@@ -42,7 +42,7 @@ import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
@@ -91,8 +91,8 @@ object SkipStageHandlerTest : SubjectSpek<SkipStageHandler>({
 
       it("ignores the message") {
         verify(repository, never()).storeStage(any())
-        verifyZeroInteractions(queue)
-        verifyZeroInteractions(publisher)
+        verifyNoMoreInteractions(queue)
+        verifyNoMoreInteractions(publisher)
       }
     }
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
@@ -80,7 +80,6 @@ import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.spy
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import java.time.Duration
 import org.assertj.core.api.Assertions.assertThat
@@ -473,7 +472,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
         }
 
         it("does not publish an event") {
-          verifyZeroInteractions(publisher)
+          verifyNoMoreInteractions(publisher)
         }
 
         it("re-queues the message with a delay") {
@@ -517,7 +516,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
         }
 
         it("publishes no events") {
-          verifyZeroInteractions(publisher)
+          verifyNoMoreInteractions(publisher)
         }
 
         it("completes the execution") {
@@ -541,11 +540,11 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
         }
 
         it("does not queue any messages") {
-          verifyZeroInteractions(queue)
+          verifyNoMoreInteractions(queue)
         }
 
         it("does not publish any events") {
-          verifyZeroInteractions(publisher)
+          verifyNoMoreInteractions(publisher)
         }
       }
     }
@@ -631,7 +630,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
           }
         }
       }
-      
+
       and("parallel stages") {
         val pipeline = pipeline {
           application = "foo"

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartWaitingExecutionsHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartWaitingExecutionsHandlerTest.kt
@@ -34,7 +34,6 @@ import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import java.time.Instant.now
 import java.util.Random
@@ -76,7 +75,7 @@ object StartWaitingExecutionsHandlerTest : SubjectSpek<StartWaitingExecutionsHan
       }
 
       it("does nothing") {
-        verifyZeroInteractions(queue)
+        verifyNoMoreInteractions(queue)
       }
     }
 

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/metrics/ZombieExecutionCheckingAgentTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/metrics/ZombieExecutionCheckingAgentTest.kt
@@ -36,7 +36,7 @@ import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import java.time.Duration
 import java.time.Instant.now
@@ -116,7 +116,7 @@ object ZombieExecutionCheckingAgentTest : SubjectSpek<ZombieExecutionCheckingAge
           subject.checkForZombies()
 
           it("does not increment zombie counter") {
-            verifyZeroInteractions(zombieCounter)
+            verifyNoMoreInteractions(zombieCounter)
           }
         }
       }
@@ -149,7 +149,7 @@ object ZombieExecutionCheckingAgentTest : SubjectSpek<ZombieExecutionCheckingAge
           subject.checkForZombies()
 
           it("does not increment the counter") {
-            verifyZeroInteractions(zombieCounter)
+            verifyNoMoreInteractions(zombieCounter)
           }
         }
       }
@@ -171,7 +171,7 @@ object ZombieExecutionCheckingAgentTest : SubjectSpek<ZombieExecutionCheckingAge
           subject.checkForZombies()
 
           it("does not increment the counter") {
-            verifyZeroInteractions(zombieCounter)
+            verifyNoMoreInteractions(zombieCounter)
           }
         }
       }


### PR DESCRIPTION
While upgrading spring boot 2.6.15, encounter similar errors as given below in multiple module of orca (keiko-core, keiko-tck, orca-clouddriver, orca-queue) during test compilation:
```
com.netflix.spinnaker.q.sql.SqlQueueTest > describe polling the queue > given there are no messages > com.netflix.spinnaker.q.sql.SqlQueueTest.it does not invoke the callback FAILED
    java.lang.NoSuchMethodError: 'void org.mockito.Mockito.verifyZeroInteractions(java.lang.Object[])'
        at com.nhaarman.mockito_kotlin.MockitoKt.verifyZeroInteractions(Mockito.kt:259)
        at com.netflix.spinnaker.q.QueueTest$1$1$1$5.invoke(QueueTest.kt:75)
        at com.netflix.spinnaker.q.QueueTest$1$1$1$5.invoke(QueueTest.kt:74)
```
Spring boot [2.6.15](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.6.15/spring-boot-dependencies-2.6.15.pom) brings mockito 4.0.0 as transitive dependency. The `verifyZeroInteractions()` was deprecated in 3.x as mentioned here: https://github.com/mockito/mockito-kotlin/issues/383 And now it is removed from mockito [4.0.0](https://github.com/mockito/mockito/releases/tag/v4.0.0). To fix these issues, replacing `verifyZeroInteractions()` with `verifyNoMoreInteractions()`.