### PR TITLE
feat(servergroup): Allow users to opt-out of the target desired size check when verifying if the instances scaled up or down successfully

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ResizeServerGroupProperties.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ResizeServerGroupProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Netflix, Inc.
+ * Copyright 2024 Harness, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ResizeServerGroupProperties.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ResizeServerGroupProperties.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "resize-server-group")
+public class ResizeServerGroupProperties {
+
+  private boolean useTargetDesiredSize = true;
+
+  public void setUseTargetDesiredSize(boolean useTargetDesiredSize) {
+    this.useTargetDesiredSize = useTargetDesiredSize;
+  }
+
+  public boolean isUseTargetDesiredSize() {
+    return useTargetDesiredSize;
+  }
+}

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupProperties.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupProperties.java
@@ -20,16 +20,28 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConfigurationProperties(prefix = "resize-server-group")
-public class ResizeServerGroupProperties {
+@ConfigurationProperties(prefix = "server-group")
+public class ServerGroupProperties {
 
-  private boolean useTargetDesiredSize = true;
+  private Resize resize = new Resize();
 
-  public void setUseTargetDesiredSize(boolean useTargetDesiredSize) {
-    this.useTargetDesiredSize = useTargetDesiredSize;
+  public static class Resize {
+    private boolean matchInstancesSize;
+
+    public void setMatchInstancesSize(boolean matchInstancesSize) {
+      this.matchInstancesSize = matchInstancesSize;
+    }
+
+    public boolean isMatchInstancesSize() {
+      return matchInstancesSize;
+    }
   }
 
-  public boolean isUseTargetDesiredSize() {
-    return useTargetDesiredSize;
+  public void setResize(Resize resize) {
+    this.resize = resize;
+  }
+
+  public Resize getResize() {
+    return resize;
   }
 }

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTask.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2024 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,6 +26,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class WaitForCapacityMatchTask extends AbstractInstancesCheckTask {
+
+  private final ResizeServerGroupProperties resizeServerGroupProperties;
+
+  public WaitForCapacityMatchTask(ResizeServerGroupProperties resizeServerGroupProperties) {
+    this.resizeServerGroupProperties = resizeServerGroupProperties;
+  }
 
   @Override
   protected Map<String, List<String>> getServerGroups(StageExecution stage) {
@@ -88,27 +94,37 @@ public class WaitForCapacityMatchTask extends AbstractInstancesCheckTask {
         desired = capacity.getDesired();
       }
 
-      Integer targetDesiredSize =
-          Optional.ofNullable((Number) context.get("targetDesiredSize"))
-              .map(Number::intValue)
-              .orElse(null);
+      if (resizeServerGroupProperties.isUseTargetDesiredSize()) {
+        Integer targetDesiredSize =
+            Optional.ofNullable((Number) context.get("targetDesiredSize"))
+                .map(Number::intValue)
+                .orElse(null);
 
-      splainer.add(
-          String.format(
-              "checking if capacity matches (desired=%s, target=%s current=%s)",
-              desired, targetDesiredSize == null ? "none" : targetDesiredSize, instances.size()));
-      if (targetDesiredSize != null && targetDesiredSize != 0) {
-        // `targetDesiredSize` is derived from `targetHealthyDeployPercentage` and if present,
-        // then scaling has succeeded if the number of instances is greater than this value.
-        if (instances.size() < targetDesiredSize) {
+        splainer.add(
+            String.format(
+                "checking if capacity matches (desired=%s, target=%s current=%s)",
+                desired, targetDesiredSize == null ? "none" : targetDesiredSize, instances.size()));
+        if (targetDesiredSize != null && targetDesiredSize != 0) {
+          // `targetDesiredSize` is derived from `targetHealthyDeployPercentage` and if present,
+          // then scaling has succeeded if the number of instances is greater than this value.
+          if (instances.size() < targetDesiredSize) {
+            splainer.add(
+                "short-circuiting out of WaitForCapacityMatchTask because targetDesired and current capacity don't match");
+            return false;
+          }
+        } else if (desired == null || desired != instances.size()) {
           splainer.add(
-              "short-circuiting out of WaitForCapacityMatchTask because targetDesired and current capacity don't match");
+              "short-circuiting out of WaitForCapacityMatchTask because expected and current capacity don't match");
           return false;
         }
-      } else if (desired == null || desired != instances.size()) {
+      } else {
         splainer.add(
-            "short-circuiting out of WaitForCapacityMatchTask because expected and current capacity don't match");
-        return false;
+            "checking if capacity matches (desired=${desired}, instances.size()=${instances.size()}) ");
+        if (desired == null || desired != instances.size()) {
+          splainer.add(
+              "short-circuiting out of WaitForCapacityMatchTask because expected and current capacity don't match}");
+          return false;
+        }
       }
 
       boolean disabled = Boolean.TRUE.equals(serverGroup.getDisabled());

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTaskSpec.groovy
@@ -30,7 +30,7 @@ import spock.lang.Unroll
 class WaitForCapacityMatchTaskSpec extends Specification {
 
   CloudDriverService cloudDriverService = Mock()
-  @Subject WaitForCapacityMatchTask task = new WaitForCapacityMatchTask() {
+  @Subject WaitForCapacityMatchTask task = new WaitForCapacityMatchTask(new ResizeServerGroupProperties()) {
     @Override
     void verifyServerGroupsExist(StageExecution stage) {
       // do nothing
@@ -262,6 +262,58 @@ class WaitForCapacityMatchTaskSpec extends Specification {
     // asg value is used when autoscaling
     true   || 4       | [min: 3, max: 10, desired: 4]   | [min: 1, max: 50, desired: 5]
     true   || 4       | [min: 3, max: 10, desired: 4]   | [min: "1", max: "50", desired: "5"]
+  }
+
+  @Unroll
+  void 'should use number of instances when determining if scaling has succeeded even if targetHealthyDeployPercentage is defined'() {
+    def properties = new ResizeServerGroupProperties()
+    properties.setUseTargetDesiredSize(false)
+    WaitForCapacityMatchTask task = new WaitForCapacityMatchTask(properties) {
+      @Override
+      void verifyServerGroupsExist(StageExecution stage) {
+        // do nothing
+      }
+    }
+    when:
+    def context  = [
+        capacity: [
+            min: configured.min,
+            max: configured.max,
+            desired: configured.desired
+        ],
+        targetHealthyDeployPercentage: targetHealthyDeployPercentage,
+        targetDesiredSize: targetHealthyDeployPercentage
+            ? Math.round(targetHealthyDeployPercentage * configured.desired / 100) : null
+    ]
+
+    def serverGroup = ModelUtils.serverGroup([
+        asg: [
+            desiredCapacity: asg.desired
+        ],
+        capacity: [
+            min: asg.min,
+            max: asg.max,
+            desired: asg.desired
+        ]
+    ])
+
+    def instances = []
+    (1..healthy).each {
+      instances << ModelUtils.instance([health: [[state: 'Up']]])
+    }
+
+    then:
+    result == task.hasSucceeded(
+        new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", "", context),
+        serverGroup, instances, null
+    )
+
+    where:
+    result || healthy | asg                             | configured                      | targetHealthyDeployPercentage
+    false  || 5       | [min: 10, max: 15, desired: 15] | [min: 10, max: 15, desired: 15] | 85
+    false  || 12      | [min: 10, max: 15, desired: 15] | [min: 10, max: 15, desired: 15] | 85
+    false  || 13      | [min: 10, max: 15, desired: 15] | [min: 10, max: 15, desired: 15] | 85
+    true   || 15      | [min: 10, max: 15, desired: 15] | [min: 10, max: 15, desired: 15] | 100
   }
 
   private static Instance makeInstance(id, healthState = 'Up') {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTaskSpec.groovy
@@ -30,7 +30,7 @@ import spock.lang.Unroll
 class WaitForCapacityMatchTaskSpec extends Specification {
 
   CloudDriverService cloudDriverService = Mock()
-  @Subject WaitForCapacityMatchTask task = new WaitForCapacityMatchTask(new ResizeServerGroupProperties()) {
+  @Subject WaitForCapacityMatchTask task = new WaitForCapacityMatchTask(new ServerGroupProperties()) {
     @Override
     void verifyServerGroupsExist(StageExecution stage) {
       // do nothing
@@ -266,9 +266,11 @@ class WaitForCapacityMatchTaskSpec extends Specification {
 
   @Unroll
   void 'should use number of instances when determining if scaling has succeeded even if targetHealthyDeployPercentage is defined'() {
-    def properties = new ResizeServerGroupProperties()
-    properties.setUseTargetDesiredSize(false)
-    WaitForCapacityMatchTask task = new WaitForCapacityMatchTask(properties) {
+    def serverGroupProperties = new ServerGroupProperties()
+    def resize = new ServerGroupProperties.Resize()
+    resize.setMatchInstancesSize(true)
+    serverGroupProperties.setResize(resize)
+    WaitForCapacityMatchTask task = new WaitForCapacityMatchTask(serverGroupProperties) {
       @Override
       void verifyServerGroupsExist(StageExecution stage) {
         // do nothing


### PR DESCRIPTION
Some of our users prefer to use the actual instance size list to verify if everything was scaled up or down accordingly instead of relying on the target percentage. They noticed this is causing instability on their end
