### PR TITLE
chore(dependencies): replace com.github.tomakehurst:wiremock

### DIFF
--- a/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca-clouddriver/orca-clouddriver.gradle
@@ -49,7 +49,7 @@ dependencies {
   testImplementation(project(":orca-test-groovy"))
   testImplementation(project(":orca-api-tck"))
   testImplementation(project(":orca-queue"))
-  testImplementation("com.github.tomakehurst:wiremock:2.15.0")
+  testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")
   testImplementation("org.springframework:spring-test")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.assertj:assertj-core")

--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -62,7 +62,7 @@ dependencies {
 
   testImplementation(project(":orca-test"))
   testImplementation(project(":orca-test-groovy"))
-  testImplementation("com.github.tomakehurst:wiremock:2.17.0")
+  testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core")

--- a/orca-kayenta/orca-kayenta.gradle
+++ b/orca-kayenta/orca-kayenta.gradle
@@ -29,5 +29,5 @@ dependencies {
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
   testImplementation(project(":orca-test-kotlin"))
-  testImplementation("com.github.tomakehurst:wiremock:2.15.0")
+  testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")
 }


### PR DESCRIPTION
with com.github.tomakehurst:wiremock-jre8-standalone

to get up to date, and to reduce the number of classes on the classpath.

before:
```
+--- com.github.tomakehurst:wiremock:2.15.0
|    +--- org.eclipse.jetty:jetty-server:9.2.22.v20170606 -> 9.4.51.v20230217
|    |    +--- javax.servlet:javax.servlet-api:3.1.0 -> 4.0.1
|    |    +--- org.eclipse.jetty:jetty-http:9.4.51.v20230217
|    |    |    +--- org.eclipse.jetty:jetty-util:9.4.51.v20230217
|    |    |    \--- org.eclipse.jetty:jetty-io:9.4.51.v20230217
|    |    |         \--- org.eclipse.jetty:jetty-util:9.4.51.v20230217
|    |    \--- org.eclipse.jetty:jetty-io:9.4.51.v20230217 (*)
|    +--- org.eclipse.jetty:jetty-servlet:9.2.22.v20170606 -> 9.4.51.v20230217
|    |    +--- org.eclipse.jetty:jetty-security:9.4.51.v20230217
|    |    |    \--- org.eclipse.jetty:jetty-server:9.4.51.v20230217 (*)
|    |    \--- org.eclipse.jetty:jetty-util-ajax:9.4.51.v20230217
|    |         \--- org.eclipse.jetty:jetty-util:9.4.51.v20230217
|    +--- org.eclipse.jetty:jetty-servlets:9.2.22.v20170606 -> 9.4.51.v20230217
|    |    +--- org.eclipse.jetty:jetty-continuation:9.4.51.v20230217
|    |    +--- org.eclipse.jetty:jetty-http:9.4.51.v20230217 (*)
|    |    +--- org.eclipse.jetty:jetty-util:9.4.51.v20230217
|    |    \--- org.eclipse.jetty:jetty-io:9.4.51.v20230217 (*)
|    +--- org.eclipse.jetty:jetty-webapp:9.2.22.v20170606 -> 9.4.51.v20230217
|    |    +--- org.eclipse.jetty:jetty-xml:9.4.51.v20230217
|    |    |    \--- org.eclipse.jetty:jetty-util:9.4.51.v20230217
|    |    \--- org.eclipse.jetty:jetty-servlet:9.4.51.v20230217 (*)
|    +--- com.google.guava:guava:20.0 -> 30.0-jre (*)
|    +--- com.fasterxml.jackson.core:jackson-core:2.8.9 -> 2.12.7 (*)
|    +--- com.fasterxml.jackson.core:jackson-annotations:2.8.9 -> 2.12.7 (*)
|    +--- com.fasterxml.jackson.core:jackson-databind:2.8.9 -> 2.12.7.1 (*)
|    +--- org.apache.httpcomponents:httpclient:4.5.3 -> 4.5.14 (*)
|    +--- org.xmlunit:xmlunit-core:2.3.0 -> 2.8.4
|    +--- org.xmlunit:xmlunit-legacy:2.3.0 -> 2.8.4
|    |    +--- org.xmlunit:xmlunit-core:2.8.4
|    |    \--- junit:junit:3.8.1 -> 4.13.2
|    |         \--- org.hamcrest:hamcrest-core:1.3 -> 2.2
|    |              \--- org.hamcrest:hamcrest:2.2
|    +--- com.jayway.jsonpath:json-path:2.4.0 -> 2.5.0 (*)
|    +--- org.slf4j:slf4j-api:1.7.12 -> 1.7.36
|    +--- net.sf.jopt-simple:jopt-simple:5.0.3
|    +--- junit:junit:4.12 -> 4.13.2 (*)
|    +--- org.apache.commons:commons-lang3:3.6 -> 3.12.0
|    +--- com.flipkart.zjsonpatch:zjsonpatch:0.3.0
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.8.5 -> 2.12.7.1 (*)
|    |    +--- com.fasterxml.jackson.core:jackson-core:2.8.5 -> 2.12.7 (*)
|    |    +--- com.google.guava:guava:18.0 -> 30.0-jre (*)
|    |    \--- org.apache.commons:commons-collections4:4.1 -> 4.4
|    \--- com.github.jknack:handlebars:4.0.6
|         +--- org.apache.commons:commons-lang3:3.1 -> 3.12.0
|         +--- org.antlr:antlr4-runtime:4.5.1-1
|         \--- org.slf4j:slf4j-api:1.6.4 -> 1.7.36
```
after:
```
+--- com.github.tomakehurst:wiremock-jre8-standalone -> 2.31.0
```