### PR TITLE
fix(sqlExecutionRepo): Return compressed columns when enabled for retrieve pipelines with configId

### DIFF
--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -667,7 +667,10 @@ class SqlExecutionRepository(
         .join(
           jooq.selectExecutions(
           PIPELINE,
-          listOf(field("id")),
+          fields = if (compressionProperties.enabled)
+            listOf(field("id")) + field("compressed_body") + field("compression_type")
+          else
+            listOf(field("id")),
           conditions = {
             var conditions = it.where(
             field("config_id").`in`(*pipelineConfigIds.toTypedArray())

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
@@ -95,10 +95,10 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
     return createExecutionRepository("test")
   }
 
-  ExecutionRepository createExecutionRepository(String partition, Interlink interlink = null) {
+  ExecutionRepository createExecutionRepository(String partition, Interlink interlink = null, boolean compression = false) {
     return InstrumentedProxy.proxy(
         new DefaultRegistry(),
-        new SqlExecutionRepository(partition, currentDatabase.context, mapper, new RetryProperties(), 10, 100, "poolName", interlink, [], new ExecutionCompressionProperties(), false),
+        new SqlExecutionRepository(partition, currentDatabase.context, mapper, new RetryProperties(), 10, 100, "poolName", interlink, [], new ExecutionCompressionProperties(enabled: compression), false),
         "namespace")
   }
 
@@ -583,15 +583,16 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
 
   def "can retrieve pipelines by configIds between build time boundaries"() {
     given:
+    ExecutionRepository repo = createExecutionRepository("test", null, compressionEnabled)
     (storeLimit + 1).times { i ->
-      repository.store(pipeline {
+      repo.store(pipeline {
         application = "spinnaker"
         pipelineConfigId = "foo1"
         name = "Execution #${i + 1}"
         buildTime = i + 1
       })
 
-      repository.store(pipeline {
+      repo.store(pipeline {
         application = "spinnaker"
         pipelineConfigId = "foo2"
         name = "Execution #${i + 1}"
@@ -600,7 +601,7 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
     }
 
     when:
-    def results = repository
+    def results = repo
       .retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
       ["foo1", "foo2"],
       0L,
@@ -614,21 +615,23 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
     }
 
     where:
-    storeLimit = 6
-    retrieveLimit = 10
+    storeLimit  |  retrieveLimit | compressionEnabled
+    6           | 10             | false
+    6           | 10             | true
   }
 
   def "can retrieve ALL pipelines by configIds between build time boundaries"() {
     given:
+    ExecutionRepository repo = createExecutionRepository("test", null, compressionEnabled)
     (storeLimit + 1).times { i ->
-      repository.store(pipeline {
+      repo.store(pipeline {
         application = "spinnaker"
         pipelineConfigId = "foo1"
         name = "Execution #${i + 1}"
         buildTime = i + 1
       })
 
-      repository.store(pipeline {
+      repo.store(pipeline {
         application = "spinnaker"
         pipelineConfigId = "foo2"
         name = "Execution #${i + 1}"
@@ -637,14 +640,14 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
     }
 
     when:
-    List<PipelineExecution> forwardResults = repository
+    List<PipelineExecution> forwardResults = repo
       .retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
       ["foo1", "foo2"],
       0L,
       5L,
       new ExecutionCriteria().setPageSize(1).setSortType(BUILD_TIME_ASC)
     )
-    List<PipelineExecution> backwardsResults = repository
+    List<PipelineExecution> backwardsResults = repo
       .retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
       ["foo1", "foo2"],
       0L,
@@ -660,18 +663,28 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
 
 
     where:
-    storeLimit = 6
+    storeLimit  | compressionEnabled
+    6           | false
+    6           | true
   }
 
   def "doesn't fail on empty configIds"() {
+    given:
+    ExecutionRepository repo = createExecutionRepository("test", null, compressionEnabled)
+
     expect:
-    repository
+    repo
       .retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(
       [],
       0L,
       5L,
       new ExecutionCriteria().setPageSize(1).setSortType(BUILD_TIME_ASC)
     ).size() == 0
+
+    where:
+    compressionEnabled | _
+    false              | _
+    true               | _
   }
 }
 


### PR DESCRIPTION
When execution repository compression is enabled the generated query for retrieving the pipelines with configId was not returning the compressed columns from the left outer join. 

Orca was failing with: 
```
org.jooq.exception.DataAccessException: SQL [select id, body, compressed_body, compression_type, `partition` from pipelines join (select id from pipelines left outer join pipelines_compressed_executions using (id) where (config_id in (?, ?) and build_time > ? and build_time < ?) order by build_time asc limit ? offset ?) as `alias_79833741` using (id) order by build_time asc]; Unknown column 'compressed_body' in 'field list'
	at app//org.jooq.impl.Tools.translate(Tools.java:2903)
	at app//org.jooq.impl.DefaultExecuteContext.sqlException(DefaultExecuteContext.java:757)
	at app//org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:389)
	at app//org.jooq.impl.AbstractResultQuery.fetch(AbstractResultQuery.java:337)
	at app//org.jooq.impl.SelectImpl.fetch(SelectImpl.java:2880)
	at app//com.netflix.spinnaker.orca.sql.pipeline.persistence.SqlExecutionRepository.fetchExecutions(SqlExecutionRepository.kt:1208)
	at app//com.netflix.spinnaker.orca.sql.pipeline.persistence.SqlExecutionRepository.retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(SqlExecutionRepository.kt:712)
	at app//com.netflix.spinnaker.orca.sql.pipeline.persistence.SqlExecutionRepository.retrieveAllPipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(SqlExecutionRepository.kt:728)
	at app//com.netflix.spinnaker.kork.telemetry.InstrumentedProxy.invoke(InstrumentedProxy.java:103)
	at com.netflix.spinnaker.orca.sql.pipeline.persistence.SqlPipelineExecutionRepositorySpec.can retrieve ALL pipelines by configIds between build time boundaries(SqlPipelineExecutionRepositorySpec.groovy:648)
Caused by: java.sql.SQLSyntaxErrorException: Unknown column 'compressed_body' in 'field list'
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:121)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:916)
	at com.mysql.cj.jdbc.ClientPreparedStatement.execute(ClientPreparedStatement.java:354)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.execute(ProxyPreparedStatement.java:44)
	at org.jooq.tools.jdbc.DefaultPreparedStatement.execute(DefaultPreparedStatement.java:214)
	at org.jooq.impl.Tools.executeStatementAndGetFirstResultSet(Tools.java:4217)
	at org.jooq.impl.AbstractResultQuery.execute(AbstractResultQuery.java:283)
	at org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:375)
	... 7 more
```

This PR fixes the issue and add tests to demonstrate the bug