### PR TITLE
fix(test/bakery): Mock http error using SpinnakerHttpException in CompletedBakeTaskSpec

### DIFF
--- a/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
+++ b/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.bakery.tasks
 
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.kork.web.selector.v2.SelectableService
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.bakery.BakerySelector
@@ -39,12 +40,12 @@ class CompletedBakeTaskSpec extends Specification {
 
   @Shared PipelineExecutionImpl pipeline = pipeline()
 
-  @Shared notFoundError = RetrofitError.httpError(
+  @Shared notFoundError = new SpinnakerHttpException(RetrofitError.httpError(
     null,
     new Response("http://bakery", HTTP_NOT_FOUND, "Not Found", [], null),
     null,
     null
-  )
+  ))
 
   def "finds the AMI and artifact created by a bake"() {
     given:
@@ -105,7 +106,7 @@ class CompletedBakeTaskSpec extends Specification {
 
     then:
     1 * task.bakerySelector.select(_) >> selectedBakeryService
-    thrown(RetrofitError)
+    thrown(SpinnakerHttpException)
 
     where:
     region = "us-west-1"


### PR DESCRIPTION
With the introduction of the commit: e63a661e215461bd10ff0af90d416e9ca7fcfa6c , the expected behaviour of all BakeryService APIs is to throw Spinnaker*Exception when any http error has occurred.

- CompletedBakeTask is invoking an API : lookupBake(region, bakeid) -https://github.com/spinnaker/orca/blob/d2f50242637207491ba9fdcc40eaf02c3255c447/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTask.groovy#L43. This API error response is mocked up with RetrofitError in the test : https://github.com/spinnaker/orca/blob/d2f50242637207491ba9fdcc40eaf02c3255c447/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/tasks/CompletedBakeTaskSpec.groovy#L84
- This test case seems to be invalid/irrelevant because it has to throw SpinnakerHttpException here.

This PR aims at correcting this unexpected behaviour.