### PR TITLE
test(core): demonstrate behavior of SpEL expression evaluation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,12 @@ subprojects {
     }
   }
 
+  // This is required for some SpEL expressions to evaluate properly with java
+  // 17.  It works with java 11 as well, but isn't required there.
+  tasks.withType(Test).configureEach {
+    jvmArgs += '--add-opens=java.base/java.util=ALL-UNNAMED'
+  }
+
   if (name != "orca-bom" && name != "orca-api") {
     apply plugin: "java-library"
 

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluatorSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/PipelineExpressionEvaluatorSpec.groovy
@@ -74,6 +74,23 @@ class PipelineExpressionEvaluatorSpec extends Specification {
     '${status == "SUCCEEDED"}'                  | false
   }
 
+  def "allows calling toString on an UnmodifiableMap"() {
+    given:
+    // This fails under java 17 without something like
+    // --add-opens=java.base/java.util=ALL-UNNAMED as an argument ot the jvm.
+    def source = [test: '${ {"foo": "bar"}.toString() }']
+    PipelineExpressionEvaluator evaluator = new PipelineExpressionEvaluator([], pluginManager, expressionProperties)
+
+    when:
+    ExpressionEvaluationSummary evaluationSummary = new ExpressionEvaluationSummary()
+    def result = evaluator.evaluate(source, [status: ExecutionStatus.TERMINAL], evaluationSummary, true)
+
+    then:
+    evaluationSummary.expressionResult.isEmpty()
+    evaluationSummary.failureCount == 0
+    result.test == '{foo=bar}'
+  }
+
   static ExpressionFunctionProvider buildExpressionFunctionProvider(String providerName) {
     new ExpressionFunctionProvider() {
       @Override


### PR DESCRIPTION
that uses a non-public constructor/method, and so requires special treatment under java 17.
