### PR TITLE
feat(sql): log the size of executions when they complete

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -136,6 +137,20 @@ public interface PipelineExecution {
   String getPartition();
 
   void setPartition(String partition);
+
+  /**
+   * The size of the pipeline execution (not including stages) in units appropriate for the
+   * implementation (e.g. characters/bytes), if available.
+   */
+  Optional<Long> getSize();
+
+  void setSize(long size);
+
+  /**
+   * The total size of the pipeline execution including stages in units appropriate for the
+   * implementation (e.g. characters/bytes), if available.
+   */
+  Optional<Long> getTotalSize();
 
   // -------
 

--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
@@ -128,6 +128,14 @@ public interface StageExecution {
 
   void setAdditionalMetricTags(Map<String, String> additionalMetricTags);
 
+  /**
+   * The size of the stage execution in units appropriate for the implementation (e.g.
+   * characters/bytes), if available.
+   */
+  Optional<Long> getSize();
+
+  void setSize(long size);
+
   // ------------- InternalStageExecution?
   // A lot of these methods are used in a single place somewhere in Orca. I don't know why we
   // decided to put a bunch

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
@@ -324,6 +324,18 @@ public class StageExecutionImpl implements StageExecution, Serializable {
 
   private LastModifiedDetails lastModified;
 
+  @JsonIgnore private Long size = null;
+
+  @Override
+  public Optional<Long> getSize() {
+    return Optional.ofNullable(this.size);
+  }
+
+  @Override
+  public void setSize(long size) {
+    this.size = size;
+  }
+
   @Nullable
   @Override
   public StageExecution.LastModifiedDetails getLastModified() {

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImplTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PipelineExecutionImplTest {
+
+  private PipelineExecutionImpl pipelineExecution;
+
+  private StageExecutionImpl stageExecution;
+
+  @BeforeEach
+  void setup() {
+    pipelineExecution = new PipelineExecutionImpl(ExecutionType.PIPELINE, "test-application");
+    stageExecution = new StageExecutionImpl();
+    stageExecution.setExecution(pipelineExecution);
+    pipelineExecution.getStages().add(stageExecution);
+  }
+
+  @Test
+  void getTotalSizeMissingPipelineSize() {
+    // given
+    assertThat(pipelineExecution.getSize()).isEmpty();
+
+    // then
+    assertThat(pipelineExecution.getTotalSize()).isEmpty();
+  }
+
+  @Test
+  void getTotalSizeMissingStageSize() {
+    // given
+    long pipelineSize = 14; // arbitrary
+
+    pipelineExecution.setSize(pipelineSize);
+    assertThat(pipelineExecution.getSize()).isPresent();
+
+    assertThat(stageExecution.getSize()).isEmpty();
+
+    // then
+    assertThat(pipelineExecution.getTotalSize()).isEmpty();
+  }
+
+  @Test
+  void getTotalSizeCompleteInfo() {
+    // given
+    long pipelineSize = 5; // arbitrary
+    long stageSize = 7; // arbitrary
+
+    pipelineExecution.setSize(pipelineSize);
+    assertThat(pipelineExecution.getSize()).isPresent();
+
+    stageExecution.setSize(stageSize);
+    assertThat(stageExecution.getSize()).isPresent();
+
+    // then
+    assertThat(pipelineExecution.getTotalSize().get()).isEqualTo(pipelineSize + stageSize);
+  }
+}

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/ExecutionMapper.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/ExecutionMapper.kt
@@ -77,6 +77,7 @@ class ExecutionMapper(
         mapper.readValue<PipelineExecution>(body)
           .also {
             execution ->
+            execution.setSize(body.length.toLong())
             results.add(execution)
             execution.partition = rs.getString("partition")
 
@@ -120,12 +121,14 @@ class ExecutionMapper(
 
   private fun mapStage(rs: ResultSet, executions: Map<String, PipelineExecution>) {
     val executionId = rs.getString("execution_id")
+    val body = getDecompressedBody(rs)
     executions.getValue(executionId)
       .stages
       .add(
-        mapper.readValue<StageExecution>(getDecompressedBody(rs))
+        mapper.readValue<StageExecution>(body)
           .apply {
             execution = executions.getValue(executionId)
+            setSize(body.length.toLong())
           }
       )
   }

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -789,6 +789,9 @@ class SqlExecutionRepository(
       val stageTableName = execution.type.stagesTableName
       val status = execution.status.toString()
       val body = mapper.writeValueAsString(execution)
+      val bodySize = body.length.toLong()
+      execution.setSize(bodySize)
+      log.debug("application ${execution.application}, pipeline name: ${execution.name}, pipeline config id ${execution.pipelineConfigId}, pipeline execution id ${execution.id}, execution size: ${bodySize}")
 
       val (executionId, legacyId) = mapLegacyId(ctx, tableName, execution.id, execution.startTime)
 
@@ -878,6 +881,10 @@ class SqlExecutionRepository(
     val stageTable = stage.execution.type.stagesTableName
     val table = stage.execution.type.tableName
     val body = mapper.writeValueAsString(stage)
+    val bodySize = body.length.toLong()
+    stage.setSize(bodySize)
+    log.debug("application ${stage.execution.application}, pipeline name: ${stage.execution.name}, pipeline config id ${stage.execution.pipelineConfigId}, pipeline execution id ${stage.execution.id}, stage name: ${stage.name}, stage id: ${stage.id}, size: ${bodySize}")
+
     val buildTime = stage.execution.buildTime
 
     val executionUlid = executionId ?: mapLegacyId(ctx, table, stage.execution.id, buildTime).first


### PR DESCRIPTION
to make changes in size over time more observable.  This makes it easier to see the impact of features like the artifact store.

Not setting the size in RedisExecutionRepository because the extra objectMapper.writeValueAsString is potentially expensive and I'm not sure how many folks are using redis for this.
