### PR TITLE
fix(jenkins): Enable properties and artifacts with job name as query parameter

### DIFF
--- a/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/BuildService.java
+++ b/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/BuildService.java
@@ -60,12 +60,16 @@ public class BuildService {
 
   public Map<String, Object> getPropertyFile(
       Integer buildNumber, String fileName, String master, String job) {
-    return igorService.getPropertyFile(buildNumber, fileName, master, encode(job));
+    return this.igorFeatureFlagProperties.isJobNameAsQueryParameter()
+        ? igorService.getPropertyFileWithJobAsQueryParam(buildNumber, fileName, master, encode(job))
+        : igorService.getPropertyFile(buildNumber, fileName, master, encode(job));
   }
 
   public List<Artifact> getArtifacts(
       Integer buildNumber, String fileName, String master, String job) {
-    return igorService.getArtifacts(buildNumber, fileName, master, encode(job));
+    return this.igorFeatureFlagProperties.isJobNameAsQueryParameter()
+        ? igorService.getArtifactsWithJobAsQueryParam(buildNumber, fileName, master, encode(job))
+        : igorService.getArtifacts(buildNumber, fileName, master, encode(job));
   }
 
   public Response updateBuild(

--- a/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -79,6 +79,13 @@ public interface IgorService {
       @Path("master") String master,
       @Path(encode = false, value = "job") String job);
 
+  @GET("/builds/properties/{buildNumber}/{fileName}/{master}")
+  Map<String, Object> getPropertyFileWithJobAsQueryParam(
+      @Path("buildNumber") Integer buildNumber,
+      @Path("fileName") String fileName,
+      @Path("master") String master,
+      @Query(encodeValue = false, value = "job") String job);
+
   @GET("/{repoType}/{projectKey}/{repositorySlug}/compareCommits")
   List compareCommits(
       @Path("repoType") String repoType,
@@ -92,6 +99,13 @@ public interface IgorService {
       @Query("propertyFile") String propertyFile,
       @Path("master") String master,
       @Path(value = "job", encode = false) String job);
+
+  @GET("/builds/artifacts/{buildNumber}/{master}")
+  List<Artifact> getArtifactsWithJobAsQueryParam(
+      @Path("buildNumber") Integer buildNumber,
+      @Query("propertyFile") String propertyFile,
+      @Path("master") String master,
+      @Query(value = "job", encodeValue = false) String job);
 
   @POST("/gcb/builds/create/{account}")
   GoogleCloudBuild createGoogleCloudBuild(

--- a/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -84,7 +84,7 @@ public interface IgorService {
       @Path("buildNumber") Integer buildNumber,
       @Path("fileName") String fileName,
       @Path("master") String master,
-      @Query(encodeValue = false, value = "job") String job);
+      @Query(value = "job") String job);
 
   @GET("/{repoType}/{projectKey}/{repositorySlug}/compareCommits")
   List compareCommits(
@@ -105,7 +105,7 @@ public interface IgorService {
       @Path("buildNumber") Integer buildNumber,
       @Query("propertyFile") String propertyFile,
       @Path("master") String master,
-      @Query(value = "job", encodeValue = false) String job);
+      @Query(value = "job") String job);
 
   @POST("/gcb/builds/create/{account}")
   GoogleCloudBuild createGoogleCloudBuild(

--- a/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
+++ b/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
@@ -72,6 +72,18 @@ class BuildServiceSpec extends Specification {
     1 * igorService.getPropertyFile(BUILD_NUMBER, FILENAME, MASTER, JOB_NAME_ENCODED)
   }
 
+  void 'getPropertyFile method with job in query when flag is true'() {
+    IgorFeatureFlagProperties igorFeatureFlagProperties = new IgorFeatureFlagProperties()
+    igorFeatureFlagProperties.setJobNameAsQueryParameter(true)
+    buildService = new BuildService(igorService, igorFeatureFlagProperties)
+
+    when:
+    buildService.getPropertyFile(BUILD_NUMBER, FILENAME, MASTER, JOB_NAME)
+
+    then:
+    1 * igorService.getPropertyFileWithJobAsQueryParam(BUILD_NUMBER, FILENAME, MASTER, JOB_NAME_ENCODED)
+  }
+
   void 'stop method sends job name in path when flag is false'() {
     IgorFeatureFlagProperties igorFeatureFlagProperties = new IgorFeatureFlagProperties()
     igorFeatureFlagProperties.setJobNameAsQueryParameter(false)


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/6928

The implementation of: 
```
        feature:
          igor:
            jobNameAsQueryParameter: true
```
did not include the support  for Jenkins artifacts and property files leading to failures on Manual triggers and rerun's of a Spinnaker pipeline retrieving BuildInfo from the sub-folder Jenkins job.
