### PR TITLE
fix(orca-sql): Add migration for mariadb support

### DIFF
--- a/orca-sql/src/main/resources/db/changelog-master.yml
+++ b/orca-sql/src/main/resources/db/changelog-master.yml
@@ -57,6 +57,9 @@ databaseChangeLog:
     file: changelog/20201214-create-compressed-executions-table.yaml
     relativeToChangelogFile: true
 - include:
+    file: changelog/20240731-add-compression-type-column-mariadb.yaml
+    relativeToChangelogFile: true
+- include:
     file: changelog/20220427-add-compression-type-column-to-compressed-executions-tables-postgres.yaml
     relativeToChangelogFile: true
 - include:

--- a/orca-sql/src/main/resources/db/changelog/20240731-add-compression-type-column-mariadb.yaml
+++ b/orca-sql/src/main/resources/db/changelog/20240731-add-compression-type-column-mariadb.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-pipelines-compressed-executions-mariadb
+      author: juangod-wise
+      changes:
+        - sql:
+            dbms: mariadb
+            sql: ALTER TABLE `pipelines_compressed_executions` ADD COLUMN `compression_type` ENUM("GZIP", "ZLIB") NOT NULL DEFAULT "ZLIB"
+  - changeSet:
+      id: create-pipeline-stages-compressed-executions-mariadb
+      author: juangod-wise
+      changes:
+        - sql:
+            dbms: mariadb
+            sql: ALTER TABLE `pipeline_stages_compressed_executions` ADD COLUMN `compression_type` ENUM("GZIP", "ZLIB") NOT NULL DEFAULT "ZLIB"
+  - changeSet:
+      id: create-orchestrations-compressed-executions-mariadb
+      author: juangod-wise
+      changes:
+        - sql:
+            dbms: mariadb
+            sql: ALTER TABLE `orchestrations_compressed_executions` ADD COLUMN `compression_type` ENUM("GZIP", "ZLIB") NOT NULL DEFAULT "ZLIB"
+  - changeSet:
+      id: create-orchestrations-stages-compressed-executions-mariadb
+      author: juangod-wise
+      changes:
+        - sql:
+            dbms: mariadb
+            sql: ALTER TABLE `orchestration_stages_compressed_executions` ADD COLUMN `compression_type` ENUM("GZIP", "ZLIB") NOT NULL DEFAULT "ZLIB"

--- a/orca-sql/src/main/resources/db/changelog/20240731-add-compression-type-column-mariadb.yaml
+++ b/orca-sql/src/main/resources/db/changelog/20240731-add-compression-type-column-mariadb.yaml
@@ -1,27 +1,27 @@
 databaseChangeLog:
   - changeSet:
-      id: create-pipelines-compressed-executions-mariadb
+      id: add-compression-type-column-to-pipelines-compressed-executions-mariadb
       author: juangod-wise
       changes:
         - sql:
             dbms: mariadb
             sql: ALTER TABLE `pipelines_compressed_executions` ADD COLUMN `compression_type` ENUM("GZIP", "ZLIB") NOT NULL DEFAULT "ZLIB"
   - changeSet:
-      id: create-pipeline-stages-compressed-executions-mariadb
+      id: add-compression-type-column-to-pipeline-stages-compressed-executions-mariadb
       author: juangod-wise
       changes:
         - sql:
             dbms: mariadb
             sql: ALTER TABLE `pipeline_stages_compressed_executions` ADD COLUMN `compression_type` ENUM("GZIP", "ZLIB") NOT NULL DEFAULT "ZLIB"
   - changeSet:
-      id: create-orchestrations-compressed-executions-mariadb
+      id: add-compression-type-column-to-orchestrations-compressed-executions-mariadb
       author: juangod-wise
       changes:
         - sql:
             dbms: mariadb
             sql: ALTER TABLE `orchestrations_compressed_executions` ADD COLUMN `compression_type` ENUM("GZIP", "ZLIB") NOT NULL DEFAULT "ZLIB"
   - changeSet:
-      id: create-orchestrations-stages-compressed-executions-mariadb
+      id: add-compression-type-column-to-orchestration-stages-compressed-executions-mariadb
       author: juangod-wise
       changes:
         - sql:


### PR DESCRIPTION
This contribution was discussed in this slack thread: 

https://spinnakerteam.slack.com/archives/C7J1CU4LA/p1722343931881969?thread_ts=1710447204.964799&cid=C7J1CU4LA

In summary: 

The migration in `20201214-create-compressed-executions-table.yaml` that is adding the column `compression_type` is not being ran for MariaDB because it contains `dbms: mysql`. This causes Orca to throw the following error on startup if using MariaDB:

```
liquibase.exception.DatabaseException: Unknown data type: 'COMPRESSION_TYPE_ENUM' [Failed SQL: (4161) ALTER TABLE spinnaker_orca.pipelines_compressed_executions ADD compression_type COMPRESSION_TYPE_ENUM DEFAULT 'ZLIB' NOT NULL
```

This happens because, since the column is not being created on that migration, the Postgres migration is ran because of this conditional:

https://github.com/spinnaker/orca/blob/ad53c1762f8a63dea8fea7b80517b5063d4109d7/orca-sql/src/main/resources/db/changelog/20220427-add-compression-type-column-to-compressed-executions-tables-postgres.yaml#L13-L18

And running the Postgres migration on MariaDB causes the error to appear. The solution for this is to create a new migration for MariaDB that is executed before the Postgres migration that adds the column only if using MariaDB. We can't change previous migrations because the changeset hash would change and would start failing for everyone who already applied it.

Spinnaker should be able to support MariaDB as there are mentions in the documentation:

https://spinnaker.io/docs/setup/productionize/persistence/orca-sql/#mariadb