### PR TITLE
feat(webhook): add webhook.auditLoggingEnabled config property

### DIFF
--- a/orca-webhook/orca-webhook.gradle
+++ b/orca-webhook/orca-webhook.gradle
@@ -31,6 +31,7 @@ dependencies {
   implementation("com.jayway.jsonpath:json-path")
   implementation("com.squareup.okhttp3:okhttp")
   implementation("com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0")
+  implementation("net.logstash.logback:logstash-logback-encoder")
 
   testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")
   testImplementation("com.squareup.okhttp3:mockwebserver")

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
@@ -117,10 +117,11 @@ public class WebhookConfiguration {
 
                   if (webhookProperties.isAuditLoggingEnabled()) {
                     log.info(
-                        "sending webhook request: {},{},{}",
+                        "sending webhook request: {},{},{},{}",
                         kv("httpMethod", request.method()),
                         kv("url", request.url()),
-                        kv("headerByteCount", request.headers().byteCount()));
+                        kv("headerByteCount", request.headers().byteCount()),
+                        kv("contentLength", getRequestBodyContentLength(request)));
                   }
 
                   Response response = chain.proceed(request);

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
@@ -203,7 +203,7 @@ public class WebhookConfiguration {
     if (totalSize > maxRequestBytes) {
       String message =
           String.format(
-              "rejecting request to %s with %s byte body, maxRequestBytes: {}",
+              "rejecting request to %s with %s byte body, maxRequestBytes: %s",
               request.url(), totalSize, maxRequestBytes);
       log.info(message);
       throw new IllegalArgumentException(message);

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
@@ -113,6 +113,8 @@ public class WebhookConfiguration {
                 chain -> {
                   Request request = chain.request();
 
+                  validateRequestSize(request, webhookProperties.getMaxRequestBytes());
+
                   if (webhookProperties.isAuditLoggingEnabled()) {
                     log.info(
                         "sending webhook request: {},{}",
@@ -120,9 +122,9 @@ public class WebhookConfiguration {
                         kv("url", request.url()));
                   }
 
-                  validateRequestSize(request, webhookProperties.getMaxRequestBytes());
-
                   Response response = chain.proceed(request);
+
+                  validateResponseSize(response, webhookProperties.getMaxResponseBytes());
 
                   if (webhookProperties.isAuditLoggingEnabled()) {
                     log.info(
@@ -134,8 +136,6 @@ public class WebhookConfiguration {
                             "latencyMs",
                             response.receivedResponseAtMillis() - response.sentRequestAtMillis()));
                   }
-
-                  validateResponseSize(response, webhookProperties.getMaxResponseBytes());
 
                   if (response.isRedirect()) {
                     String redirectLocation = response.header("Location");

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
@@ -77,7 +77,7 @@ import org.springframework.web.client.RestTemplate;
 public class WebhookConfiguration {
   private final WebhookProperties webhookProperties;
 
-  private final Logger log = LoggerFactory.getLogger(getClass());
+  private final Logger log = LoggerFactory.getLogger(WebhookConfiguration.class);
 
   @Autowired
   public WebhookConfiguration(WebhookProperties webhookProperties) {

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfiguration.java
@@ -117,9 +117,10 @@ public class WebhookConfiguration {
 
                   if (webhookProperties.isAuditLoggingEnabled()) {
                     log.info(
-                        "sending webhook request: {},{}",
+                        "sending webhook request: {},{},{}",
                         kv("httpMethod", request.method()),
-                        kv("url", request.url()));
+                        kv("url", request.url()),
+                        kv("headerByteCount", request.headers().byteCount()));
                   }
 
                   Response response = chain.proceed(request);
@@ -128,10 +129,11 @@ public class WebhookConfiguration {
 
                   if (webhookProperties.isAuditLoggingEnabled()) {
                     log.info(
-                        "received webhook response: {},{},{},{}",
+                        "received webhook response: {},{},{},{},{}",
                         kv("httpMethod", response.request().method()),
                         kv("url", response.request().url()),
                         kv("responseCode", response.code()),
+                        kv("headerByteCount", response.headers().byteCount()),
                         kv(
                             "latencyMs",
                             response.receivedResponseAtMillis() - response.sentRequestAtMillis()));

--- a/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -99,6 +99,9 @@ public class WebhookProperties {
    */
   private long readTimeoutMs = 20000L;
 
+  /** True to enable audit logging */
+  private boolean auditLoggingEnabled = false;
+
   @Data
   @NoArgsConstructor
   public static class TrustSettings {


### PR DESCRIPTION
which defaults to false. When true, log information about each webhook request and response.

with a small fix to a response-too-big error message as well.