### PR TITLE
chore(dependencies): unpin com.jayway.jsonpath:json-path

### DIFF
--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -51,7 +51,7 @@ dependencies {
   implementation("org.apache.httpcomponents:httpclient")
   implementation("javax.servlet:javax.servlet-api:4.0.1")
   implementation("javax.validation:validation-api")
-  implementation("com.jayway.jsonpath:json-path:2.2.0")
+  implementation("com.jayway.jsonpath:json-path")
   implementation("org.yaml:snakeyaml")
   implementation("org.codehaus.groovy:groovy")
   implementation("net.javacrumbs.shedlock:shedlock-spring:4.44.0")

--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -10,7 +10,7 @@ dependencies {
   implementation("com.hubspot.jinjava:jinjava")
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-  implementation("com.jayway.jsonpath:json-path:2.2.0")
+  implementation("com.jayway.jsonpath:json-path")
   implementation("org.slf4j:slf4j-api")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("org.springframework:spring-context")

--- a/orca-webhook/orca-webhook.gradle
+++ b/orca-webhook/orca-webhook.gradle
@@ -25,7 +25,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")
-  implementation("com.jayway.jsonpath:json-path:2.2.0")
+  implementation("com.jayway.jsonpath:json-path")
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
   testImplementation("org.springframework:spring-test")


### PR DESCRIPTION
because the version from kork-bom/spring boot takes precedence.

From `$ ./gradlew orca-core:dependencies`, `$./gradlew orca-webhook:dependencies` and `$ ./gradlew orca-pipelinetemplate:dependencies` before:
```
+--- com.jayway.jsonpath:json-path:2.2.0 -> 2.5.0
|    +--- net.minidev:json-smart:2.3 -> 2.4.10
|    |    \--- net.minidev:accessors-smart:2.4.9
|    |         \--- org.ow2.asm:asm:9.3
```
after:
```
+--- com.jayway.jsonpath:json-path -> 2.5.0
|    +--- net.minidev:json-smart:2.3 -> 2.4.10
|    |    \--- net.minidev:accessors-smart:2.4.9
|    |         \--- org.ow2.asm:asm:9.3
```