### PR TITLE
fix(dokka): use version 1.9.20 of org.jetbrains.dokka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
   id "org.jetbrains.kotlin.jvm" version "$kotlinVersion" apply false
   id "org.jetbrains.kotlin.plugin.allopen" version "$kotlinVersion" apply false
   id "io.gitlab.arturbosch.detekt" version "1.17.1" apply false
-  id "org.jetbrains.dokka" version "1.4.32" apply false
+  id "org.jetbrains.dokka" version "1.9.20" apply false
 }
 
 allprojects {

--- a/gradle/dokka.gradle
+++ b/gradle/dokka.gradle
@@ -19,7 +19,7 @@ apply plugin: "org.jetbrains.dokka"
 dokkaHtml {
   dokkaSourceSets {
     configureEach {
-      jdkVersion.set(11)
+      jdkVersion.set(17)
     }
   }
 }


### PR DESCRIPTION
to fix release builds (e.g. https://github.com/spinnaker/orca/actions/runs/9485164370/job/26140574935) that fail with:
```
2024-06-12T16:46:31.8095689Z java.lang.UnsupportedOperationException: PermittedSubclasses requires ASM9
2024-06-12T16:46:31.8098205Z 	at org.jetbrains.org.objectweb.asm.ClassVisitor.visitPermittedSubclass(ClassVisitor.java:266)
2024-06-12T16:46:31.8100476Z 	at org.jetbrains.org.objectweb.asm.ClassReader.accept(ClassReader.java:684)
2024-06-12T16:46:31.8103055Z 	at org.jetbrains.org.objectweb.asm.ClassReader.accept(ClassReader.java:402)
2024-06-12T16:46:31.8105572Z 	at org.jetbrains.kotlin.load.kotlin.FileBasedKotlinClass.create(FileBasedKotlinClass.java:96)
2024-06-12T16:46:31.8108484Z 	at org.jetbrains.kotlin.load.kotlin.VirtualFileKotlinClass$Factory$create$1.invoke(VirtualFileKotlinClass.kt:67)
2024-06-12T16:46:31.8111511Z 	at org.jetbrains.kotlin.load.kotlin.VirtualFileKotlinClass$Factory$create$1.invoke(VirtualFileKotlinClass.kt:61)
2024-06-12T16:46:31.8114493Z 	at org.jetbrains.kotlin.util.PerformanceCounter.time(PerformanceCounter.kt:101)
2024-06-12T16:46:31.8117409Z 	at org.jetbrains.kotlin.load.kotlin.VirtualFileKotlinClass$Factory.create(VirtualFileKotlinClass.kt:61)
2024-06-12T16:46:31.8120743Z 	at org.jetbrains.kotlin.load.kotlin.KotlinBinaryClassCache$Companion$getKotlinBinaryClassOrClassFileContent$aClass$1.compute(KotlinBinaryClassCache.kt:75)
2024-06-12T16:46:31.8122732Z
2024-06-12T16:46:31.8124543Z 	at org.jetbrains.kotlin.load.kotlin.KotlinBinaryClassCache$Companion$getKotlinBinaryClassOrClassFileContent$aClass$1.compute(KotlinBinaryClassCache.kt:73)
2024-06-12T16:46:31.8127356Z 	at com.intellij.mock.MockApplication.runReadAction(MockApplication.java:178)
2024-06-12T16:46:31.8130888Z 	at org.jetbrains.kotlin.load.kotlin.KotlinBinaryClassCache$Companion.getKotlinBinaryClassOrClassFileContent(KotlinBinaryClassCache.kt:73)
2024-06-12T16:46:31.8134657Z 	at org.jetbrains.kotlin.load.kotlin.KotlinBinaryClassCache$Companion.getKotlinBinaryClassOrClassFileContent$default(KotlinBinaryClassCache.kt:59)
2024-06-12T16:46:31.8138203Z 	at org.jetbrains.kotlin.load.kotlin.VirtualFileFinder.findKotlinClassOrContent(VirtualFileFinder.kt:34)
2024-06-12T16:46:31.8141821Z 	at org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaPackageScope$classes$1.invoke(LazyJavaPackageScope.kt:62)
2024-06-12T16:46:31.8145173Z 	at org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaPackageScope$classes$1.invoke(LazyJavaPackageScope.kt:54)
2024-06-12T16:46:31.8148554Z 	at org.jetbrains.kotlin.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke(LockBasedStorageManager.java:578)
2024-06-12T16:46:31.8152308Z 	at org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaPackageScope.findClassifier(LazyJavaPackageScope.kt:142)
2024-06-12T16:46:31.8156049Z 	at org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaPackageScope.getContributedClassifier(LazyJavaPackageScope.kt:132)
2024-06-12T16:46:31.8159649Z 	at org.jetbrains.kotlin.load.java.lazy.descriptors.JvmPackageScope.getContributedClassifier(JvmPackageScope.kt:55)
2024-06-12T16:46:31.8162984Z 	at org.jetbrains.kotlin.resolve.scopes.ChainedMemberScope.getContributedClassifier(ChainedMemberScope.kt:35)
2024-06-12T16:46:31.8166062Z 	at org.jetbrains.kotlin.resolve.scopes.AbstractScopeAdapter.getContributedClassifier(AbstractScopeAdapter.kt:44)
2024-06-12T16:46:31.8169027Z 	at org.jetbrains.kotlin.resolve.lazy.ResolveSessionUtils.findClassByRelativePath(ResolveSessionUtils.java:88)
2024-06-12T16:46:31.8172200Z 	at org.jetbrains.kotlin.resolve.lazy.ResolveSessionUtils.getClassOrObjectDescriptorsByFqName(ResolveSessionUtils.java:65)
2024-06-12T16:46:31.8175477Z 	at org.jetbrains.kotlin.resolve.lazy.ResolveSessionUtils.getClassDescriptorsByFqName(ResolveSessionUtils.java:47)
2024-06-12T16:46:31.8178782Z 	at org.jetbrains.kotlin.cli.jvm.compiler.CliKotlinAsJavaSupport.findClassOrObjectDeclarations(CliKotlinAsJavaSupport.kt:119)
2024-06-12T16:46:31.8214083Z 	at org.jetbrains.kotlin.asJava.finder.JavaElementFinder.findClassesAndObjects(JavaElementFinder.kt:71)
2024-06-12T16:46:31.8216746Z 	at org.jetbrains.kotlin.asJava.finder.JavaElementFinder.findClasses(JavaElementFinder.kt:57)
2024-06-12T16:46:31.8219261Z 	at org.jetbrains.kotlin.asJava.finder.JavaElementFinder.findClass(JavaElementFinder.kt:46)
2024-06-12T16:46:31.8221723Z 	at com.intellij.psi.impl.JavaPsiFacadeImpl.doFindClass(JavaPsiFacadeImpl.java:96)
2024-06-12T16:46:31.8314696Z 	at com.intellij.psi.impl.JavaPsiFacadeImpl.findClass(JavaPsiFacadeImpl.java:73)
2024-06-12T16:46:31.8318034Z 	at com.intellij.psi.impl.compiled.ClsJavaCodeReferenceElementImpl.resolveElement(ClsJavaCodeReferenceElementImpl.java:248)
2024-06-12T16:46:31.8321556Z 	at com.intellij.psi.impl.compiled.ClsJavaCodeReferenceElementImpl.advancedResolveImpl(ClsJavaCodeReferenceElementImpl.java:125)
2024-06-12T16:46:31.8324896Z 	at com.intellij.psi.impl.compiled.ClsJavaCodeReferenceElementImpl.access$000(ClsJavaCodeReferenceElementImpl.java:42)
2024-06-12T16:46:31.8328158Z 	at com.intellij.psi.impl.compiled.ClsJavaCodeReferenceElementImpl$Resolver.resolve(ClsJavaCodeReferenceElementImpl.java:118)
2024-06-12T16:46:31.8356145Z 	at com.intellij.psi.impl.compiled.ClsJavaCodeReferenceElementImpl$Resolver.resolve(ClsJavaCodeReferenceElementImpl.java:113)
2024-06-12T16:46:31.8359080Z 	at com.intellij.psi.impl.source.resolve.ResolveCache.lambda$resolveWithCaching$2(ResolveCache.java:185)
2024-06-12T16:46:31.8361229Z 	at com.intellij.openapi.util.Computable.get(Computable.java:17)
2024-06-12T16:46:31.8363491Z 	at com.intellij.psi.impl.source.resolve.ResolveCache.lambda$loggingResolver$3(ResolveCache.java:227)
2024-06-12T16:46:31.8366170Z 	at com.intellij.openapi.util.RecursionManager$1.doPreventingRecursion(RecursionManager.java:112)
2024-06-12T16:46:31.8369081Z 	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:71)
2024-06-12T16:46:31.8371656Z 	at com.intellij.psi.impl.source.resolve.ResolveCache.resolve(ResolveCache.java:204)
2024-06-12T16:46:31.8374237Z 	at com.intellij.psi.impl.source.resolve.ResolveCache.resolveWithCaching(ResolveCache.java:185)
2024-06-12T16:46:31.8377287Z 	at com.intellij.psi.impl.compiled.ClsJavaCodeReferenceElementImpl.multiResolve(ClsJavaCodeReferenceElementImpl.java:208)
2024-06-12T16:46:31.8380609Z 	at com.intellij.psi.impl.compiled.ClsJavaCodeReferenceElementImpl.advancedResolve(ClsJavaCodeReferenceElementImpl.java:196)
2024-06-12T16:46:31.8383734Z 	at com.intellij.psi.impl.source.PsiClassReferenceType.resolveGenerics(PsiClassReferenceType.java:177)
2024-06-12T16:46:31.8386507Z 	at com.intellij.psi.impl.source.PsiClassReferenceType.resolve(PsiClassReferenceType.java:121)
2024-06-12T16:46:31.8390039Z 	at org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator$DokkaPsiParser$getBound$3.invoke(DefaultPsiToDocumentableTranslator.kt:435)
2024-06-12T16:46:31.8535652Z 	at org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator$DokkaPsiParser.getBound(DefaultPsiToDocumentableTranslator.kt:473)
2024-06-12T16:46:31.8539830Z 	at org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator$DokkaPsiParser.getVariance(DefaultPsiToDocumentableTranslator.kt:482)
2024-06-12T16:46:31.8543866Z 	at org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator$DokkaPsiParser.getProjection(DefaultPsiToDocumentableTranslator.kt:489)
2024-06-12T16:46:31.8548025Z 	at org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator$DokkaPsiParser.access$getProjection(DefaultPsiToDocumentableTranslator.kt:107)
2024-06-12T16:46:31.8552258Z 	at org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator$DokkaPsiParser$getBound$3.invoke(DefaultPsiToDocumentableTranslator.kt:454)
2024-06-12T16:46:31.8556520Z 	at org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator$DokkaPsiParser.getBound(DefaultPsiToDocumentableTranslator.kt:473)
2024-06-12T16:46:31.8560440Z 	at org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator$DokkaPsiParser.parseFunction(DefaultPsiToDocumentableTranslator.kt:389)
2024-06-12T16:46:31.8564567Z 	at org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator$DokkaPsiParser.parseFunction$default(DefaultPsiToDocumentableTranslator.kt:357)
2024-06-12T16:46:31.8568940Z 	at org.jetbrains.dokka.base.translators.psi.DefaultPsiToDocumentableTranslator$DokkaPsiParser$parseClasslike$2$invokeSuspend$$inlined$with$lambda$3$2$1.invokeSuspend(parallelCollectionOperations.kt:19)
2024-06-12T16:46:31.8572857Z 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
2024-06-12T16:46:31.8575048Z 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
2024-06-12T16:46:31.8577263Z 	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
2024-06-12T16:46:31.8579537Z 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
2024-06-12T16:46:31.8581982Z 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
2024-06-12T16:46:31.8584396Z 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```
I can reproduce this locally with java 17 and:
```
$ ./gradlew -PenableCrossCompilerPlugin=true clean orca-api:dokkaJavadoc
```
with the previous version (1.4.32).  It works with 1.9.20.
