### PR TITLE
feat(sql): use a connection pool named "read" for some read operations in SqlExecutionRepository

### DIFF
--- a/orca-queue-sql/src/test/kotlin/com/netflix/spinnaker/orca/q/sql/SqlQueueIntegrationTest.kt
+++ b/orca-queue-sql/src/test/kotlin/com/netflix/spinnaker/orca/q/sql/SqlQueueIntegrationTest.kt
@@ -55,9 +55,11 @@ import java.util.Optional
 import org.jooq.DSLContext
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import javax.sql.DataSource
 
 @Configuration
 class SqlTestConfig {
@@ -121,7 +123,8 @@ class SqlTestConfig {
     registry: Registry,
     properties: SqlProperties,
     orcaSqlProperties: OrcaSqlProperties,
-    compressionProperties: ExecutionCompressionProperties
+    compressionProperties: ExecutionCompressionProperties,
+    dataSource: DataSource
   ) = SqlExecutionRepository(
     orcaSqlProperties.partitionName,
     dsl,
@@ -131,7 +134,8 @@ class SqlTestConfig {
     orcaSqlProperties.stageReadSize,
     interlink = null,
     compressionProperties = compressionProperties,
-    pipelineRefEnabled = false
+    pipelineRefEnabled = false,
+    dataSource = dataSource
   )
 
   @Bean
@@ -192,4 +196,7 @@ class SqlTestConfig {
     "spring.application.name=orcaTest"
   ]
 )
-class SqlQueueIntegrationTest : QueueIntegrationTest()
+class SqlQueueIntegrationTest : QueueIntegrationTest() {
+  @MockBean
+  var dataSource: DataSource? = null
+}

--- a/orca-sql/orca-sql.gradle
+++ b/orca-sql/orca-sql.gradle
@@ -50,12 +50,14 @@ dependencies {
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("dev.minutest:minutest")
   testImplementation("com.nhaarman:mockito-kotlin")
+  testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("org.testcontainers:mysql")
   testImplementation("org.testcontainers:postgresql")
 
   testRuntimeOnly("com.mysql:mysql-connector-j")
   testRuntimeOnly("org.postgresql:postgresql")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  testRuntimeOnly(project(":keiko-sql")) // so SpringLiquibaseProxy has changelog-keiko.yml
 }
 
 test {

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -1275,14 +1275,10 @@ class SqlExecutionRepository(
   private fun selectExecution(
     ctx: DSLContext,
     type: ExecutionType,
-    id: String,
-    forUpdate: Boolean = false
+    id: String
   ): PipelineExecution? {
     withPool(poolName) {
       val select = ctx.selectExecution(type, compressionProperties).where(id.toWhereCondition())
-      if (forUpdate) {
-        select.forUpdate()
-      }
       return select.fetchExecution()
     }
   }

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -192,10 +192,8 @@ class SqlExecutionRepository(
     validateHandledPartitionOrThrow(execution)
 
     withPool(poolName) {
-      jooq.transactional {
-        it.delete(execution.type.stagesTableName)
-          .where(stageId.toWhereCondition()).execute()
-      }
+      jooq.delete(execution.type.stagesTableName)
+        .where(stageId.toWhereCondition()).execute()
     }
   }
 
@@ -699,9 +697,7 @@ class SqlExecutionRepository(
     // If we get here, there's an execution with the given correlation id, but
     // it's complete, so clean up the correlation_ids table.
     withPool(poolName) {
-      jooq.transactional {
-        it.deleteFrom(table("correlation_ids")).where(field("id").eq(correlationId)).execute()
-      }
+      jooq.deleteFrom(table("correlation_ids")).where(field("id").eq(correlationId)).execute()
     }
 
     // Treat a completed execution similar to not finding one at all.
@@ -735,9 +731,7 @@ class SqlExecutionRepository(
     // If we get here, there's an execution with the given correlation id, but
     // it's complete, so clean up the correlation_ids table.
     withPool(poolName) {
-      jooq.transactional {
-        it.deleteFrom(table("correlation_ids")).where(field("id").eq(correlationId)).execute()
-      }
+      jooq.deleteFrom(table("correlation_ids")).where(field("id").eq(correlationId)).execute()
     }
 
     throw ExecutionNotFoundException("Complete Pipeline found for correlation ID $correlationId")

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/OldPipelineCleanupPollingNotificationAgentSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.config.OrcaSqlProperties
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 
+import javax.sql.DataSource
 import java.time.Clock
 import java.time.Instant
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -80,7 +81,19 @@ abstract class OldPipelineCleanupPollingNotificationAgentSpec extends Specificat
 
   def setupSpec() {
     currentDatabase = getDatabase()
-    executionRepository = new SqlExecutionRepository("test", currentDatabase.context, mapper, new RetryProperties(), 10, 100, "poolName", null, [], new ExecutionCompressionProperties(), false)
+    executionRepository = new SqlExecutionRepository("test",
+        currentDatabase.context,
+        mapper,
+        new RetryProperties(),
+        10,
+        100,
+        "poolName",
+        "readPoolName",
+        null,
+        [],
+        new ExecutionCompressionProperties(),
+        false,
+        Mock(DataSource))
   }
 
   def cleanup() {

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/cleanup/TopApplicationExecutionCleanupPollingNotificationAgentSpec.groovy
@@ -31,11 +31,11 @@ import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.sql.pipeline.persistence.SqlExecutionRepository
-import org.jooq.SQLDialect
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 
+import javax.sql.DataSource
 import java.time.Instant
 
 import static com.netflix.spinnaker.kork.sql.test.SqlTestUtil.*
@@ -82,7 +82,7 @@ abstract class TopApplicationExecutionCleanupPollingNotificationAgentSpec extend
 
   def setupSpec() {
     currentDatabase = getDatabase()
-    executionRepository = new SqlExecutionRepository("test", currentDatabase.context, mapper, new RetryProperties(), 10, 100, "poolName", null, [], new ExecutionCompressionProperties(), false)
+    executionRepository = new SqlExecutionRepository("test", currentDatabase.context, mapper, new RetryProperties(), 10, 100, "poolName", "readPoolName", null, [], new ExecutionCompressionProperties(), false, Mock(DataSource))
   }
 
   def cleanup() {

--- a/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
+++ b/orca-sql/src/test/groovy/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlPipelineExecutionRepositorySpec.groovy
@@ -43,6 +43,8 @@ import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
 
+import javax.sql.DataSource
+
 import static com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import static com.netflix.spinnaker.kork.sql.test.SqlTestUtil.initDualTcMysqlDatabases
 import static com.netflix.spinnaker.kork.sql.test.SqlTestUtil.initDualTcPostgresDatabases
@@ -98,7 +100,19 @@ abstract class SqlPipelineExecutionRepositorySpec extends PipelineExecutionRepos
   ExecutionRepository createExecutionRepository(String partition, Interlink interlink = null, boolean compression = false) {
     return InstrumentedProxy.proxy(
         new DefaultRegistry(),
-        new SqlExecutionRepository(partition, currentDatabase.context, mapper, new RetryProperties(), 10, 100, "poolName", interlink, [], new ExecutionCompressionProperties(enabled: compression), false),
+        new SqlExecutionRepository(partition,
+            currentDatabase.context,
+            mapper,
+            new RetryProperties(),
+            10,
+            100,
+            "poolName",
+            "readPoolName",
+            interlink,
+            [],
+            new ExecutionCompressionProperties(enabled: compression),
+            false,
+            Mock(DataSource)),
         "namespace")
   }
 

--- a/orca-sql/src/test/java/com/netflix/spinnaker/orca/testconfig/SqlConfigurationTest.java
+++ b/orca-sql/src/test/java/com/netflix/spinnaker/orca/testconfig/SqlConfigurationTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.testconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.spinnaker.config.SqlConfiguration;
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.boot.context.annotation.UserConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+
+class SqlConfigurationTest {
+
+  private static SqlTestUtil.TestDatabase database = SqlTestUtil.initTcMysqlDatabase();
+
+  // Without .withAllowBeanDefinitionOverriding(true), this fails with an error:
+  //
+  // org.springframework.beans.factory.support.BeanDefinitionOverrideException:
+  // Invalid bean definition with name 'liquibase' defined in
+  // com.netflix.spinnaker.config.SqlConfiguration: Cannot register bean
+  // definition [Root bean: class [null]; scope=; abstract=false; lazyInit=null;
+  // autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false;
+  // factoryBeanName=sqlConfiguration; factoryMethodName=liquibase;
+  // initMethodName=null; destroyMethodName=(inferred); defined in
+  // com.netflix.spinnaker.config.SqlConfiguration] for bean 'liquibase': There
+  // is already [Root bean: class [null]; scope=; abstract=false; lazyInit=null;
+  // autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false;
+  // factoryBeanName=com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration;
+  // factoryMethodName=liquibase; initMethodName=null;
+  // destroyMethodName=(inferred); defined in
+  // com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration] bound.
+  //
+  // Even though DefaultSqlConfiguration has
+  //
+  // @Bean
+  // @ConditionalOnMissingBean(SpringLiquibase::class)
+  // fun liquibase(properties: SqlProperties, @Value("\${sql.read-only:false}") sqlReadOnly:
+  // Boolean): SpringLiquibase =
+  //   SpringLiquibaseProxy(properties.migration, sqlReadOnly)
+  //
+  // which makes sense if DefaultSqlConfiguration gets processed first...
+  private final ApplicationContextRunner runner =
+      new ApplicationContextRunner()
+          .withPropertyValues(
+              "sql.enabled=true",
+              "sql.connectionPools.default.default=true",
+              "sql.connectionPools.default.jdbcUrl=" + SqlTestUtil.tcJdbcUrl,
+              "sql.migration.jdbcUrl=" + SqlTestUtil.tcJdbcUrl)
+          .withAllowBeanDefinitionOverriding(true)
+          .withConfiguration(UserConfigurations.of(SqlConfiguration.class));
+
+  @BeforeEach
+  void init(TestInfo testInfo) {
+    System.out.println("--------------- Test " + testInfo.getDisplayName());
+  }
+
+  @Test
+  void testDataSourceWithDefaultConnectionPool() {
+    runner.run(
+        ctx -> {
+          DataSource dataSource = ctx.getBean(DataSource.class);
+          assertThat(dataSource).isNotNull();
+          // with only one connection pool configured, we get a "plain" data source with no routing.
+          assertThat(dataSource instanceof AbstractRoutingDataSource).isFalse();
+        });
+  }
+
+  @Test
+  void testDataSourceWithReadConnectionPool() {
+    runner
+        .withPropertyValues("sql.connectionPools.read.jdbcUrl=" + SqlTestUtil.tcJdbcUrl)
+        .run(
+            ctx -> {
+              DataSource dataSource = ctx.getBean(DataSource.class);
+              assertThat(dataSource).isNotNull();
+              // with multiple connection pools configured, we get a routing data source
+              assertThat(dataSource instanceof AbstractRoutingDataSource).isTrue();
+            });
+  }
+}

--- a/orca-web/src/test/kotlin/com/netflix/spinnaker/orca/controllers/TaskControllerTest.kt
+++ b/orca-web/src/test/kotlin/com/netflix/spinnaker/orca/controllers/TaskControllerTest.kt
@@ -61,7 +61,8 @@ class TaskControllerTest : JUnit5Minutests {
       mapper = OrcaObjectMapper.getInstance(),
       retryProperties = RetryProperties(),
       compressionProperties = ExecutionCompressionProperties(),
-      pipelineRefEnabled = false
+      pipelineRefEnabled = false,
+      dataSource = mock()
     )
 
     private val taskControllerConfigurationProperties: TaskControllerConfigurationProperties = TaskControllerConfigurationProperties()


### PR DESCRIPTION
Introduce a read pool for some read-only database queries in SqlExecutionRepository.  Enable this by configuring an additional connection pool named `"read"`, like this:
```
sql:
  connectionPools:
    default:
      <...>
    read:
      jdbcUrl: jdbc:...
      user: orca_service
      password: 
      connectionTimeoutMs: 
      validationTimeoutMs: 
      maxPoolSize:
      minIdle:
      maxLifetimeMs:
      idleTimeoutMs:
```

Additional read-only database queries happen in places that expect to see "just-written" contents.  They're not safe to convert to use the read replica until there's logic in place to be aware of replication lag, and wait until the read replica is up-to-date.