### PR TITLE
perf(repository): Remove duplicate storeStage call

### DIFF
--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
@@ -95,7 +95,6 @@ class StartStageHandler(
               try {
                 // Set the startTime in case we throw an exception.
                 stage.startTime = clock.millis()
-                repository.storeStage(stage)
                 stage.plan()
                 stage.status = RUNNING
                 repository.storeStage(stage)

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
@@ -162,7 +162,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       }
 
       it("updates the stage status") {
-        verify(repository, times(2)).storeStage(
+        verify(repository).storeStage(
           check {
             assertThat(it.status).isEqualTo(RUNNING)
             assertThat(it.startTime).isEqualTo(clock.millis())
@@ -171,7 +171,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       }
 
       it("attaches tasks to the stage") {
-        verify(repository, times(2)).storeStage(
+        verify(repository).storeStage(
           check {
             assertThat(it.tasks.size).isEqualTo(1)
             it.tasks.first().apply {
@@ -222,7 +222,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
         }
 
         it("updates the stage status") {
-          verify(repository, times(2)).storeStage(
+          verify(repository).storeStage(
             check {
               assertThat(it.status).isEqualTo(RUNNING)
               assertThat(it.startTime).isEqualTo(clock.millis())
@@ -267,7 +267,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
         }
 
         it("updates the stage status") {
-          verify(repository, times(2)).storeStage(
+          verify(repository).storeStage(
             check {
               assertThat(it.status).isEqualTo(RUNNING)
               assertThat(it.startTime).isEqualTo(clock.millis())
@@ -312,7 +312,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       afterGroup(::resetMocks)
 
       it("attaches tasks to the stage") {
-        verify(repository, times(2)).storeStage(
+        verify(repository).storeStage(
           check {
             assertThat(it.tasks.size).isEqualTo(3)
             it.tasks[0].apply {
@@ -702,7 +702,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       }
 
       it("starts the stage") {
-        verify(repository, times(2)).storeStage(
+        verify(repository).storeStage(
           check {
             assertThat(it.type).isEqualTo("bar")
             assertThat(it.status).isEqualTo(RUNNING)
@@ -712,7 +712,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       }
 
       it("attaches a task to the stage") {
-        verify(repository, times(2)).storeStage(
+        verify(repository).storeStage(
           check {
             assertThat(it.tasks.size).isEqualTo(1)
             it.tasks.first().apply {
@@ -793,7 +793,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
           }
 
           it("attaches the exception to the stage context") {
-            verify(repository, times(2)).storeStage(
+            verify(repository).storeStage(
               check {
                 assertThat(it.context["exception"]).isEqualTo(exceptionDetails)
               }
@@ -833,7 +833,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
           }
 
           it("attaches the exception to the stage context") {
-            verify(repository, times(2)).storeStage(
+            verify(repository).storeStage(
               check {
                 assertThat(it.context["exception"]).isEqualTo(exceptionDetails)
               }
@@ -841,7 +841,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
           }
 
           it("attaches flag to the stage context to indicate that before stage planning failed") {
-            verify(repository, times(2)).storeStage(
+            verify(repository).storeStage(
               check {
                 assertThat(it.context["beforeStagePlanningFailed"]).isEqualTo(true)
               }
@@ -881,7 +881,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
           }
 
           it("attaches the exception to the stage context") {
-            verify(repository, times(2)).storeStage(
+            verify(repository).storeStage(
               check {
                 assertThat(it.context["exception"]).isEqualTo(exceptionDetails)
               }
@@ -889,7 +889,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
           }
 
           it("attaches flag to the stage context to indicate that before stage planning failed") {
-            verify(repository, times(2)).storeStage(
+            verify(repository).storeStage(
               check {
                 assertThat(it.context["beforeStagePlanningFailed"]).isEqualTo(true)
               }
@@ -953,7 +953,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       }
 
       it("updates the stage status") {
-        verify(repository, times(2)).storeStage(
+        verify(repository).storeStage(
           check {
             assertThat(it.status).isEqualTo(RUNNING)
             assertThat(it.startTime).isEqualTo(clock.millis())
@@ -962,7 +962,7 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
       }
 
       it("attaches tasks to the stage") {
-        verify(repository, times(2)).storeStage(
+        verify(repository).storeStage(
           check {
             assertThat(it.tasks.size).isEqualTo(1)
             it.tasks.first().apply {

--- a/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
+++ b/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
@@ -799,6 +799,14 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
               }
             )
           }
+
+          it("updates the stage with a non-default start time") {
+            verify(repository).storeStage(
+              check {
+                assertThat(it.startTime).isPositive()
+              }
+            )
+          }
         }
 
         and("only the branch should fail") {
@@ -839,6 +847,14 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
               }
             )
           }
+
+          it("updates the stage with a non-default start time") {
+            verify(repository).storeStage(
+              check {
+                assertThat(it.startTime).isPositive()
+              }
+            )
+          }
         }
 
         and("the branch should be allowed to continue") {
@@ -876,6 +892,14 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
             verify(repository, times(2)).storeStage(
               check {
                 assertThat(it.context["beforeStagePlanningFailed"]).isEqualTo(true)
+              }
+            )
+          }
+
+          it("updates the stage with a non-default start time") {
+            verify(repository).storeStage(
+              check {
+                assertThat(it.startTime).isPositive()
               }
             )
           }


### PR DESCRIPTION
The duplicate repository.storeStage call was originally added in https://github.com/spinnaker/orca/commit/e872ce859e5e82ca9a4726bea596ae1513b0e765 to ensure that the start time for a stage is set even if the handler encounters an exception. 

However, even without the extra repository.storeStage, orca still sets the start time for a stage when it encounters an exception.
