### PR TITLE
refactor(dependency): replace groovy coordinates and code adjustment to accomodate upgrade of groovy 4.x

### DIFF
--- a/gradle/groovy.gradle
+++ b/gradle/groovy.gradle
@@ -21,7 +21,7 @@
 apply plugin: "groovy"
 
 dependencies {
-  implementation("org.codehaus.groovy:groovy")
+  implementation("org.apache.groovy:groovy")
   testImplementation("org.spockframework:spock-core")
   testImplementation("cglib:cglib-nodep")
   testImplementation("org.objenesis:objenesis")

--- a/gradle/spock.gradle
+++ b/gradle/spock.gradle
@@ -24,7 +24,7 @@ dependencies {
   testImplementation("org.spockframework:spock-core")
   testImplementation("cglib:cglib-nodep")
   testImplementation("org.objenesis:objenesis")
-  testImplementation("org.codehaus.groovy:groovy")
+  testImplementation("org.apache.groovy:groovy")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 

--- a/orca-bakery/orca-bakery.gradle
+++ b/orca-bakery/orca-bakery.gradle
@@ -25,7 +25,7 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava")
   implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
-  implementation("org.codehaus.groovy:groovy-datetime")
+  implementation("org.apache.groovy:groovy-datetime")
   implementation("io.spinnaker.kork:kork-retrofit")
 
   api("io.spinnaker.kork:kork-web")

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
@@ -263,7 +263,7 @@ abstract class AbstractClusterWideClouddriverTask implements RetryableTask, Clou
   }
 
   static boolean isActive(TargetServerGroup serverGroup) {
-    return serverGroup.disabled == false || serverGroup.instances.any { it.healthState == HealthState.Up }
+    return serverGroup.isDisabled() == false || serverGroup.instances.any { it.healthState == HealthState.Up }
   }
 
   static class IsActive implements Comparator<TargetServerGroup> {

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolver.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolver.groovy
@@ -112,7 +112,7 @@ class SourceResolver {
     }
 
     def instanceSize = { ServerGroup asg -> asg.instances?.size() ?: 0 }
-    def created = { ServerGroup asg -> asg.createdTime ?: 0 }
+    def created = { ServerGroup asg -> asg.createdTime ?: 0L }
     if (stageData.useSourceCapacity) {
       regionalAsgs = regionalAsgs.sort { a1, a2 -> instanceSize(a1) <=> instanceSize(a2) ?: created(a2) <=> created(a1) }
     }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/JarDiffsTask.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.kato.tasks
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.model.Instance.InstanceInfo
+import org.slf4j.Logger
 import retrofit.converter.JacksonConverter
 
 import java.util.concurrent.TimeUnit
@@ -65,6 +66,10 @@ class JarDiffsTask implements DiffTask {
   OortHelper oortHelper
 
   int platformPort = 8077
+
+  private Logger getLog() {
+    return log
+  }
 
   @Override
   public TaskResult execute(StageExecution stage) {
@@ -137,19 +142,19 @@ class JarDiffsTask implements DiffTask {
     int numberOfInstancesChecked = 0;
     instances.find { key, instanceInfo ->
       if (numberOfInstancesChecked++ >= 5) {
-        log.info("Unable to check jar list after 5 attempts, giving up!")
+        getLog().info("Unable to check jar list after 5 attempts, giving up!")
         return true
       }
 
       String hostName = instanceInfo.privateIpAddress ?: instanceInfo.hostName
-      log.debug("attempting to get a jar list from : ${key} (${hostName}:${platformPort})")
+      getLog().debug("attempting to get a jar list from : ${key} (${hostName}:${platformPort})")
       def instanceService = createInstanceService("http://${hostName}:${platformPort}")
       try {
         def instanceResponse = instanceService.getJars()
         jarMap = objectMapper.readValue(instanceResponse.body.in().text, Map)
         return true
       } catch(Exception e) {
-        log.debug("could not get a jar list from : ${key} (${hostName}:${platformPort}) - ${e.message}")
+        getLog().debug("could not get a jar list from : ${key} (${hostName}:${platformPort}) - ${e.message}")
         // swallow it so we can try the next instance
         return false
       }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/quip/TriggerQuipTask.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
 import com.netflix.spinnaker.orca.clouddriver.InstanceService
 import groovy.util.logging.Slf4j
+import org.slf4j.Logger
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import retrofit.client.Client
@@ -44,6 +45,10 @@ class TriggerQuipTask extends AbstractQuipTask implements RetryableTask {
 
   long backoffPeriod = 10000
   long timeout = 600000 // 10min
+
+  private Logger getLog() {
+    return log
+  }
 
   @Override
   TaskResult execute(StageExecution stage) {
@@ -76,7 +81,7 @@ class TriggerQuipTask extends AbstractQuipTask implements RetryableTask {
             taskIdMap.put(instanceHostName, ref.substring(1 + ref.lastIndexOf('/')))
             patchedInstanceIds << instanceId
           } catch (SpinnakerServerException e) {
-            log.warn("Error in Quip request: {}", e.message)
+            getLog().warn("Error in Quip request: {}", e.message)
           }
         }
       }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/tasks/rollingpush/DetermineTerminationCandidatesTask.groovy
@@ -51,7 +51,7 @@ class DetermineTerminationCandidatesTask implements Task {
         .orElseGet { serverGroupInstances*.instanceId }
     def terminationInstancePool = knownInstanceIds
     if (stage.context.termination?.instances) {
-      terminationInstancePool = knownInstanceIds.intersect(stage.context.termination?.instances)
+      terminationInstancePool = stage.context.termination?.instances.intersect(knownInstanceIds)
       if (stage.context.termination.order == 'given') {
         terminationInstancePool = terminationInstancePool.sort { stage.context.termination.instances.indexOf(it) }
       }

--- a/orca-core/orca-core.gradle
+++ b/orca-core/orca-core.gradle
@@ -53,7 +53,7 @@ dependencies {
   implementation("javax.validation:validation-api")
   implementation("com.jayway.jsonpath:json-path")
   implementation("org.yaml:snakeyaml")
-  implementation("org.codehaus.groovy:groovy")
+  implementation("org.apache.groovy:groovy")
   implementation("net.javacrumbs.shedlock:shedlock-spring:4.44.0")
   implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.44.0")
 

--- a/orca-front50/orca-front50.gradle
+++ b/orca-front50/orca-front50.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation(project(":orca-core"))
   implementation(project(":orca-retrofit"))
 
-  api("org.codehaus.groovy:groovy")
+  api("org.apache.groovy:groovy")
 
   implementation("io.spinnaker.fiat:fiat-api:$fiatVersion")
   implementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
@@ -38,7 +38,7 @@ dependencies {
   testImplementation(project(":orca-test-groovy"))
   testImplementation(project(":orca-pipelinetemplate"))
   testImplementation("com.github.ben-manes.caffeine:guava")
-  testImplementation("org.codehaus.groovy:groovy-json")
+  testImplementation("org.apache.groovy:groovy-json")
   testRuntimeOnly("net.bytebuddy:byte-buddy")
 }
 

--- a/orca-integrations-cloudfoundry/orca-integrations-cloudfoundry.gradle
+++ b/orca-integrations-cloudfoundry/orca-integrations-cloudfoundry.gradle
@@ -12,7 +12,7 @@ dependencies {
   implementation(project(":orca-core"))
 
   implementation("org.jetbrains:annotations")
-  testImplementation("org.codehaus.groovy:groovy")
+  testImplementation("org.apache.groovy:groovy")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core:2.25.0")

--- a/orca-keel/orca-keel.gradle
+++ b/orca-keel/orca-keel.gradle
@@ -31,7 +31,7 @@ dependencies {
   testImplementation("io.mockk:mockk")
   testImplementation("io.strikt:strikt-jackson")
   testImplementation("org.assertj:assertj-core")
-  testImplementation("org.codehaus.groovy:groovy")
+  testImplementation("org.apache.groovy:groovy")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")

--- a/orca-pipelinetemplate/orca-pipelinetemplate.gradle
+++ b/orca-pipelinetemplate/orca-pipelinetemplate.gradle
@@ -28,7 +28,7 @@ dependencies {
 
   testImplementation("org.slf4j:slf4j-simple")
   testImplementation("org.assertj:assertj-core")
-  testImplementation("org.codehaus.groovy:groovy-json")
+  testImplementation("org.apache.groovy:groovy-json")
   testImplementation("io.spinnaker.fiat:fiat-core:$fiatVersion")
   testImplementation("io.spinnaker.kork:kork-retrofit")
   testRuntimeOnly("net.bytebuddy:byte-buddy")

--- a/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy
+++ b/orca-pipelinetemplate/src/test/groovy/com/netflix/spinnaker/orca/pipelinetemplate/v1schema/V1SchemaIntegrationSpec.groovy
@@ -114,13 +114,13 @@ class V1SchemaIntegrationSpec extends Specification {
         }
 
         if (it.filename.endsWith('-config.yml')) {
-          test.configuration = objectMapper.convertValue(yaml.load(it.file.text), TemplateConfiguration)
+          test.configuration = objectMapper.convertValue(yaml.load(it.getFile().text), TemplateConfiguration)
         } else if (it.filename.endsWith('-expected.json')) {
-          test.expected = objectMapper.readValue(it.file, Map)
+          test.expected = objectMapper.readValue(it.getFile(), Map)
         } else if (it.filename.endsWith('-request.json')) {
-          test.request = objectMapper.readValue(it.file, Map)
+          test.request = objectMapper.readValue(it.getFile(), Map)
         } else {
-          test.template.add(objectMapper.convertValue(yaml.load(it.file.text), PipelineTemplate))
+          test.template.add(objectMapper.convertValue(yaml.load(it.getFile().text), PipelineTemplate))
         }
       }
 

--- a/orca-queue/orca-queue.gradle
+++ b/orca-queue/orca-queue.gradle
@@ -41,6 +41,6 @@ dependencies {
   testImplementation(project(":orca-queue-tck"))
   testImplementation(project(":orca-queue-redis"))
   testImplementation(project(":orca-echo"))
-  testImplementation("org.codehaus.groovy:groovy")
+  testImplementation("org.apache.groovy:groovy")
   testImplementation("org.assertj:assertj-core")
 }

--- a/orca-retrofit/orca-retrofit.gradle
+++ b/orca-retrofit/orca-retrofit.gradle
@@ -19,7 +19,7 @@ apply from: "$rootDir/gradle/groovy.gradle"
 dependencies {
   api("com.squareup.retrofit:retrofit")
   api("com.squareup.retrofit:converter-jackson")
-  api("org.codehaus.groovy:groovy")
+  api("org.apache.groovy:groovy")
   api("io.spinnaker.kork:kork-web")
   api("com.jakewharton.retrofit:retrofit1-okhttp3-client")
 

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -93,7 +93,7 @@ dependencies {
   testImplementation("dev.minutest:minutest")
   testImplementation("io.strikt:strikt-core")
   testImplementation("io.mockk:mockk")
-  testImplementation("org.codehaus.groovy:groovy-json")
+  testImplementation("org.apache.groovy:groovy-json")
 }
 
 test {

--- a/orca-webhook/orca-webhook.gradle
+++ b/orca-webhook/orca-webhook.gradle
@@ -29,7 +29,7 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
   testImplementation("org.springframework:spring-test")
-  testImplementation("org.codehaus.groovy:groovy-json")
+  testImplementation("org.apache.groovy:groovy-json")
   testRuntimeOnly("net.bytebuddy:byte-buddy")
 
   implementation("io.spinnaker.fiat:fiat-api:$fiatVersion")


### PR DESCRIPTION
- Replacing the groovy coordinates from `org.codehaus.groovy` to `org.apache.groovy` supported by groovy 4.x and above versions.

- While upgrading groovy 4.0.15:

Encounter below error during test executions of orca-clouddriver module and similar errors in orca-pipelinetemplate module:
```
No such property: disabled for class: com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
groovy.lang.MissingPropertyException: No such property: disabled for class: com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
	at app//com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideClouddriverTask.isActive(AbstractClusterWideClouddriverTask.groovy:266)
	at com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideClouddriverTask.filterActiveGroups_closure9(AbstractClusterWideClouddriverTask.groovy:187)
	at app//com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideClouddriverTask.filterActiveGroups(AbstractClusterWideClouddriverTask.groovy:187)
	at app//com.netflix.spinnaker.orca.clouddriver.tasks.cluster.ScaleDownClusterTask.filterServerGroups(ScaleDownClusterTask.groovy:75)
	at com.netflix.spinnaker.orca.clouddriver.tasks.cluster.ScaleDownClusterTaskSpec.extracts config from context(ScaleDownClusterTaskSpec.groovy:49)
```
To fix this issue, replaced the fields with its getter method.

Encounter below error during compilation of orca-clouddriver module:
```
startup failed:
/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/kato/pipeline/support/SourceResolver.groovy: 118: [Static type checking] - Cannot find matching method ?#compareTo(?). Please check if the declared type is correct and if the method exists.
 @ line 118, column 92.
   ze(a1)<=> instanceSize(a2) ?: created(a2
                                 ^

1 error

> Task :orca-clouddriver:compileGroovy FAILED
```
The root cause seems to be the type mismatch returned by `created` closure. To fix this issue typecasted the return value of `0` from Integer to Long.

Encounter below error during test executions of orca-clouddriver module and similar errors in orca-pipelinetemplate module:
```
No signature of method: com.netflix.spinnaker.orca.kato.tasks.JarDiffsTask.getLog() is applicable for argument types: () values: []
Possible solutions: getAt(java.lang.String), getClass(), notify(), $getLookup(), every(), grep()
groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.orca.kato.tasks.JarDiffsTask.getLog() is applicable for argument types: () values: []
Possible solutions: getAt(java.lang.String), getClass(), notify(), $getLookup(), every(), grep()
	at com.netflix.spinnaker.orca.kato.tasks.JarDiffsTask.getJarList_closure2(JarDiffsTask.groovy:150)
	at app//com.netflix.spinnaker.orca.kato.tasks.JarDiffsTask.getJarList(JarDiffsTask.groovy:143)
	at app//org.spockframework.mock.runtime.ByteBuddyMethodInvoker.respond(ByteBuddyMethodInvoker.java:20)
	at app//org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:61)
	at app//org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:30)
	at app//org.spockframework.mock.runtime.MockController.handle(MockController.java:50)
	at app//org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:86)
	at app//org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
	at com.netflix.spinnaker.orca.kato.tasks.JarDiffsTaskSpec.getJarList single server(JarDiffsTaskSpec.groovy:87)
```

```
No signature of method: com.netflix.spinnaker.orca.kato.tasks.quip.TriggerQuipTask.getLog() is applicable for argument types: () values: []
Possible solutions: getAt(java.lang.String), getClass(), notify(), $getLookup(), $getLookup(), every()
groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.orca.kato.tasks.quip.TriggerQuipTask.getLog() is applicable for argument types: () values: []
Possible solutions: getAt(java.lang.String), getClass(), notify(), $getLookup(), $getLookup(), every()
	at com.netflix.spinnaker.orca.kato.tasks.quip.TriggerQuipTask.execute_closure2(TriggerQuipTask.groovy:87)
	at app//groovy.lang.Closure.call(Closure.java:433)
	at app//com.netflix.spinnaker.orca.kato.tasks.quip.TriggerQuipTask.execute(TriggerQuipTask.groovy:71)
	at app//org.spockframework.mock.runtime.ByteBuddyMethodInvoker.respond(ByteBuddyMethodInvoker.java:20)
	at app//org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:61)
	at app//org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:30)
	at app//org.spockframework.mock.runtime.MockController.handle(MockController.java:50)
	at app//org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:86)
	at app//org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
	at com.netflix.spinnaker.orca.kato.tasks.quip.TriggerQuipTaskSpec.servers return errors, expect RUNNING(TriggerQuipTaskSpec.groovy:175)
```
To fix this issue, explicitly defined a method to return `log` object inside `find{}` and `each{}` closure. It may be related to this [issue](https://issues.apache.org/jira/browse/GROOVY-8820)

https://github.com/micronaut-projects/micronaut-core/issues/4933#issuecomment-779278160

Encounter below error during test executions of orca-clouddriver module:
```
Condition not satisfied:

response.context.terminationInstanceIds == expectedTerminations
|        |       |                      |  |
|        |       [i-2, i-3, i-4]        |  [i-4, i-2, i-3]
|        |                              false
|        [terminationInstanceIds:[i-2, i-3, i-4], knownInstanceIds:[i-1, i-2, i-3, i-4], skipRemainingWait:true, waitTime:0]
TaskResult(status=SUCCEEDED, context={terminationInstanceIds=[i-2, i-3, i-4], knownInstanceIds=[i-1, i-2, i-3, i-4], skipRemainingWait=true, waitTime=0}, outputs={})

Condition not satisfied:

response.context.terminationInstanceIds == expectedTerminations
|        |       |                      |  |
|        |       [i-2, i-3, i-4]        |  [i-4, i-2, i-3]
|        |                              false
|        [terminationInstanceIds:[i-2, i-3, i-4], knownInstanceIds:[i-1, i-2, i-3, i-4], skipRemainingWait:true, waitTime:0]
TaskResult(status=SUCCEEDED, context={terminationInstanceIds=[i-2, i-3, i-4], knownInstanceIds=[i-1, i-2, i-3, i-4], skipRemainingWait=true, waitTime=0}, outputs={})

	at com.netflix.spinnaker.orca.kato.tasks.rollingpush.DetermineTerminationCandidatesTaskSpec.should order and filter instances correctly(DetermineTerminationCandidatesTaskSpec.groovy:58)

```
The root cause of this issue is breaking change, in the usage of `intersect()` method, introduced in groovy 4 [here](https://groovy-lang.org/releasenotes/groovy-4.0.html#Groovy4.0-breaking). To fix this issue, refactoring the code.
