### PR TITLE
fix(test/clouddriver): Mock http error using SpinnakerHttpException in WaitForCloudFormationCompletionTaskSpec

### DIFF
--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTaskSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/WaitForCloudFormationCompletionTaskSpec.groovy
@@ -177,7 +177,7 @@ class WaitForCloudFormationCompletionTaskSpec extends Specification {
       'kato.tasks': [[resultObjects: [[stackId: 'stackId']]]]
     ]
     def stage = new StageExecutionImpl(pipeline, 'test', 'test', context)
-    def error500 = RetrofitError.httpError("url", new Response("url", 500, "reason", [], null), null, null)
+    def error500 = new SpinnakerHttpException(RetrofitError.httpError("url", new Response("url", 500, "reason", [], null), null, null))
 
     when:
     def result = waitForCloudFormationCompletionTask.execute(stage)
@@ -185,7 +185,7 @@ class WaitForCloudFormationCompletionTaskSpec extends Specification {
     then:
     1 * oortService.getCloudFormationStack('stackId') >> { throw error500 }
     RuntimeException ex = thrown()
-    ex.message == "500 reason"
+    ex.message == "Status: 500, URL: url, Message: reason"
     result == null
   }
 


### PR DESCRIPTION
With the introduction of the commit: 84a7106c512ceada65d7799f527a956262d964d5 , the expected behaviour of all OortService APIs is to throw SpinnakerHttpException when any http error has occurred.

Here in this test the response of the API : https://github.com/spinnaker/orca/blob/a1b32d7398eb9b1ff610d7f3afd980b51f6cf7b1/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java#L182 is mocked up with RetrofitError which makes the test irrelvant.

Wrapping the RetrofitError in SpinnakerHttpException to make it in compliance with the retrofit configuration.
