### PR TITLE
fix(retrofit): use SpinnakerServerException.getHttpMethod() instead of reflection in SpinnakerServerExceptionHandler

### DIFF
--- a/orca-retrofit/orca-retrofit.gradle
+++ b/orca-retrofit/orca-retrofit.gradle
@@ -37,6 +37,8 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("org.mockito:mockito-core")
   testImplementation("org.springframework.boot:spring-boot-test")
+  testImplementation("com.squareup.okhttp3:mockwebserver")
+  testImplementation("com.squareup.retrofit2:converter-jackson")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
   testRuntimeOnly("org.springframework:spring-test")
 

--- a/orca-retrofit/src/main/java/com/netflix/spinnaker/orca/retrofit/exceptions/SpinnakerServerExceptionHandler.java
+++ b/orca-retrofit/src/main/java/com/netflix/spinnaker/orca/retrofit/exceptions/SpinnakerServerExceptionHandler.java
@@ -43,6 +43,7 @@ public class SpinnakerServerExceptionHandler extends BaseRetrofitExceptionHandle
 
     String kind;
     Integer responseCode = null;
+    String httpMethod = ex.getHttpMethod();
 
     if (ex instanceof SpinnakerNetworkException) {
       kind = "NETWORK";
@@ -108,6 +109,12 @@ public class SpinnakerServerExceptionHandler extends BaseRetrofitExceptionHandle
 
     responseDetails.put("kind", kind);
 
+    // http method may be null if exception is created from RetrofitError
+    // so only include in responseDetails when value is valid
+    if (httpMethod != null) {
+      responseDetails.put("method", httpMethod);
+    }
+
     // Although Spinnaker*Exception has a retryable property that other parts of
     // spinnaker use, ignore it here for compatibility with
     // RetrofitExceptionHandler, specifically because that doesn't retry (most)
@@ -116,6 +123,6 @@ public class SpinnakerServerExceptionHandler extends BaseRetrofitExceptionHandle
         ex.getClass().getSimpleName(),
         taskName,
         responseDetails,
-        shouldRetry(ex, kind, responseCode));
+        shouldRetry(ex, kind, httpMethod, responseCode));
   }
 }


### PR DESCRIPTION
`BaseRetrofitExceptionHandler`'s retry behavior uses a method called `findHttpMethodAnnotation` to retrieve an exception's HTTP method. For retrofit2 exceptions, this method no longer works due to things being annotated differently in retrofit2. However, Spinnaker*Exceptions can use `getHttpMethod()` to retrieve this value, so this PR updates the exception handler to default to using the getter and only use `findHttpMethodAnnotation` if the getter returns null.