### PR TITLE
feat(webhook): add http method + url-based allow list to webhook stages

### DIFF
--- a/orca-webhook/orca-webhook.gradle
+++ b/orca-webhook/orca-webhook.gradle
@@ -32,8 +32,10 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
 
+  testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")
   testImplementation("com.squareup.okhttp3:mockwebserver")
   testImplementation("io.spinnaker.kork:kork-test")
+  testImplementation("org.assertj:assertj-core")
   testImplementation("org.bouncycastle:bcpkix-jdk18on")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.mockito:mockito-core")

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -64,6 +64,14 @@ public class WebhookProperties {
   private boolean insecureSkipHostnameVerification = false;
   private boolean insecureTrustSelfSigned = false;
 
+  /** True to enable matching against allowedRequests. */
+  private boolean allowedRequestsEnabled = false;
+
+  /**
+   * Only specified http method + hosts are allowed. An empty list means no requests are allowed.
+   */
+  private List<AllowedRequest> allowedRequests = new ArrayList<>();
+
   @Data
   @NoArgsConstructor
   public static class TrustSettings {
@@ -86,6 +94,16 @@ public class WebhookProperties {
 
     private String identityKeyPem;
     private String identityCertPem;
+  }
+
+  @Data
+  @NoArgsConstructor
+  public static class AllowedRequest {
+    /** The allowed http method(s) (e.g. GET, POST, PUT) */
+    private List<String> httpMethods;
+
+    /** The url must start with this string to be considered valid. */
+    private String urlPrefix;
   }
 
   @Data

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookService.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookService.java
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
 import com.netflix.spinnaker.orca.webhook.config.WebhookProperties;
 import com.netflix.spinnaker.orca.webhook.pipeline.WebhookStage;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,11 +54,21 @@ public class WebhookService {
           "X-SPINNAKER-REQUEST-ID",
           "X-SPINNAKER-EXECUTION-ID");
 
-  @Autowired private List<RestTemplateProvider> restTemplateProviders = new ArrayList<>();
+  private final List<RestTemplateProvider> restTemplateProviders;
 
-  @Autowired private UserConfiguredUrlRestrictions userConfiguredUrlRestrictions;
+  private final UserConfiguredUrlRestrictions userConfiguredUrlRestrictions;
 
-  @Autowired private WebhookProperties preconfiguredWebhookProperties;
+  private final WebhookProperties preconfiguredWebhookProperties;
+
+  @Autowired
+  public WebhookService(
+      List<RestTemplateProvider> restTemplateProviders,
+      UserConfiguredUrlRestrictions userConfiguredUrlRestrictions,
+      WebhookProperties preconfiguredWebhookProperties) {
+    this.restTemplateProviders = restTemplateProviders;
+    this.userConfiguredUrlRestrictions = userConfiguredUrlRestrictions;
+    this.preconfiguredWebhookProperties = preconfiguredWebhookProperties;
+  }
 
   public ResponseEntity<Object> callWebhook(StageExecution stageExecution) {
     RestTemplateData restTemplateData = getRestTemplateData(WebhookTaskType.CREATE, stageExecution);

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookService.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookService.java
@@ -58,16 +58,16 @@ public class WebhookService {
 
   private final UserConfiguredUrlRestrictions userConfiguredUrlRestrictions;
 
-  private final WebhookProperties preconfiguredWebhookProperties;
+  private final WebhookProperties webhookProperties;
 
   @Autowired
   public WebhookService(
       List<RestTemplateProvider> restTemplateProviders,
       UserConfiguredUrlRestrictions userConfiguredUrlRestrictions,
-      WebhookProperties preconfiguredWebhookProperties) {
+      WebhookProperties webhookProperties) {
     this.restTemplateProviders = restTemplateProviders;
     this.userConfiguredUrlRestrictions = userConfiguredUrlRestrictions;
-    this.preconfiguredWebhookProperties = preconfiguredWebhookProperties;
+    this.webhookProperties = webhookProperties;
   }
 
   public ResponseEntity<Object> callWebhook(StageExecution stageExecution) {
@@ -173,7 +173,7 @@ public class WebhookService {
   }
 
   public List<WebhookProperties.PreconfiguredWebhook> getPreconfiguredWebhooks() {
-    return preconfiguredWebhookProperties.getPreconfigured().stream()
+    return webhookProperties.getPreconfigured().stream()
         .filter(WebhookProperties.PreconfiguredWebhook::isEnabled)
         .collect(Collectors.toList());
   }

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
@@ -67,10 +67,9 @@ class WebhookServiceSpec extends Specification {
   def server = MockRestServiceServer.createServer(restTemplateProvider.restTemplate)
 
   @Subject
-  def webhookService = new WebhookService(
-    restTemplateProviders: [restTemplateProvider],
-    userConfiguredUrlRestrictions: userConfiguredUrlRestrictions,
-    preconfiguredWebhookProperties: preconfiguredWebhookProperties)
+  def webhookService = new WebhookService(List.of(restTemplateProvider),
+                                          userConfiguredUrlRestrictions,
+                                          preconfiguredWebhookProperties)
 
   @Unroll
   def "Webhook is being called with correct parameters"() {

--- a/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
+++ b/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2024 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.webhook.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import com.netflix.spinnaker.orca.webhook.config.WebhookConfiguration;
+import com.netflix.spinnaker.orca.webhook.config.WebhookProperties;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+class WebhookServiceTest {
+
+  /** See https://wiremock.org/docs/junit-jupiter/#advanced-usage---programmatic. */
+  @RegisterExtension
+  private static WireMockExtension apiProvider =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  private ObjectMapper mapper = Jackson2ObjectMapperBuilder.json().build();
+
+  private WebhookProperties webhookProperties = new WebhookProperties();
+
+  private OkHttpClientConfigurationProperties okHttpClientConfigurationProperties =
+      new OkHttpClientConfigurationProperties();
+
+  private WebhookConfiguration webhookConfiguration = new WebhookConfiguration(webhookProperties);
+
+  private UserConfiguredUrlRestrictions userConfiguredUrlRestrictions =
+      new UserConfiguredUrlRestrictions.Builder()
+          .withRejectLocalhost(false)
+          .withAllowedHostnamesRegex(".*")
+          .build();
+
+  private WebhookService webhookService;
+
+  @BeforeEach
+  void init(TestInfo testInfo) throws Exception {
+    System.out.println("--------------- Test " + testInfo.getDisplayName());
+
+    ClientHttpRequestFactory requestFactory =
+        webhookConfiguration.webhookRequestFactory(
+            okHttpClientConfigurationProperties, userConfiguredUrlRestrictions);
+
+    RestTemplateProvider restTemplateProvider =
+        new DefaultRestTemplateProvider(webhookConfiguration.restTemplate(requestFactory));
+
+    webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider), userConfiguredUrlRestrictions, webhookProperties);
+  }
+
+  @Test
+  void testAllowedRequestsEnabledTrueEmptyList() {
+    webhookProperties.setAllowedRequestsEnabled(true);
+
+    String url = "https://localhost"; // arbitrary, but needs to include a resolvable hostname
+
+    // The StageExecutionImpl constructor mutates the map, so use a mutable map.
+    Map<String, Object> webhookStageData =
+        new HashMap<>(Map.of("url", url, "method", HttpMethod.GET));
+    StageExecution stage =
+        new StageExecutionImpl(null, "webhook", "test-webhook-stage", webhookStageData);
+
+    Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("uri: '" + url + "' not allowed");
+
+    apiProvider.verify(0, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  void testAllowedRequestsMatchingMethodAndUrl() throws Exception {
+    webhookProperties.setAllowedRequestsEnabled(true);
+    WebhookProperties.AllowedRequest allowedRequest = new WebhookProperties.AllowedRequest();
+    allowedRequest.setHttpMethods(List.of("POST"));
+    allowedRequest.setUrlPrefix("http://localhost:" + apiProvider.getPort() + "/path/to/an/");
+    webhookProperties.setAllowedRequests(List.of(allowedRequest));
+
+    String path = "/path/to/an/endpoint";
+    String url = apiProvider.baseUrl() + path;
+
+    String bodyStr = "{ \"foo\": \"bar\" }";
+    apiProvider.stubFor(
+        post(urlMatching(path))
+            .willReturn(aResponse().withStatus(HttpStatus.OK.value()).withBody(bodyStr)));
+
+    // The StageExecutionImpl constructor mutates the map, so use a mutable map.
+    Map<String, Object> webhookStageData =
+        new HashMap<>(Map.of("url", url, "method", HttpMethod.POST));
+    StageExecution stage =
+        new StageExecutionImpl(null, "webhook", "test-webhook-stage", webhookStageData);
+
+    ResponseEntity<Object> result = webhookService.callWebhook(stage);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    var body = mapper.readValue(result.getBody().toString(), Map.class);
+    assertThat(body.get("foo")).isEqualTo("bar");
+
+    apiProvider.verify(postRequestedFor(urlPathEqualTo(path)));
+  }
+
+  @Test
+  void testAllowedRequestsUrlMatchesButNotMethod() throws Exception {
+    webhookProperties.setAllowedRequestsEnabled(true);
+    WebhookProperties.AllowedRequest allowedRequest = new WebhookProperties.AllowedRequest();
+    allowedRequest.setHttpMethods(List.of("POST"));
+    allowedRequest.setUrlPrefix("http://localhost:" + apiProvider.getPort() + "/path/to/an/");
+    webhookProperties.setAllowedRequests(List.of(allowedRequest));
+
+    String path = "/path/to/an/endpoint";
+    String url = apiProvider.baseUrl() + path;
+
+    String bodyStr = "{ \"foo\": \"bar\" }";
+    apiProvider.stubFor(
+        post(urlMatching(path))
+            .willReturn(aResponse().withStatus(HttpStatus.OK.value()).withBody(bodyStr)));
+
+    // The StageExecutionImpl constructor mutates the map, so use a mutable map.
+    Map<String, Object> webhookStageData =
+        new HashMap<>(Map.of("url", url, "method", HttpMethod.PUT));
+    StageExecution stage =
+        new StageExecutionImpl(null, "webhook", "test-webhook-stage", webhookStageData);
+
+    Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("uri: '" + url + "' not allowed");
+
+    apiProvider.verify(0, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  void testAllowedRequestsMethodlMatchesButNotUrl() throws Exception {
+    webhookProperties.setAllowedRequestsEnabled(true);
+    WebhookProperties.AllowedRequest allowedRequest = new WebhookProperties.AllowedRequest();
+    allowedRequest.setHttpMethods(List.of("POST"));
+    allowedRequest.setUrlPrefix("http://localhost:" + apiProvider.getPort() + "/path/to/an/");
+    webhookProperties.setAllowedRequests(List.of(allowedRequest));
+
+    String path = "/path/to/another/endpoint";
+    String url = apiProvider.baseUrl() + path;
+
+    String bodyStr = "{ \"foo\": \"bar\" }";
+    apiProvider.stubFor(
+        post(urlMatching(path))
+            .willReturn(aResponse().withStatus(HttpStatus.OK.value()).withBody(bodyStr)));
+
+    // The StageExecutionImpl constructor mutates the map, so use a mutable map.
+    Map<String, Object> webhookStageData =
+        new HashMap<>(Map.of("url", url, "method", HttpMethod.POST));
+    StageExecution stage =
+        new StageExecutionImpl(null, "webhook", "test-webhook-stage", webhookStageData);
+
+    Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("uri: '" + url + "' not allowed");
+
+    apiProvider.verify(0, RequestPatternBuilder.allRequests());
+  }
+}


### PR DESCRIPTION
Configure with the following properties:
```
webhook.allowedRequestsEnabled (default: false)
webhook.allowedRequests: (default: empty list)
  - httpMethods: list of strings, e.g. [ "GET" ]
    urlPrefix: "https://my-url:port/path/starts/with"
```
Note, if allowRequestsEnabled is true, and allowedRequests is empty, no requests are allowed.
