### PR TITLE
feat(webhook): add webhook-specific configuration properties for read and connect timeout

### DIFF
--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
@@ -20,7 +20,6 @@ package com.netflix.spinnaker.orca.webhook.config;
 import com.netflix.spinnaker.kork.crypto.TrustStores;
 import com.netflix.spinnaker.kork.crypto.X509Identity;
 import com.netflix.spinnaker.kork.crypto.X509IdentitySource;
-import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
 import com.netflix.spinnaker.orca.webhook.util.UnionX509TrustManager;
 import java.io.FileInputStream;
@@ -96,7 +95,6 @@ public class WebhookConfiguration {
 
   @Bean
   public ClientHttpRequestFactory webhookRequestFactory(
-      OkHttpClientConfigurationProperties okHttpClientConfigurationProperties,
       UserConfiguredUrlRestrictions userConfiguredUrlRestrictions,
       WebhookProperties webhookProperties)
       throws IOException {
@@ -138,10 +136,8 @@ public class WebhookConfiguration {
 
     var client = builder.build();
     var requestFactory = new OkHttp3ClientHttpRequestFactory(client);
-    requestFactory.setReadTimeout(
-        Math.toIntExact(okHttpClientConfigurationProperties.getReadTimeoutMs()));
-    requestFactory.setConnectTimeout(
-        Math.toIntExact(okHttpClientConfigurationProperties.getConnectTimeoutMs()));
+    requestFactory.setReadTimeout(Math.toIntExact(webhookProperties.getReadTimeoutMs()));
+    requestFactory.setConnectTimeout(Math.toIntExact(webhookProperties.getConnectTimeoutMs()));
     return requestFactory;
   }
 

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -87,6 +87,18 @@ public class WebhookProperties {
    */
   private long maxResponseBytes = 0L;
 
+  /**
+   * If the timeout expires before a connection can be established, a SocketTimeoutException is
+   * raised. A timeout of 0 is considered infinite.
+   */
+  private long connectTimeoutMs = 15000L;
+
+  /**
+   * If the timeout expires before there is data available in the input stream to read, a
+   * SocketTimeoutException is raised. A timeout of 0 is considered infinite.
+   */
+  private long readTimeoutMs = 20000L;
+
   @Data
   @NoArgsConstructor
   public static class TrustSettings {

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.orca.webhook.service
 
-import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
@@ -45,9 +44,6 @@ class WebhookServiceSpec extends Specification {
   def webhookProperties = new WebhookProperties()
 
   @Shared
-  def okHttpClientConfigurationProperties = new OkHttpClientConfigurationProperties()
-
-  @Shared
   def webhookConfiguration = new WebhookConfiguration(webhookProperties)
 
   @Shared
@@ -55,7 +51,6 @@ class WebhookServiceSpec extends Specification {
 
   @Shared
   def requestFactory = webhookConfiguration.webhookRequestFactory(
-    okHttpClientConfigurationProperties,
     userConfiguredUrlRestrictions,
     webhookProperties
   )

--- a/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
+++ b/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
@@ -17,11 +17,13 @@
 
 package com.netflix.spinnaker.orca.webhook.service
 
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import com.netflix.spinnaker.orca.webhook.config.WebhookProperties
 import com.netflix.spinnaker.orca.webhook.config.WebhookConfiguration
+import org.springframework.core.env.Environment
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -44,14 +46,17 @@ class WebhookServiceSpec extends Specification {
   def webhookProperties = new WebhookProperties()
 
   @Shared
+  def okHttpClientConfigurationProperties = new OkHttpClientConfigurationProperties()
+
+  @Shared
   def webhookConfiguration = new WebhookConfiguration(webhookProperties)
 
   @Shared
   def userConfiguredUrlRestrictions = new UserConfiguredUrlRestrictions.Builder().withRejectLocalhost(false).withAllowedHostnamesRegex(".*").build()
 
   @Shared
-  def requestFactory = webhookConfiguration.webhookRequestFactory(
-    userConfiguredUrlRestrictions,
+  def requestFactory = webhookConfiguration.webhookRequestFactory(Mock(Environment),
+    okHttpClientConfigurationProperties, userConfiguredUrlRestrictions,
     webhookProperties
   )
 

--- a/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfigurationTest.java
+++ b/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfigurationTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2025 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.webhook.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.fiat.shared.FiatService;
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
+import java.lang.reflect.Field;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.annotation.UserConfigurations;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
+import org.springframework.util.ReflectionUtils;
+
+class WebhookConfigurationTest {
+
+  private final ApplicationContextRunner runner =
+      new ApplicationContextRunner()
+          .withBean(ObjectMapper.class)
+          .withConfiguration(
+              UserConfigurations.of(
+                  WebhookConfiguration.class,
+                  OkHttpClientConfigurationProperties.class,
+                  WebhookTestConfiguration.class));
+
+  @Test
+  void testReadTimeoutViaWebhookProperties() {
+    long webhookReadTimeout = 17;
+    runner
+        .withPropertyValues("webhook.readTimeoutMs:" + webhookReadTimeout)
+        .run(
+            ctx -> {
+              OkHttpClient client = getOkHttpClient(ctx);
+              assertThat(client.readTimeoutMillis()).isEqualTo(webhookReadTimeout);
+            });
+  }
+
+  @Test
+  void testReadTimeoutViaOkHttp() {
+    long okHttpClientReadTimeout = 5;
+    runner
+        .withPropertyValues("ok-http-client.readTimeoutMs:" + okHttpClientReadTimeout)
+        .run(
+            ctx -> {
+              OkHttpClient client = getOkHttpClient(ctx);
+              assertThat(client.readTimeoutMillis()).isEqualTo(okHttpClientReadTimeout);
+            });
+  }
+
+  @Test
+  void testReadTimeoutDemonstratePrecedence() {
+    long okHttpClientReadTimeout = 5;
+    long webhookReadTimeout = 17;
+    runner
+        .withPropertyValues(
+            "ok-http-client.readTimeoutMs:" + okHttpClientReadTimeout,
+            "webhook.readTimeoutMs:" + webhookReadTimeout)
+        .run(
+            ctx -> {
+              OkHttpClient client = getOkHttpClient(ctx);
+              assertThat(client.readTimeoutMillis()).isEqualTo(webhookReadTimeout);
+            });
+  }
+
+  @Test
+  void testReadTimeoutKebabCase() {
+    long okHttpClientReadTimeout = 5;
+    long webhookReadTimeout = 17;
+    runner
+        .withPropertyValues(
+            "ok-http-client.read-timeout-ms:" + okHttpClientReadTimeout,
+            "webhook.read-timeout-ms:" + webhookReadTimeout)
+        .run(
+            ctx -> {
+              OkHttpClient client = getOkHttpClient(ctx);
+              assertThat(client.readTimeoutMillis()).isEqualTo(webhookReadTimeout);
+            });
+  }
+
+  @Test
+  void testConnectTimeoutViaWebhookProperties() {
+    long webhookConnectTimeout = 17;
+    runner
+        .withPropertyValues("webhook.connectTimeoutMs:" + webhookConnectTimeout)
+        .run(
+            ctx -> {
+              OkHttpClient client = getOkHttpClient(ctx);
+              assertThat(client.connectTimeoutMillis()).isEqualTo(webhookConnectTimeout);
+            });
+  }
+
+  @Test
+  void testConnectTimeoutViaOkHttp() {
+    long okHttpClientConnectTimeout = 0;
+    runner
+        .withPropertyValues("ok-http-client.connectTimeoutMs:" + okHttpClientConnectTimeout)
+        .run(
+            ctx -> {
+              OkHttpClient client = getOkHttpClient(ctx);
+              assertThat(client.connectTimeoutMillis()).isEqualTo(okHttpClientConnectTimeout);
+            });
+  }
+
+  @Test
+  void testConnectTimeoutDemonstratePrecedence() {
+    long okHttpClientConnectTimeout = 5;
+    long webhookConnectTimeout = 17;
+    runner
+        .withPropertyValues(
+            "ok-http-client.connectTimeoutMs:" + okHttpClientConnectTimeout,
+            "webhook.connectTimeoutMs:" + webhookConnectTimeout)
+        .run(
+            ctx -> {
+              OkHttpClient client = getOkHttpClient(ctx);
+              assertThat(client.connectTimeoutMillis()).isEqualTo(webhookConnectTimeout);
+            });
+  }
+
+  @Test
+  void testConnectTimeoutKebabCase() {
+    long okHttpClientConnectTimeout = 5;
+    long webhookConnectTimeout = 17;
+    runner
+        .withPropertyValues(
+            "ok-http-client.connect-timeout-ms:" + okHttpClientConnectTimeout,
+            "webhook.connect-timeout-ms:" + webhookConnectTimeout)
+        .run(
+            ctx -> {
+              OkHttpClient client = getOkHttpClient(ctx);
+              assertThat(client.connectTimeoutMillis()).isEqualTo(webhookConnectTimeout);
+            });
+  }
+
+  /** Retrieve the client member from the OkHttp3ClientHttpRequestFactory bean */
+  private static OkHttpClient getOkHttpClient(AssertableApplicationContext ctx) {
+    OkHttp3ClientHttpRequestFactory requestFactory =
+        ctx.getBean(OkHttp3ClientHttpRequestFactory.class);
+    assertThat(requestFactory).isNotNull();
+    Field clientField =
+        ReflectionUtils.findField(
+            OkHttp3ClientHttpRequestFactory.class, "client", OkHttpClient.class);
+    assertThat(clientField).isNotNull();
+    clientField.setAccessible(true);
+    OkHttpClient client = (OkHttpClient) ReflectionUtils.getField(clientField, requestFactory);
+    assertThat(client).isNotNull();
+    return client;
+  }
+
+  private static class WebhookTestConfiguration {
+    @Bean
+    UserConfiguredUrlRestrictions userConfiguredUrlRestrictions() {
+      return new UserConfiguredUrlRestrictions.Builder().build();
+    }
+
+    /**
+     * WebhookConfiguration has @ComponentScan("com.netflix.spinnaker.orca.webhook") which picks up
+     * PreconfiguredWebhookStage, which depends on FiatService.
+     */
+    @Bean
+    FiatService fiatService() {
+      return mock(FiatService.class);
+    }
+  }
+}

--- a/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
+++ b/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
@@ -26,10 +26,12 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
@@ -42,6 +44,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -59,6 +62,9 @@ class WebhookServiceTest {
 
   private WebhookProperties webhookProperties = new WebhookProperties();
 
+  private OkHttpClientConfigurationProperties okHttpClientConfigurationProperties =
+      new OkHttpClientConfigurationProperties();
+
   private WebhookConfiguration webhookConfiguration = new WebhookConfiguration(webhookProperties);
 
   private UserConfiguredUrlRestrictions userConfiguredUrlRestrictions =
@@ -75,7 +81,10 @@ class WebhookServiceTest {
 
     ClientHttpRequestFactory requestFactory =
         webhookConfiguration.webhookRequestFactory(
-            userConfiguredUrlRestrictions, webhookProperties);
+            mock(Environment.class),
+            okHttpClientConfigurationProperties,
+            userConfiguredUrlRestrictions,
+            webhookProperties);
 
     RestTemplateProvider restTemplateProvider =
         new DefaultRestTemplateProvider(webhookConfiguration.restTemplate(requestFactory));

--- a/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
+++ b/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
@@ -30,7 +30,6 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
-import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
@@ -60,9 +59,6 @@ class WebhookServiceTest {
 
   private WebhookProperties webhookProperties = new WebhookProperties();
 
-  private OkHttpClientConfigurationProperties okHttpClientConfigurationProperties =
-      new OkHttpClientConfigurationProperties();
-
   private WebhookConfiguration webhookConfiguration = new WebhookConfiguration(webhookProperties);
 
   private UserConfiguredUrlRestrictions userConfiguredUrlRestrictions =
@@ -79,7 +75,7 @@ class WebhookServiceTest {
 
     ClientHttpRequestFactory requestFactory =
         webhookConfiguration.webhookRequestFactory(
-            okHttpClientConfigurationProperties, userConfiguredUrlRestrictions, webhookProperties);
+            userConfiguredUrlRestrictions, webhookProperties);
 
     RestTemplateProvider restTemplateProvider =
         new DefaultRestTemplateProvider(webhookConfiguration.restTemplate(requestFactory));


### PR DESCRIPTION
`webhook.readTimeoutMs` (default 20000) and `webhook.connectTimeoutMs` (default 15000).

If not present, fall back to `ok-http-client.readTimeoutMs` and `ok-http-client.connectTimeoutMs` (same defaults) to mantain behavior where those ok-http-client properties are set.

This way it's possible to configure webhook stages independently of the way spinnaker microservices communicate with each other.
