### PR TITLE
chore(dependency): add explicit byte-buddy dependency while upgrading spockframework to 2.2-groovy-3.0

### DIFF
--- a/orca-applications/orca-applications.gradle
+++ b/orca-applications/orca-applications.gradle
@@ -29,4 +29,5 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok")
 
   testImplementation(project(":orca-test-groovy"))
+  testRuntimeOnly("net.bytebuddy:byte-buddy")
 }

--- a/orca-clouddriver-provider-titus/orca-clouddriver-provider-titus.gradle
+++ b/orca-clouddriver-provider-titus/orca-clouddriver-provider-titus.gradle
@@ -29,4 +29,5 @@ dependencies {
   testImplementation(project(":orca-test-groovy"))
 
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  testRuntimeOnly("net.bytebuddy:byte-buddy")
 }

--- a/orca-echo/orca-echo.gradle
+++ b/orca-echo/orca-echo.gradle
@@ -31,6 +31,7 @@ dependencies {
   implementation("io.spinnaker.kork:kork-retrofit")
 
   testImplementation("com.squareup.retrofit:retrofit-mock")
+  testRuntimeOnly("net.bytebuddy:byte-buddy")
 }
 
 tasks.withType(Javadoc) {

--- a/orca-front50/orca-front50.gradle
+++ b/orca-front50/orca-front50.gradle
@@ -38,6 +38,7 @@ dependencies {
   testImplementation(project(":orca-test-groovy"))
   testImplementation(project(":orca-pipelinetemplate"))
   testImplementation("com.github.ben-manes.caffeine:guava")
+  testRuntimeOnly("net.bytebuddy:byte-buddy")
 }
 
 sourceSets {

--- a/orca-igor/orca-igor.gradle
+++ b/orca-igor/orca-igor.gradle
@@ -33,6 +33,7 @@ dependencies {
   testImplementation("org.springframework:spring-test")
   testImplementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
   testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")
+  testRuntimeOnly("net.bytebuddy:byte-buddy")
 }
 
 sourceSets {

--- a/orca-interlink/orca-interlink.gradle
+++ b/orca-interlink/orca-interlink.gradle
@@ -30,4 +30,5 @@ dependencies {
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")
   testImplementation(project(":orca-test"))
+  testRuntimeOnly("net.bytebuddy:byte-buddy")
 }

--- a/orca-mine/orca-mine.gradle
+++ b/orca-mine/orca-mine.gradle
@@ -29,6 +29,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("org.assertj:assertj-core")
   testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")
+  testRuntimeOnly("net.bytebuddy:byte-buddy")
 }
 
 sourceSets {

--- a/orca-peering/orca-peering.gradle
+++ b/orca-peering/orca-peering.gradle
@@ -25,4 +25,5 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-autoconfigure")
 
   testImplementation(project(":orca-test-groovy"))
+  testRuntimeOnly("net.bytebuddy:byte-buddy")
 }

--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -31,4 +31,5 @@ dependencies {
   testImplementation("org.codehaus.groovy:groovy-json")
   testImplementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
   testImplementation("io.spinnaker.kork:kork-retrofit")
+  testRuntimeOnly("net.bytebuddy:byte-buddy")
 }

--- a/orca-webhook/orca-webhook.gradle
+++ b/orca-webhook/orca-webhook.gradle
@@ -30,6 +30,7 @@ dependencies {
   implementation("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
   testImplementation("org.springframework:spring-test")
   testImplementation("org.codehaus.groovy:groovy-json")
+  testRuntimeOnly("net.bytebuddy:byte-buddy")
 
   implementation("io.spinnaker.fiat:fiat-api:$fiatVersion")
   implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")


### PR DESCRIPTION
While upgrading spockframework from 2.0-groovy-3.0 to 2.2-groovy-3.0, encountered similar errors as mentioned below during test execution of orca-mine, orca-pipelinetemplate, orca-applications, orca-echo, orca-clouddriver-provider-titus, orca-front50, orca-igor, orca-peering, orca-interlink and orca-webhook module:

```
Caused by: net.sf.cglib.core.CodeGenerationException: java.lang.reflect.InaccessibleObjectException-->Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @5f9b2141
        at app//net.sf.cglib.core.ReflectUtils.defineClass(ReflectUtils.java:464)
        at app//net.sf.cglib.core.AbstractClassGenerator.generate(AbstractClassGenerator.java:339)
        at app//net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:96)
        at app//net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:94)
        at app//net.sf.cglib.core.internal.LoadingCache$2.call(LoadingCache.java:54)
        at java.base@17.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at app//net.sf.cglib.core.internal.LoadingCache.createEntry(LoadingCache.java:61)
        at app//net.sf.cglib.core.internal.LoadingCache.get(LoadingCache.java:34)
        at app//net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData.get(AbstractClassGenerator.java:119)
        at app//net.sf.cglib.core.AbstractClassGenerator.create(AbstractClassGenerator.java:294)
        at app//net.sf.cglib.core.KeyFactory$Generator.create(KeyFactory.java:221)
        at app//net.sf.cglib.core.KeyFactory.create(KeyFactory.java:174)
        at app//net.sf.cglib.core.KeyFactory.create(KeyFactory.java:153)
        at app//net.sf.cglib.proxy.Enhancer.<clinit>(Enhancer.java:73)
        ... 10 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @5f9b2141
        at net.sf.cglib.core.ReflectUtils$1.run(ReflectUtils.java:61)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:569)
        at net.sf.cglib.core.ReflectUtils.<clinit>(ReflectUtils.java:52)
        at net.sf.cglib.core.KeyFactory$Generator.generateClass(KeyFactory.java:243)
        at net.sf.cglib.core.DefaultGeneratorStrategy.generate(DefaultGeneratorStrategy.java:25)
        at net.sf.cglib.core.AbstractClassGenerator.generate(AbstractClassGenerator.java:332)
        ... 22 more
```
This issue caused due to dropping of `net.bytebuddy:byte-buddy` transitive dependency from [spock 2.2](https://repo1.maven.org/maven2/org/spockframework/spock-core/2.2-groovy-3.0/spock-core-2.2-groovy-3.0.pom), while it is part of [spock 2.0](https://repo1.maven.org/maven2/org/spockframework/spock-core/2.0-groovy-3.0/spock-core-2.0-groovy-3.0.pom). So, introducing the `testRuntimeOnly` byte-buddy explicit dependency to fix this issue. Since spring boot 2.7.18 bring byte-buddy as transitive dependency with [1.12.23](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom) version, so tying the byte-buddy version with spring boot by unpinning it.
