### PR TITLE
refactor(mysql): update mysql connector coordinate during upgrade to spring boot 2.7.x

### DIFF
--- a/keiko-sql/keiko-sql.gradle
+++ b/keiko-sql/keiko-sql.gradle
@@ -19,5 +19,5 @@ dependencies {
   testImplementation project(":keiko-tck")
   testImplementation "io.spinnaker.kork:kork-sql-test"
   testImplementation "org.testcontainers:mysql"
-  testImplementation "mysql:mysql-connector-java"
+  testImplementation "com.mysql:mysql-connector-j"
 }

--- a/orca-queue-sql/orca-queue-sql.gradle
+++ b/orca-queue-sql/orca-queue-sql.gradle
@@ -25,5 +25,5 @@ dependencies {
   testImplementation("org.springframework:spring-test")
   testImplementation("org.springframework.boot:spring-boot-test")
 
-  testRuntimeOnly("mysql:mysql-connector-java")
+  testRuntimeOnly("com.mysql:mysql-connector-j")
 }

--- a/orca-sql-mysql/orca-sql-mysql.gradle
+++ b/orca-sql-mysql/orca-sql-mysql.gradle
@@ -1,4 +1,4 @@
 dependencies {
   implementation(project(":orca-sql"))
-  runtimeOnly("mysql:mysql-connector-java")
+  runtimeOnly("com.mysql:mysql-connector-j")
 }

--- a/orca-sql/orca-sql.gradle
+++ b/orca-sql/orca-sql.gradle
@@ -52,7 +52,7 @@ dependencies {
   testImplementation("org.testcontainers:mysql")
   testImplementation("org.testcontainers:postgresql")
 
-  testRuntimeOnly("mysql:mysql-connector-java")
+  testRuntimeOnly("com.mysql:mysql-connector-j")
   testRuntimeOnly("org.postgresql:postgresql")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }


### PR DESCRIPTION
In spring boot 2.7.8 onwards mysql connector coordinate `mysql:mysql-connector-java` has been removed and only `com.mysql:mysql-connector-j` coordinate exist.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#mysql-jdbc-driver

So, updating the mysql connector coordinate as `com.mysql:mysql-connector-j` with spring boot upgrade to 2.7.18.

https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom
