### PR TITLE
fix(orca-clouddriver): replace getType() with StageDefinitionBuilder.getType() for DestroyServerGroup

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStage.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.ForceCacheRefreshAware
@@ -33,7 +34,7 @@ import org.springframework.stereotype.Component
 @Component
 class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport implements ForceCacheRefreshAware {
   private static final Logger log = LoggerFactory.getLogger(DestroyServerGroupStage.class)
-  
+
   static final String PIPELINE_CONFIG_TYPE = "destroyServerGroup"
 
   private final DynamicConfigService dynamicConfigService
@@ -47,11 +48,11 @@ class DestroyServerGroupStage extends TargetServerGroupLinearStageSupport implem
     boolean skipDisable = (boolean)context.getOrDefault("skipDisableBeforeDestroy", false)
 
     if (!skipDisable) {
-      // conditional opt-out for server groups where an explicit disable is unnecessary 
+      // conditional opt-out for server groups where an explicit disable is unnecessary
       // (ie. they do not register in service discovery or a load balancer)
       graph.add {
         it.name = "disableServerGroup"
-        it.type = getType(DisableServerGroupStage)
+        it.type = StageDefinitionBuilder.getType(DisableServerGroupStage)
         it.context.putAll(context)
       }
     } else {

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DestroyServerGroupStageSpec.groovy
@@ -1,0 +1,102 @@
+package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
+import com.netflix.spinnaker.orca.pipeline.graph.StageGraphBuilderImpl
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
+import spock.lang.Specification
+
+class DestroyServerGroupStageSpec extends Specification {
+
+  DynamicConfigService dynamicConfigService = Mock(DynamicConfigService)
+  DestroyServerGroupStage destroyServerGroupStage = new DestroyServerGroupStage(dynamicConfigService)
+  PipelineExecutionImpl pipelineExecution = new PipelineExecutionImpl(ExecutionType.PIPELINE, 'foo')
+  def context = [
+        credentials           : 'test',
+        cluster: 'foo-main',
+        moniker               : [
+            app: 'foo',
+            cluster: 'foo-main',
+            stack: 'main'],
+        regions               : ['us-west-2'],
+        target: 'current_asg_dynamic',
+    ]
+  StageExecutionImpl parentStage = new StageExecutionImpl(pipelineExecution, "destroyServerGroup", context)
+
+  def "should add disable stage to graph when skipDisableBeforeDestroy is false"() {
+    given:
+    def context = [skipDisableBeforeDestroy: false]
+    def graph = StageGraphBuilderImpl.beforeStages(parentStage)
+
+    when:
+    destroyServerGroupStage.preStatic(context, graph)
+
+    then:
+    def stages = graph.build().collect { it }
+    stages.size() == 1
+    def stage = stages.first()
+    stage.name == "disableServerGroup"
+    stage.type == StageDefinitionBuilder.getType(DisableServerGroupStage)
+    stage.context == context
+  }
+
+  def "should add disable stage in preStatic method"() {
+    given:
+    def context = [skipDisableBeforeDestroy: false]
+    def graph = StageGraphBuilderImpl.beforeStages(parentStage)
+
+    when:
+    destroyServerGroupStage.preStatic(context, graph)
+
+    then:
+    def stages = graph.build().collect { it }
+    stages.size() == 1
+    def stage = stages.first()
+    stage.name == "disableServerGroup"
+    stage.type == StageDefinitionBuilder.getType(DisableServerGroupStage)
+    stage.context == context
+  }
+
+  def "should add disable stage in preDynamic method"() {
+    given:
+    def context = [skipDisableBeforeDestroy: false]
+    def graph = StageGraphBuilderImpl.beforeStages(parentStage)
+
+    when:
+    destroyServerGroupStage.preDynamic(context, graph)
+
+    then:
+    def stages = graph.build().collect { it }
+    stages.size() == 1
+    def stage = stages.first()
+    stage.name == "disableServerGroup"
+    stage.type == StageDefinitionBuilder.getType(DisableServerGroupStage)
+    stage.context == context
+  }
+
+  def "should not add disable stage in preStatic method when skipDisableBeforeDestroy is true"() {
+    given:
+    def context = [skipDisableBeforeDestroy: true]
+    def graph = StageGraphBuilderImpl.beforeStages(parentStage)
+
+    when:
+    destroyServerGroupStage.preStatic(context, graph)
+
+    then:
+    graph.build().size() == 0
+  }
+
+  def "should not add disable stage in preDynamic method when skipDisableBeforeDestroy is true"() {
+    given:
+    def context = [skipDisableBeforeDestroy: true]
+    def graph = StageGraphBuilderImpl.beforeStages(parentStage)
+
+    when:
+    destroyServerGroupStage.preDynamic(context, graph)
+
+    then:
+    graph.build().size() == 0
+  }
+}


### PR DESCRIPTION
Related to https://github.com/spinnaker/orca/pull/4745; fixes the issue on the DestroyServerGroup stage

Failing tests before the fix:
![image](https://github.com/spinnaker/orca/assets/28927773/100322c0-5664-4cf3-9fbd-bea3e8978865)
