### PR TITLE
fix(SqlExecutionRepository): fixed bug in sql repository in orca-sql …

### DIFF
--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -1105,12 +1105,16 @@ class SqlExecutionRepository(
         type,
         conditions = {
           if (cursor == null) {
-            it.where("1=1")
+            if (where == null) {
+              it.where("1=1")
+            } else {
+              where(it)
+            }
           } else {
             if (where == null) {
-              it.where(field("id").gt(cursor))
+              it.where(field("id").lt(cursor))
             } else {
-              where(it).and(field("id").gt(cursor))
+              where(it).and(field("id").lt(cursor))
             }
           }
         },

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -100,7 +100,7 @@ abstract class OldPipelineCleanupPollingNotificationAgentSpec extends Specificat
     def allExecutions = executionRepository.retrievePipelinesForApplication(app).toList().toBlocking().first().unique()
 
     then:
-    allExecutions.size() == 10
+    allExecutions.size() == 12
 
     when:
     cleanupAgent.tick()
@@ -125,7 +125,7 @@ abstract class OldPipelineCleanupPollingNotificationAgentSpec extends Specificat
     def allExecutions = executionRepository.retrievePipelinesForApplication(app).toList().toBlocking().first().unique()
 
     then:
-    allExecutions.size() == 10
+    allExecutions.size() == 12
 
     when:
     cleanupAgent.tick()

--- a/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositoryTest.kt
+++ b/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositoryTest.kt
@@ -244,6 +244,21 @@ class SqlExecutionRepositoryTest : JUnit5Minutests {
         assertThat(actualPipelineExecution).isEqualTo(pipelineExecution)
       }
     }
+
+    context("retrievePipelinesForApplication") {
+      val pipelineExecution1 = PipelineExecutionImpl(ExecutionType.PIPELINE, "application-1")
+      val pipelineExecution2 = PipelineExecutionImpl(ExecutionType.PIPELINE, "application-2")
+
+      test("correctly use where clause") {
+        // Store pipelines in two different applications
+        sqlExecutionRepository.store(pipelineExecution1)
+        sqlExecutionRepository.store(pipelineExecution2)
+
+        val observable = sqlExecutionRepository.retrievePipelinesForApplication("application-2")
+        val executions = observable.toList().toBlocking().single()
+        assertThat(executions.map(PipelineExecution::getApplication).single()).isEqualTo("application-2")
+      }
+    }
   }
 
   private inner class Fixture {


### PR DESCRIPTION
This fixes two bugs in the `selectExecutions` method of the `orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt` file. These were probably never found because they are only used for some cleanup job: `OldPipelineCleanupPollingNotificationAgent`.
