### PR TITLE
feat(kubernetes): identify and retry if the deploy manifest k8s task owner died while orca is monitoring the task

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/model/TaskOwner.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/model/TaskOwner.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public final class TaskOwner {
+  public String name;
+
+  @JsonIgnore
+  public String getName() {
+    return name;
+  }
+
+  @JsonProperty
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/RunJobTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/RunJobTask.groovy
@@ -35,6 +35,8 @@ import java.time.Duration
 @Component
 class RunJobTask implements CloudProviderAware, RetryableTask {
 
+  public static final String TASK_NAME = "runJob";
+
   @Autowired
   KatoService kato
 

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/CloudDriverTaskStatusService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/CloudDriverTaskStatusService.java
@@ -17,10 +17,14 @@
 package com.netflix.spinnaker.orca.clouddriver;
 
 import com.netflix.spinnaker.orca.clouddriver.model.Task;
+import com.netflix.spinnaker.orca.clouddriver.model.TaskOwner;
 import retrofit.http.GET;
 import retrofit.http.Path;
 
 public interface CloudDriverTaskStatusService {
   @GET("/task/{id}")
   Task lookupTask(@Path("id") String id);
+
+  @GET("/{cloudProvider}/task/{id}/owner")
+  TaskOwner lookupTaskOwner(@Path("cloudProvider") String cloudProvider, @Path("id") String id);
 }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingCloudDriverTaskStatusService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingCloudDriverTaskStatusService.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.orca.clouddriver;
 
 import com.netflix.spinnaker.kork.web.selector.SelectableService;
 import com.netflix.spinnaker.orca.clouddriver.model.Task;
+import com.netflix.spinnaker.orca.clouddriver.model.TaskOwner;
+import javax.annotation.Nonnull;
 
 public class DelegatingCloudDriverTaskStatusService
     extends DelegatingClouddriverService<CloudDriverTaskStatusService>
@@ -30,5 +32,10 @@ public class DelegatingCloudDriverTaskStatusService
   @Override
   public Task lookupTask(String id) {
     return getService().lookupTask(id);
+  }
+
+  @Override
+  public TaskOwner lookupTaskOwner(@Nonnull String cloudProvider, String id) {
+    return getService().lookupTaskOwner(cloudProvider, id);
   }
 }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingKatoRestService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingKatoRestService.java
@@ -45,6 +45,17 @@ public class DelegatingKatoRestService extends DelegatingClouddriverService<Kato
   }
 
   @Override
+  public TaskId updateTask(String cloudProvider, String id, Map details) {
+    return getService().updateTask(cloudProvider, id, details);
+  }
+
+  @Override
+  public TaskId restartTaskViaOperations(
+      String cloudProvider, String id, Collection<? extends Map<String, Map>> operations) {
+    return getService().restartTaskViaOperations(cloudProvider, id, operations);
+  }
+
+  @Override
   public Response collectJob(String app, String account, String region, String id) {
     return getService().collectJob(app, account, region, id);
   }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/KatoRestService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/KatoRestService.java
@@ -10,6 +10,7 @@ import retrofit.client.Response;
 import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
+import retrofit.http.PATCH;
 import retrofit.http.POST;
 import retrofit.http.Path;
 import retrofit.http.Query;
@@ -38,6 +39,17 @@ public interface KatoRestService {
       @Path("cloudProvider") String cloudProvider,
       @Path("operationName") String operationName,
       @Body OperationContext operation);
