### PR TITLE
chore(build): exercise dokka in prs and branch builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.build_variables.outputs.VERSION }}
-        run: ./gradlew build --stacktrace ${{ steps.build_variables.outputs.REPO }}-web:installDist
+        run: ./gradlew build --stacktrace ${{ steps.build_variables.outputs.REPO }}-web:installDist orca-api:dokkaJavadoc
       - name: Build local slim container image for testing
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.build_variables.outputs.VERSION }}
-        run: ./gradlew build ${{ steps.build_variables.outputs.REPO }}-web:installDist
+        run: ./gradlew build ${{ steps.build_variables.outputs.REPO }}-web:installDist orca-api:dokkaJavadoc
       - name: Build slim container image
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
so things fail earlier, as opposed to later during publishing as part of a release

See e.g. https://github.com/spinnaker/orca/actions/runs/9485164370/job/26140574935.