### PR TITLE
refactor(test): replace assertion used from library unitils-core to assertj-core while spockframework upgrade to 2.2-groovy-3.0

### DIFF
--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -27,7 +27,7 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok")
 
   testImplementation("org.slf4j:slf4j-simple")
-  testImplementation("org.spockframework:spock-unitils")
+  testImplementation("org.assertj:assertj-core")
   testImplementation("org.codehaus.groovy:groovy-json")
   testImplementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
   testImplementation("io.spinnaker.kork:kork-retrofit")

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy
@@ -37,12 +37,11 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.model.StageDefinitio
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.JinjaRenderer
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.YamlRenderedValueConverter
-import org.unitils.reflectionassert.ReflectionComparatorMode
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
-import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals
+import static org.assertj.core.api.Assertions.assertThat
 
 class PipelineTemplatePipelinePreprocessorSpec extends Specification {
 
@@ -186,7 +185,7 @@ class PipelineTemplatePipelinePreprocessorSpec extends Specification {
       triggers: [],
       expectedArtifacts: []
     ]
-    assertReflectionEquals(expected, result, ReflectionComparatorMode.IGNORE_DEFAULTS)
+    assertThat(expected).usingRecursiveComparison().ignoringActualNullFields().isEqualTo(result)
   }
 
   def 'should render jackson mapping exceptions'() {

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy
@@ -38,13 +38,12 @@ import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.Renderer
 import com.netflix.spinnaker.orca.pipelinetemplate.v1schema.render.YamlRenderedValueConverter
 import org.springframework.core.io.Resource
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver
-import org.unitils.reflectionassert.ReflectionComparatorMode
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals
+import static org.assertj.core.api.Assertions.assertThat
 
 class V1SchemaIntegrationSpec extends Specification {
 
@@ -89,7 +88,7 @@ class V1SchemaIntegrationSpec extends Specification {
     def result = subject.process(integration.toRequest())
 
     then:
-    assertReflectionEquals(expected, result, ReflectionComparatorMode.IGNORE_DEFAULTS)
+    assertThat(expected).usingRecursiveComparison().ignoringActualNullFields().isEqualTo(result)
 
     where:
     integration << new IntegrationTestDataProvider().provide()


### PR DESCRIPTION
While upgrading spockframework from 2.0-groovy-3.0 to 2.2-groovy-3.0, encountered below errors during test execution of orca-pipelinetemplate module:
```
> Task :orca-pipelinetemplate:compileTestGroovy FAILED
startup failed:
/orca/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy: 40: unable to resolve class org.unitils.reflectionassert.ReflectionComparatorMode
 @ line 40, column 1.
   import org.unitils.reflectionassert.ReflectionComparatorMode
   ^

/orca/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePipelinePreprocessorSpec.groovy: 45: unable to resolve class org.unitils.reflectionassert.ReflectionAssert
 @ line 45, column 1.
   import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals
   ^

/orca/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy: 41: unable to resolve class org.unitils.reflectionassert.ReflectionComparatorMode
 @ line 41, column 1.
   import org.unitils.reflectionassert.ReflectionComparatorMode
   ^

/orca/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy: 47: unable to resolve class org.unitils.reflectionassert.ReflectionAssert
 @ line 47, column 1.
   import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals
   ^

4 errors
```
The `org.unitils:unitils-core` dependency has been dropped from [spock 2.2](https://repo1.maven.org/maven2/org/spockframework/spock-unitils/2.2-groovy-3.0/spock-unitils-2.2-groovy-3.0.pom), that is part of [spock 2.0](https://repo1.maven.org/maven2/org/spockframework/spock-unitils/2.0-groovy-3.0/spock-unitils-2.0-groovy-3.0.pom), this breaking change causes the above mentioned issue. The `unitils-core` is a dormant library since 2017, so replacing it with `assertj-core` to resolve this issue.