+
+  @PATCH("/{cloudProvider}/task/{id}")
+  TaskId updateTask(
+      @Path("cloudProvider") String cloudProvider, @Path("id") String id, @Body Map details);
+
+  @POST("/{cloudProvider}/task/{id}/restart")
+  @Retry(name = "katoRetrofitServiceWriter")
+  TaskId restartTaskViaOperations(
+      @Path("cloudProvider") String cloudProvider,
+      @Path("id") String id,
+      @Body Collection<? extends Map<String, Map>> operations);
 
   @GET("/applications/{app}/jobs/{account}/{region}/{id}")
   Response collectJob(

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/KatoService.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/KatoService.java
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.orca.clouddriver.model.OperationContext;
 import com.netflix.spinnaker.orca.clouddriver.model.SubmitOperationResult;
 import com.netflix.spinnaker.orca.clouddriver.model.Task;
 import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
+import com.netflix.spinnaker.orca.clouddriver.model.TaskOwner;
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
 import java.io.InputStream;
 import java.time.Duration;
@@ -88,6 +89,22 @@ public class KatoService {
   @Nonnull
   public TaskId resumeTask(@Nonnull String id) {
     return katoRestService.resumeTask(id);
+  }
+
+  public TaskOwner lookupTaskOwner(@Nonnull String cloudProvider, String id) {
+    return cloudDriverTaskStatusService.lookupTaskOwner(cloudProvider, id);
+  }
+
+  public TaskId updateTaskRetryability(@Nonnull String cloudProvider, String id, boolean retry) {
+    return katoRestService.updateTask(cloudProvider, id, Map.of("retry", retry));
+  }
+
+  @Nonnull
+  public TaskId restartTask(
+      @Nonnull String cloudProvider,
+      @Nonnull String id,
+      Collection<? extends Map<String, Map>> operations) {
+    return katoRestService.restartTaskViaOperations(cloudProvider, id, operations);
   }
 
   private String requestId(Object payload) {

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/job/RunJobStage.java
@@ -54,7 +54,9 @@ public class RunJobStage implements StageDefinitionBuilder, CancellableStage {
 
   @Override
   public void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {
-    builder.withTask("runJob", RunJobTask.class).withTask("monitorDeploy", MonitorJobTask.class);
+    builder
+        .withTask(RunJobTask.TASK_NAME, RunJobTask.class)
+        .withTask(MonitorJobTask.TASK_NAME, MonitorJobTask.class);
 
     getCloudProviderDecorator(stage).ifPresent(it -> it.afterRunJobTaskGraph(stage, builder));
 

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
@@ -63,7 +63,7 @@ public class DeployManifestStage extends ExpressionAwareStageDefinitionBuilder {
     builder
         .withTask(ResolveDeploySourceManifestTask.TASK_NAME, ResolveDeploySourceManifestTask.class)
         .withTask(DeployManifestTask.TASK_NAME, DeployManifestTask.class)
-        .withTask("monitorDeploy", MonitorKatoTask.class)
+        .withTask(MonitorDeployManifestTask.TASK_NAME, MonitorDeployManifestTask.class)
         .withTask(PromoteManifestKatoOutputsTask.TASK_NAME, PromoteManifestKatoOutputsTask.class)
         .withTask(WaitForManifestStableTask.TASK_NAME, WaitForManifestStableTask.class)
         .withTask(CleanupArtifactsTask.TASK_NAME, CleanupArtifactsTask.class)

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/MonitorJobTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/MonitorJobTask.java
@@ -23,15 +23,21 @@ import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.KatoService;
+import com.netflix.spinnaker.orca.clouddriver.model.Task;
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MonitorJobTask extends MonitorKatoTask {
+  public static final String TASK_NAME = "monitorDeploy";
   private final JobUtils jobUtils;
+  private static final Logger log = LoggerFactory.getLogger(MonitorJobTask.class);
 
   @Autowired
   public MonitorJobTask(
@@ -63,5 +69,11 @@ public class MonitorJobTask extends MonitorKatoTask {
   @Override
   public void onCancel(@Nonnull StageExecution stage) {
     jobUtils.cancelWait(stage);
+  }
+
+  @Override
+  protected void handleClouddriverRetries(
+      StageExecution stage, Task katoTask, Map<String, Object> outputs) {
+    log.debug("handling clouddriver retries is not supported for Jobs");
   }
 }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestTask.java
@@ -55,7 +55,8 @@ public final class DeployManifestTask implements CloudProviderAware, Task {
     return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).build();
   }
 
-  private ImmutableMap<String, Map> getOperation(StageExecution stage) {
+  /** Build the operation map necessary for a DeployManifestTask. */
+  public static ImmutableMap<String, Map> getOperation(StageExecution stage) {
     DeployManifestContext context = stage.mapTo(DeployManifestContext.class);
 
     Map<String, Object> task = new HashMap<>(stage.getContext());

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/MonitorDeployManifestTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/MonitorDeployManifestTask.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2021 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.kork.annotations.VisibleForTesting;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.KatoService;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.model.Manifest;
+import com.netflix.spinnaker.orca.clouddriver.model.Task;
+import com.netflix.spinnaker.orca.clouddriver.model.TaskOwner;
+import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask;
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.model.SystemNotification;
+import groovy.util.logging.Slf4j;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class MonitorDeployManifestTask extends MonitorKatoTask {
+  public static final String TASK_NAME = "monitorDeploy";
+  private final OortService oortService;
+  private static final Logger log = LoggerFactory.getLogger(MonitorDeployManifestTask.class);
+
+  public MonitorDeployManifestTask(
+      KatoService katoService,
+      OortService oortService,
+      Registry registry,
+      DynamicConfigService dynamicConfigService,
+      RetrySupport retrySupport) {
+    super(katoService, registry, dynamicConfigService, retrySupport);
+    this.oortService = oortService;
+  }
+
+  long maximumPeriodOfInactivity() {
+    return getDynamicConfigService()
+        .getConfig(
+            Long.class,
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.maximum-period-inactivity-ms",
+            300000L);
+  }
+
+  long maximumForcedRetries() {
+    return getDynamicConfigService()
+        .getConfig(
+            Integer.class,
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.maximum-forced-retries",
+            3);
+  }
+
+  @Override
+  protected void handleClouddriverRetries(
+      StageExecution stage, Task katoTask, Map<String, Object> outputs) {
+    if (shouldRetryKubernetesTask(stage, katoTask)) {
+      try {
+        retryKubernetesTask(stage, katoTask, outputs);
+      } catch (Exception e) {
+        log.debug(
+            "exception occurred when attempting to retry task with id: " + katoTask.getId(), e);
+      }
+    }
+  }
+
+  /**
+   * Determine if it's appropriate to retry a task
+   *
+   * @param stage the stage containing the task
+   * @param katoTask the task under consideration
+   * @return true when task is a kubernetes task and the feature is enabled and previous attempts to
+   *     retry didn't fail and there are attempts remaining and the task has been executing longer
+   *     than the maximum inactivity period
+   */
+  private boolean shouldRetryKubernetesTask(StageExecution stage, Task katoTask) {
+    String cloudProvider = getCloudProvider(stage);
+    if (cloudProvider == null
+        || !cloudProvider.equals("kubernetes")
+        || !getDynamicConfigService()
+            .isEnabled("tasks.monitor-kato-task.kubernetes.deploy-manifest.retry-task", false)) {
+      log.info("task: {} did not meet the conditions required for a retry", katoTask.getId());
+      return false;
+    }
+
+    Boolean hasPreviousRetryFailed =
+        (Boolean) stage.getContext().getOrDefault("kato.task.forceRetryFatalError", false);
+    if (hasPreviousRetryFailed) {
+      log.warn(
+          "previous forced retry attempts failed with a terminal error. Will not attempt to retry any further");
+      return false;
+    }
+
+    Integer retryCount = (Integer) stage.getContext().getOrDefault("kato.task.forcedRetries", 0);
+    if (retryCount > maximumForcedRetries()) {
+      log.warn(
+          "Number of forced retry attempts has exceeded maximum number allowed: {}. Will not "
+              + "attempt to retry any further",
+          maximumForcedRetries());
+      return false;
+    }
+
+    Optional<Duration> elapsedTime =
+        getCurrentTaskExecutionTime(stage, katoTask, MonitorDeployManifestTask.TASK_NAME);
+    if (elapsedTime.isEmpty()) {
+      log.debug(
+          "error occurred in calculating how long the current task: {} for task id: {} has been running - "
+              + "will not attempt to retry",
+          MonitorDeployManifestTask.TASK_NAME,
+          katoTask.getId());
+      return false;
+    }
+
+    if (Duration.ofMillis(maximumPeriodOfInactivity()).compareTo(elapsedTime.get()) < 0) {
+      log.info(
+          "task: {} is eligible for retries as its status has not been updated for some time",
+          katoTask.getId());
+      return true;
+    }
+    log.info(
+        "the Running task: {} has not yet crossed the configured period of inactivity threshold - not attempting "
+            + "to retry",
+        katoTask.getId());
+    return false;
+  }
+
+  /**
+   * Restart a kubernetes task if the clouddriver pod that owns the task is no longer present. This
+   * assumes that clouddriver itself is running in kubernetes.
+   *
+   * <p>On return, the following information in the outputs map indicates what happened: -
+   * kato.task.forceRetryAttempts incremented, or set it to 1 if previously unset -
+   * kato.task.forceRetryFatalError set to true if there's an error - kato.task.forcedRetries
+   * incremented if the task was successfully restarted
+   *
+   * @param stage the stage containing the task
+   * @param katoTask the task to retry
+   * @param outputs outputs of the task
+   */
+  private void retryKubernetesTask(
+      StageExecution stage, Task katoTask, Map<String, Object> outputs) {
+    Integer retryAttempts =
+        (Integer) stage.getContext().getOrDefault("kato.task.forcedRetryAttempts", 0) + 1;
+    Integer forcedRetries = (Integer) stage.getContext().getOrDefault("kato.task.forcedRetries", 0);
+    log.info(
+        "retrying kubernetes cloudprovider task with ID: {}. Attempt: {}",
+        katoTask.getId(),
+        retryAttempts);
+    outputs.put("kato.task.forcedRetryAttempts", retryAttempts);
+    TaskOwner clouddriverPodName;
+    try {
+      clouddriverPodName = getKatoService().lookupTaskOwner("kubernetes", katoTask.getId());
+    } catch (SpinnakerServerException re) {
+      log.warn(
+          "failed to retrieve clouddriver owner information from task ID: {}. Retry failed. Error: ",
+          katoTask.getId(),
+          re);
+      outputs.put("kato.task.forceRetryFatalError", true);
+      stage.getContext().put("kato.task.forceRetryFatalError", true);
+      return;
+    }
+
+    if (clouddriverPodName == null || clouddriverPodName.getName() == null) {
+      log.warn(
+          "failed to retrieve clouddriver owner information for task ID: {}. Retry failed",
+          katoTask.getId());
+      outputs.put("kato.task.forceRetryFatalError", true);
+      stage.getContext().put("kato.task.forceRetryFatalError", true);
+      return;
+    }
+
+    // manifest will be returned only if it actually exists - which means the
+    // owner clouddriver pod is alive and functional. We don't need to force
+    // retry in this case.
+    String clouddriverAccount =
+        getDynamicConfigService()
+            .getConfig(
+                String.class, "tasks.monitor-kato-task.kubernetes.deploy-manifest.account", "");
+    if (clouddriverAccount.isBlank()) {
+      log.warn(
+          "tasks.monitor-kato-task.kubernetes.deploy-manifest.account is a required property. Retry failed for task: {}",
+          katoTask.getId());
+      outputs.put("kato.task.forceRetryFatalError", true);
+      stage.getContext().put("kato.task.forceRetryFatalError", true);
+      return;
+    }
+
+    String clouddriverNamespace =
+        getDynamicConfigService()
+            .getConfig(
+                String.class,
+                "tasks.monitor-kato-task.kubernetes.deploy-manifest.namespace",
+                "spinnaker");
+
+    try {
+      Manifest _ignored =
+          oortService.getManifest(
+              clouddriverAccount,
+              clouddriverNamespace,
+              "pod " + clouddriverPodName.getName(),
+              false);
+      log.info(
+          "task ID: {} owner: {} is up and running. No need to force a retry of the task",
+          katoTask.getId(),
+          clouddriverPodName);
+    } catch (Exception e) {
+      log.warn(
+          "exception occurred while attempting to lookup task: {} owner clouddriver information",
+          katoTask.getId(),
+          e);
+      if (e instanceof SpinnakerHttpException) {
+        SpinnakerHttpException spinnakerHttpException = (SpinnakerHttpException) e;
+        // only attempt a retry if clouddriver owner pod manifest results in a 404
+        if (spinnakerHttpException.getResponseCode() == HttpStatus.NOT_FOUND.value()) {
+          log.info(
+              "Since task ID {} owner: {} manifest not found, attempting to force retry task execution",
+              katoTask.getId(),
+              clouddriverPodName.getName());
+          ((PipelineExecutionImpl) stage.getExecution())
+              .getSystemNotifications()
+              .add(
+                  new SystemNotification(
+                      getClock().millis(),
+                      "katoRetryTask",
+                      "Issue detected with the current clouddriver owner of the task. Retrying "
+                          + "downstream cloud provider operation",
+                      false));
+          try {
+            // we need to reschedule the task so that it can be picked up by a different clouddriver
+            // pod
+            getKatoService().updateTaskRetryability("kubernetes", katoTask.getId(), true);
+            getKatoService()
+                .restartTask("kubernetes", katoTask.getId(), ImmutableList.of(getOperation(stage)));
+            log.info(
+                "task: {} has been successfully rescheduled on another clouddriver pod",
+                katoTask.getId());
+            outputs.put("kato.task.forcedRetries", forcedRetries + 1);
+            stage.getContext().put("kato.task.forcedRetries", forcedRetries + 1);
+          } catch (Exception clouddriverException) {
+            log.warn(
+                "Attempt failed to retry task with id: {}", katoTask.getId(), clouddriverException);
+            outputs.put("kato.task.forceRetryFatalError", true);
+            stage.getContext().put("kato.task.forceRetryFatalError", true);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Determine the operation map necessary for restarting the DeployManifestTask task in a stage.
+   */
+  @VisibleForTesting
+  public ImmutableMap<String, Map> getOperation(StageExecution stage) {
+    if (!hasSuccessfulTask(stage, DeployManifestTask.TASK_NAME)) {
+      throw new IllegalStateException(
+          "getOperation requires a successful " + DeployManifestTask.TASK_NAME + " task");
+    }
+
+    return DeployManifestTask.getOperation(stage);
+  }
+}

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/model/TaskOwnerTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/model/TaskOwnerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.model;
+
+import static com.netflix.spinnaker.orca.TestUtils.getResource;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+final class TaskOwnerTest {
+  private static final ObjectMapper objectMapper = OrcaObjectMapper.newInstance();
+
+  @Test
+  public void deserializeTaskOwner() throws IOException {
+    String resource = getResource("clouddriver/model/tasks/owners/success.json");
+    TaskOwner taskOwner = objectMapper.readValue(resource, TaskOwner.class);
+    assertThat(taskOwner.getName()).isNotNull();
+    assertThat(taskOwner.getName()).isEqualTo("spin-clouddriver-123");
+  }
+}

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/MonitorDeployManifestTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/MonitorDeployManifestTaskTest.java
@@ -1,0 +1,443 @@
+/*
+ * Copyright 2021 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
+import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import com.netflix.spinnaker.orca.api.pipeline.models.TaskExecution;
+import com.netflix.spinnaker.orca.clouddriver.KatoService;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.model.Manifest;
+import com.netflix.spinnaker.orca.clouddriver.model.Task;
+import com.netflix.spinnaker.orca.clouddriver.model.TaskId;
+import com.netflix.spinnaker.orca.clouddriver.model.TaskOwner;
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.model.TaskExecutionImpl;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.annotation.DirtiesContext;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+import retrofit.converter.JacksonConverter;
+import retrofit.mime.TypedByteArray;
+
+@ExtendWith(MockitoExtension.class)
+@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+final class MonitorDeployManifestTaskTest {
+
+  private static final String UNSTABLE_MESSAGE = "manifest is unstable";
+  private static final String FAILED_MESSAGE = "manifest failed";
+
+  private static final String ACCOUNT = "my-account";
+  private static final String MANIFEST_1 = "my-manifest-1";
+
+  private final TaskOwner taskOwner = new TaskOwner();
+
+  private MonitorDeployManifestTask task;
+  @Mock private KatoService katoService;
+
+  @Mock private OortService oortService;
+
+  @Mock private DynamicConfigService dynamicConfigService;
+
+  @Spy private RetrySupport retrySupport;
+
+  private final Registry noopRegistry = new NoopRegistry();
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private final JacksonConverter jacksonConverter = new JacksonConverter(objectMapper);
+
+  private Task katoTask;
+
+  private StageExecutionImpl myStage;
+
+  @BeforeEach
+  void setUp() {
+    task =
+        new MonitorDeployManifestTask(
+            katoService, oortService, noopRegistry, dynamicConfigService, retrySupport);
+    katoTask = new Task("2", new Task.Status(false, false, false), List.of(), List.of(), List.of());
+
+    myStage =
+        createStageWithContext(
+            ImmutableMap.of(
+                "account.name",
+                ACCOUNT,
+                "outputs.manifestNamesByNamespace",
+                ImmutableList.of(MANIFEST_1),
+                "kato.last.task.id",
+                new TaskId("2"),
+                "cloudProvider",
+                "kubernetes"));
+    TaskExecution deployManifestTask = new TaskExecutionImpl();
+    deployManifestTask.setId("1");
+    deployManifestTask.setName(DeployManifestTask.TASK_NAME);
+    deployManifestTask.setStartTime(Instant.now().minusMillis(390000L).toEpochMilli());
+    deployManifestTask.setImplementingClass(DeployManifestTask.class.getSimpleName());
+    deployManifestTask.setStatus(ExecutionStatus.SUCCEEDED);
+    TaskExecution monitorTask = new TaskExecutionImpl();
+    monitorTask.setId("2");
+    monitorTask.setStartTime(Instant.now().minusMillis(360000L).toEpochMilli());
+    monitorTask.setImplementingClass(MonitorDeployManifestTask.class.getSimpleName());
+    monitorTask.setStatus(ExecutionStatus.RUNNING);
+    monitorTask.setName(MonitorDeployManifestTask.TASK_NAME);
+    myStage.setTasks(List.of(deployManifestTask, monitorTask));
+
+    taskOwner.setName("owner-clouddriver-pod-name");
+  }
+
+  @Test
+  void retryKubernetesTaskFeatureFlagDisabled() {
+    when(katoService.lookupTask("2", false)).thenReturn(katoTask);
+
+    when(dynamicConfigService.isEnabled(
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.retry-task", false))
+        .thenReturn(false);
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    verifyNoMoreInteractions(katoService);
+    verifyNoInteractions(oortService);
+  }
+
+  @Test
+  void maxPeriodOfInactivityNotExceeded() {
+    mockRetryProperties();
+    when(dynamicConfigService.getConfig(
+            Long.class,
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.maximum-period-inactivity-ms",
+            300000L))
+        .thenReturn(600000L);
+    when(katoService.lookupTask("2", false)).thenReturn(katoTask);
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    verifyNoMoreInteractions(katoService);
+    verifyNoInteractions(oortService);
+  }
+
+  @Test
+  void lookupTaskOwnerCallFails() {
+    mockRetryProperties();
+    when(katoService.lookupTask("2", false)).thenReturn(katoTask);
+    when(katoService.lookupTaskOwner("kubernetes", "2")).thenThrow(SpinnakerServerException.class);
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    verify(katoService).lookupTaskOwner("kubernetes", "2");
+    verifyNoMoreInteractions(katoService);
+    verifyNoInteractions(oortService);
+
+    assertThat(myStage.getContext().containsKey("kato.task.forceRetryFatalError")).isTrue();
+    assertThat(myStage.getContext().get("kato.task.forceRetryFatalError")).isEqualTo(true);
+  }
+
+  @Test
+  void previousRetryAttemptsFailedWithAFatalError() {
+    mockRetryProperties();
+    when(katoService.lookupTask("2", false)).thenReturn(katoTask);
+    when(katoService.lookupTaskOwner("kubernetes", "2")).thenThrow(SpinnakerServerException.class);
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    verify(katoService).lookupTaskOwner("kubernetes", "2");
+    verifyNoMoreInteractions(katoService);
+    verifyNoInteractions(oortService);
+    assertThat(myStage.getContext().containsKey("kato.task.forceRetryFatalError")).isTrue();
+    assertThat(myStage.getContext().get("kato.task.forceRetryFatalError")).isEqualTo(true);
+
+    TaskResult result2 = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result2.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    verifyNoMoreInteractions(katoService);
+    verifyNoInteractions(oortService);
+  }
+
+  @Test
+  void clouddriverOwnerPodIsAlive() {
+    mockRetryProperties();
+    when(katoService.lookupTask("2", false)).thenReturn(katoTask);
+    when(katoService.lookupTaskOwner("kubernetes", "2")).thenReturn(taskOwner);
+
+    when(dynamicConfigService.getConfig(
+            String.class, "tasks.monitor-kato-task.kubernetes.deploy-manifest.account", ""))
+        .thenReturn("account");
+
+    when(dynamicConfigService.getConfig(
+            String.class,
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.namespace",
+            "spinnaker"))
+        .thenReturn("ns");
+
+    when(oortService.getManifest("account", "ns", "pod owner-clouddriver-pod-name", false))
+        .thenReturn(manifestBuilder().stable(true).failed(false).build());
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    verify(katoService).lookupTaskOwner("kubernetes", "2");
+    verify(oortService).getManifest("account", "ns", "pod owner-clouddriver-pod-name", false);
+    verifyNoMoreInteractions(katoService);
+  }
+
+  @Test
+  void clouddriverOwnerPodManifestLookupResultsInError() {
+    mockRetryProperties();
+    when(katoService.lookupTask("2", false)).thenReturn(katoTask);
+    when(katoService.lookupTaskOwner("kubernetes", "2")).thenReturn(taskOwner);
+
+    when(dynamicConfigService.getConfig(
+            String.class, "tasks.monitor-kato-task.kubernetes.deploy-manifest.account", ""))
+        .thenReturn("account");
+
+    when(dynamicConfigService.getConfig(
+            String.class,
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.namespace",
+            "spinnaker"))
+        .thenReturn("ns");
+
+    when(oortService.getManifest("account", "ns", "pod owner-clouddriver-pod-name", false))
+        .thenThrow(SpinnakerHttpException.class);
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    verify(katoService).lookupTaskOwner("kubernetes", "2");
+    verify(oortService).getManifest("account", "ns", "pod owner-clouddriver-pod-name", false);
+    verifyNoMoreInteractions(katoService);
+  }
+
+  @Test
+  void noClouddriverOwnerPodManifestFound() {
+    mockRetryProperties();
+    myStage.getContext().put("kato.task.retriedOperation", true);
+    myStage.getContext().put("kato.task.forcedRetries", 0);
+
+    ImmutableMap<String, Map> operation = task.getOperation(myStage);
+    assertThat(ImmutableList.of(operation)).isNotNull();
+
+    when(katoService.lookupTask("2", false)).thenReturn(katoTask);
+    when(katoService.lookupTaskOwner("kubernetes", "2")).thenReturn(taskOwner);
+
+    when(dynamicConfigService.getConfig(
+            String.class, "tasks.monitor-kato-task.kubernetes.deploy-manifest.account", ""))
+        .thenReturn("account");
+    when(dynamicConfigService.getConfig(
+            String.class,
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.namespace",
+            "spinnaker"))
+        .thenReturn("ns");
+
+    when(oortService.getManifest("account", "ns", "pod owner-clouddriver-pod-name", false))
+        .thenThrow(notFoundError());
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    verify(katoService).lookupTaskOwner("kubernetes", "2");
+    verify(oortService).getManifest("account", "ns", "pod owner-clouddriver-pod-name", false);
+
+    verify(katoService).updateTaskRetryability("kubernetes", "2", true);
+    verify(katoService).restartTask("kubernetes", "2", ImmutableList.of(operation));
+
+    // verify that the retry count was incremented
+    assertThat(myStage.getContext().get("kato.task.forcedRetries")).isEqualTo(1);
+  }
+
+  @Test
+  void clouddriverOwnerPodManifestFoundButUpdateTaskRetryabilityFails() {
+    mockRetryProperties();
+    myStage.getContext().put("kato.task.retriedOperation", true);
+    myStage.getContext().put("kato.task.forcedRetries", 0);
+
+    ImmutableMap<String, Map> operation = task.getOperation(myStage);
+    assertThat(ImmutableList.of(operation)).isNotNull();
+
+    when(katoService.lookupTask("2", false)).thenReturn(katoTask);
+    when(katoService.lookupTaskOwner("kubernetes", "2")).thenReturn(taskOwner);
+    when(katoService.updateTaskRetryability("kubernetes", "2", true))
+        .thenThrow(
+            SpinnakerServerException
+                .class); // arbitrary exception since the idea is to swallow all errors
+
+    when(dynamicConfigService.getConfig(
+            String.class, "tasks.monitor-kato-task.kubernetes.deploy-manifest.account", ""))
+        .thenReturn("account");
+    when(dynamicConfigService.getConfig(
+            String.class,
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.namespace",
+            "spinnaker"))
+        .thenReturn("ns");
+
+    when(oortService.getManifest("account", "ns", "pod owner-clouddriver-pod-name", false))
+        .thenThrow(notFoundError());
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    verify(katoService).lookupTaskOwner("kubernetes", "2");
+    verify(oortService).getManifest("account", "ns", "pod owner-clouddriver-pod-name", false);
+
+    verify(katoService).updateTaskRetryability("kubernetes", "2", true);
+    verifyNoMoreInteractions(katoService);
+
+    // verify that the retry count was not incremented
+    assertThat(myStage.getContext().get("kato.task.forcedRetries")).isEqualTo(0);
+
+    assertThat(myStage.getContext().containsKey("kato.task.forceRetryFatalError")).isTrue();
+    assertThat(myStage.getContext().get("kato.task.forceRetryFatalError")).isEqualTo(true);
+  }
+
+  @Test
+  void clouddriverOwnerPodManifestFoundButForceTaskRetryFails() {
+    mockRetryProperties();
+    myStage.getContext().put("kato.task.retriedOperation", true);
+    myStage.getContext().put("kato.task.forcedRetries", 0);
+
+    ImmutableMap<String, Map> operation = task.getOperation(myStage);
+    assertThat(ImmutableList.of(operation)).isNotNull();
+
+    when(katoService.lookupTask("2", false)).thenReturn(katoTask);
+    when(katoService.lookupTaskOwner("kubernetes", "2")).thenReturn(taskOwner);
+    when(katoService.restartTask("kubernetes", "2", ImmutableList.of(operation)))
+        .thenThrow(
+            SpinnakerServerException
+                .class); // arbitrary exception since the idea is to swallow all errors
+
+    when(dynamicConfigService.getConfig(
+            String.class, "tasks.monitor-kato-task.kubernetes.deploy-manifest.account", ""))
+        .thenReturn("account");
+    when(dynamicConfigService.getConfig(
+            String.class,
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.namespace",
+            "spinnaker"))
+        .thenReturn("ns");
+
+    when(oortService.getManifest("account", "ns", "pod owner-clouddriver-pod-name", false))
+        .thenThrow(notFoundError());
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    verify(katoService).lookupTaskOwner("kubernetes", "2");
+    verify(oortService).getManifest("account", "ns", "pod owner-clouddriver-pod-name", false);
+
+    verify(katoService).updateTaskRetryability("kubernetes", "2", true);
+
+    verify(katoService).restartTask("kubernetes", "2", ImmutableList.of(operation));
+
+    // verify that the retry count was not incremented
+    assertThat(myStage.getContext().get("kato.task.forcedRetries")).isEqualTo(0);
+
+    assertThat(myStage.getContext().containsKey("kato.task.forceRetryFatalError")).isTrue();
+    assertThat(myStage.getContext().get("kato.task.forceRetryFatalError")).isEqualTo(true);
+  }
+
+  private void mockRetryProperties() {
+    when(dynamicConfigService.isEnabled(
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.retry-task", false))
+        .thenReturn(true);
+
+    when(dynamicConfigService.getConfig(
+            Integer.class,
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.maximum-forced-retries",
+            3))
+        .thenReturn(3);
+
+    when(dynamicConfigService.getConfig(
+            Long.class,
+            "tasks.monitor-kato-task.kubernetes.deploy-manifest.maximum-period-inactivity-ms",
+            300000L))
+        .thenReturn(300000L);
+  }
+
+  private StageExecutionImpl createStageWithContext(Map<String, ?> context) {
+    return new StageExecutionImpl(
+        new PipelineExecutionImpl(ExecutionType.PIPELINE, "test"), "test", new HashMap<>(context));
+  }
+
+  private static ManifestBuilder manifestBuilder() {
+    return new ManifestBuilder();
+  }
+
+  private static class ManifestBuilder {
+    private static final Manifest.Condition UNSTABLE =
+        new Manifest.Condition(false, UNSTABLE_MESSAGE);
+    private static final Manifest.Condition FAILED = new Manifest.Condition(true, FAILED_MESSAGE);
+
+    private boolean stable;
+    private boolean failed;
+
+    ManifestBuilder stable(boolean state) {
+      stable = state;
+      return this;
+    }
+
+    ManifestBuilder failed(boolean state) {
+      failed = state;
+      return this;
+    }
+
+    private Manifest.Status getStatus() {
+      Manifest.Condition stableCondition = stable ? Manifest.Condition.emptyTrue() : UNSTABLE;
+      Manifest.Condition failedCondition = failed ? FAILED : Manifest.Condition.emptyFalse();
+      return Manifest.Status.builder().stable(stableCondition).failed(failedCondition).build();
+    }
+
+    public Manifest build() {
+      return Manifest.builder().status(getStatus()).build();
+    }
+  }
+
+  private SpinnakerHttpException notFoundError() {
+    return new SpinnakerHttpException(
+        RetrofitError.httpError(
+            "http://localhost",
+            new Response(
+                "http://localhost",
+                404,
+                "Manifest (account: account, location: ns, name: pod spin-clouddriver-6df9f7768c-zzr2t) not found",
+                List.of(),
+                new TypedByteArray(
+                    "application/json",
+                    "{\"error\":\"Not Found\",\"message\":\"Manifest (account: k8s-spinnaker1-v2-account, location: spinnaker, name: spin-clouddriver-6df9f7768c-zzr2t) not found\",\"status\":404,\"timestamp\":\"2021-01-25T18:29:59.277+00:00\"}"
+                        .getBytes())),
+            jacksonConverter,
+            Task.class));
+  }
+}

--- a/orca-clouddriver/src/test/resources/com/netflix/spinnaker/orca/clouddriver/model/tasks/owners/success.json
+++ b/orca-clouddriver/src/test/resources/com/netflix/spinnaker/orca/clouddriver/model/tasks/owners/success.json
@@ -1,0 +1,3 @@
+{
+  "name" : "spin-clouddriver-123"
+}

--- a/orca-clouddriver/src/test/resources/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/monitorDeployManifestTask/owner-pod-manifest-not-found.json
+++ b/orca-clouddriver/src/test/resources/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/monitorDeployManifestTask/owner-pod-manifest-not-found.json
@@ -1,0 +1,6 @@
+{
+  "error":"Not Found",
+  "message":"Manifest (account: k8s-spinnaker1-v2-account, location: spinnaker, name: pod spin-clouddriver-7b6d557868-s8d6s) not found",
+  "status":404,
+  "timestamp":"2021-01-25T21:52:25.252+00:00"
+}


### PR DESCRIPTION
Before this, DeployManifestStage uses MonitorKatoTask to wait for a DeployManifestTask operation to complete. If the task isn't complete, MonitorKatoTask does have logic to call kato.resumeTask (POST task/{id}:resume, clouddriver's OperationsController.resumeTask), but that only applies when the task is retryable. Before this change only tasks in sagas are potentially retryable, so then it's up to orca to re-execute the MonitorKatoTask, and all that's happening is waiting for clouddriver to do its work.

This PR introduces a MonitorDeployManifestTask that starts a new DeployManifestTask if it detects that the clouddriver pod executing the current DeployManifestTask is no longer present. This is only relevant if clouddriver itself is running in kubernetes, and that clouddriver is configured with a kubernetes account for "itself".

Kubernetes DeployManifestTask tasks in orca correspond to KubernetesDeployManifestOperations in clouddriver. That operation is responsible for kubectl apply (or similar based on annotations in the manifest(s) being deployed). It's not typically a long operation, but if there are multiple (or large) manifests, or unreliable communications with the target cluster, it's certainly possible for the clouddriver pod to die before it completes.

The following configuration flags (and their defaults) control the behavior of this new feature:
```
tasks.monitor-kato-task.kubernetes.deploy-manifest:
  retry-task.enabled: false
  maximum-period-inactivity-ms: 300000L
  maximum-forced-retries: 3
  account: "" # the name of the account where clouddriver runs, required if enabled is true
  namespace: spinnaker
```
The execution context of kubernetes deploy manifest stages contain the following information to track the progress of additional attempts:
```
kato.task.forcedRetryAttempts: this is more for debugging....if forcedRetryAttempts < forcedRetries then forceRetryFatalError is true
kato.task.forcedRetries: the number of retries
kato.task.forceRetryFatalError: true if there was an error retrying
```
It's a little unfortunate that restarting the DeployManifestTask means creating a whole new task. Clouddriver's task repository doesn't store its inputs, at least for non-saga tasks, so it's not possible to restart an existing one. See OperationsService.collectAtomicOperationsFromSagas for more.

depends on https://github.com/spinnaker/clouddriver/pull/5833