### PR TITLE
feat(batchUpdate): Pipeline config batch update

### DIFF
--- a/orca-front50/orca-front50.gradle
+++ b/orca-front50/orca-front50.gradle
@@ -38,6 +38,7 @@ dependencies {
   testImplementation(project(":orca-test-groovy"))
   testImplementation(project(":orca-pipelinetemplate"))
   testImplementation("com.github.ben-manes.caffeine:guava")
+  testImplementation("org.codehaus.groovy:groovy-json")
   testRuntimeOnly("net.bytebuddy:byte-buddy")
 }
 

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -74,6 +74,9 @@ interface Front50Service {
   @POST("/pipelines")
   Response savePipeline(@Body Map pipeline, @Query("staleCheck") boolean staleCheck)
 
+  @POST("/pipelines/bulksave")
+  Response savePipelineList(@Body List<Map<String, Object>> pipelineList, @Query("staleCheck") boolean staleCheck)
+
   @PUT("/pipelines/{pipelineId}")
   Response updatePipeline(@Path("pipelineId") String pipelineId, @Body Map pipeline)
 

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/Front50Service.groovy
@@ -74,8 +74,8 @@ interface Front50Service {
   @POST("/pipelines")
   Response savePipeline(@Body Map pipeline, @Query("staleCheck") boolean staleCheck)
 
-  @POST("/pipelines/bulksave")
-  Response savePipelineList(@Body List<Map<String, Object>> pipelineList, @Query("staleCheck") boolean staleCheck)
+  @POST("/pipelines/batchUpdate")
+  Response savePipelines(@Body List<Map<String, Object>> pipelines, @Query("staleCheck") boolean staleCheck)
 
   @PUT("/pipelines/{pipelineId}")
   Response updatePipeline(@Path("pipelineId") String pipelineId, @Body Map pipeline)

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.retrofit.RetrofitConfiguration
 import com.netflix.spinnaker.orca.retrofit.logging.RetrofitSlf4jLog
 import groovy.transform.CompileStatic
+import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -41,6 +42,8 @@ import retrofit.Endpoint
 import retrofit.RequestInterceptor
 import retrofit.RestAdapter
 import retrofit.converter.JacksonConverter
+
+import java.util.concurrent.TimeUnit
 
 import static retrofit.Endpoints.newFixedEndpoint
 
@@ -65,6 +68,9 @@ class Front50Configuration {
   @Autowired
   RequestInterceptor spinnakerRequestInterceptor
 
+  @Value('${okhttp.timeout:10}')
+  Integer okhttpTimeout
+
   @Bean
   Endpoint front50Endpoint(Front50ConfigurationProperties front50ConfigurationProperties) {
     newFixedEndpoint(front50ConfigurationProperties.getBaseUrl())
@@ -72,10 +78,14 @@ class Front50Configuration {
 
   @Bean
   Front50Service front50Service(Endpoint front50Endpoint, ObjectMapper mapper) {
+    OkHttpClient okHttpClient = clientProvider.getClient(new DefaultServiceEndpoint("front50", front50Endpoint.getUrl())); println(' timeout : ' + okhttpTimeout)
+    okHttpClient = okHttpClient.newBuilder().readTimeout(okhttpTimeout, TimeUnit.SECONDS)
+        .writeTimeout(okhttpTimeout, TimeUnit.SECONDS)
+        .connectTimeout(okhttpTimeout, TimeUnit.SECONDS).build();
     new RestAdapter.Builder()
       .setRequestInterceptor(spinnakerRequestInterceptor)
       .setEndpoint(front50Endpoint)
-      .setClient(new Ok3Client(clientProvider.getClient(new DefaultServiceEndpoint("front50", front50Endpoint.getUrl()))))
+      .setClient(new Ok3Client(okHttpClient))
       .setLogLevel(retrofitLogLevel)
       .setLog(new RetrofitSlf4jLog(Front50Service))
       .setConverter(new JacksonConverter(mapper))

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
@@ -68,20 +68,19 @@ class Front50Configuration {
   @Autowired
   RequestInterceptor spinnakerRequestInterceptor
 
-  @Value('${okhttp.timeout:10}')
-  Integer okhttpTimeout
-
   @Bean
   Endpoint front50Endpoint(Front50ConfigurationProperties front50ConfigurationProperties) {
     newFixedEndpoint(front50ConfigurationProperties.getBaseUrl())
   }
 
   @Bean
-  Front50Service front50Service(Endpoint front50Endpoint, ObjectMapper mapper) {
-    OkHttpClient okHttpClient = clientProvider.getClient(new DefaultServiceEndpoint("front50", front50Endpoint.getUrl())); println(' timeout : ' + okhttpTimeout)
-    okHttpClient = okHttpClient.newBuilder().readTimeout(okhttpTimeout, TimeUnit.SECONDS)
-        .writeTimeout(okhttpTimeout, TimeUnit.SECONDS)
-        .connectTimeout(okhttpTimeout, TimeUnit.SECONDS).build();
+  Front50Service front50Service(Endpoint front50Endpoint, ObjectMapper mapper, Front50ConfigurationProperties front50ConfigurationProperties) {
+    OkHttpClient okHttpClient = clientProvider.getClient(new DefaultServiceEndpoint("front50", front50Endpoint.getUrl()));
+    okHttpClient = okHttpClient.newBuilder()
+        .readTimeout(front50ConfigurationProperties.okhttp.readTimeoutMs, TimeUnit.MILLISECONDS)
+        .writeTimeout(front50ConfigurationProperties.okhttp.writeTimeoutMs, TimeUnit.MILLISECONDS)
+        .connectTimeout(front50ConfigurationProperties.okhttp.connectTimeoutMs, TimeUnit.MILLISECONDS)
+        .build();
     new RestAdapter.Builder()
       .setRequestInterceptor(spinnakerRequestInterceptor)
       .setEndpoint(front50Endpoint)

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50ConfigurationProperties.java
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50ConfigurationProperties.java
@@ -33,4 +33,15 @@ public class Front50ConfigurationProperties {
    * <p>When true: GET /pipelines/triggeredBy/{pipelineId}/{status} When false: GET /pipelines
    */
   boolean useTriggeredByEndpoint = true;
+
+  OkHttpConfigurationProperties okhttp = new OkHttpConfigurationProperties();
+
+  @Data
+  public static class OkHttpConfigurationProperties {
+    int readTimeoutMs = 10000;
+
+    int writeTimeoutMs = 10000;
+
+    int connectTimeoutMs = 10000;
+  }
 }

--- a/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
+++ b/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/spring/DependentPipelineExecutionListener.groovy
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.orca.exceptions.PipelineTemplateValidationException
 import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor
 import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
 import com.netflix.spinnaker.orca.front50.Front50Service
-import com.netflix.spinnaker.orca.front50.config.Front50Configuration
 import com.netflix.spinnaker.orca.front50.config.Front50ConfigurationProperties
 import com.netflix.spinnaker.orca.listeners.ExecutionListener
 import com.netflix.spinnaker.orca.listeners.Persister

--- a/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
+++ b/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.front50.tasks;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
@@ -34,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 @Component
@@ -197,9 +197,9 @@ public class SavePipelineTask implements RetryableTask {
     if (StringUtils.isNotEmpty(newPipelineID)) {
       try {
         return front50Service.getPipeline(newPipelineID);
-      } catch (RetrofitError e) {
+      } catch (SpinnakerHttpException e) {
         // Return a null if pipeline with expected id not found
-        if (e.getResponse() != null && e.getResponse().getStatus() == HTTP_NOT_FOUND) {
+        if (e.getResponseCode() == HTTP_NOT_FOUND) {
           log.debug("Existing pipeline with id {} not found. Returning null.", newPipelineID);
         }
       }

--- a/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
+++ b/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
@@ -64,42 +64,60 @@ public class SavePipelineTask implements RetryableTask {
       throw new IllegalArgumentException("pipeline context must be provided");
     }
 
-    Map<String, Object> pipeline;
+    Map<String, Object> pipeline = null;
+    List<Map<String, Object>> pipelineList = new ArrayList<>();
+    Boolean staleCheck = false;
+    Boolean isSavingMultiplePipelines = false;
+    boolean bulksave = false;
     if (!(stage.getContext().get("pipeline") instanceof String)) {
       pipeline = (Map<String, Object>) stage.getContext().get("pipeline");
+    } else if (stage.getContext().containsKey("bulksave")
+        && (boolean) stage.getContext().get("bulksave")) {
+      pipelineList = (List) stage.decodeBase64("/pipeline", List.class);
+      bulksave = true;
     } else {
       pipeline = (Map<String, Object>) stage.decodeBase64("/pipeline", Map.class);
+      pipelineList.add(pipeline);
     }
-
-    if (!pipeline.containsKey("index")) {
-      Map<String, Object> existingPipeline = fetchExistingPipeline(pipeline);
-      if (existingPipeline != null) {
-        pipeline.put("index", existingPipeline.get("index"));
+    for (Map<String, Object> obj : pipelineList) {
+      pipeline = obj;
+      if (!pipeline.containsKey("index")) {
+        Map<String, Object> existingPipeline = fetchExistingPipeline(pipeline);
+        if (existingPipeline != null) {
+          pipeline.put("index", existingPipeline.get("index"));
+        }
       }
-    }
-    String serviceAccount = (String) stage.getContext().get("pipeline.serviceAccount");
-    if (serviceAccount != null) {
-      updateServiceAccount(pipeline, serviceAccount);
-    }
-    final Boolean isSavingMultiplePipelines =
-        (Boolean)
-            Optional.ofNullable(stage.getContext().get("isSavingMultiplePipelines")).orElse(false);
-    final Boolean staleCheck =
-        (Boolean) Optional.ofNullable(stage.getContext().get("staleCheck")).orElse(false);
-    if (stage.getContext().get("pipeline.id") != null
-        && pipeline.get("id") == null
-        && !isSavingMultiplePipelines) {
-      pipeline.put("id", stage.getContext().get("pipeline.id"));
+      String serviceAccount = (String) stage.getContext().get("pipeline.serviceAccount");
+      if (serviceAccount != null) {
+        updateServiceAccount(pipeline, serviceAccount);
+      }
+      isSavingMultiplePipelines =
+          (Boolean)
+              Optional.ofNullable(stage.getContext().get("isSavingMultiplePipelines"))
+                  .orElse(false);
+      staleCheck =
+          (Boolean) Optional.ofNullable(stage.getContext().get("staleCheck")).orElse(false);
+      if (stage.getContext().get("pipeline.id") != null
+          && pipeline.get("id") == null
+          && !isSavingMultiplePipelines) {
+        pipeline.put("id", stage.getContext().get("pipeline.id"));
 
-      // We need to tell front50 to regenerate cron trigger id's
-      pipeline.put("regenerateCronTriggerIds", true);
+        // We need to tell front50 to regenerate cron trigger id's
+        pipeline.put("regenerateCronTriggerIds", true);
+      }
+
+      Map<String, Object> finalPipeline = pipeline;
+      Map<String, Object> finalPipeline1 = pipeline;
+      pipelineModelMutators.stream()
+          .filter(m -> m.supports(finalPipeline))
+          .forEach(m -> m.mutate(finalPipeline1));
     }
-
-    pipelineModelMutators.stream()
-        .filter(m -> m.supports(pipeline))
-        .forEach(m -> m.mutate(pipeline));
-
-    Response response = front50Service.savePipeline(pipeline, staleCheck);
+    Response response = null;
+    if (bulksave) {
+      response = front50Service.savePipelineList(pipelineList, false);
+    } else {
+      response = front50Service.savePipeline(pipeline, staleCheck);
+    }
 
     Map<String, Object> outputs = new HashMap<>();
     outputs.put("notification.type", "savepipeline");
@@ -109,7 +127,7 @@ public class SavePipelineTask implements RetryableTask {
     try {
       Map<String, Object> savedPipeline =
           (Map<String, Object>) objectMapper.readValue(response.getBody().in(), Map.class);
-      outputs.put("pipeline.id", savedPipeline.get("id"));
+      outputs.put("bulksave", savedPipeline);
     } catch (Exception e) {
       log.error("Unable to deserialize saved pipeline, reason: ", e.getMessage());
 

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -46,6 +46,9 @@ tasks:
   executionWindow:
     timezone: ${global.spinnaker.timezone:America/Los_Angeles}
 
+okhttp:
+  timeout: 10
+
 logging:
   config: classpath:logback-defaults.xml
 

--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -46,9 +46,6 @@ tasks:
   executionWindow:
     timezone: ${global.spinnaker.timezone:America/Los_Angeles}
 
-okhttp:
-  timeout: 10
-
 logging:
   config: classpath:logback-defaults.xml
 


### PR DESCRIPTION
Change is dependent on https://github.com/spinnaker/front50/pull/1483

Added code to save multiple pipelines at once to sql database.

This is part of: spinnaker/spinnaker#6147.

Enhanced SavePipelineTask.java to

Added code to ensure that the SavePipelineTask.java also accepts list of pipelines json.
This method will validate all the pipelines.
This method will call the front50 service to save the pipelines list.

Enhanced Front50Service.groovy to

Added new rest api which accepts list of pipelines json.

Also contains some changes to make the timeout values in the front50 client configurable.  They all default to 10000:
* front50.okhttp.readTimeoutMs
* front50.okhttp.writeTimeoutMs
* front50.okhttp.connectTimeoutMs