### PR TITLE
feat(webhook): add request/response size limits

### DIFF
--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -72,6 +72,12 @@ public class WebhookProperties {
    */
   private List<AllowedRequest> allowedRequests = new ArrayList<>();
 
+  /**
+   * The maximum number of header + body bytes allowed in a webhook request, or <= 0 to allow any
+   * size.
+   */
+  private long maxRequestBytes = 0L;
+
   @Data
   @NoArgsConstructor
   public static class TrustSettings {

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -78,6 +78,12 @@ public class WebhookProperties {
    */
   private long maxRequestBytes = 0L;
 
+  /**
+   * The maximum number of header + body bytes allowed in a webhook response, or <= 0 to allow any
+   * size.
+   */
+  private long maxResponseBytes = 0L;
+
   @Data
   @NoArgsConstructor
   public static class TrustSettings {

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
@@ -56,7 +56,8 @@ class WebhookServiceSpec extends Specification {
   @Shared
   def requestFactory = webhookConfiguration.webhookRequestFactory(
     okHttpClientConfigurationProperties,
-    userConfiguredUrlRestrictions
+    userConfiguredUrlRestrictions,
+    webhookProperties
   )
 
   @Shared

--- a/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
+++ b/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
@@ -35,7 +35,6 @@ import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import com.netflix.spinnaker.orca.webhook.config.WebhookConfiguration;
 import com.netflix.spinnaker.orca.webhook.config.WebhookProperties;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +47,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
-import org.springframework.web.client.ResourceAccessException;
 
 class WebhookServiceTest {
 
@@ -221,9 +219,8 @@ class WebhookServiceTest {
     Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
 
     assertThat(thrown)
-        .isInstanceOf(ResourceAccessException.class)
-        .hasRootCauseExactlyInstanceOf(IOException.class)
-        .hasRootCauseMessage("Canceled");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rejecting request to " + url);
 
     apiProvider.verify(0, RequestPatternBuilder.allRequests());
   }
@@ -246,9 +243,8 @@ class WebhookServiceTest {
     Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
 
     assertThat(thrown)
-        .isInstanceOf(ResourceAccessException.class)
-        .hasRootCauseExactlyInstanceOf(IOException.class)
-        .hasRootCauseMessage("Canceled");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rejecting request to " + url);
 
     apiProvider.verify(0, RequestPatternBuilder.allRequests());
   }
@@ -308,9 +304,8 @@ class WebhookServiceTest {
     Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
 
     assertThat(thrown)
-        .isInstanceOf(ResourceAccessException.class)
-        .hasRootCauseExactlyInstanceOf(IOException.class)
-        .hasRootCauseMessage("Canceled");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rejecting response from " + url);
 
     apiProvider.verify(getRequestedFor(urlPathEqualTo(path)));
   }
@@ -337,9 +332,8 @@ class WebhookServiceTest {
     Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
 
     assertThat(thrown)
-        .isInstanceOf(ResourceAccessException.class)
-        .hasRootCauseExactlyInstanceOf(IOException.class)
-        .hasRootCauseMessage("Canceled");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rejecting response from " + url);
 
     apiProvider.verify(getRequestedFor(urlPathEqualTo(path)));
   }

--- a/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
+++ b/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
@@ -16,6 +16,8 @@
 package com.netflix.spinnaker.orca.webhook.service;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
@@ -283,5 +285,95 @@ class WebhookServiceTest {
     assertThat(body.get("hello")).isEqualTo("there");
 
     apiProvider.verify(postRequestedFor(urlPathEqualTo(path)));
+  }
+
+  @Test
+  void testResponseHeadersTooBig() throws Exception {
+    // Even with an empty body, even one response header (e.g. Matched-Stub-Id) is too big.
+    webhookProperties.setMaxResponseBytes(1L);
+
+    String path = "/some/path";
+    String url = apiProvider.baseUrl() + path;
+
+    apiProvider.stubFor(
+        get(urlMatching(path))
+            .willReturn(aResponse().withStatus(HttpStatus.OK.value()).withBody("")));
+
+    // The StageExecutionImpl constructor mutates the map, so use a mutable map.
+    Map<String, Object> webhookStageData =
+        new HashMap<>(Map.of("url", url, "method", HttpMethod.GET));
+    StageExecution stage =
+        new StageExecutionImpl(null, "webhook", "test-webhook-stage", webhookStageData);
+
+    Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
+
+    assertThat(thrown)
+        .isInstanceOf(ResourceAccessException.class)
+        .hasRootCauseExactlyInstanceOf(IOException.class)
+        .hasRootCauseMessage("Canceled");
+
+    apiProvider.verify(getRequestedFor(urlPathEqualTo(path)));
+  }
+
+  @Test
+  void testResponseHeadersAndBodyTooBig() throws Exception {
+    // Empirically, this is bigger than the headers in this test, and smaller than headers + body.
+    webhookProperties.setMaxResponseBytes(150L);
+
+    String path = "/some/path";
+    String url = apiProvider.baseUrl() + path;
+
+    apiProvider.stubFor(
+        get(urlMatching(path))
+            .willReturn(
+                aResponse().withStatus(HttpStatus.OK.value()).withBody("test response body")));
+
+    // The StageExecutionImpl constructor mutates the map, so use a mutable map.
+    Map<String, Object> webhookStageData =
+        new HashMap<>(Map.of("url", url, "method", HttpMethod.GET));
+    StageExecution stage =
+        new StageExecutionImpl(null, "webhook", "test-webhook-stage", webhookStageData);
+
+    Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
+
+    assertThat(thrown)
+        .isInstanceOf(ResourceAccessException.class)
+        .hasRootCauseExactlyInstanceOf(IOException.class)
+        .hasRootCauseMessage("Canceled");
+
+    apiProvider.verify(getRequestedFor(urlPathEqualTo(path)));
+  }
+
+  @Test
+  void testResponseHeadersAndBodySmallEnough() throws Exception {
+    // Verify that response processing still functions properly after verifying
+    // the response size.
+
+    // Empirically, this is bigger than the headers in this test, and bigger
+    // than headers + body.
+    webhookProperties.setMaxResponseBytes(500L);
+
+    String path = "/some/path";
+    String url = apiProvider.baseUrl() + path;
+
+    String responseBodyString = "test response body";
+    apiProvider.stubFor(
+        get(urlMatching(path))
+            .willReturn(
+                aResponse().withStatus(HttpStatus.OK.value()).withBody(responseBodyString)));
+
+    // The StageExecutionImpl constructor mutates the map, so use a mutable map.
+    Map<String, Object> webhookStageData =
+        new HashMap<>(Map.of("url", url, "method", HttpMethod.GET));
+    StageExecution stage =
+        new StageExecutionImpl(null, "webhook", "test-webhook-stage", webhookStageData);
+
+    ResponseEntity<Object> result = webhookService.callWebhook(stage);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody().toString()).isEqualTo(responseBodyString);
+
+    apiProvider.verify(getRequestedFor(urlPathEqualTo(path)));
   }
 }


### PR DESCRIPTION
via new config properties webhook.maxRequestBytes and webhook.maxResponseBytes. The default value for both is 0.
When greater than 0, only requests/responses whose header + body size is less than or equal to the max are allowed.