### PR TITLE
fix(test/keel): Javadoc referring to missing method in ImportDeliveryConfigTaskTest

### DIFF
--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTask.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.keel.task
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.kork.annotations.VisibleForTesting
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerNetworkException
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException
@@ -182,7 +183,8 @@ constructor(
    * Handle (potentially) retryable failures by looking at the HTTP status code. A few 4xx errors
    * are handled as special cases to provide more friendly error messages to the UI.
    */
-  private fun handleRetryableFailures(httpException: SpinnakerHttpException, context: ImportDeliveryConfigContext): TaskResult{
+  @VisibleForTesting
+  fun handleRetryableFailures(httpException: SpinnakerHttpException, context: ImportDeliveryConfigContext): TaskResult{
     return when {
       httpException.responseCode in 400..499 -> {
         val responseBody = httpException.responseBody

--- a/orca-keel/src/test/java/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTaskTest.java
+++ b/orca-keel/src/test/java/com/netflix/spinnaker/orca/keel/task/ImportDeliveryConfigTaskTest.java
@@ -35,6 +35,7 @@ import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor;
 import com.netflix.spinnaker.orca.KeelService;
@@ -62,7 +63,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 import retrofit.RestAdapter;
-import retrofit.RetrofitError;
 import retrofit.client.OkClient;
 import retrofit.converter.JacksonConverter;
 
@@ -143,7 +143,7 @@ public class ImportDeliveryConfigTaskTest {
    * This test is a positive case which verifies if the task returns {@link
    * ImportDeliveryConfigTask.SpringHttpError} on 4xx http error. Here the error body is mocked with
    * timestamps in supported Time Units, which will be parsed to exact same timestamp in the
-   * method @see {@link ImportDeliveryConfigTask#handleRetryableFailures(RetrofitError,
+   * method @see {@link ImportDeliveryConfigTask#handleRetryableFailures(SpinnakerHttpException,
    * ImportDeliveryConfigTask.ImportDeliveryConfigContext)} and results in successful assertions of
    * all the fields.
    *
@@ -176,7 +176,7 @@ public class ImportDeliveryConfigTaskTest {
    * This test is a negative case which verifies if the task returns {@link
    * ImportDeliveryConfigTask.SpringHttpError} on 4xx http error. Here the error body is mocked with
    * timestamp in Time Units that are unsupported, which WILL NOT be parsed to exact timestamp in
-   * the method @see {@link ImportDeliveryConfigTask#handleRetryableFailures(RetrofitError,
+   * the method @see {@link ImportDeliveryConfigTask#handleRetryableFailures(SpinnakerHttpException,
    * ImportDeliveryConfigTask.ImportDeliveryConfigContext)} and results in will contain incorrect
    * timestamp.
    *


### PR DESCRIPTION
This fix removes the javadoc link to the missing method: handleRetryableFailures(RetrofitError, ImportDeliveryConfigContext), which was cleaned up as part of the commit : 32e6571ad0578b9745a30fde75a85e8ac0d2b6b1.
