### PR TITLE
refactor(clouddriver): replace getType() with StageDefinitionBuilder.getType() during upgrade to spring boot 2.7.x

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/PinServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/PinServerGroupStage.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
@@ -38,7 +39,7 @@ import org.springframework.stereotype.Component
 @Component
 @Slf4j
 class PinServerGroupStage extends TargetServerGroupLinearStageSupport {
-  public static final String TYPE = getType(PinServerGroupStage)
+  public static final String TYPE = StageDefinitionBuilder.getType(PinServerGroupStage)
 
   @Override
   protected void taskGraphInternal(StageExecution stage, TaskNode.Builder builder) {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ModifyAwsScalingProcessStage
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport
@@ -37,7 +38,7 @@ import org.springframework.stereotype.Component
 @Component
 @Slf4j
 class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
-  public static final String TYPE = getType(ResizeServerGroupStage)
+  public static final String TYPE = StageDefinitionBuilder.getType(ResizeServerGroupStage)
 
   @Override
   protected void taskGraphInternal(StageExecution stage, TaskNode.Builder builder) {


### PR DESCRIPTION
While upgrading spring boot 2.7.18, encounter below error during test compilation of orca-clouddriver module:
```
Caused by: groovy.lang.MissingMethodException: No signature of method: static com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.PinServerGroupStage.getType() is applicable for argument types: (Class) values: [class com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.PinServerGroupStage]
Possible solutions: asType(java.lang.Class), getName(), grep(), getAt(java.lang.String)
        at app//groovy.lang.MetaClassImpl.invokeStaticMissingMethod(MetaClassImpl.java:1570)
        at app//groovy.lang.MetaClassImpl.invokeStaticMethod(MetaClassImpl.java:1556)
        at app//org.codehaus.groovy.runtime.callsite.StaticMetaClassSite.callStatic(StaticMetaClassSite.java:62)
        at app//org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallStatic(CallSiteArray.java:55)
        at app//org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:217)
        at app//org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:231)
        at app//com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.PinServerGroupStage.<clinit>(PinServerGroupStage.groovy:41)
        ... 227 more
```
Spring boot 2.7.18 brings groovy 3.0.19 as transitive dependency. The root cause of the issue is a breaking change introduced from groovy 3.0.18 onwards, that allows a Java class to inherit static methods from its interface. To fix this issue replacing getType() with StageDefinitionBuilder.getType().

http://groovy-lang.org/changelogs/changelog-3.0.18.html 
https://issues.apache.org/jira/browse/GROOVY-8164

Before:
```
$ ./gradlew orca-clouddriver:dI --dependency org.codehaus.groovy --configuration testCompileClasspath

> Task :orca-clouddriver:dependencyInsight
org.codehaus.groovy:groovy:3.0.17
  Variant compile:
    | Attribute Name                     | Provided | Requested         |
    |------------------------------------|----------|-------------------|
    | org.gradle.status                  | release  |                   |
    | org.gradle.category                | library  | library           |
    | org.gradle.libraryelements         | jar      | classes+resources |
    | org.gradle.usage                   | java-api | java-api          |
    | org.gradle.dependency.bundling     |          | external          |
    | org.gradle.jvm.environment         |          | standard-jvm      |
    | org.gradle.jvm.version             |          | 11                |
    | org.jetbrains.kotlin.platform.type |          | jvm               |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy:3.0.17
+--- io.spinnaker.kork:kork-bom:7.227.0
|    \--- testCompileClasspath
\--- io.spinnaker.kork:kork-web:7.227.0
     +--- testCompileClasspath (requested io.spinnaker.kork:kork-web)
     +--- io.spinnaker.kork:kork-bom:7.227.0 (*)
     +--- project :orca-retrofit (requested io.spinnaker.kork:kork-web)
     |    \--- testCompileClasspath
     \--- project :orca-bakery (requested io.spinnaker.kork:kork-web)
          \--- testCompileClasspath

org.codehaus.groovy:groovy -> 3.0.17
+--- testCompileClasspath
+--- project :orca-front50
|    \--- testCompileClasspath
\--- project :orca-retrofit
     \--- testCompileClasspath

org.codehaus.groovy:groovy:3.0.8 -> 3.0.17
\--- org.spockframework:spock-core:2.0-groovy-3.0
     +--- testCompileClasspath (requested org.spockframework:spock-core)
     \--- io.spinnaker.kork:kork-bom:7.227.0
          \--- testCompileClasspath
```

After:
```
$ ./gradlew orca-clouddriver:dI --dependency org.codehaus.groovy --configuration testCompileClasspath

> Task :orca-clouddriver:dependencyInsight
org.codehaus.groovy:groovy:3.0.19
  Variant compile:
    | Attribute Name                     | Provided | Requested         |
    |------------------------------------|----------|-------------------|
    | org.gradle.status                  | release  |                   |
    | org.gradle.category                | library  | library           |
    | org.gradle.libraryelements         | jar      | classes+resources |
    | org.gradle.usage                   | java-api | java-api          |
    | org.gradle.dependency.bundling     |          | external          |
    | org.gradle.jvm.environment         |          | standard-jvm      |
    | org.gradle.jvm.version             |          | 11                |
    | org.jetbrains.kotlin.platform.type |          | jvm               |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy:3.0.19
+--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT
|    \--- testCompileClasspath
\--- io.spinnaker.kork:kork-web:sb2718-SNAPSHOT
     +--- testCompileClasspath (requested io.spinnaker.kork:kork-web)
     +--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT (*)
     +--- project :orca-retrofit (requested io.spinnaker.kork:kork-web)
     |    \--- testCompileClasspath
     \--- project :orca-bakery (requested io.spinnaker.kork:kork-web)
          \--- testCompileClasspath

org.codehaus.groovy:groovy -> 3.0.19
+--- testCompileClasspath
+--- project :orca-front50
|    \--- testCompileClasspath
\--- project :orca-retrofit
     \--- testCompileClasspath

org.codehaus.groovy:groovy:3.0.8 -> 3.0.19
\--- org.spockframework:spock-core:2.0-groovy-3.0
     +--- testCompileClasspath (requested org.spockframework:spock-core)
     \--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT
          \--- testCompileClasspath
```