### PR TITLE
feat(execution): remove spinnaker accounts from execution context

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/config/ExecutionConfigurationProperties.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/config/ExecutionConfigurationProperties.java
@@ -42,6 +42,9 @@ public class ExecutionConfigurationProperties {
    */
   private Set<OrchestrationExecution> allowedOrchestrationExecutions = Set.of();
 
+  /** flag to include/exclude the set of allowed accounts in an execution context */
+  private boolean includeAllowedAccounts = true;
+
   /**
    * helper method that returns an {@link Optional<OrchestrationExecution>} object if the
    * orchestration execution provided as an input is in the allowed orchestration executions set.

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -269,8 +269,14 @@ public class ExecutionLauncher {
     PipelineExecution.AuthenticationDetails auth = new PipelineExecution.AuthenticationDetails();
     auth.setUser(getString(config, "user"));
 
-    orchestration.setAuthentication(
-        PipelineExecutionImpl.AuthenticationHelper.build().orElse(auth));
+    if (executionConfigurationProperties.isIncludeAllowedAccounts()) {
+      orchestration.setAuthentication(
+          PipelineExecutionImpl.AuthenticationHelper.build().orElse(auth));
+    } else {
+      orchestration.setAuthentication(
+          PipelineExecutionImpl.AuthenticationHelper.buildWithoutAccounts().orElse(auth));
+    }
+
     orchestration.setOrigin((String) config.getOrDefault("origin", "unknown"));
     orchestration.setStartTimeExpiry((Long) config.get("startTimeExpiry"));
     orchestration.setSpelEvaluator(getString(config, "spelEvaluator"));

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java
@@ -230,6 +230,7 @@ public class ExecutionLauncher {
                     config.get("source"), PipelineExecution.PipelineSource.class))
         .withSpelEvaluator(getString(config, "spelEvaluator"))
         .withTemplateVariables(getMap(config, "templateVariables"))
+        .withIncludeAllowedAccounts(executionConfigurationProperties.isIncludeAllowedAccounts())
         .build();
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
@@ -26,8 +26,15 @@ import java.util.Map;
 
 @Deprecated
 public class PipelineBuilder {
+  private boolean includeAllowedAccounts;
+
   public PipelineBuilder(String application) {
     pipeline = PipelineExecutionImpl.newPipeline(application);
+  }
+
+  public PipelineBuilder withIncludeAllowedAccounts(boolean includeAllowedAccounts) {
+    this.includeAllowedAccounts = includeAllowedAccounts;
+    return this;
   }
 
   public PipelineBuilder withId(String id) {
@@ -113,9 +120,15 @@ public class PipelineBuilder {
 
   public PipelineExecution build() {
     pipeline.setBuildTime(System.currentTimeMillis());
-    pipeline.setAuthentication(
-        PipelineExecutionImpl.AuthenticationHelper.build()
-            .orElse(new PipelineExecution.AuthenticationDetails()));
+    if (this.includeAllowedAccounts) {
+      pipeline.setAuthentication(
+          PipelineExecutionImpl.AuthenticationHelper.build()
+              .orElse(new PipelineExecution.AuthenticationDetails()));
+    } else {
+      pipeline.setAuthentication(
+          PipelineExecutionImpl.AuthenticationHelper.buildWithoutAccounts()
+              .orElse(new PipelineExecution.AuthenticationDetails()));
+    }
 
     return pipeline;
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
@@ -444,5 +444,13 @@ public class PipelineExecutionImpl implements PipelineExecution, Serializable {
 
       return Optional.empty();
     }
+
+    public static Optional<AuthenticationDetails> buildWithoutAccounts() {
+      Optional<String> spinnakerUserOptional = AuthenticatedRequest.getSpinnakerUser();
+      if (spinnakerUserOptional.isPresent()) {
+        return Optional.of(new AuthenticationDetails(spinnakerUserOptional.orElse(null)));
+      }
+      return Optional.empty();
+    }
   }
 }

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImplSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImplSpec.groovy
@@ -57,6 +57,19 @@ class PipelineExecutionImplSpec extends Specification {
     authenticationDetails.allowedAccounts == ["Account1", "Account2"] as Set
   }
 
+  def "should build AuthenticationDetails without accounts"() {
+    given:
+    MDC.put(Header.USER.header, "SpinnakerUser")
+    MDC.put(Header.ACCOUNTS.header, "Account1,Account2")
+
+    when:
+    def authenticationDetails = PipelineExecutionImpl.AuthenticationHelper.buildWithoutAccounts().get()
+
+    then:
+    authenticationDetails.user == "SpinnakerUser"
+    authenticationDetails.allowedAccounts == [] as Set
+  }
+
   def "should calculate context from outputs of all stages"() {
     given:
     def pipeline = pipeline {

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncherTest.java
@@ -16,13 +16,14 @@
 
 package com.netflix.spinnaker.orca.pipeline;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.kork.common.Header;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.config.ExecutionConfigurationProperties;
@@ -31,12 +32,14 @@ import com.netflix.spinnaker.orca.test.YamlFileApplicationContextInitializer;
 import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -73,6 +76,7 @@ public class ExecutionLauncherTest extends YamlFileApplicationContextInitializer
     clock = Clock.systemUTC();
     pipelineValidator = Optional.empty();
     registry = Optional.empty();
+    MDC.clear();
 
     executionLauncher =
         new ExecutionLauncher(
@@ -197,6 +201,79 @@ public class ExecutionLauncherTest extends YamlFileApplicationContextInitializer
             "system",
             "Failed on startup: ad-hoc execution of type: savePipeline has been"
                 + " disabled for user: not-explicitly-permitted-user@abc.com");
+  }
+
+  @DisplayName(
+      "when includeAllowedAccounts: true, then the orchestration should contain Spinnaker accounts")
+  @Test
+  public void testIncludeSpinnakerAccounts() throws Exception {
+    // given
+    MDC.put(Header.USER.getHeader(), "SpinnakerUser");
+    MDC.put(Header.ACCOUNTS.getHeader(), "Account1,Account2");
+
+    // override properties to allow orchestration executions
+    ExecutionConfigurationProperties executionConfigurationProperties =
+        new ExecutionConfigurationProperties();
+    executionConfigurationProperties.setBlockOrchestrationExecutions(false);
+    executionLauncher =
+        new ExecutionLauncher(
+            objectMapper,
+            executionRepository,
+            executionRunner,
+            clock,
+            applicationEventPublisher,
+            pipelineValidator,
+            registry,
+            executionConfigurationProperties);
+
+    // when
+    PipelineExecution pipelineExecution =
+        executionLauncher.start(
+            ExecutionType.ORCHESTRATION, getConfigJson("ad-hoc/deploy-manifest.json"));
+
+    // then
+    // verify that the execution runner attempted to start the execution as expected
+    verify(executionRunner).start(pipelineExecution);
+    // verify that accounts are set in the pipeline execution
+    assertThat(pipelineExecution.getAuthentication().getAllowedAccounts())
+        .isEqualTo(Set.of("Account1", "Account2"));
+  }
+
+  @DisplayName(
+      "when includeAllowedAccounts: false, then the orchestration should not contain Spinnaker accounts")
+  @Test
+  public void testExcludeSpinnakerAccounts() throws Exception {
+    // given
+    MDC.put(Header.USER.getHeader(), "SpinnakerUser");
+    MDC.put(Header.ACCOUNTS.getHeader(), "Account1,Account2");
+
+    // override properties to 1. allow orchestration executions and 2. set includeAllowedAccounts to
+    // false
+    ExecutionConfigurationProperties executionConfigurationProperties =
+        new ExecutionConfigurationProperties();
+    executionConfigurationProperties.setBlockOrchestrationExecutions(false);
+    executionConfigurationProperties.setIncludeAllowedAccounts(false);
+    executionLauncher =
+        new ExecutionLauncher(
+            objectMapper,
+            executionRepository,
+            executionRunner,
+            clock,
+            applicationEventPublisher,
+            pipelineValidator,
+            registry,
+            executionConfigurationProperties);
+
+    // when
+    PipelineExecution pipelineExecution =
+        executionLauncher.start(
+            ExecutionType.ORCHESTRATION, getConfigJson("ad-hoc/deploy-manifest.json"));
+
+    // then
+    // verify that the execution runner attempted to start the execution as expected
+    verify(executionRunner).start(pipelineExecution);
+    // verify that accounts are not set in the pipeline execution
+    assertThat(pipelineExecution.getAuthentication().getAllowedAccounts()).isEqualTo(Set.of());
   }
 
   private Map<String, Object> getConfigJson(String resource) throws Exception {

--- a/orca-core/src/test/resources/execution-launcher-properties.yml
+++ b/orca-core/src/test/resources/execution-launcher-properties.yml
@@ -7,3 +7,4 @@ executions:
     - name: updateApplication # eg. config to show how to set the name and allowAllUsers properties for an execution
       allowAllUsers: true
     - name: saveApplication # eg. config to show how to set just the name of an execution. It defaults to allowAllUsers: true
+  includeAllowedAccounts: true


### PR DESCRIPTION
Add the `executions.includeAllowedAccounts` flag which defaults to true. If set to true, `authentication.allowedAccounts` will continue to be populated by accounts in the pipeline execution json. If set to false, the pipeline execution json will show `authentication.allowedAccounts = []`

Testing notes:
After setting the feature flag to false,

1. Pipelines triggered manually (by clicking play) and automatically (using a service account) continue to run. Pipelines that deploy resources into a kubernetes cluster are still able to do so
2. If the user or service account is unauthorized to run the pipeline, the pipeline will not run