### PR TITLE
fix(gha): fix branch detection error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       # Given a tag, determine what branch we are on, so we can bump dependencies in the correct branch
       - name: Get Branch
         run: |
-          BRANCHES=$(git branch -r --contains ${{ github.ref }})
+          BRANCHES=$(git branch -r --contains ${{ github.ref }} | grep -v 'HEAD')
           echo "BRANCHES is '${BRANCHES}'"
           # Check for no branches explicitly...Otherwise echo adds a newline so wc thinks there's
           # one branch.  And echo -n makes it appears that there's one less branch than there


### PR DESCRIPTION
from e.g. https://github.com/spinnaker/orca/actions/runs/13415978286/job/37476832943
```
Run BRANCHES=$(git branch -r --contains refs/tags/v8.60.0) BRANCHES is '  origin/HEAD -> origin/master
  origin/master'
NUM_BRANCHES is '2'
exactly one branch required to release orca, but there are 2 (  origin/HEAD -> origin/master
  origin/master)
```
similar to https://github.com/spinnaker/fiat/pull/1205