### PR TITLE
refactor(integrations-gremlin): use SpinnakerRetrofitErrorHandler with GremlinService

### DIFF
--- a/orca-integrations-gremlin/orca-integrations-gremlin.gradle
+++ b/orca-integrations-gremlin/orca-integrations-gremlin.gradle
@@ -6,6 +6,7 @@ dependencies {
   implementation(project(":orca-retrofit"))
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("org.slf4j:slf4j-api")
+  implementation("io.spinnaker.kork:kork-retrofit")
 
   testImplementation(project(":orca-core-tck"))
 }

--- a/orca-integrations-gremlin/src/main/java/com/netflix/spinnaker/orca/config/GremlinConfiguration.kt
+++ b/orca-integrations-gremlin/src/main/java/com/netflix/spinnaker/orca/config/GremlinConfiguration.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.orca.config
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
 import com.netflix.spinnaker.orca.gremlin.GremlinConverter
 import com.netflix.spinnaker.orca.gremlin.GremlinService
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
@@ -47,6 +48,7 @@ class GremlinConfiguration {
       .setEndpoint(gremlinEndpoint)
       .setClient(retrofitClient)
       .setLogLevel(RestAdapter.LogLevel.BASIC)
+      .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .setLog(RetrofitSlf4jLog(GremlinService::class.java))
       .setConverter(GremlinConverter(mapper))
       .build()


### PR DESCRIPTION
As part of the upgradation process of retrofit version to 2.x, this PR aims at ensuring the uniformity across all the retrofit client configurations.

Since the use of RetrofitError are not detected, no changes in the exception handler and no behaviour changes as well.
