### PR TITLE
feat(sql): Optimize executions

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
@@ -221,10 +221,12 @@ class DualExecutionRepository(
 
   override fun retrievePipelineExecutionDetailsForApplication(
     @Nonnull application: String,
-    pipelineConfigIds: List<String>): Collection<PipelineExecution> {
+    pipelineConfigIds: List<String>,
+    queryTimeoutSeconds: Int
+  ): Collection<PipelineExecution> {
     return (
-      primary.retrievePipelineExecutionDetailsForApplication(application, pipelineConfigIds) +
-      previous.retrievePipelineExecutionDetailsForApplication(application, pipelineConfigIds)
+      primary.retrievePipelineExecutionDetailsForApplication(application, pipelineConfigIds, queryTimeoutSeconds) +
+      previous.retrievePipelineExecutionDetailsForApplication(application, pipelineConfigIds, queryTimeoutSeconds)
       ).distinctBy { it.id }
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
@@ -192,6 +192,13 @@ class DualExecutionRepository(
     ).distinct { it.id }
   }
 
+  override fun retrievePipelineConfigIdsForApplication(application: String): List<String> {
+    return (
+      primary.retrievePipelineConfigIdsForApplication(application) +
+      previous.retrievePipelineConfigIdsForApplication(application)
+      ).distinct()
+  }
+
   override fun retrievePipelinesForPipelineConfigId(
     pipelineConfigId: String,
     criteria: ExecutionCriteria
@@ -200,6 +207,17 @@ class DualExecutionRepository(
       primary.retrievePipelinesForPipelineConfigId(pipelineConfigId, criteria),
       previous.retrievePipelinesForPipelineConfigId(pipelineConfigId, criteria)
     ).distinct { it.id }
+  }
+
+  override fun retrievePipelineExecutionsForApplication(
+    application: String,
+    pipelineConfigIds: List<String>,
+    criteria: ExecutionCriteria
+  ): Collection<PipelineExecution> {
+    return (
+      primary.retrievePipelineExecutionsForApplication(application, pipelineConfigIds, criteria) +
+      previous.retrievePipelineExecutionsForApplication(application, pipelineConfigIds, criteria)
+      ).distinctBy { it.id }
   }
 
   override fun retrievePipelinesForPipelineConfigIdsBetweenBuildTimeBoundary(

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
@@ -30,6 +30,7 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Component
 import rx.Observable
+import javax.annotation.Nonnull
 
 /**
  * Intended for performing red/black Orca deployments which do not share the
@@ -209,14 +210,19 @@ class DualExecutionRepository(
     ).distinct { it.id }
   }
 
-  override fun retrievePipelineExecutionsForApplication(
-    application: String,
-    pipelineConfigIds: List<String>,
-    criteria: ExecutionCriteria
-  ): Collection<PipelineExecution> {
+  override fun filterPipelineExecutionsForApplication(@Nonnull application: String,
+                                             @Nonnull pipelineConfigIds: List<String>,
+                                             @Nonnull criteria: ExecutionCriteria): List<String>{
+    return primary.filterPipelineExecutionsForApplication(application, pipelineConfigIds, criteria) +
+      previous.filterPipelineExecutionsForApplication(application,pipelineConfigIds, criteria)
+  }
+
+  override fun retrievePipelineExecutionsDetailsForApplication(
+    @Nonnull application: String,
+    pipelineConfigIds: List<String>): Collection<PipelineExecution> {
     return (
-      primary.retrievePipelineExecutionsForApplication(application, pipelineConfigIds, criteria) +
-      previous.retrievePipelineExecutionsForApplication(application, pipelineConfigIds, criteria)
+      primary.retrievePipelineExecutionsDetailsForApplication(application, pipelineConfigIds) +
+      previous.retrievePipelineExecutionsDetailsForApplication(application,pipelineConfigIds)
       ).distinctBy { it.id }
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/DualExecutionRepository.kt
@@ -210,19 +210,21 @@ class DualExecutionRepository(
     ).distinct { it.id }
   }
 
-  override fun filterPipelineExecutionsForApplication(@Nonnull application: String,
-                                             @Nonnull pipelineConfigIds: List<String>,
-                                             @Nonnull criteria: ExecutionCriteria): List<String>{
-    return primary.filterPipelineExecutionsForApplication(application, pipelineConfigIds, criteria) +
-      previous.filterPipelineExecutionsForApplication(application,pipelineConfigIds, criteria)
+  override fun retrieveAndFilterPipelineExecutionIdsForApplication(
+    @Nonnull application: String,
+    @Nonnull pipelineConfigIds: List<String>,
+    @Nonnull criteria: ExecutionCriteria
+  ): List<String> {
+    return primary.retrieveAndFilterPipelineExecutionIdsForApplication(application, pipelineConfigIds, criteria) +
+      previous.retrieveAndFilterPipelineExecutionIdsForApplication(application, pipelineConfigIds, criteria)
   }
 
-  override fun retrievePipelineExecutionsDetailsForApplication(
+  override fun retrievePipelineExecutionDetailsForApplication(
     @Nonnull application: String,
     pipelineConfigIds: List<String>): Collection<PipelineExecution> {
     return (
-      primary.retrievePipelineExecutionsDetailsForApplication(application, pipelineConfigIds) +
-      previous.retrievePipelineExecutionsDetailsForApplication(application,pipelineConfigIds)
+      primary.retrievePipelineExecutionDetailsForApplication(application, pipelineConfigIds) +
+      previous.retrievePipelineExecutionDetailsForApplication(application, pipelineConfigIds)
       ).distinctBy { it.id }
   }
 

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -96,10 +96,14 @@ public interface ExecutionRepository {
   Collection<String> retrievePipelineConfigIdsForApplication(@Nonnull String application);
 
   @Nonnull
-  Collection<PipelineExecution> retrievePipelineExecutionsForApplication(
+  Collection<String> filterPipelineExecutionsForApplication(
       @Nonnull String application,
       @Nonnull List<String> pipelineConfigIds,
       @Nonnull ExecutionCriteria criteria);
+
+  @Nonnull
+  Collection<PipelineExecution> retrievePipelineExecutionsDetailsForApplication(
+      @Nonnull String application, @Nonnull List<String> pipelineConfigIds);
 
   /**
    * Returns executions in the time boundary. Redis impl does not respect pageSize or offset params,

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -92,6 +92,15 @@ public interface ExecutionRepository {
   Observable<PipelineExecution> retrievePipelinesForPipelineConfigId(
       @Nonnull String pipelineConfigId, @Nonnull ExecutionCriteria criteria);
 
+  @Nonnull
+  Collection<String> retrievePipelineConfigIdsForApplication(@Nonnull String application);
+
+  @Nonnull
+  Collection<PipelineExecution> retrievePipelineExecutionsForApplication(
+      @Nonnull String application,
+      @Nonnull List<String> pipelineConfigIds,
+      @Nonnull ExecutionCriteria criteria);
+
   /**
    * Returns executions in the time boundary. Redis impl does not respect pageSize or offset params,
    * and returns all executions. Sql impl respects these params.

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -103,7 +103,9 @@ public interface ExecutionRepository {
 
   @Nonnull
   Collection<PipelineExecution> retrievePipelineExecutionDetailsForApplication(
-      @Nonnull String application, @Nonnull List<String> pipelineConfigIds);
+      @Nonnull String application,
+      @Nonnull List<String> pipelineConfigIds,
+      int queryTimeoutSeconds);
 
   /**
    * Returns executions in the time boundary. Redis impl does not respect pageSize or offset params,

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/ExecutionRepository.java
@@ -96,13 +96,13 @@ public interface ExecutionRepository {
   Collection<String> retrievePipelineConfigIdsForApplication(@Nonnull String application);
 
   @Nonnull
-  Collection<String> filterPipelineExecutionsForApplication(
+  Collection<String> retrieveAndFilterPipelineExecutionIdsForApplication(
       @Nonnull String application,
       @Nonnull List<String> pipelineConfigIds,
       @Nonnull ExecutionCriteria criteria);
 
   @Nonnull
-  Collection<PipelineExecution> retrievePipelineExecutionsDetailsForApplication(
+  Collection<PipelineExecution> retrievePipelineExecutionDetailsForApplication(
       @Nonnull String application, @Nonnull List<String> pipelineConfigIds);
 
   /**

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/InMemoryExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/InMemoryExecutionRepository.kt
@@ -276,6 +276,24 @@ class InMemoryExecutionRepository : ExecutionRepository {
     )
   }
 
+  override fun retrievePipelineExecutionsForApplication(
+    application: String,
+    pipelineConfigIds: List<String>,
+    criteria: ExecutionCriteria
+  ): Collection<PipelineExecution> {
+    return pipelines.values
+        .filter { it.pipelineConfigId in pipelineConfigIds && it.application == application }
+        .applyCriteria(criteria)
+        .distinctBy { it.id }
+  }
+
+  override fun retrievePipelineConfigIdsForApplication(application: String): List<String> {
+    return pipelines.values
+      .filter {  it.application == application }
+      .map { it.pipelineConfigId }
+      .distinct()
+  }
+
   override fun retrieveOrchestrationForCorrelationId(correlationId: String): PipelineExecution {
     return retrieveByCorrelationId(ORCHESTRATION, correlationId)
   }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/InMemoryExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/InMemoryExecutionRepository.kt
@@ -279,28 +279,29 @@ class InMemoryExecutionRepository : ExecutionRepository {
 
   override fun retrievePipelineConfigIdsForApplication(application: String): List<String> {
     return pipelines.values
-      .filter {  it.application == application }
+      .filter { it.application == application }
       .map { it.pipelineConfigId }
       .distinct()
   }
 
-  override fun filterPipelineExecutionsForApplication(@Nonnull application: String,
-                                                      @Nonnull pipelineConfigIds: List<String>,
-                                                      @Nonnull criteria: ExecutionCriteria): List<String> {
+  override fun retrieveAndFilterPipelineExecutionIdsForApplication(
+    @Nonnull application: String,
+    @Nonnull pipelineConfigIds: List<String>,
+    @Nonnull criteria: ExecutionCriteria
+  ): List<String> {
     return pipelines.values
-      .filter {  it.application == application && pipelineConfigIds.contains(it.pipelineConfigId) }
+      .filter { it.application == application && pipelineConfigIds.contains(it.pipelineConfigId) }
       .applyCriteria(criteria)
       .map { it.id }
   }
 
-  override fun retrievePipelineExecutionsDetailsForApplication(
+  override fun retrievePipelineExecutionDetailsForApplication(
     application: String,
     pipelineConfigIds: List<String>): Collection<PipelineExecution> {
     return pipelines.values
       .filter { it.application == application && pipelineConfigIds.contains(it.pipelineConfigId) }
       .distinctBy { it.id }
   }
-
 
   override fun retrieveOrchestrationForCorrelationId(correlationId: String): PipelineExecution {
     return retrieveByCorrelationId(ORCHESTRATION, correlationId)

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/InMemoryExecutionRepository.kt
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/InMemoryExecutionRepository.kt
@@ -297,7 +297,9 @@ class InMemoryExecutionRepository : ExecutionRepository {
 
   override fun retrievePipelineExecutionDetailsForApplication(
     application: String,
-    pipelineConfigIds: List<String>): Collection<PipelineExecution> {
+    pipelineConfigIds: List<String>,
+    queryTimeoutSeconds: Int
+  ): Collection<PipelineExecution> {
     return pipelines.values
       .filter { it.application == application && pipelineConfigIds.contains(it.pipelineConfigId) }
       .distinctBy { it.id }

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -55,6 +55,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -374,6 +375,15 @@ public class RedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
+  public @Nonnull List<String> retrievePipelineConfigIdsForApplication(
+      @Nonnull String application) {
+    // TODO: not implemented yet - this method, at present, is primarily meant for the
+    // SqlExecutionRepository
+    //  implementation.
+    return List.of();
+  }
+
+  @Override
   public @Nonnull Observable<PipelineExecution> retrievePipelinesForApplication(
       @Nonnull String application) {
     List<Observable<PipelineExecution>> observables =
@@ -477,6 +487,17 @@ public class RedisExecutionRepository implements ExecutionRepository {
     }
 
     return currentObservable;
+  }
+
+  @Override
+  public @NotNull List<PipelineExecution> retrievePipelineExecutionsForApplication(
+      @NotNull String application,
+      @NotNull List<String> pipelineConfigIds,
+      @NotNull ExecutionCriteria executionCriteria) {
+    List<Observable<PipelineExecution>> output = new ArrayList<>();
+    pipelineConfigIds.forEach(
+        configId -> output.add(retrievePipelinesForPipelineConfigId(configId, executionCriteria)));
+    return Observable.merge(output).subscribeOn(Schedulers.io()).toList().toBlocking().single();
   }
 
   /*

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -55,7 +55,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -490,7 +489,7 @@ public class RedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
-  public @Nonnull List<String> filterPipelineExecutionsForApplication(
+  public @Nonnull List<String> retrieveAndFilterPipelineExecutionIdsForApplication(
       @Nonnull String application,
       @Nonnull List<String> pipelineConfigIds,
       @Nonnull ExecutionCriteria criteria) {
@@ -501,8 +500,8 @@ public class RedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
-  public @NotNull List<PipelineExecution> retrievePipelineExecutionsDetailsForApplication(
-      @Nonnull String application, @NotNull List<String> pipelineExecutionIds) {
+  public @Nonnull List<PipelineExecution> retrievePipelineExecutionDetailsForApplication(
+      @Nonnull String application, @Nonnull List<String> pipelineExecutionIds) {
     // TODO: not implemented yet - this method, at present, is primarily meant for the
     // SqlExecutionRepository
     //  implementation.

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -501,7 +501,9 @@ public class RedisExecutionRepository implements ExecutionRepository {
 
   @Override
   public @Nonnull List<PipelineExecution> retrievePipelineExecutionDetailsForApplication(
-      @Nonnull String application, @Nonnull List<String> pipelineExecutionIds) {
+      @Nonnull String application,
+      @Nonnull List<String> pipelineExecutionIds,
+      int queryTimeoutSeconds) {
     // TODO: not implemented yet - this method, at present, is primarily meant for the
     // SqlExecutionRepository
     //  implementation.

--- a/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
+++ b/orca-redis/src/main/java/com/netflix/spinnaker/orca/pipeline/persistence/jedis/RedisExecutionRepository.java
@@ -375,15 +375,6 @@ public class RedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
-  public @Nonnull List<String> retrievePipelineConfigIdsForApplication(
-      @Nonnull String application) {
-    // TODO: not implemented yet - this method, at present, is primarily meant for the
-    // SqlExecutionRepository
-    //  implementation.
-    return List.of();
-  }
-
-  @Override
   public @Nonnull Observable<PipelineExecution> retrievePipelinesForApplication(
       @Nonnull String application) {
     List<Observable<PipelineExecution>> observables =
@@ -490,14 +481,32 @@ public class RedisExecutionRepository implements ExecutionRepository {
   }
 
   @Override
-  public @NotNull List<PipelineExecution> retrievePipelineExecutionsForApplication(
-      @NotNull String application,
-      @NotNull List<String> pipelineConfigIds,
-      @NotNull ExecutionCriteria executionCriteria) {
-    List<Observable<PipelineExecution>> output = new ArrayList<>();
-    pipelineConfigIds.forEach(
-        configId -> output.add(retrievePipelinesForPipelineConfigId(configId, executionCriteria)));
-    return Observable.merge(output).subscribeOn(Schedulers.io()).toList().toBlocking().single();
+  public @Nonnull List<String> retrievePipelineConfigIdsForApplication(
+      @Nonnull String application) {
+    // TODO: not implemented yet - this method, at present, is primarily meant for the
+    // SqlExecutionRepository
+    //  implementation.
+    return List.of();
+  }
+
+  @Override
+  public @Nonnull List<String> filterPipelineExecutionsForApplication(
+      @Nonnull String application,
+      @Nonnull List<String> pipelineConfigIds,
+      @Nonnull ExecutionCriteria criteria) {
+    // TODO: not implemented yet - this method, at present, is primarily meant for the
+    // SqlExecutionRepository
+    //  implementation.
+    return List.of();
+  }
+
+  @Override
+  public @NotNull List<PipelineExecution> retrievePipelineExecutionsDetailsForApplication(
+      @Nonnull String application, @NotNull List<String> pipelineExecutionIds) {
+    // TODO: not implemented yet - this method, at present, is primarily meant for the
+    // SqlExecutionRepository
+    //  implementation.
+    return List.of();
   }
 
   /*

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -553,7 +553,9 @@ class SqlExecutionRepository(
    */
   override fun retrievePipelineExecutionDetailsForApplication(
     application: String,
-    pipelineExecutions: List<String>): Collection<PipelineExecution> {
+    pipelineExecutions: List<String>,
+    queryTimeoutSeconds: Int
+  ): Collection<PipelineExecution> {
     withPool(poolName) {
       val baseQuery = jooq.select(selectExecutionFields(compressionProperties))
         .from(
@@ -565,6 +567,7 @@ class SqlExecutionRepository(
           field("application").eq(application)
             .and(field("id").`in`(*pipelineExecutions.toTypedArray()))
         )
+        .queryTimeout(queryTimeoutSeconds) // add an explicit timeout so that the query doesn't run forever
         .fetch()
 
       log.info("getting stage information for all the executions found so far")

--- a/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -512,7 +512,6 @@ class SqlExecutionRepository(
 
     val finalResult: MutableList<String> = mutableListOf()
 
-    log.info("getting execution ids")
     withPool(poolName) {
       val baseQuery = jooq.select(field("config_id"), field("id"))
         .from(table)
@@ -570,7 +569,7 @@ class SqlExecutionRepository(
         .queryTimeout(queryTimeoutSeconds) // add an explicit timeout so that the query doesn't run forever
         .fetch()
 
-      log.info("getting stage information for all the executions found so far")
+      log.debug("getting stage information for all the executions found so far")
       return ExecutionMapper(mapper, stageReadSize,compressionProperties, pipelineRefEnabled).map(baseQuery.intoResultSet(), jooq)
     }
   }

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -94,6 +94,9 @@ dependencies {
   testImplementation("io.strikt:strikt-core")
   testImplementation("io.mockk:mockk")
   testImplementation("org.apache.groovy:groovy-json")
+  testImplementation("com.nhaarman:mockito-kotlin")
+  testImplementation("io.spinnaker.kork:kork-sql-test")
+  testImplementation("org.testcontainers:mysql")
   testImplementation ("com.squareup.retrofit2:retrofit-mock")
 }
 

--- a/orca-web/orca-web.gradle
+++ b/orca-web/orca-web.gradle
@@ -97,6 +97,13 @@ dependencies {
   testImplementation ("com.squareup.retrofit2:retrofit-mock")
 }
 
+sourceSets {
+  main {
+    java { srcDirs = [] }    // no source dirs for the java compiler
+    groovy { srcDirs = ["src/main/java", "src/main/groovy"] }  // compile   everything in src/ with groovy
+  }
+}
+
 test {
   //The Implementation-Version is set in the MANIFEST.MF for the JAR produced via testing so that
   //assertions can be made against the version (see orca-plugins-test, for example).

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -607,9 +607,9 @@ class TaskController {
 
     // get all relevant pipeline and strategy configs from front50
     def pipelineConfigIds = front50Service.getPipelines(application, false)*.id as List<String>
-    log.info("received ${pipelineConfigIds.size()} pipelines for application: $application from front50")
+    log.debug("received ${pipelineConfigIds.size()} pipelines for application: $application from front50")
     def strategyConfigIds = front50Service.getStrategies(application)*.id as List<String>
-    log.info("received ${strategyConfigIds.size()} strategies for application: $application from front50")
+    log.debug("received ${strategyConfigIds.size()} strategies for application: $application from front50")
 
     def allFront50PipelineConfigIds = pipelineConfigIds + strategyConfigIds
 
@@ -628,11 +628,11 @@ class TaskController {
 
     allPipelineExecutions.sort(startTimeOrId)
     if (!expand) {
-      log.info("unexpanding pipeline executions")
+      log.debug("unexpanding pipeline executions")
       unexpandPipelineExecutions(allPipelineExecutions)
     }
 
-    log.info("filtering pipelines by history")
+    log.debug("filtering pipelines by history")
     return filterPipelinesByHistoryCutoff(allPipelineExecutions, limit)
   }
 

--- a/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
+++ b/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/TaskController.groovy
@@ -603,35 +603,72 @@ class TaskController {
       statuses: (statuses.split(",") as Collection)
     )
 
+    // get all relevant pipeline and strategy configs from front50
     def pipelineConfigIds = front50Service.getPipelines(application, false)*.id as List<String>
     log.info("received ${pipelineConfigIds.size()} pipelines for application: $application from front50")
     def strategyConfigIds = front50Service.getStrategies(application)*.id as List<String>
     log.info("received ${strategyConfigIds.size()} strategies for application: $application from front50")
-    def allIds = pipelineConfigIds + strategyConfigIds
+    def allFrontIds = pipelineConfigIds + strategyConfigIds
 
-    List<String> commonPipelineConfigIds
+    List<PipelineExecution> allPipelineExecutions = []
+
+    // this optimized flow is meant to speed up the execution retrieval process per pipeline config id. It does it in two
+    // steps:
+    // 1. it first compares the list of pipeline ids obtained from front50 with what is stored in orca db itself.
+    // There is no need to process config ids have no executions associated with them. The absence of
+    // a pipeline config id from the orca db indicates the same. So to reduce the number of config ids to process, we
+    // intersect the result obtained from front50 and orca db, which gives us the reduced list. Note: this could be
+    // further optimized by cutting front50 out from the picture completely. But I do not know what other side-effects
+    // that may cause, so am going ahead with the above logic.
+    //
+    // 2. We now process n pipeline configs at a time from this reduced set, since processing one config at a
+    // time was proving to be time consuming for applications with loads of pipelines and executions. In additon to this,
+    // we also make use of a thread pool to do this, so we can parallelize processing of multiple such batches. By doing
+    // this, we move away from the Rx Observable logic that was defined previously.
     if (this.configurationProperties.getOptimizeExecutionRetrieval()) {
-      log.info("running optimized execution retrieval process")
+      log.info("running optimized execution retrieval process with: " +
+          "${this.configurationProperties.getMaxExecutionRetrievalThreads()} threads and processing" +
+          " ${this.configurationProperties.getMaxNumberOfPipelineConfigIdsToProcess()} pipeline config ids at a time")
+
+      List<String> commonIdsInFront50AndOrca
       try {
-        List<String> pipelineConfigIdsInOrca = executionRepository.retrievePipelineConfigIdsForApplication(application)
-        log.info("found ${pipelineConfigIdsInOrca.size()} pipeline config ids for application: $application in orca")
-        commonPipelineConfigIds = allIds.intersect(pipelineConfigIdsInOrca)
-        log.info("found ${commonPipelineConfigIds.size()} pipeline config ids that are common in orca and front50 " +
+        List<String> allOrcaIds = executionRepository.retrievePipelineConfigIdsForApplication(application)
+        log.info("found ${allOrcaIds.size()} pipeline config ids for application: $application in orca")
+        commonIdsInFront50AndOrca = allFrontIds.intersect(allOrcaIds)
+        log.info("found ${commonIdsInFront50AndOrca.size()} pipeline config ids that are common in orca and front50 " +
             "for application: $application." +
-            " Saved ${allIds.size() - commonPipelineConfigIds.size()} extra pipeline config id queries")
+            " Saved ${allFrontIds.size() - commonIdsInFront50AndOrca.size()} extra pipeline config id queries")
       } catch (Exception e) {
         log.warn("retrieving pipeline config ids from orca db failed. using the result obtained from front50 ", e)
-        commonPipelineConfigIds = allIds
+        commonIdsInFront50AndOrca = allFrontIds
+      }
+      def executor = Executors.newFixedThreadPool(this.configurationProperties.getMaxExecutionRetrievalThreads(),
+          new ThreadFactoryBuilder()
+              .setNameFormat("taskcontroller" + "-%d")
+              .build())
+      def futures = new ArrayList(commonIdsInFront50AndOrca.size())
+
+      log.info("processing ${commonIdsInFront50AndOrca.size()} pipeline config ids")
+      commonIdsInFront50AndOrca
+          .collate(this.configurationProperties.getMaxNumberOfPipelineConfigIdsToProcess())
+          .each {
+            def chunkedList = it
+            futures.add(
+                executor.submit({
+                  executionRepository.retrievePipelineExecutionsForApplication(application, chunkedList, executionCriteria)
+                } as Callable))
+          }
+      futures.each {
+        allPipelineExecutions.addAll(it.get())
       }
     } else {
-      commonPipelineConfigIds = allIds
+      allPipelineExecutions = rx.Observable.merge(allFrontIds.collect {
+        log.debug("processing pipeline config id: $it")
+        executionRepository.retrievePipelinesForPipelineConfigId(it, executionCriteria)
+      }).subscribeOn(Schedulers.io()).toList().toBlocking().single()
     }
 
-    List<PipelineExecution> allPipelineExecutions = rx.Observable.merge(commonPipelineConfigIds.collect {
-      log.info("processing pipeline config id: $it")
-      executionRepository.retrievePipelinesForPipelineConfigId(it, executionCriteria)
-    }).subscribeOn(Schedulers.io()).toList().toBlocking().single().sort(startTimeOrId)
-
+    allPipelineExecutions.sort(startTimeOrId)
     if (!expand) {
       log.info("unexpanding pipeline executions")
       unexpandPipelineExecutions(allPipelineExecutions)

--- a/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
+++ b/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
@@ -39,19 +39,19 @@ public class TaskControllerConfigurationProperties {
    * process the queries to retrieve the executions. Needs to be tuned appropriately since this has
    * the potential to exhaust the connection pool size for the database.
    */
-  int maxExecutionRetrievalThreads = 10;
+  int maxExecutionRetrievalThreads = 4;
 
   /**
    * only applicable if optimizeExecutionRetrieval = true. It specifies how many pipeline executions
-   * should be processed at a time. 150 pipeline executions was selected as the default after
-   * testing this number against an orca sql db that contained lots of pipelines and executions for
-   * a single application (about 1200 pipelines and 1500 executions). Each execution was 1 MB or
-   * more in size.
+   * should be processed at a time. 150 worked with an orca sql db that contained lots of pipelines
+   * and executions for a single application (about 1200 pipelines and 1500 executions with each
+   * execution of size >= 1 MB). 50 is kept as default, keeping in view that majority of the cases
+   * have lesser number of executions.
    *
    * <p>It can be further tuned, depending on your setup, since 150 executions work well for some
    * applications but a higher number may be appropriate for others.
    */
-  int maxNumberOfPipelineExecutionsToProcess = 150;
+  int maxNumberOfPipelineExecutionsToProcess = 50;
 
   /**
    * only applicable if optimizeExecutionRetrieval = true. It specifies the max time after which the

--- a/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
+++ b/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
@@ -31,6 +31,23 @@ public class TaskControllerConfigurationProperties {
    */
   boolean optimizeExecutionRetrieval = false;
 
+  /**
+   * only applicable if optimizeExecutionRetrieval = true. It specifies how many threads should
+   * process the queries to retrieve the executions. Needs to be tuned appropriately since this has
+   * the potential to exhaust the connection pool size for the database.
+   */
+  int maxExecutionRetrievalThreads = 10;
+
+  /**
+   * only applicable if optimizeExecutionRetrieval = true. It specifies how many pipeline config ids
+   * should be processed at a time. 15 pipeline config ids was selected as the default after testing
+   * this number against an orca sql db that contained lots of pipelines and executions for a single
+   * application (about 1200 pipelines and 1000 executions). More than 15 resulted in a query that
+   * took too long to complete. It will have to be tuned though, since 50 config ids work for some
+   * other applications easily but not for others.
+   */
+  int maxNumberOfPipelineConfigIdsToProcess = 15;
+
   /** moved this to here. Earlier definition was in the {@link TaskController} class */
   int daysOfExecutionHistory = 14;
 
@@ -44,5 +61,9 @@ public class TaskControllerConfigurationProperties {
   // need to set this explicitly so that it works in kotlin tests
   public void setOptimizeExecutionRetrieval(boolean optimizeExecutionRetrieval) {
     this.optimizeExecutionRetrieval = optimizeExecutionRetrieval;
+  }
+
+  public int getDaysOfExecutionHistory() {
+    return this.daysOfExecutionHistory;
   }
 }

--- a/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
+++ b/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
@@ -39,19 +39,19 @@ public class TaskControllerConfigurationProperties {
    * process the queries to retrieve the executions. Needs to be tuned appropriately since this has
    * the potential to exhaust the connection pool size for the database.
    */
-  int maxExecutionRetrievalThreads = 20;
+  int maxExecutionRetrievalThreads = 10;
 
   /**
    * only applicable if optimizeExecutionRetrieval = true. It specifies how many pipeline executions
-   * should be processed at a time. 30 pipeline executions was selected as the default after testing
-   * this number against an orca sql db that contained lots of pipelines and executions for a single
-   * application (about 1200 pipelines and 1000 executions). Each execution was 1 MB or more in
-   * size.
+   * should be processed at a time. 150 pipeline executions was selected as the default after
+   * testing this number against an orca sql db that contained lots of pipelines and executions for
+   * a single application (about 1200 pipelines and 1500 executions). Each execution was 1 MB or
+   * more in size.
    *
-   * <p>It can be further tuned, depending on your setup, since 30 executions work well for some
+   * <p>It can be further tuned, depending on your setup, since 150 executions work well for some
    * applications but a higher number may be appropriate for others.
    */
-  int maxNumberOfPipelineExecutionsToProcess = 30;
+  int maxNumberOfPipelineExecutionsToProcess = 150;
 
   /**
    * only applicable if optimizeExecutionRetrieval = true. No retrieval thread should take more than

--- a/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
+++ b/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
@@ -54,10 +54,10 @@ public class TaskControllerConfigurationProperties {
   int maxNumberOfPipelineExecutionsToProcess = 150;
 
   /**
-   * only applicable if optimizeExecutionRetrieval = true. No retrieval thread should take more than
-   * 60s to complete.
+   * only applicable if optimizeExecutionRetrieval = true. It specifies the max time after which the
+   * execution retrieval query will timeout.
    */
-  long executionRetrievalTimeoutSeconds = 60;
+  int executionRetrievalTimeoutSeconds = 60;
 
   /** moved this to here. Earlier definition was in the {@link TaskController} class */
   int daysOfExecutionHistory = 14;

--- a/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
+++ b/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
@@ -53,6 +53,12 @@ public class TaskControllerConfigurationProperties {
    */
   int maxNumberOfPipelineExecutionsToProcess = 30;
 
+  /**
+   * only applicable if optimizeExecutionRetrieval = true. No retrieval thread should take more than
+   * 60s to complete.
+   */
+  long executionRetrievalTimeoutSeconds = 60;
+
   /** moved this to here. Earlier definition was in the {@link TaskController} class */
   int daysOfExecutionHistory = 14;
 

--- a/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
+++ b/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config;
+
+import com.netflix.spinnaker.orca.controllers.TaskController;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("tasks.controller")
+@Data
+public class TaskControllerConfigurationProperties {
+  /**
+   * flag to enable speeding up execution retrieval. This is applicable for the {@link
+   * TaskController#getPipelinesForApplication(String, int, String, Boolean)} endpoint
+   */
+  boolean optimizeExecutionRetrieval = false;
+
+  /** moved this to here. Earlier definition was in the {@link TaskController} class */
+  int daysOfExecutionHistory = 14;
+
+  /** moved this to here. Earlier definition was in the {@link TaskController} class */
+  int numberOfOldPipelineExecutionsToInclude = 2;
+
+  public boolean getOptimizeExecutionRetrieval() {
+    return this.optimizeExecutionRetrieval;
+  }
+
+  // need to set this explicitly so that it works in kotlin tests
+  public void setOptimizeExecutionRetrieval(boolean optimizeExecutionRetrieval) {
+    this.optimizeExecutionRetrieval = optimizeExecutionRetrieval;
+  }
+}

--- a/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
+++ b/orca-web/src/main/java/com/netflix/spinnaker/config/TaskControllerConfigurationProperties.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.config;
 
 import com.netflix.spinnaker.orca.controllers.TaskController;
+import com.netflix.spinnaker.orca.sql.pipeline.persistence.SqlExecutionRepository;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -27,7 +28,9 @@ import org.springframework.context.annotation.Configuration;
 public class TaskControllerConfigurationProperties {
   /**
    * flag to enable speeding up execution retrieval. This is applicable for the {@link
-   * TaskController#getPipelinesForApplication(String, int, String, Boolean)} endpoint
+   * TaskController#getPipelinesForApplication(String, int, String, Boolean)} endpoint. Only valid
+   * for {@link SqlExecutionRepository} currently. The implementation for all the other execution
+   * repositories needs to be added
    */
   boolean optimizeExecutionRetrieval = false;
 
@@ -36,17 +39,19 @@ public class TaskControllerConfigurationProperties {
    * process the queries to retrieve the executions. Needs to be tuned appropriately since this has
    * the potential to exhaust the connection pool size for the database.
    */
-  int maxExecutionRetrievalThreads = 10;
+  int maxExecutionRetrievalThreads = 20;
 
   /**
-   * only applicable if optimizeExecutionRetrieval = true. It specifies how many pipeline config ids
-   * should be processed at a time. 15 pipeline config ids was selected as the default after testing
+   * only applicable if optimizeExecutionRetrieval = true. It specifies how many pipeline executions
+   * should be processed at a time. 30 pipeline executions was selected as the default after testing
    * this number against an orca sql db that contained lots of pipelines and executions for a single
-   * application (about 1200 pipelines and 1000 executions). More than 15 resulted in a query that
-   * took too long to complete. It will have to be tuned though, since 50 config ids work for some
-   * other applications easily but not for others.
+   * application (about 1200 pipelines and 1000 executions). Each execution was 1 MB or more in
+   * size.
+   *
+   * <p>It can be further tuned, depending on your setup, since 30 executions work well for some
+   * applications but a higher number may be appropriate for others.
    */
-  int maxNumberOfPipelineConfigIdsToProcess = 15;
+  int maxNumberOfPipelineExecutionsToProcess = 30;
 
   /** moved this to here. Earlier definition was in the {@link TaskController} class */
   int daysOfExecutionHistory = 14;

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -63,8 +63,9 @@ class TaskControllerSpec extends Specification {
   def registry = new NoopRegistry()
 
   def clock = Clock.fixed(Instant.now(), UTC)
-  int daysOfExecutionHistory = 14
+  def taskControllerConfigurationProperties = new TaskControllerConfigurationProperties()
 
+  int daysOfExecutionHistory = taskControllerConfigurationProperties.getDaysOfExecutionHistory()
   ObjectMapper objectMapper = OrcaObjectMapper.newInstance()
 
   void setup() {
@@ -80,7 +81,7 @@ class TaskControllerSpec extends Specification {
             mapper,
             registry,
             Mock(StageDefinitionBuilderFactory),
-            new TaskControllerConfigurationProperties()
+            taskControllerConfigurationProperties
         )
     ).build()
   }

--- a/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
+++ b/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/TaskControllerSpec.groovy
@@ -19,16 +19,19 @@ package com.netflix.spinnaker.orca.controllers
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.collect.Collections2
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.TaskControllerConfigurationProperties
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
-import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
+import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
 import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator
 import com.netflix.spinnaker.orca.pipeline.ExecutionRunner
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory
 import com.netflix.spinnaker.orca.pipeline.model.*
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
+import com.netflix.spinnaker.orca.util.ExpressionUtils
 import groovy.json.JsonSlurper
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletResponse
@@ -61,24 +64,24 @@ class TaskControllerSpec extends Specification {
 
   def clock = Clock.fixed(Instant.now(), UTC)
   int daysOfExecutionHistory = 14
-  int numberOfOldPipelineExecutionsToInclude = 2
 
   ObjectMapper objectMapper = OrcaObjectMapper.newInstance()
 
   void setup() {
     mockMvc = MockMvcBuilders.standaloneSetup(
-      new TaskController(
-        front50Service: front50Service,
-        executionRepository: executionRepository,
-        executionRunner: executionRunner,
-        daysOfExecutionHistory: daysOfExecutionHistory,
-        numberOfOldPipelineExecutionsToInclude: numberOfOldPipelineExecutionsToInclude,
-        clock: clock,
-        mapper: mapper,
-        registry: registry,
-        contextParameterProcessor: new ContextParameterProcessor(),
-        executionOperator: executionOperator
-      )
+        new TaskController(
+            front50Service,
+            executionRepository,
+            executionRunner,
+            executionOperator,
+            List.of(Mock(StageDefinitionBuilder)),
+            new ContextParameterProcessor(),
+            Mock(ExpressionUtils),
+            mapper,
+            registry,
+            Mock(StageDefinitionBuilderFactory),
+            new TaskControllerConfigurationProperties()
+        )
     ).build()
   }
 
@@ -246,6 +249,8 @@ class TaskControllerSpec extends Specification {
     })
     front50Service.getPipelines(app, false) >> [[id: "1"], [id: "2"]]
     front50Service.getStrategies(app) >> []
+
+    executionRepository.retrievePipelineConfigIdsForApplication(app) >> { return List.of( '2')}
 
     when:
     def response = mockMvc.perform(get("/applications/$app/pipelines")).andReturn().response

--- a/orca-web/src/test/kotlin/com/netflix/spinnaker/orca/controllers/TaskControllerTest.kt
+++ b/orca-web/src/test/kotlin/com/netflix/spinnaker/orca/controllers/TaskControllerTest.kt
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.controllers
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.ExecutionCompressionProperties
+import com.netflix.spinnaker.config.TaskControllerConfigurationProperties
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
+import com.netflix.spinnaker.orca.front50.Front50Service
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
+import com.netflix.spinnaker.orca.sql.pipeline.persistence.SqlExecutionRepository
+import com.nhaarman.mockito_kotlin.mock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.table
+import org.mockito.Mockito
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+class TaskControllerTest : JUnit5Minutests {
+  data class Fixture(val optimizeExecution: Boolean) {
+
+    private val clock: Clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
+    val database: SqlTestUtil.TestDatabase = SqlTestUtil.initTcMysqlDatabase()!!
+
+
+
+    private val executionRepository: SqlExecutionRepository = SqlExecutionRepository(
+      partitionName = "test",
+      jooq = database.context,
+      mapper = OrcaObjectMapper.getInstance(),
+      retryProperties = RetryProperties(),
+      compressionProperties = ExecutionCompressionProperties(),
+      pipelineRefEnabled = false
+    )
+
+    private val taskControllerConfigurationProperties: TaskControllerConfigurationProperties = TaskControllerConfigurationProperties()
+      .apply { optimizeExecutionRetrieval = optimizeExecution }
+
+    private val daysOfExecutionHistory: Long = taskControllerConfigurationProperties.daysOfExecutionHistory.toLong()
+
+    private val front50Service: Front50Service = mock()
+
+    private val taskController: TaskController = TaskController(
+      front50Service,
+      executionRepository,
+      mock(),
+      mock(),
+      listOf(mock()),
+      ContextParameterProcessor(),
+      mock(),
+      OrcaObjectMapper.getInstance(),
+      NoopRegistry(),
+      mock(),
+      taskControllerConfigurationProperties
+    )
+
+    val subject: MockMvc = MockMvcBuilders.standaloneSetup(taskController).build()
+
+    fun setup() {
+      database.context
+        .insertInto(table("pipelines"),
+          listOf(
+            field("config_id"),
+            field("id"),
+            field("application"),
+            field("build_time"),
+            field("start_time"),
+            field("body"),
+            field("status")
+          ))
+        .values(
+          listOf(
+            "1",
+            "1-exec-id-1",
+            "test-app",
+            clock.instant().minus(daysOfExecutionHistory, ChronoUnit.DAYS).minus(120, ChronoUnit.MINUTES).toEpochMilli(),
+            clock.instant().minus(daysOfExecutionHistory, ChronoUnit.DAYS).minus(120, ChronoUnit.HOURS).toEpochMilli(),
+            "{\"id\": \"1-exec-id-1\", \"type\": \"PIPELINE\", \"pipelineConfigId\": \"1\"}",
+            "SUCCEEDED"
+          )
+        )
+        .values(
+          listOf(
+            "1",
+            "1-exec-id-2",
+            "test-app",
+            clock.instant().minus(daysOfExecutionHistory, ChronoUnit.DAYS).minus(115, ChronoUnit.MINUTES).toEpochMilli(),
+            clock.instant().minus(daysOfExecutionHistory, ChronoUnit.DAYS).minus(115, ChronoUnit.MINUTES).toEpochMilli(),
+            "{\"id\": \"1-exec-id-2\", \"type\": \"PIPELINE\", \"pipelineConfigId\": \"1\"}",
+            "TERMINAL"
+          )
+        )
+        .values(
+          listOf(
+            "1",
+            "1-exec-id-3",
+            "test-app",
+            clock.instant().minus(daysOfExecutionHistory, ChronoUnit.DAYS).minus(114, ChronoUnit.MINUTES).toEpochMilli(),
+            clock.instant().minus(daysOfExecutionHistory, ChronoUnit.DAYS).minus(114, ChronoUnit.MINUTES).toEpochMilli(),
+            "{\"id\": \"1-exec-id-3\", \"type\": \"PIPELINE\", \"pipelineConfigId\": \"1\"}",
+            "RUNNING"
+          )
+        )
+        .values(
+          listOf(
+            "2",
+            "2-exec-id-1",
+            "test-app",
+            clock.instant().minus(daysOfExecutionHistory, ChronoUnit.DAYS).minus(2, ChronoUnit.HOURS).toEpochMilli(),
+            clock.instant().minus(daysOfExecutionHistory, ChronoUnit.DAYS).minus(2, ChronoUnit.HOURS).toEpochMilli(),
+            "{\"id\": \"2-exec-id-1\", \"type\": \"PIPELINE\", \"pipelineConfigId\": \"2\"}",
+            "NOT_STARTED"
+          )
+        )
+        .values(
+          listOf(
+            "3",
+            "3-exec-id-1",
+            "test-app-2",
+            clock.instant().minus(daysOfExecutionHistory + 1, ChronoUnit.DAYS).minus(2, ChronoUnit.HOURS).toEpochMilli(),
+            clock.instant().minus(daysOfExecutionHistory + 1, ChronoUnit.DAYS).minus(2, ChronoUnit.HOURS).toEpochMilli(),
+            "{\"id\": \"3-exec-id-1\", \"type\": \"PIPELINE\", \"pipelineConfigId\": \"3\"}",
+            "STOPPED"
+          )
+        )
+        .execute()
+      Mockito.`when`(front50Service.getPipelines("test-app", false))
+        .thenReturn(
+          listOf(
+            mapOf("id" to "1"),
+            mapOf("id" to "2")),
+        )
+
+      Mockito.`when`(front50Service.getStrategies("test-app"))
+        .thenReturn(listOf())
+    }
+
+    fun cleanUp() {
+      SqlTestUtil.cleanupDb(database.context)
+    }
+  }
+
+  fun tests() = rootContext<Fixture> {
+    context("execution retrieval without optimization") {
+      fixture {
+        Fixture(false)
+      }
+
+      before { setup() }
+      after { cleanUp() }
+
+      test("retrieve executions with limit = 2 & expand = false") {
+        expectThat(database.context.fetchCount(table("pipelines"))).isEqualTo(5)
+        val response = subject.perform(get("/applications/test-app/pipelines?limit=2&expand=false")).andReturn().response
+        val results = OrcaObjectMapper.getInstance().readValue(response.contentAsString, object : TypeReference<List<PipelineExecution>>() {})
+        val expectedOutput = listOf("1-exec-id-2", "1-exec-id-3","2-exec-id-1")
+        expectThat(results.size).isEqualTo(3)
+        results.forEach {
+          assert(it.id in expectedOutput)
+        }
+      }
+
+      test("retrieve executions with limit = 2 & expand = false with statuses") {
+        expectThat(database.context.fetchCount(table("pipelines"))).isEqualTo(5)
+        val response = subject.perform(get(
+          "/applications/test-app/pipelines?limit=2&expand=false&statuses=RUNNING,SUSPENDED,PAUSED,NOT_STARTED")
+        ).andReturn().response
+        val results = OrcaObjectMapper.getInstance().readValue(response.contentAsString, object : TypeReference<List<PipelineExecution>>() {})
+        val expectedOutput = listOf("1-exec-id-3","2-exec-id-1")
+        expectThat(results.size).isEqualTo(2)
+        results.forEach {
+          assert(it.id in expectedOutput)
+        }
+      }
+    }
+
+    context("execution retrieval with optimization") {
+      fixture {
+        Fixture(true)
+      }
+
+      before { setup() }
+      after { cleanUp() }
+
+      test("retrieve executions with limit = 2 & expand = false") {
+        expectThat(database.context.fetchCount(table("pipelines"))).isEqualTo(5)
+        val response = subject.perform(get("/applications/test-app/pipelines?limit=2&expand=false")).andReturn().response
+        val results = OrcaObjectMapper.getInstance().readValue(response.contentAsString, object : TypeReference<List<PipelineExecution>>() {})
+        val expectedOutput = listOf("1-exec-id-2", "1-exec-id-3","2-exec-id-1")
+        expectThat(results.size).isEqualTo(3)
+        results.forEach {
+          assert(it.id in expectedOutput)
+        }
+      }
+
+      test("retrieve executions with limit = 2 & expand = false with statuses") {
+        expectThat(database.context.fetchCount(table("pipelines"))).isEqualTo(5)
+        val response = subject.perform(get(
+          "/applications/test-app/pipelines?limit=2&expand=false&statuses=RUNNING,SUSPENDED,PAUSED,NOT_STARTED")
+        ).andReturn().response
+        val results = OrcaObjectMapper.getInstance().readValue(response.contentAsString, object : TypeReference<List<PipelineExecution>>() {})
+        val expectedOutput = listOf("1-exec-id-3","2-exec-id-1")
+        expectThat(results.size).isEqualTo(2)
+        results.forEach {
+          assert(it.id in expectedOutput)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR improves performance when using sql as the backend by optimizing the way the results are obtained for the api call `/applications/{application}/pipelines?expand=false&limit=2` frequently initiated by deck.

Deck makes that call to Gate. Gate further forwards that call to Orca, specifically to `/v2/applications/{application}/pipelines` endpoint.

Orca calls front50 to get the pipeline and strategy config ids and then merges them. Then for each id in the merged list, it queries its own db (SQL) to handle the query parameters, such as limit=2 and filter by statuses. It is observed that these db operations are taking longer times and this PR fixes the slowness by optimizing the queries to the db.

Refactored TaskController to support externalized config properties

Optimize getPipelinesForApplication() by reducing the number of relevant pipeline config ids to query

Further optimize getPipelinesForApplication() by processing multiple pipeline config ids at a time and multi-threading each config id batch 

#### Breaking changes:
These configuration properties
```yaml
tasks:
   days-of-execution-history:  
   number-of-old-pipeline-executions-to-include: 
```
are replaced by the below configuration along with few more newly added ones:
```yaml
tasks:
   controller:
      days-of-execution-history: 
      number-of-old-pipeline-executions-to-include: 

      optimize-execution-retrieval: <boolean>
      max-execution-retrieval-threads:
      max-number-of-pipeline-executions-to-process: 
      execution-retrieval-timeout-seconds: 
```