### PR TITLE
feat(clouddriver): add a new task that checks if the application specified in the moniker or cluster keys exists in front50 and/or clouddriver

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/tasks/CheckIfApplicationExistsTaskConfig.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/tasks/CheckIfApplicationExistsTaskConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config.tasks;
+
+import lombok.Data;
+
+@Data
+public class CheckIfApplicationExistsTaskConfig {
+  // controls whether clouddriver should be queried for an application or not. Defaults to true
+  boolean checkClouddriver = true;
+
+  // front50 specific retry config. This is only applicable when services.front50.enabled: true
+  private RetryConfig front50Retries = new RetryConfig();
+
+  // clouddriver specific retry config. This is only applicable when checkClouddriver: true
+  private RetryConfig clouddriverRetries = new RetryConfig();
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/tasks/CheckIfApplicationExistsTaskConfig.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/tasks/CheckIfApplicationExistsTaskConfig.java
@@ -23,6 +23,9 @@ public class CheckIfApplicationExistsTaskConfig {
   // controls whether clouddriver should be queried for an application or not. Defaults to true
   boolean checkClouddriver = true;
 
+  // controls whether the task should fail or simply log a warning
+  boolean auditModeEnabled = true;
+
   // front50 specific retry config. This is only applicable when services.front50.enabled: true
   private RetryConfig front50Retries = new RetryConfig();
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/tasks/RetryConfig.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/config/tasks/RetryConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.config.tasks;
+
+import lombok.Data;
+
+@Data
+public class RetryConfig {
+  // total number of attempts
+  int maxAttempts = 6;
+
+  // time in ms to wait before subsequent retry attempts
+  long backOffInMs = 5000;
+
+  // flag to enable exponential backoff
+  boolean exponentialBackoffEnabled = false;
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CloneServerGroupStage.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.orca.clouddriver.ForceCacheRefreshAware
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.AbstractDeployStrategyStage
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.instance.WaitForUpInstancesTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CheckIfApplicationExistsForServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CloneServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.AddServerGroupEntityTagsTask
@@ -77,5 +78,14 @@ class CloneServerGroupStage extends AbstractDeployStrategyStage implements Force
     }
 
     return tasks
+  }
+
+  @Override
+  protected Map<String, Class> getOptionalPreValidationTasks(){
+    Map<String, Class> output = [:]
+    if (isCheckIfApplicationExistsEnabled(dynamicConfigService)) {
+      output[CheckIfApplicationExistsForServerGroupTask.getTaskName()] = CheckIfApplicationExistsForServerGroupTask
+    }
+    return output
   }
 }

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.ModifyAwsSc
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroupLinearStageSupport
 import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.MonitorKatoTask
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CheckIfApplicationExistsForServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ResizeServerGroupTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCacheForceRefreshTask
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForCapacityMatchTask
@@ -43,6 +44,7 @@ class ResizeServerGroupStage extends TargetServerGroupLinearStageSupport {
   @Override
   protected void taskGraphInternal(StageExecution stage, TaskNode.Builder builder) {
     builder
+      .withTask(CheckIfApplicationExistsForServerGroupTask.getTaskName(), CheckIfApplicationExistsForServerGroupTask)
       .withTask("determineHealthProviders", DetermineHealthProvidersTask)
       .withTask("resizeServerGroup", ResizeServerGroupTask)
       .withTask("monitorServerGroup", MonitorKatoTask)

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractCheckIfApplicationExistsTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/AbstractCheckIfApplicationExistsTask.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import com.netflix.spinnaker.orca.api.pipeline.Task;
+import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.config.TaskConfigurationProperties;
+import com.netflix.spinnaker.orca.clouddriver.config.tasks.CheckIfApplicationExistsTaskConfig;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.front50.model.Application;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import retrofit.client.Response;
+
+/**
+ * Abstract class that is meant to test the presence of a spinnaker application. It will first check
+ * if the application exists in front50. Since front50 can be disabled, it falls back to checking
+ * for the application in clouddriver.
+ *
+ * <p>If the application doesn't exist, the task fails.
+ *
+ * <p>The motivation for adding such a task is to prevent creation of any ad-hoc applications in
+ * amazon deployment pipeline stages. Depending on what is the application value set in the moniker
+ * and/or the cluster keys in such stages, any application that didn't previously exist can be
+ * created on demand. This can have an adverse effect on the security of such applications since
+ * these applications aren't created via a controlled process.
+ */
+@Slf4j
+@Component
+public abstract class AbstractCheckIfApplicationExistsTask implements Task {
+  @Getter private static final String taskName = "checkIfApplicationExists";
+  @Nullable private final Front50Service front50Service;
+  private final OortService oortService;
+  private final ObjectMapper objectMapper;
+  private final RetrySupport retrySupport;
+  private final CheckIfApplicationExistsTaskConfig config;
+
+  public AbstractCheckIfApplicationExistsTask(
+      @Nullable Front50Service front50Service,
+      OortService oortService,
+      ObjectMapper objectMapper,
+      RetrySupport retrySupport,
+      TaskConfigurationProperties configurationProperties) {
+    this.front50Service = front50Service;
+    this.oortService = oortService;
+    this.objectMapper = objectMapper;
+    this.retrySupport = retrySupport;
+    this.config = configurationProperties.getCheckIfApplicationExistsTask();
+  }
+
+  @Nonnull
+  @Override
+  public TaskResult execute(@Nonnull StageExecution stage) {
+    Map<String, Object> outputs = new HashMap<>();
+    // get the application name
+    String applicationName = getApplicationName(stage);
+
+    // first check front50 to see if this application exists in it
+    log.info("Querying front50 to get information about the application: {}", applicationName);
+    Application fetchedApplication = getApplicationFromFront50(applicationName);
+    String errorMessage = "did not find application: " + applicationName + " in front50";
+    if (fetchedApplication == null) {
+      if (this.config.isCheckClouddriver()) {
+        log.info("querying clouddriver for application: {}", applicationName);
+        fetchedApplication = getApplicationFromClouddriver(applicationName);
+        if (fetchedApplication == null) {
+          errorMessage += " and in clouddriver.";
+        }
+      }
+    }
+    if (fetchedApplication == null) {
+      log.error(errorMessage);
+      throw new NotFoundException(errorMessage);
+    }
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).outputs(outputs).build();
+  }
+
+  /**
+   * attempts to query front50 for the application name that is provided to it as an input.
+   *
+   * <p>If front50 is disabled, then it returns null. It also returns null if the application
+   * doesn't exist or if any exception arises on querying this data from front50. The expectation is
+   * that the caller method should handle the return value in a suitable manner
+   *
+   * @param applicationName the application to search for in front50
+   * @return the application, if it exists in front50, or null otherwise
+   */
+  protected Application getApplicationFromFront50(String applicationName) {
+    // this can happen if front50 is disabled
+    if (front50Service == null) {
+      log.info("Front50 is disabled, cannot query application: {}", applicationName);
+      return null;
+    }
+    return retrySupport.retry(
+        () -> {
+          try {
+            Application fetchedApplication = front50Service.get(applicationName);
+            if (fetchedApplication == null) {
+              log.warn("Application: " + applicationName + " does not exist in front50");
+            } else {
+              log.info("Application: " + applicationName + " found in front50");
+            }
+            return fetchedApplication;
+          } catch (Exception e) {
+            log.error(
+                "Application: " + applicationName + " could not be retrieved from front50. Error: ",
+                e);
+            return null;
+          }
+        },
+        this.config.getFront50Retries().getMaxAttempts(),
+        Duration.ofMillis(this.config.getFront50Retries().getBackOffInMs()),
+        this.config.getFront50Retries().isExponentialBackoffEnabled());
+  }
+
+  /**
+   * attempts to query clouddriver for the application name that is provided to it as an input.
+   *
+   * <p>It returns null if the application doesn't exist in clouddriver or if any exception arises
+   * on querying this data from clouddriver. The expectation is that the caller method should handle
+   * the return value in a suitable manner
+   *
+   * @param applicationName the application to search for in clouddriver
+   * @return the application, if it exists in clouddriver, or null otherwise
+   */
+  protected Application getApplicationFromClouddriver(String applicationName) {
+    return retrySupport.retry(
+        () -> {
+          try {
+            Response response = oortService.getApplication(applicationName);
+            Application fetchedApplication =
+                objectMapper.readValue(response.getBody().in(), Application.class);
+            if (fetchedApplication == null) {
+              log.warn("Application: " + applicationName + " does not exist in clouddriver");
+            } else {
+              log.info("Application: " + applicationName + " found in clouddriver");
+            }
+            return fetchedApplication;
+          } catch (Exception e) {
+            log.error(
+                "Application: "
+                    + applicationName
+                    + " could not be retrieved from clouddriver. Error: ",
+                e);
+            return null;
+          }
+        },
+        this.config.getClouddriverRetries().getMaxAttempts(),
+        Duration.ofMillis(this.config.getClouddriverRetries().getBackOffInMs()),
+        this.config.getClouddriverRetries().isExponentialBackoffEnabled());
+  }
+
+  public abstract String getApplicationName(@Nonnull StageExecution stageExecution);
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractWaitForClusterWideClouddriverTask.groovy
@@ -113,7 +113,7 @@ abstract class AbstractWaitForClusterWideClouddriverTask implements CloudProvide
     }
 
     Optional<Cluster> cluster = cloudDriverService.maybeCluster(clusterSelection.getApplication(), clusterSelection.credentials, clusterSelection.cluster, clusterSelection.cloudProvider)
-    if (!cluster.isPresent()) {
+    if (cluster.isEmpty()) {
       return missingClusterResult(stage, clusterSelection)
     }
 

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/CheckIfApplicationExistsForClusterTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/CheckIfApplicationExistsForClusterTask.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.cluster;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.config.TaskConfigurationProperties;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.AbstractClusterWideClouddriverOperationStage.ClusterSelection;
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCheckIfApplicationExistsTask;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import javax.annotation.Nonnull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * This checks if the application name provided for any cluster related tasks actually exists in
+ * front50 and/or clouddriver
+ */
+@Component
+public class CheckIfApplicationExistsForClusterTask extends AbstractCheckIfApplicationExistsTask {
+  public CheckIfApplicationExistsForClusterTask(
+      @Nullable Front50Service front50Service,
+      OortService oortService,
+      ObjectMapper objectMapper,
+      RetrySupport retrySupport,
+      TaskConfigurationProperties configurationProperties) {
+    super(front50Service, oortService, objectMapper, retrySupport, configurationProperties);
+  }
+
+  @Override
+  public String getApplicationName(@Nonnull StageExecution stageExecution) {
+    ClusterSelection clusterSelection = stageExecution.mapTo(ClusterSelection.class);
+    return clusterSelection.getApplication();
+  }
+}

--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CheckIfApplicationExistsForServerGroupTask.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CheckIfApplicationExistsForServerGroupTask.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.frigga.Names;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.moniker.Moniker;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.config.TaskConfigurationProperties;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.CreateServerGroupStage;
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCheckIfApplicationExistsTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.DetermineHealthProvidersTask;
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * This checks if the application name provided for any server group related tasks actually exists
+ * in front50 and/or clouddriver
+ */
+@Slf4j
+@Component
+public class CheckIfApplicationExistsForServerGroupTask
+    extends AbstractCheckIfApplicationExistsTask {
+
+  public CheckIfApplicationExistsForServerGroupTask(
+      @Nullable Front50Service front50Service,
+      OortService oortService,
+      ObjectMapper objectMapper,
+      RetrySupport retrySupport,
+      TaskConfigurationProperties config) {
+    super(front50Service, oortService, objectMapper, retrySupport, config);
+  }
+
+  /**
+   * get the application name from the provided stage context.
+   *
+   * <p>This matches the logic to retrieve application name from {@link
+   * DetermineHealthProvidersTask#execute(StageExecution)} method. The rationale is that this task
+   * will appear before the above-mentioned task in stages like {@link CreateServerGroupStage}.
+   * Therefore, if an application is referenced in later tasks, we should use the same criteria in
+   * this task to determine if such an application exists or not.
+   *
+   * @param stage the stage execution context
+   * @return the application name
+   */
+  @Override
+  public String getApplicationName(@Nonnull StageExecution stage) {
+    String applicationName = (String) stage.getContext().get("application");
+    if (applicationName == null) {
+      Moniker moniker = MonikerHelper.monikerFromStage(stage);
+      if (moniker != null && moniker.getApp() != null) {
+        applicationName = moniker.getApp();
+      } else if (stage.getContext().containsKey("serverGroupName")) {
+        applicationName =
+            Names.parseName((String) stage.getContext().get("serverGroupName")).getApp();
+      } else if (stage.getContext().containsKey("asgName")) {
+        applicationName = Names.parseName((String) stage.getContext().get("asgName")).getApp();
+      } else if (stage.getContext().containsKey("cluster")) {
+        applicationName = Names.parseName((String) stage.getContext().get("cluster")).getApp();
+      }
+    }
+    return applicationName;
+  }
+}

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/TaskConfigurationProperties.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/TaskConfigurationProperties.java
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.orca.clouddriver.config;
 
+import com.netflix.spinnaker.orca.clouddriver.config.tasks.CheckIfApplicationExistsTaskConfig;
+import com.netflix.spinnaker.orca.clouddriver.config.tasks.RetryConfig;
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCheckIfApplicationExistsTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.job.WaitOnJobCompletion;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.PromoteManifestKatoOutputsTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.manifest.ResolveDeploySourceManifestTask;
@@ -23,9 +26,9 @@ import java.util.Set;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/** configuration properties for various Orca tasks that are in the orca-clouddriver module */
 @Data
 @ConfigurationProperties("tasks.clouddriver")
-/** configuration properties for various Orca tasks that are in the orca-clouddriver module */
 public class TaskConfigurationProperties {
 
   /** properties that pertain to {@link WaitOnJobCompletion} task. */
@@ -40,6 +43,10 @@ public class TaskConfigurationProperties {
   private ResolveDeploySourceManifestTaskConfig resolveDeploySourceManifestTask =
       new ResolveDeploySourceManifestTaskConfig();
 
+  /** properties that pertain to {@link AbstractCheckIfApplicationExistsTask} task */
+  private CheckIfApplicationExistsTaskConfig checkIfApplicationExistsTask =
+      new CheckIfApplicationExistsTaskConfig();
+
   @Data
   public static class WaitOnJobCompletionTaskConfig {
     /**
@@ -48,21 +55,9 @@ public class TaskConfigurationProperties {
      */
     private Set<String> excludeKeysFromOutputs = Set.of();
 
-    private Retries jobStatusRetry = new Retries();
+    private RetryConfig jobStatusRetry = new RetryConfig();
 
-    private Retries fileContentRetry = new Retries();
-
-    @Data
-    public static class Retries {
-      // total number of attempts
-      int maxAttempts = 6;
-
-      // time in ms to wait before subsequent retry attempts
-      long backOffInMs = 5000;
-
-      // flag to enable exponential backoff
-      boolean exponentialBackoffEnabled = false;
-    }
+    private RetryConfig fileContentRetry = new RetryConfig();
   }
 
   @Data

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/DetermineHealthProvidersTask.java
@@ -103,16 +103,18 @@ public class DetermineHealthProvidersTask implements RetryableTask, CloudProvide
 
     try {
       String applicationName = (String) stage.getContext().get("application");
-      Moniker moniker = MonikerHelper.monikerFromStage(stage);
-      if (applicationName == null && moniker != null && moniker.getApp() != null) {
-        applicationName = moniker.getApp();
-      } else if (applicationName == null && stage.getContext().containsKey("serverGroupName")) {
-        applicationName =
-            Names.parseName((String) stage.getContext().get("serverGroupName")).getApp();
-      } else if (applicationName == null && stage.getContext().containsKey("asgName")) {
-        applicationName = Names.parseName((String) stage.getContext().get("asgName")).getApp();
-      } else if (applicationName == null && stage.getContext().containsKey("cluster")) {
-        applicationName = Names.parseName((String) stage.getContext().get("cluster")).getApp();
+      if (applicationName == null) {
+        Moniker moniker = MonikerHelper.monikerFromStage(stage);
+        if (moniker != null && moniker.getApp() != null) {
+          applicationName = moniker.getApp();
+        } else if (stage.getContext().containsKey("serverGroupName")) {
+          applicationName =
+              Names.parseName((String) stage.getContext().get("serverGroupName")).getApp();
+        } else if (stage.getContext().containsKey("asgName")) {
+          applicationName = Names.parseName((String) stage.getContext().get("asgName")).getApp();
+        } else if (stage.getContext().containsKey("cluster")) {
+          applicationName = Names.parseName((String) stage.getContext().get("cluster")).getApp();
+        }
       }
 
       if (front50Service == null) {

--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/CheckIfApplicationExistsForManifestTask.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/CheckIfApplicationExistsForManifestTask.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.moniker.Moniker;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.config.TaskConfigurationProperties;
+import com.netflix.spinnaker.orca.clouddriver.tasks.AbstractCheckIfApplicationExistsTask;
+import com.netflix.spinnaker.orca.clouddriver.utils.MonikerHelper;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * This checks if the application name provided for any server group related tasks actually exists
+ * in front50 and/or clouddriver
+ */
+@Slf4j
+@Component
+public class CheckIfApplicationExistsForManifestTask extends AbstractCheckIfApplicationExistsTask {
+
+  public CheckIfApplicationExistsForManifestTask(
+      @Nullable Front50Service front50Service,
+      OortService oortService,
+      ObjectMapper objectMapper,
+      RetrySupport retrySupport,
+      TaskConfigurationProperties configurationProperties) {
+    super(front50Service, oortService, objectMapper, retrySupport, configurationProperties);
+  }
+
+  /**
+   * get the application name from the provided stage context.
+   *
+   * @param stage the stage execution context
+   * @return the application name
+   */
+  @Override
+  public String getApplicationName(@Nonnull StageExecution stage) {
+    String applicationName = (String) stage.getContext().get("application");
+    if (applicationName == null) {
+      Moniker moniker = MonikerHelper.monikerFromStage(stage);
+      if (moniker != null && moniker.getApp() != null) {
+        applicationName = moniker.getApp();
+      }
+    }
+    return applicationName;
+  }
+}

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
@@ -16,8 +16,9 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
-
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import com.netflix.spinnaker.orca.clouddriver.FeaturesService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.DeployStagePreProcessor
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
@@ -38,11 +39,16 @@ class CreateServerGroupStageSpec extends Specification {
   def env = new MockEnvironment()
 
   @Subject
-  def createServerGroupStage = new CreateServerGroupStage(
-    rollbackClusterStage: new RollbackClusterStage(),
-    destroyServerGroupStage: new DestroyServerGroupStage(),
-    deployStagePreProcessors: [ deployStagePreProcessor ]
-  )
+  CreateServerGroupStage createServerGroupStage
+
+  def setup() {
+    def dynamicConfigService = Mock(DynamicConfigService)
+    createServerGroupStage = new CreateServerGroupStage(Mock(FeaturesService),
+        new RollbackClusterStage(),
+        new DestroyServerGroupStage(dynamicConfigService),
+        dynamicConfigService)
+    createServerGroupStage.deployStagePreProcessors = [ deployStagePreProcessor ]
+  }
 
   @Unroll
   def "should build RollbackStage when 'rollbackOnFailure' is enabled"() {

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/AbstractClusterWideClouddriverOperationStageTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/cluster/AbstractClusterWideClouddriverOperationStageTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.cluster;
+
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPELINE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractClusterWideClouddriverTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.AbstractWaitForClusterWideClouddriverTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.CheckIfApplicationExistsForClusterTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.ShrinkClusterTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.cluster.WaitForClusterShrinkTask;
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class AbstractClusterWideClouddriverOperationStageTest {
+  private DynamicConfigService dynamicConfigService;
+  TestStage testStage;
+  StageExecutionImpl stageExecution;
+
+  @BeforeEach
+  public void setup() {
+    dynamicConfigService = mock(DynamicConfigService.class);
+    testStage = new TestStage(dynamicConfigService);
+    PipelineExecutionImpl pipeline = new PipelineExecutionImpl(PIPELINE, "1", "testapp");
+
+    // Test Stage
+    stageExecution =
+        new StageExecutionImpl(pipeline, TestStage.STAGE_TYPE, "Test Stage", new HashMap<>());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testPresenceOfCheckIfApplicationExistsForClusterTask(boolean isTaskEnabled) {
+    // setup:
+    when(dynamicConfigService.isEnabled("stages.test-stage.check-if-application-exists", false))
+        .thenReturn(isTaskEnabled);
+
+    // when:
+    TaskNode.TaskGraph taskGraph = testStage.buildTaskGraph(stageExecution);
+
+    // then:
+    Iterator<TaskNode> iterator = taskGraph.iterator();
+    AtomicBoolean doesTaskExist = new AtomicBoolean(false);
+    iterator.forEachRemaining(
+        element -> {
+          if (element instanceof TaskNode.TaskDefinition) {
+            if (((TaskNode.TaskDefinition) element)
+                .getImplementingClass()
+                .equals(CheckIfApplicationExistsForClusterTask.class)) {
+              doesTaskExist.set(true);
+            }
+          }
+        });
+
+    assertThat(doesTaskExist.get()).isEqualTo(isTaskEnabled);
+  }
+
+  /**
+   * helper class that is created only for test purposes. It mimics the ShrinkClusterStage class
+   * with the way some methods are overridden in it. But this class exists since I wanted to test
+   * the abstract class itself and not any one specific class that extends it.
+   */
+  private static class TestStage extends AbstractClusterWideClouddriverOperationStage {
+    protected static final String STAGE_TYPE = "testStage";
+
+    protected TestStage(DynamicConfigService dynamicConfigService) {
+      super(dynamicConfigService);
+    }
+
+    protected Class<? extends AbstractClusterWideClouddriverTask> getClusterOperationTask() {
+      return ShrinkClusterTask.class;
+    }
+
+    protected Class<? extends AbstractWaitForClusterWideClouddriverTask> getWaitForTask() {
+      return WaitForClusterShrinkTask.class;
+    }
+  }
+}

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.orca.clouddriver.FeaturesService;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.RollbackClusterStage;
+import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CheckIfApplicationExistsForServerGroupTask;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class CreateServerGroupStageTest {
+  private DynamicConfigService dynamicConfigService;
+  CreateServerGroupStage createServerGroupStage;
+
+  @BeforeEach
+  public void setup() {
+    FeaturesService featuresService = mock(FeaturesService.class);
+    RollbackClusterStage rollbackClusterStage = mock(RollbackClusterStage.class);
+    DestroyServerGroupStage destroyServerGroupStage = mock(DestroyServerGroupStage.class);
+    dynamicConfigService = mock(DynamicConfigService.class);
+    createServerGroupStage =
+        new CreateServerGroupStage(
+            featuresService, rollbackClusterStage, destroyServerGroupStage, dynamicConfigService);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testPresenceOfCheckIfApplicationExistsForServerGroupTask(boolean isTaskEnabled) {
+    when(dynamicConfigService.isEnabled(
+            "stages.create-server-group-stage.check-if-application-exists", false))
+        .thenReturn(isTaskEnabled);
+    Map<String, Class> optionalTasks = createServerGroupStage.getOptionalPreValidationTasks();
+
+    if (isTaskEnabled) {
+      assertFalse(optionalTasks.isEmpty());
+      assertThat(optionalTasks.size()).isEqualTo(1);
+      assertTrue(
+          optionalTasks.containsKey(CheckIfApplicationExistsForServerGroupTask.getTaskName()));
+      assertTrue(optionalTasks.containsValue(CheckIfApplicationExistsForServerGroupTask.class));
+    } else {
+      assertTrue(optionalTasks.isEmpty());
+    }
+  }
+}

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletionTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/job/WaitOnJobCompletionTest.java
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.KatoRestService;
 import com.netflix.spinnaker.orca.clouddriver.config.TaskConfigurationProperties;
+import com.netflix.spinnaker.orca.clouddriver.config.tasks.RetryConfig;
 import com.netflix.spinnaker.orca.clouddriver.exception.JobFailedException;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.front50.model.Application;
@@ -79,8 +80,7 @@ public final class WaitOnJobCompletionTest {
     mockFront50Service = mock(Front50Service.class);
 
     configProperties = new TaskConfigurationProperties();
-    TaskConfigurationProperties.WaitOnJobCompletionTaskConfig.Retries retries =
-        new TaskConfigurationProperties.WaitOnJobCompletionTaskConfig.Retries();
+    RetryConfig retries = new RetryConfig();
     retries.setMaxAttempts(3);
     retries.setBackOffInMs(1);
     configProperties.getWaitOnJobCompletionTask().setFileContentRetry(retries);

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CheckIfApplicationExistsForServerGroupTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/CheckIfApplicationExistsForServerGroupTaskTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.servergroup;
+
+import static com.netflix.spinnaker.orca.TestUtils.getResourceAsStream;
+import static com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType.PIPELINE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.config.TaskConfigurationProperties;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.CreateServerGroupStage;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.front50.model.Application;
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+import retrofit.client.Response;
+import retrofit.mime.TypedByteArray;
+
+public class CheckIfApplicationExistsForServerGroupTaskTest {
+  private @Nullable Front50Service front50Service;
+  private OortService oortService;
+  private ObjectMapper objectMapper;
+  private RetrySupport retrySupport;
+  private CheckIfApplicationExistsForServerGroupTask task;
+  private Application front50Application;
+  private TaskConfigurationProperties configurationProperties;
+  StageExecutionImpl stageExecution;
+
+  @BeforeEach
+  public void setup() {
+    front50Service = mock(Front50Service.class);
+    oortService = mock(OortService.class);
+    objectMapper = new ObjectMapper();
+    retrySupport = new RetrySupport();
+    configurationProperties = new TaskConfigurationProperties();
+
+    front50Application = new Application();
+    front50Application.setUser("test-user");
+    PipelineExecutionImpl pipeline = new PipelineExecutionImpl(PIPELINE, "1", "testapp");
+
+    // Test Stage
+    stageExecution =
+        new StageExecutionImpl(
+            pipeline, CreateServerGroupStage.PIPELINE_CONFIG_TYPE, "Test Stage", new HashMap<>());
+  }
+
+  @DisplayName("parameterized test where front50 is queried for an application")
+  @ParameterizedTest(
+      name = "{index} ==> when application name is obtained from = {0} key in the context")
+  @ValueSource(strings = {"application", "moniker", "serverGroupName", "asgName", "cluster"})
+  public void testSuccessfulRetrievalOfApplicationFromFront50(String applicationNameSource) {
+    // setup:
+    task =
+        new CheckIfApplicationExistsForServerGroupTask(
+            front50Service, oortService, objectMapper, retrySupport, configurationProperties);
+
+    assert front50Service != null;
+    when(front50Service.get("testapp")).thenReturn(front50Application);
+    stageExecution.setContext(getStageContext(applicationNameSource));
+
+    // when:
+    TaskResult result = task.execute(stageExecution);
+
+    // then:
+    assertThat(task.getApplicationName(stageExecution)).isEqualTo("testapp");
+    assertThat(front50Application.getUser()).isEqualTo("test-user");
+    verify(front50Service).get("testapp");
+    assertEquals(result.getStatus(), ExecutionStatus.SUCCEEDED);
+    verifyNoInteractions(oortService);
+  }
+
+  @DisplayName(
+      "parameterized test where clouddriver is queried for an application "
+          + "if the application is not found in front50")
+  @ParameterizedTest(
+      name = "{index} ==> when application name is obtained from = {0} key in the context")
+  @ValueSource(strings = {"application", "moniker", "serverGroupName", "asgName", "cluster"})
+  public void testSuccessfulRetrievalOfApplicationFromClouddriverIfFront50IsDisabled(
+      String applicationNameSource) throws IOException {
+    // setup:
+    task =
+        new CheckIfApplicationExistsForServerGroupTask(
+            null, oortService, objectMapper, retrySupport, configurationProperties);
+
+    when(oortService.getApplication("testapp"))
+        .thenReturn(
+            getApplicationResponse("clouddriver/tasks/servergroup/clouddriver-application.json"));
+    stageExecution.setContext(getStageContext(applicationNameSource));
+
+    // when:
+    TaskResult result = task.execute(stageExecution);
+
+    // then:
+    assertThat(task.getApplicationName(stageExecution)).isEqualTo("testapp");
+    verifyNoInteractions(front50Service);
+    verify(oortService).getApplication("testapp");
+    assertEquals(result.getStatus(), ExecutionStatus.SUCCEEDED);
+  }
+
+  @Test
+  public void testIfApplicationCannotBeRetrievedFromFront50AndCheckClouddriverIsFalse() {
+    TaskConfigurationProperties configurationProperties = new TaskConfigurationProperties();
+    configurationProperties.getCheckIfApplicationExistsTask().setCheckClouddriver(false);
+    // setup:
+    task =
+        new CheckIfApplicationExistsForServerGroupTask(
+            null, oortService, objectMapper, retrySupport, configurationProperties);
+
+    stageExecution.setContext(getStageContext("application"));
+
+    // then
+    NotFoundException thrown =
+        assertThrows(NotFoundException.class, () -> task.execute(stageExecution));
+
+    assertThat(thrown.getMessage()).contains("did not find application: testapp in front50");
+
+    verifyNoInteractions(front50Service);
+    verifyNoInteractions(oortService);
+  }
+
+  @Test
+  public void testAnApplicationWhichDoesNotExistInBothFront50AndClouddriver() {
+    // setup:
+    task =
+        new CheckIfApplicationExistsForServerGroupTask(
+            null, oortService, objectMapper, retrySupport, configurationProperties);
+
+    when(oortService.getApplication("invalid app"))
+        .thenReturn(
+            new Response(
+                "test-url",
+                HttpStatus.NOT_FOUND.value(),
+                "application does not exist",
+                Collections.emptyList(),
+                new TypedByteArray("application/json", new byte[0])));
+
+    Map<String, Object> stageContext = new HashMap<>();
+    stageContext.put("application", "invalid app");
+    stageExecution.setContext(stageContext);
+
+    // then
+    NotFoundException thrown =
+        assertThrows(NotFoundException.class, () -> task.execute(stageExecution));
+
+    assertThat(thrown.getMessage())
+        .contains("did not find application: invalid app in front50 and in clouddriver.");
+    verifyNoInteractions(front50Service);
+    verify(oortService).getApplication("invalid app");
+  }
+
+  private Map<String, Object> getStageContext(String applicationNameSource) {
+    Map<String, Object> stageContext = new HashMap<>();
+    switch (applicationNameSource) {
+      case "application":
+        stageContext.put("application", "testapp");
+        break;
+      case "moniker":
+        stageContext.put("moniker", Map.of("app", "testapp", "stack", "preprod", "detail", "test"));
+        break;
+      case "serverGroupName":
+        stageContext.put("serverGroupName", "testapp-preprod-test-v003");
+        break;
+      case "asgName":
+        stageContext.put("asgName", "testapp-preprod-test-v003");
+        break;
+      case "cluster":
+        stageContext.put("cluster", "testapp-preprod-test");
+        break;
+    }
+    return stageContext;
+  }
+
+  private Response getApplicationResponse(String resourceName) throws IOException {
+    InputStream jobStatusInputStream = getResourceAsStream(resourceName);
+
+    return new Response(
+        "test-url",
+        200,
+        "test-reason",
+        Collections.emptyList(),
+        new TypedByteArray("application/json", IOUtils.toByteArray(jobStatusInputStream)));
+  }
+}

--- a/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestExpressionEvaluationTest.kt
+++ b/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestExpressionEvaluationTest.kt
@@ -143,7 +143,7 @@ class DeployManifestExpressionEvaluationTest : JUnit5Minutests {
     override val contextParameterProcessor = ContextParameterProcessor()
     override val stageDefinitionBuilderFactory = StageDefinitionBuilderFactory { execution ->
       when (execution.type) {
-        "deployManifest" -> DeployManifestStage(mockk())
+        "deployManifest" -> DeployManifestStage(mockk(), mockk())
         else -> throw IllegalArgumentException("Test factory can't make \"${execution.type}\" stages.")
       }
     }

--- a/orca-clouddriver/src/test/resources/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/clouddriver-application.json
+++ b/orca-clouddriver/src/test/resources/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/clouddriver-application.json
@@ -1,0 +1,30 @@
+{
+  "name": "testapp",
+  "attributes": {
+    "cloudProviders": "aws",
+    "name": "testapp",
+    "accounts": "test-account-1, test-account-2"
+  },
+  "clusters": {
+    "test-account-1": [
+      {
+        "loadBalancers": [],
+        "name": "testapp-preprod-test",
+        "provider": "aws",
+        "serverGroups": [
+          "testapp-preprod-test-v003"
+        ]
+      }
+    ],
+    "test-account-2": [
+      {
+        "loadBalancers": [],
+        "name": "testapp-preprod-apoorvtest",
+        "provider": "aws",
+        "serverGroups": [
+          "testapp-preprod-test-v005"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Introduces a new CheckIfApplicationExists task that is meant to be added to various pipeline stages. This task performs the following actions:

  - checks if the application defined in the pipeline stage context is known to front50 and/or clouddriver. If it isn't, this stage throws an exception. Without this task, clouddriver ends up creating a new synthetic application that is not known to front50 and it causes a whole lot of problems for us, as this application does not have any permissions, doesn't have account rbac etc.

  - There are three main types of pipeline stages where this task needs to be added:
      - ServerGroup (aws)
      - Cluster (aws)
      - Manifests (kubernetes)
  - Servergroup, cluster and manifests stages obtain an application name in different ways. Hence, a separate CheckIfApplicationExists exists for all of them which extend a common AbstractCheckIfApplicationExistsTask

  - Config knobs are provided at each stage so that all of these stages can be individually configured to not perform this check if needed. These configs are by default set to false, so this is an opt-in capability. The complete list of configs are:

```yaml
stages:
# server group stages
  bulk-destroy-server-group-stage:
    check-if-application-exists.enabled: true
  create-server-group-stage:
    check-if-application-exists.enabled: true
  clone-server-group-stage:
    check-if-application-exists.enabled: true
  resize-server-group-stage:
    check-if-application-exists.enabled: true
    
# cluster stages
  disable-cluster-stage:
    check-if-application-exists.enabled: true
  scale-down-cluster-stage:
    check-if-application-exists.enabled: true
  shrink-cluster-stage:
    check-if-application-exists.enabled: true

 # k8s manifest stages
  deploy-manifest-stage:
    check-if-application-exists.enabled: true
```
  - Separate config knobs are also provided at the AbstractCheckIfApplicationExistsTask level to determine if clouddriver needs to be queried for the application or not. It is by default set to true, so it is an opt-out capability. the config property is:
```yaml
tasks:
  clouddriver:
    checkIfApplicationExistsTask:
      checkClouddriver: false
```
  - run this in audit mode. By default it is set to true. Opt-out of it (which will start failing pipelines) by:
```yaml  
tasks:
    clouddriver:
      checkIfApplicationExistsTask:
        auditModeEnabled: false
```