### PR TITLE
refactor(echo): use SpinnakerRetrofitErrorHandler with EchoService

### DIFF
--- a/orca-echo/orca-echo.gradle
+++ b/orca-echo/orca-echo.gradle
@@ -28,6 +28,7 @@ dependencies {
   implementation("javax.validation:validation-api")
   implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
   implementation("io.spinnaker.fiat:fiat-api:$fiatVersion")
+  implementation("io.spinnaker.kork:kork-retrofit")
 
   testImplementation("com.squareup.retrofit:retrofit-mock")
 }

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
@@ -21,6 +21,7 @@ import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
 import com.netflix.spinnaker.orca.echo.EchoService
 import com.netflix.spinnaker.orca.echo.spring.EchoNotifyingExecutionListener
 import com.netflix.spinnaker.orca.echo.spring.EchoNotifyingStageListener
@@ -69,6 +70,7 @@ class EchoConfiguration {
       .setEndpoint(echoEndpoint)
       .setClient(new Ok3Client(clientProvider.getClient(new DefaultServiceEndpoint("echo", echoEndpoint.url))))
       .setLogLevel(retrofitLogLevel)
+      .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .setLog(new RetrofitSlf4jLog(EchoService))
       .setConverter(new JacksonConverter())
       .build()


### PR DESCRIPTION
This code change is to maintain the uniformity across all the retrofit client configurations in ORCA,  as part of upgrading the retrofit version to 2.x.

There are neither any changes to the exception handler logics nor any behaviour changes involved.