### PR TITLE
feat(queue): provide a way for pipeline stages to specify a backoff period

### DIFF
--- a/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
+++ b/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/StageExecution.java
@@ -181,6 +181,9 @@ public interface StageExecution {
   @Nonnull
   Optional<Long> getTimeout();
 
+  @Nonnull
+  Optional<Long> getBackoffPeriod();
+
   boolean getAllowSiblingStagesToContinueOnFailure();
 
   void setAllowSiblingStagesToContinueOnFailure(boolean allowSiblingStagesToContinueOnFailure);

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
@@ -768,6 +768,20 @@ public class StageExecutionImpl implements StageExecution, Serializable {
     return Optional.empty();
   }
 
+  @Nonnull
+  @JsonIgnore
+  public Optional<Long> getBackoffPeriod() {
+    Object backoffPeriod = getContext().get(STAGE_BACKOFF_PERIOD_OVERRIDE_KEY);
+    if (backoffPeriod instanceof Integer) {
+      return Optional.of((Integer) backoffPeriod).map(Integer::longValue);
+    } else if (backoffPeriod instanceof Long) {
+      return Optional.of((Long) backoffPeriod);
+    } else if (backoffPeriod instanceof Double) {
+      return Optional.of((Double) backoffPeriod).map(Double::longValue);
+    }
+    return Optional.empty();
+  }
+
   /**
    * Check if this stage should propagate FAILED_CONTINUE to parent stage. Normally, if a synthetic
    * child fails with FAILED_CONTINUE {@link
@@ -861,5 +875,6 @@ public class StageExecutionImpl implements StageExecution, Serializable {
     return (status == ExecutionStatus.TERMINAL);
   }
 
+  public static final String STAGE_BACKOFF_PERIOD_OVERRIDE_KEY = "backoffPeriodMs";
   public static final String STAGE_TIMEOUT_OVERRIDE_KEY = "stageTimeoutMs";
 }

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
@@ -756,30 +756,28 @@ public class StageExecutionImpl implements StageExecution, Serializable {
 
   @Nonnull
   @JsonIgnore
-  public Optional<Long> getTimeout() {
-    Object timeout = getContext().get(STAGE_TIMEOUT_OVERRIDE_KEY);
-    if (timeout instanceof Integer) {
-      return Optional.of((Integer) timeout).map(Integer::longValue);
-    } else if (timeout instanceof Long) {
-      return Optional.of((Long) timeout);
-    } else if (timeout instanceof Double) {
-      return Optional.of((Double) timeout).map(Double::longValue);
+  private Optional<Long> getLongFromContext(String key) {
+    Object value = getContext().get(key);
+    if (value instanceof Integer) {
+      return Optional.of((Integer) value).map(Integer::longValue);
+    } else if (value instanceof Long) {
+      return Optional.of((Long) value);
+    } else if (value instanceof Double) {
+      return Optional.of((Double) value).map(Double::longValue);
     }
     return Optional.empty();
   }
 
   @Nonnull
   @JsonIgnore
+  public Optional<Long> getTimeout() {
+    return getLongFromContext(STAGE_TIMEOUT_OVERRIDE_KEY);
+  }
+
+  @Nonnull
+  @JsonIgnore
   public Optional<Long> getBackoffPeriod() {
-    Object backoffPeriod = getContext().get(STAGE_BACKOFF_PERIOD_OVERRIDE_KEY);
-    if (backoffPeriod instanceof Integer) {
-      return Optional.of((Integer) backoffPeriod).map(Integer::longValue);
-    } else if (backoffPeriod instanceof Long) {
-      return Optional.of((Long) backoffPeriod);
-    } else if (backoffPeriod instanceof Double) {
-      return Optional.of((Double) backoffPeriod).map(Double::longValue);
-    }
-    return Optional.empty();
+    return getLongFromContext(STAGE_BACKOFF_PERIOD_OVERRIDE_KEY);
   }
 
   /**

--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
@@ -758,12 +758,8 @@ public class StageExecutionImpl implements StageExecution, Serializable {
   @JsonIgnore
   private Optional<Long> getLongFromContext(String key) {
     Object value = getContext().get(key);
-    if (value instanceof Integer) {
-      return Optional.of((Integer) value).map(Integer::longValue);
-    } else if (value instanceof Long) {
-      return Optional.of((Long) value);
-    } else if (value instanceof Double) {
-      return Optional.of((Double) value).map(Double::longValue);
+    if (value instanceof Number) {
+      return Optional.of(((Number) value).longValue());
     }
     return Optional.empty();
   }

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -333,6 +333,9 @@ class RunTaskHandler(
       )
     )
 
+    val stageOverrideBackoffPeriod = stage.getBackoffPeriod()
+    stageOverrideBackoffPeriod.ifPresent { backOffs.add(it) }
+
     if (this is CloudProviderAware && hasCloudProvider(stage)) {
       backOffs.add(
         dynamicConfigService.getConfig(

--- a/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -316,6 +316,9 @@ class RunTaskHandler(
    * `tasks.aws.backOffPeriod = 80000`
    * `tasks.aws.someAccount.backoffPeriod = 60000`
    * `tasks.aws.backoffPeriod` will be used (given the criteria matches and unless the default dynamicBackOffPeriod is greater).
+   *
+   * This function also considers the `backoffPeriodMs` property in a stage
+   * configuration.  If it's larger than the above, it's used.
    */
   private fun RetryableTask.retryableBackOffPeriod(
     taskModel: TaskExecution,


### PR DESCRIPTION
via a new backoffPeriodMs stage configuration property. Before this, pipeline authors had no control over the backoff period. It came from either spinnaker configuration properties or implementations of RetryableTask.getDynamicBackoffPeriod.

This makes it possible for pipeline authors to, for example, control the delay between attempts when webhook stages retry. The actual backoff used is the largest of:

- backoffPeriodMs in the stage
- tasks.global.backOffPeriod
- tasks.<cloud provider>.backOffPeriod
- tasks.<cloud provider>.<account name>.backOffPeriod