### PR TITLE
fix(explicitRollback): Add configurable timeout for serverGroup lookup from Clouddriver API

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
+import com.netflix.spinnaker.orca.clouddriver.config.RollbackConfigurationProperties
 import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ApplySourceServerGroupCapacityStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.CaptureSourceServerGroupCapacityStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DisableServerGroupStage
@@ -50,7 +51,8 @@ class ExplicitRollback implements Rollback {
   Boolean disableOnly
   Boolean enableAndDisableOnly
 
-  @Value('${rollback.explicitRollback.timeout:5}') Integer rollbackTimeout
+  @Autowired
+  RollbackConfigurationProperties rollbackConfigurationProperties;
 
   @JsonIgnore
   private final ExecutorService executor = java.util.concurrent.Executors.newSingleThreadExecutor()
@@ -152,6 +154,7 @@ class ExplicitRollback implements Rollback {
 
   @Nullable TargetServerGroup lookupServerGroup(StageExecution parentStage, String serverGroupName) {
     def fromContext = parentStage.mapTo(ResizeStrategy.Source)
+    def rollbackTimeout = rollbackConfigurationProperties.explicitRollback.getTimeout()
 
     try {
       // we use an executor+future to timebox how long we can spend in this remote call

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollback.groovy
@@ -52,6 +52,7 @@ class ExplicitRollback implements Rollback {
   Boolean enableAndDisableOnly
 
   @Autowired
+  @JsonIgnore
   RollbackConfigurationProperties rollbackConfigurationProperties;
 
   @JsonIgnore

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/RollbackConfigurationProperties.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/RollbackConfigurationProperties.java
@@ -16,7 +16,10 @@
 
 package com.netflix.spinnaker.orca.clouddriver.config;
 
-import lombok.*;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/RollbackConfigurationProperties.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/RollbackConfigurationProperties.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config;
+
+import lombok.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "rollback")
+public class RollbackConfigurationProperties {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(RollbackConfigurationProperties.class);
+
+  @Value("${rollback.timeout.enabled:false}")
+  private boolean dynamicRollbackEnabled;
+
+  @Deprecated
+  @DeprecatedConfigurationProperty(replacement = "rollback.dynamicRollback.enabled")
+  public boolean getDynamicRollbackEnabled() {
+    return dynamicRollbackEnabled;
+  }
+
+  @NestedConfigurationProperty private ExplicitRollback explicitRollback = new ExplicitRollback();
+
+  @NestedConfigurationProperty private DynamicRollback dynamicRollback = new DynamicRollback();
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  public static class ExplicitRollback {
+    private int timeout = 5;
+  }
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  public static class DynamicRollback {
+    private boolean enabled = false;
+  }
+
+  public boolean isDynamicRollbackEnabled() {
+    if (getDynamicRollbackEnabled()) {
+      logger.warn(
+          "The rollback.timeout.enabled property is deprecated and will be removed in a future release. Please use rollback.dynamicRollback.enabled instead.");
+    }
+    return dynamicRollback.isEnabled() || getDynamicRollbackEnabled();
+  }
+}

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTask.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService;
 import com.netflix.spinnaker.orca.clouddriver.FeaturesService;
+import com.netflix.spinnaker.orca.clouddriver.config.RollbackConfigurationProperties;
 import com.netflix.spinnaker.orca.clouddriver.model.Cluster;
 import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup;
 import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup.Capacity;
@@ -52,7 +53,6 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -92,13 +92,13 @@ public class DetermineRollbackCandidatesTask implements CloudProviderAware, Retr
       RetrySupport retrySupport,
       CloudDriverService cloudDriverService,
       FeaturesService featuresService,
-      @Value("${rollback.timeout.enabled:false}") boolean dynamicRollbackTimeoutEnabled) {
+      RollbackConfigurationProperties rollbackConfigurationProperties) {
     this.retrySupport = retrySupport;
     this.cloudDriverService = cloudDriverService;
     this.previousImageRollbackSupport =
         new PreviousImageRollbackSupport(
             objectMapper, cloudDriverService, featuresService, retrySupport);
-    this.dynamicRollbackTimeoutEnabled = dynamicRollbackTimeoutEnabled;
+    this.dynamicRollbackTimeoutEnabled = rollbackConfigurationProperties.isDynamicRollbackEnabled();
   }
 
   @Override

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollbackSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollbackSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.rollback
 
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
+import com.netflix.spinnaker.orca.clouddriver.config.RollbackConfigurationProperties
 import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ApplySourceServerGroupCapacityStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.CaptureSourceServerGroupCapacityStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.DisableServerGroupStage
@@ -43,6 +44,14 @@ class ExplicitRollbackSpec extends Specification {
   def applySourceServerGroupCapacityStage = new ApplySourceServerGroupCapacityStage()
   def waitStage = new WaitStage()
 
+  def explicitRollback = new RollbackConfigurationProperties.ExplicitRollback(
+      timeout: 20
+  )
+  def rollbackConfigurationProperties = new RollbackConfigurationProperties(
+      explicitRollback: explicitRollback
+
+  )
+
   CloudDriverService cloudDriverService = Mock()
 
   def stage = stage {
@@ -63,13 +72,13 @@ class ExplicitRollbackSpec extends Specification {
     applySourceServerGroupCapacityStage: applySourceServerGroupCapacityStage,
     waitStage: waitStage,
     cloudDriverService: cloudDriverService,
+    rollbackConfigurationProperties: rollbackConfigurationProperties
   )
 
   def setup() {
     rollback.rollbackServerGroupName = rollbackServerGroupName
     rollback.restoreServerGroupName = restoreServerGroupName
     rollback.targetHealthyRollbackPercentage = 95
-    rollback.rollbackTimeout = 5
   }
 
   def serverGroup(String name, int desired, Integer min = null, Integer max = null) {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollbackSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/rollback/ExplicitRollbackSpec.groovy
@@ -42,6 +42,7 @@ class ExplicitRollbackSpec extends Specification {
   def captureSourceServerGroupCapacityStage = new CaptureSourceServerGroupCapacityStage()
   def applySourceServerGroupCapacityStage = new ApplySourceServerGroupCapacityStage()
   def waitStage = new WaitStage()
+
   CloudDriverService cloudDriverService = Mock()
 
   def stage = stage {
@@ -61,13 +62,14 @@ class ExplicitRollbackSpec extends Specification {
     captureSourceServerGroupCapacityStage: captureSourceServerGroupCapacityStage,
     applySourceServerGroupCapacityStage: applySourceServerGroupCapacityStage,
     waitStage: waitStage,
-    cloudDriverService: cloudDriverService
+    cloudDriverService: cloudDriverService,
   )
 
   def setup() {
     rollback.rollbackServerGroupName = rollbackServerGroupName
     rollback.restoreServerGroupName = restoreServerGroupName
     rollback.targetHealthyRollbackPercentage = 95
+    rollback.rollbackTimeout = 5
   }
 
   def serverGroup(String name, int desired, Integer min = null, Integer max = null) {
@@ -213,4 +215,5 @@ class ExplicitRollbackSpec extends Specification {
     1 * cloudDriverService.getTargetServerGroup(_, rollbackServerGroupName, _) >> { throw new Exception(":(") }
     thrown(SpinnakerException)
   }
+
 }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DetermineRollbackCandidatesTaskSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.moniker.Moniker
 import com.netflix.spinnaker.orca.clouddriver.CloudDriverService
 import com.netflix.spinnaker.orca.clouddriver.FeaturesService
 import com.netflix.spinnaker.orca.clouddriver.ModelUtils
+import com.netflix.spinnaker.orca.clouddriver.config.RollbackConfigurationProperties
 import com.netflix.spinnaker.orca.clouddriver.model.EntityTags
 import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup
 import spock.lang.Specification
@@ -34,6 +35,12 @@ import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
 class DetermineRollbackCandidatesTaskSpec extends Specification {
   def objectMapper = new ObjectMapper()
   def featuresService = Mock(FeaturesService)
+  def dynamicRollback = new RollbackConfigurationProperties.DynamicRollback(
+      enabled: true
+  )
+  def rollbackConfigurationProperties = new RollbackConfigurationProperties(
+      dynamicRollback: dynamicRollback
+  )
   CloudDriverService cloudDriverService = Mock()
 
   @Subject
@@ -42,7 +49,7 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
       new RetrySupport(),
       cloudDriverService,
       featuresService,
-      true
+      rollbackConfigurationProperties
   )
 
   def stage = stage {
@@ -68,6 +75,7 @@ class DetermineRollbackCandidatesTaskSpec extends Specification {
 
   def "should use dynamic timeout" () {
     given: "The user preferred rollbackTimeout is present in the context"
+
     stage.context["rollbackTimeout"] = 2
 
     when: "The dynamicRollback is enabled"


### PR DESCRIPTION
When a user performs an Ad-Hoc Rollback through Deck, Orca is expecting to receive a response from Clouddriver about the serverGroup details in a hardcoded 5 seconds timeout. 
Although in most cases this is enough, in higher scale environments with thousands of AWS/ECS accounts and especially in applications that have a large amount of serverGroups the 5 sec timeout is too strict resulting in error during the serverGroup lookup.
![TimeoutFailure](https://github.com/spinnaker/orca/assets/28927773/7c690cfc-3adb-4e25-99eb-2347399f21e5)



With this change we can configure the timeout (in seconds) through Orca config - while defaulting to the previous timeout of 5secs.

