### PR TITLE
refactor(retrofit): remove all com.squareup.okhttp dependencies

### DIFF
--- a/orca-retrofit/src/main/java/com/netflix/spinnaker/orca/retrofit/RetrofitInterceptorProvider.java
+++ b/orca-retrofit/src/main/java/com/netflix/spinnaker/orca/retrofit/RetrofitInterceptorProvider.java
@@ -20,6 +20,4 @@ import java.util.List;
 
 public interface RetrofitInterceptorProvider {
   List<okhttp3.Interceptor> getInterceptors();
-
-  List<com.squareup.okhttp.Interceptor> getLegacyInterceptors();
 }


### PR DESCRIPTION
All references to com.squareup.okhttp will be removed with this PR.

Refer https://github.com/spinnaker/kork/pull/1210 for kork PR which completes the removal of okhttp2 dependencies.
