### PR TITLE
fix(ubuntu): add commands so apt-get can install libc

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
 RUN adduser --system --uid 10111 --group spinnaker
 COPY orca-web/build/install/orca /opt/orca
 RUN mkdir -p /opt/orca/plugins && chown -R spinnaker:nogroup /opt/orca/plugins


### PR DESCRIPTION
specifically:
```
rm /var/lib/dpkg/info/libc-bin.* && apt-get clean
```
to fix errors like
```
#10 102.8 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
#10 102.9 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#10 103.2 Segmentation fault (core dumped)
#10 103.3 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#10 103.7 Segmentation fault (core dumped)
#10 103.7 dpkg: error processing package libc-bin (--configure):
#10 103.7  installed libc-bin package post-installation script subprocess returned error exit status 139
```
from https://github.com/spinnaker/orca/actions/runs/13273184717/job/37058303079 and https://github.com/spinnaker/orca/actions/runs/13273184717/job/37058303079

suggestion from https://stackoverflow.com/a/78107622