### PR TITLE
fix(artifacts): fix NPE when expected artifact is null 

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -120,6 +120,9 @@ public final class ArtifactResolver {
     ImmutableList.Builder<ExpectedArtifact> boundExpectedArtifacts = ImmutableList.builder();
 
     for (ExpectedArtifact expectedArtifact : expectedArtifacts) {
+      if (expectedArtifact == null) {
+        throw new InvalidRequestException("expected artifact cannot be null.");
+      }
       Artifact resolved =
           resolveSingleArtifact(expectedArtifact)
               .orElseThrow(

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverTest.java
@@ -24,6 +24,8 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver.ResolveResult;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 final class ArtifactResolverTest {
@@ -54,6 +56,20 @@ final class ArtifactResolverTest {
     assertThat(result.getResolvedArtifacts()).containsExactly(DOCKER_ARTIFACT);
     assertThat(result.getResolvedExpectedArtifacts())
         .containsExactly(bindArtifact(expected, DOCKER_ARTIFACT));
+  }
+
+  @Test
+  void testMatchForNullArtifact() {
+    ArtifactResolver resolver =
+        ArtifactResolver.getInstance(
+            ImmutableList.of(DOCKER_ARTIFACT, GCE_IMAGE_ARTIFACT),
+            /* requireUniqueMatches= */ true);
+
+    List<ExpectedArtifact> list = new ArrayList<>();
+    list.add(null);
+
+    assertThatThrownBy(() -> resolver.resolveExpectedArtifacts(list))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverTest.java
+++ b/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolverTest.java
@@ -69,7 +69,7 @@ final class ArtifactResolverTest {
     list.add(null);
 
     assertThatThrownBy(() -> resolver.resolveExpectedArtifacts(list))
-        .isInstanceOf(NullPointerException.class);
+        .isInstanceOf(InvalidRequestException.class);
   }
 
   @Test


### PR DESCRIPTION
This is to address the issue : https://github.com/spinnaker/spinnaker/issues/7004

While resolving expected artifact NullPointerException is thrown if the artifact is null. 

Added a test to demonstrate the issue and provided the fix which identifies null artifact and throws InvalidRequestException which is a SpinnakerException.