### PR TITLE
refactor(flex): use SpinnakerRetrofitErrorHandler with FlexService

### DIFF
--- a/orca-flex/orca-flex.gradle
+++ b/orca-flex/orca-flex.gradle
@@ -24,4 +24,5 @@ dependencies {
   implementation("com.netflix.frigga:frigga")
   implementation("io.spinnaker.kork:kork-core")
   implementation("io.spinnaker.kork:kork-moniker")
+  implementation("io.spinnaker.kork:kork-retrofit")
 }

--- a/orca-flex/src/main/groovy/com/netflix/spinnaker/orca/flex/config/FlexConfiguration.groovy
+++ b/orca-flex/src/main/groovy/com/netflix/spinnaker/orca/flex/config/FlexConfiguration.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.flex.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
 import com.netflix.spinnaker.orca.flex.FlexService
 import com.netflix.spinnaker.orca.retrofit.RetrofitConfiguration
 import com.netflix.spinnaker.orca.retrofit.logging.RetrofitSlf4jLog
@@ -59,6 +60,7 @@ class FlexConfiguration {
       .setEndpoint(flexEndpoint)
       .setClient(retrofitClient)
       .setLogLevel(retrofitLogLevel)
+      .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .setLog(new RetrofitSlf4jLog(FlexService))
       .setConverter(new JacksonConverter(mapper))
       .build()


### PR DESCRIPTION
This code change is to maintain the uniformity across all the retrofit client configurations in ORCA,  as part of upgrading the retrofit version to 2.x.

There are neither any changes to the exception handler logics nor any behaviour changes involved.
