### PR TITLE
fix(tests): refactor tests and junit platform name to execute startup tests

### DIFF
--- a/keiko-mem-spring/keiko-mem-spring.gradle
+++ b/keiko-mem-spring/keiko-mem-spring.gradle
@@ -12,9 +12,3 @@ dependencies {
 
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
-
-test {
-  useJUnitPlatform {
-    includeEngines "jupiter"
-  }
-}

--- a/keiko-mem-spring/src/test/kotlin/com/netflix/spinnaker/q/mem/spring/SpringStartupTests.kt
+++ b/keiko-mem-spring/src/test/kotlin/com/netflix/spinnaker/q/mem/spring/SpringStartupTests.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.q.mem.spring
 
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.MemQueueConfiguration
 import com.netflix.spinnaker.config.QueueConfiguration
 import com.netflix.spinnaker.q.DeadMessageCallback
@@ -13,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import com.netflix.spectator.api.Registry
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
@@ -34,4 +36,7 @@ internal class SpringStartupTests {
 internal class TestConfiguration {
   @Bean
   fun deadMessageCallback(): DeadMessageCallback = { _, _ -> }
+
+  @Bean
+  fun registry(): Registry = NoopRegistry()
 }

--- a/keiko-redis-spring/keiko-redis-spring.gradle
+++ b/keiko-redis-spring/keiko-redis-spring.gradle
@@ -9,12 +9,7 @@ dependencies {
   testImplementation "org.springframework:spring-test"
   testImplementation "org.springframework.boot:spring-boot-test"
   testImplementation "org.assertj:assertj-core"
+  testImplementation("io.spinnaker.kork:kork-jedis-test")
 
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
-}
-
-test {
-  useJUnitPlatform {
-    includeEngines "jupiter"
-  }
 }

--- a/keiko-redis-spring/src/test/kotlin/com/netflix/spinnaker/q/redis/spring/SpringStartupTests.kt
+++ b/keiko-redis-spring/src/test/kotlin/com/netflix/spinnaker/q/redis/spring/SpringStartupTests.kt
@@ -1,5 +1,7 @@
 package com.netflix.spinnaker.q.redis.spring
 
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.QueueConfiguration
 import com.netflix.spinnaker.config.RedisQueueConfiguration
 import com.netflix.spinnaker.q.Queue
@@ -10,11 +12,15 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import redis.clients.jedis.JedisPool
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
-  classes = [QueueConfiguration::class, RedisQueueConfiguration::class],
+  classes = [QueueConfiguration::class, RedisQueueConfiguration::class, TestConfiguration::class],
   webEnvironment = NONE
 )
 internal class SpringStartupTests {
@@ -26,4 +32,12 @@ internal class SpringStartupTests {
   fun `starts up successfully`() {
     Assertions.assertThat(queue).isNotNull.isInstanceOf(RedisQueue::class.java)
   }
+}
+@Configuration
+internal class TestConfiguration {
+  @Bean
+  fun registry(): Registry = NoopRegistry()
+
+  @Bean
+  fun queueRedisPool(): JedisPool = EmbeddedRedis.embed().pool
 }


### PR DESCRIPTION
Startup test under module keiko-mem-spring and keiko-redis-spring are not executing and throwing below error:
```
> Task :keiko-mem-spring:test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':keiko-mem-spring:test'.
> No tests found for given includes: [com.netflix.spinnaker.q.mem.spring.SpringStartupTests](--tests filter)

```
```
> Task :keiko-redis-spring:test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':keiko-redis-spring:test'.
> No tests found for given includes: [com.netflix.spinnaker.q.redis.spring.SpringStartupTests](--tests filter)

```

After fixing these issues by refactoring the junit platform as `junit-jupiter`, encountered below errors while execution:
```
Failed to load ApplicationContext
Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'com.netflix.spectator.api.Registry' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
	at app//org.springframework.beans.factory.support.DefaultListableBeanFactory.raiseNoMatchingBeanFound(DefaultListableBeanFactory.java:1801)
	at app//org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1357)
	at app//org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1311)
	at app//org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:911)
	at app//org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:788)
	... 133 more
```

```
Failed to load ApplicationContext
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.netflix.spinnaker.q.redis.RedisQueue]: Factory method 'queue' threw exception; nested exception is redis.clients.jedis.exceptions.JedisConnectionException: Could not get a resource from the pool
	at app//org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:185)
	at app//org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:648)
	... 120 more
```
To fix these errors refactored the test by adding `Registry` and `JedisPool` beans.
