### PR TITLE
refactor(kayenta): use SpinnakerRetrofitErrorHandler with KayentaService

### DIFF
--- a/orca-kayenta/orca-kayenta.gradle
+++ b/orca-kayenta/orca-kayenta.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation("com.netflix.frigga:frigga")
   implementation("io.spinnaker.kork:kork-moniker")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+  implementation("io.spinnaker.kork:kork-retrofit")
 
   testImplementation(project(":orca-test-kotlin"))
   testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")

--- a/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/config/KayentaConfiguration.kt
+++ b/orca-kayenta/src/main/kotlin/com/netflix/spinnaker/orca/kayenta/config/KayentaConfiguration.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.kayenta.config
 
 import com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS
 import com.netflix.spinnaker.kork.api.expressions.ExpressionFunctionProvider
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.kayenta.KayentaService
 import com.netflix.spinnaker.orca.retrofit.RetrofitConfiguration
@@ -77,6 +78,7 @@ class KayentaConfiguration {
       .setLogLevel(retrofitLogLevel)
       .setLog(RetrofitSlf4jLog(KayentaService::class.java))
       .setConverter(JacksonConverter(mapper))
+      .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .build()
       .create(KayentaService::class.java)
   }


### PR DESCRIPTION
As part of the upgradation process of retrofit version to 2.x, this PR aims at ensuring the uniformity across all the retrofit client configurations.

Since the use of RetrofitError are not detected, no changes in the exception handler and no behaviour changes as well.