### PR TITLE
chore(dependency): add explicit assertj-core dependency while spockframework upgrade to 2.2-groovy-3.0

### DIFF
--- a/orca-mine/orca-mine.gradle
+++ b/orca-mine/orca-mine.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation("io.spinnaker.kork:kork-retrofit")
 
   testImplementation("org.junit.jupiter:junit-jupiter-params")
+  testImplementation("org.assertj:assertj-core")
   testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")
 }
 


### PR DESCRIPTION
While upgrading spockframework from 2.0-groovy-3.0 to 2.2-groovy-3.0, encountered below errors during test execution of orca-mine module:
```
/orca/orca-mine/src/test/java/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTaskTest.java:22: error: package org.assertj.core.api does not exist
import static org.assertj.core.api.Assertions.assertThatThrownBy;
                                  ^

/orca/orca-mine/src/test/java/com/netflix/spinnaker/orca/mine/tasks/RegisterCanaryTaskTest.java:150: error: cannot find symbol
    assertThatThrownBy(() -> registerCanaryTask.execute(deployCanaryStage))
    ^
  symbol:   method assertThatThrownBy(()->regist[...]tage))
  location: class RegisterCanaryTaskTest
```
To fix this issue added assertj-core dependency explicitly.
