### PR TITLE
fix(orca-clouddriver): Fix exception in mapping of trafficManagement when null

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStage.java
@@ -92,20 +92,22 @@ public class DeployManifestStage extends ExpressionAwareStageDefinitionBuilder {
 
   @Override
   public void afterStages(@Nonnull StageExecution stage, @Nonnull StageGraphBuilder graph) {
-    TrafficManagement trafficManagement =
-        stage.mapTo("/trafficManagement", TrafficManagement.class);
-    if (trafficManagement.isEnabled()) {
-      switch (trafficManagement.getOptions().getStrategy()) {
-        case RED_BLACK:
-        case BLUE_GREEN:
-          oldManifestActionAppender.deleteOrDisableOldManifest(stage.getContext(), graph);
-          break;
-        case HIGHLANDER:
-          oldManifestActionAppender.disableOldManifest(stage.getContext(), graph);
-          oldManifestActionAppender.deleteOldManifest(stage.getContext(), graph);
-          break;
-        case NONE:
-          // do nothing
+    if (stage.getContext().get("trafficManagement") != null) {
+      TrafficManagement trafficManagement =
+          stage.mapTo("/trafficManagement", TrafficManagement.class);
+      if (trafficManagement.isEnabled()) {
+        switch (trafficManagement.getOptions().getStrategy()) {
+          case RED_BLACK:
+          case BLUE_GREEN:
+            oldManifestActionAppender.deleteOrDisableOldManifest(stage.getContext(), graph);
+            break;
+          case HIGHLANDER:
+            oldManifestActionAppender.disableOldManifest(stage.getContext(), graph);
+            oldManifestActionAppender.deleteOldManifest(stage.getContext(), graph);
+            break;
+          case NONE:
+            // do nothing
+        }
       }
     }
     if (shouldRemoveStageOutputs(stage)) {

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStageTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/manifest/DeployManifestStageTest.java
@@ -116,6 +116,14 @@ final class DeployManifestStageTest {
   }
 
   @Test
+  void rolloutStrategyMissing() {
+    StageExecutionImpl stage = new StageExecutionImpl();
+    stage.setContext(getContext(DeployManifestContext.builder().build()));
+    stage.getContext().remove("trafficManagement");
+    assertThat(getAfterStages(stage)).isEmpty();
+  }
+
+  @Test
   void rolloutStrategyRedBlack() {
     givenManifestIsStable();
     when(oortService.getClusterManifests(ACCOUNT, NAMESAPCE, "replicaSet", APPLICATION, CLUSTER))


### PR DESCRIPTION
Fixes the mapping exception when trafficManagement is not defined in the Deploy stage definition. 

Exception: 
<img width="833" alt="Screenshot 2025-02-21 at 14 29 24" src="https://github.com/user-attachments/assets/1da284f2-c87e-4865-9e05-08eed8e3ac65" />

Resulted from changes in https://github.com/spinnaker/orca/pull/4823