### PR TITLE
fix(check-pre-condition): CheckPrecondition doesn't evaluate expressi…

### DIFF
--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/CompoundExecutionOperatorTest.java
@@ -41,6 +41,9 @@ final class CompoundExecutionOperatorTest {
   private static final String PIPELINE = "mypipeline";
   private static final String EXECUTION_ID = "EXECUTION_ID";
   private static final String STAGE_ID = "STAGE_ID";
+  private static final String UPSTREAM_STAGE = "UPSTREAM_STAGE";
+  private static final String UPSTREAM_STAGE_ID = "UPSTREAM_STAGE_ID";
+  private static final int PRECONDITION_STAGE_LIST_SIZE = 2;
   private final ExecutionRepository repository = mock(ExecutionRepository.class);
   private final ExecutionRunner runner = mock(ExecutionRunner.class);
   private final RetrySupport retrySupport = mock(RetrySupport.class);
@@ -74,6 +77,46 @@ final class CompoundExecutionOperatorTest {
     assertEquals(expression, updatedContextMap.get("expression"));
     assertEquals(expectedStageMap.get("type"), updatedExecution.getStages().get(0).getType());
     assertEquals(APPLICATION, updatedExecution.getApplication());
+  }
+
+  @Test
+  void restartUpstreamStageWithMultiplePreconditionStages() {
+    // ARRANGE
+    StageExecution upstreamStage = buildUpstreamStage();
+    List<StageExecution> preconditionStages = new ArrayList<>(PRECONDITION_STAGE_LIST_SIZE);
+    List<StageExecution> executionStages = execution.getStages();
+    executionStages.add(upstreamStage);
+
+    for (int i = 0; i < PRECONDITION_STAGE_LIST_SIZE; i++) {
+      StageExecution preconditionStage =
+          buildPreconditionStage("expression_" + i, "precondition_" + i, "precondition_stage_" + i);
+      preconditionStages.add(preconditionStage);
+      executionStages.add(preconditionStage);
+    }
+
+    Map<String, Object> restartDetails =
+        Map.of(
+            "application", APPLICATION,
+            "name", PIPELINE,
+            "executionId", EXECUTION_ID,
+            "stages", buildExpectedRestartStageList(preconditionStages, upstreamStage));
+
+    when(repository.retrieve(any(), anyString())).thenReturn(execution);
+    when(repository.handlesPartition(execution.getPartition())).thenReturn(true);
+
+    // ACT
+    PipelineExecution updatedExecution =
+        executionOperator.restartStage(EXECUTION_ID, STAGE_ID, restartDetails);
+
+    // ASSERT
+    assertEquals(APPLICATION, updatedExecution.getApplication());
+    for (int i = 0, size = preconditionStages.size(); i < size; i++) {
+      StageExecution originalPreconditionStage = preconditionStages.get(i);
+      StageExecution updatedPreconditionStage = updatedExecution.getStages().get(i + 1);
+      assertEquals(originalPreconditionStage.getContext(), updatedPreconditionStage.getContext());
+      assertEquals(originalPreconditionStage.getType(), updatedPreconditionStage.getType());
+      assertEquals(originalPreconditionStage.getName(), updatedPreconditionStage.getName());
+    }
   }
 
   @Test
@@ -133,6 +176,55 @@ final class CompoundExecutionOperatorTest {
       execution.getStages().add(jenkinsStage);
     }
     return execution;
+  }
+
+  private List<Map<String, Object>> buildExpectedRestartStageList(
+      List<StageExecution> preconditionStages, StageExecution upstreamStage) {
+    List<Map<String, Object>> restartStageList = new ArrayList<>(preconditionStages.size() + 1);
+
+    Map<String, Object> upstreamStageMap =
+        Map.of(
+            "name", upstreamStage.getName(),
+            "type", upstreamStage.getType());
+    restartStageList.add(upstreamStageMap);
+
+    for (StageExecution stage : preconditionStages) {
+      Map<String, Object> stageMap =
+          Map.of(
+              "name", stage.getName(),
+              "type", stage.getType(),
+              "preconditions", stage.getContext().get("preconditions"));
+      restartStageList.add(stageMap);
+    }
+    return restartStageList;
+  }
+
+  private StageExecution buildPreconditionStage(
+      String stageStatus, String stageId, String preConditionStageName) {
+    StageExecution preconditionStage = new StageExecutionImpl();
+    preconditionStage.setId(stageId);
+    preconditionStage.setType("checkPreconditions");
+    preconditionStage.setName(preConditionStageName);
+    Map<String, Object> contextMap = new HashMap<>();
+    contextMap.put("stageName", UPSTREAM_STAGE);
+    contextMap.put("stageStatus", stageStatus);
+    List<Map<String, Object>> preconditionList = new ArrayList<>();
+    Map<String, Object> preconditionMap = new HashMap<>();
+    preconditionMap.put("context", contextMap);
+    preconditionMap.put("failPipeline", true);
+    preconditionMap.put("type", "stageStatus");
+    preconditionList.add(preconditionMap);
+    contextMap.put("preconditions", preconditionList);
+    preconditionStage.setContext(contextMap);
+    return preconditionStage;
+  }
+
+  private StageExecution buildUpstreamStage() {
+    StageExecution upstreamStage = new StageExecutionImpl();
+    upstreamStage.setId(UPSTREAM_STAGE_ID);
+    upstreamStage.setType("manualJudgment");
+    upstreamStage.setName(UPSTREAM_STAGE);
+    return upstreamStage;
   }
 
   private Map buildExpectedRestartDetailsMap(String expression) {


### PR DESCRIPTION
This PR includes the changes to fix the https://github.com/spinnaker/spinnaker/issues/6933

**Root cause:**
If pipeline created from template, CheckPrecondition doesn't evaluate expression correctly after upstream stages get restarted
**Fix:**
Replace precondition List with precondition Map containing stage refId and preconditions. Modify the replace condition to replace pre-condition context with corresponding preCondition stage context.