### PR TITLE
fix(build): revert java17 changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: |
-            11
             17
+            11
           distribution: 'zulu'
           cache: 'gradle'
       - name: Prepare build variables
@@ -38,7 +38,7 @@ jobs:
       - name: Build
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.build_variables.outputs.VERSION }}
-        run: ./gradlew -PenableCrossCompilerPlugin=true build --stacktrace ${{ steps.build_variables.outputs.REPO }}-web:installDist
+        run: ./gradlew build --stacktrace ${{ steps.build_variables.outputs.REPO }}-web:installDist
       - name: Build local slim container image for testing
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: |
-            11
             17
+            11
           distribution: 'zulu'
           cache: 'gradle'
       - name: Prepare build variables
@@ -32,7 +32,7 @@ jobs:
       - name: Build
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.build_variables.outputs.VERSION }}
-        run: ./gradlew -PenableCrossCompilerPlugin=true build ${{ steps.build_variables.outputs.REPO }}-web:installDist
+        run: ./gradlew build ${{ steps.build_variables.outputs.REPO }}-web:installDist
       - name: Build slim container image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: |
-            11
             17
+            11
           distribution: 'zulu'
           cache: 'gradle'
       - name: Assemble release info
@@ -72,14 +72,14 @@ jobs:
           ORG_GRADLE_PROJECT_nexusPgpSigningKey: ${{ secrets.NEXUS_PGP_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_nexusPgpSigningPassword: ${{ secrets.NEXUS_PGP_SIGNING_PASSWORD }}
         run: |
-          ./gradlew -PenableCrossCompilerPlugin=true --info build ${{ steps.build_variables.outputs.REPO }}-web:installDist publishToNexus closeAndReleaseNexusStagingRepository
+          ./gradlew --info build ${{ steps.build_variables.outputs.REPO }}-web:installDist publishToNexus closeAndReleaseNexusStagingRepository
       - name: Publish apt packages to Google Artifact Registry
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.release_info.outputs.RELEASE_VERSION }}
           ORG_GRADLE_PROJECT_artifactRegistryPublishEnabled: true
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
-          ./gradlew -PenableCrossCompilerPlugin=true --info publish
+          ./gradlew --info publish
       - name: Login to Google Cloud
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -5,4 +5,4 @@ RUN apt-get update && apt-get install -y \
 LABEL maintainer="sig-platform@spinnaker.io"
 ENV GRADLE_USER_HOME /workspace/.gradle
 ENV GRADLE_OPTS -Xmx6g
-CMD ./gradlew -PenableCrossCompilerPlugin=true --no-daemon orca-web:installDist -x test
+CMD ./gradlew --no-daemon orca-web:installDist -x test

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,17 @@ allprojects {
 
   group = "io.spinnaker.orca"
 
+  tasks.withType(JavaCompile).configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+      languageVersion = JavaLanguageVersion.of(11)
+    }
+  }
+  tasks.withType(Test).configureEach {
+    javaLauncher = javaToolchains.launcherFor {
+      languageVersion = JavaLanguageVersion.of(17)
+    }
+  }
+
   tasks.withType(JavaExec) {
     if (System.getProperty('DEBUG', 'false') == 'true') {
       jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8183'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
   id "org.jetbrains.kotlin.jvm" version "$kotlinVersion" apply false
   id "org.jetbrains.kotlin.plugin.allopen" version "$kotlinVersion" apply false
   id "io.gitlab.arturbosch.detekt" version "1.17.1" apply false
-  id "org.jetbrains.dokka" version "1.9.20" apply false
+  id "org.jetbrains.dokka" version "1.4.32" apply false
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlinVersion=1.6.21
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx6g
 spinnakerGradleVersion=8.32.1
-targetJava17=false
+targetJava11=true
 
 # To enable a composite reference to a project, set the
 #  project property `'<projectName>Composite=true'`.

--- a/gradle/dokka.gradle
+++ b/gradle/dokka.gradle
@@ -19,7 +19,7 @@ apply plugin: "org.jetbrains.dokka"
 dokkaHtml {
   dokkaSourceSets {
     configureEach {
-      jdkVersion.set(17)
+      jdkVersion.set(11)
     }
   }
 }

--- a/orca-api/orca-api.gradle
+++ b/orca-api/orca-api.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("net.ltgt.errorprone") version "4.0.0"
+  id("net.ltgt.errorprone") version "1.2.1"
 }
 
 apply from: "$rootDir/gradle/kotlin.gradle"
@@ -28,7 +28,7 @@ sourceSets {
 }
 
 dependencies {
-  errorprone("com.google.errorprone:error_prone_core:2.28.0")
+  errorprone("com.google.errorprone:error_prone_core:2.4.0")
 
   implementation platform("io.spinnaker.kork:kork-bom:$korkVersion")
   annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")


### PR DESCRIPTION
since it's not possible to release orca jars, which we need to do to finish adopting spring boot 2.7 everywhere (e.g. in kayenta).

This reverts https://github.com/spinnaker/orca/pull/4747 and https://github.com/spinnaker/orca/pull/4738.