### PR TITLE
test(stage): add test to cover scenario when clouddriver returns a failure

### DIFF
--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskTest.java
@@ -17,11 +17,7 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -38,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import okhttp3.Request;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 
 final class WaitForManifestStableTaskTest {
@@ -61,7 +58,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(true).failed(true).build());
 
     TaskResult result = task.execute(myStage);
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
     assertThat(getMessages(result)).containsExactly(failedMessage(MANIFEST_1));
     assertThat(getErrors(result)).containsExactly(failedMessage(MANIFEST_1));
   }
@@ -78,7 +75,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(true).build());
 
     TaskResult result = task.execute(myStage);
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
     assertThat(getMessages(result)).containsExactly(failedMessage(MANIFEST_1));
     assertThat(getErrors(result)).containsExactly(failedMessage(MANIFEST_1));
   }
@@ -95,7 +92,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result)).containsExactly(waitingToStabilizeMessage(MANIFEST_1));
     assertThat(getErrors(result)).isEmpty();
   }
@@ -112,7 +109,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(true).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
     assertThat(getMessages(result)).isEmpty();
     assertThat(getErrors(result)).isEmpty();
   }
@@ -129,7 +126,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().build());
 
     TaskResult result = task.execute(myStage);
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result)).containsExactly(waitingToStabilizeMessage(MANIFEST_1));
     assertThat(getErrors(result)).isEmpty();
   }
@@ -149,7 +146,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
 
     reset(oortService);
 
@@ -163,7 +160,7 @@ final class WaitForManifestStableTaskTest {
                     .putAll(myStage.getContext())
                     .putAll(result.getContext())
                     .build()));
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
     verify(oortService, times(0)).getManifest(ACCOUNT, NAMESPACE, MANIFEST_1, false);
   }
 
@@ -182,7 +179,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result)).containsExactly(waitingToStabilizeMessage(MANIFEST_2));
     assertThat(getErrors(result)).isEmpty();
 
@@ -198,7 +195,7 @@ final class WaitForManifestStableTaskTest {
                     .putAll(myStage.getContext())
                     .putAll(result.getContext())
                     .build()));
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
     assertThat(getMessages(result)).containsExactly(waitingToStabilizeMessage(MANIFEST_2));
     assertThat(getErrors(result)).isEmpty();
   }
@@ -218,7 +215,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result))
         .containsExactly(failedMessage(MANIFEST_1), waitingToStabilizeMessage(MANIFEST_2));
     assertThat(getErrors(result)).containsExactly(failedMessage(MANIFEST_1));
@@ -236,7 +233,7 @@ final class WaitForManifestStableTaskTest {
                     .putAll(result.getContext())
                     .build()));
 
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
     assertThat(getMessages(result))
         .containsExactly(failedMessage(MANIFEST_1), waitingToStabilizeMessage(MANIFEST_2));
     assertThat(getErrors(result)).containsExactly(failedMessage(MANIFEST_1));
@@ -257,7 +254,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().build());
 
     TaskResult result = task.execute(myStage);
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result))
         .containsExactly(failedMessage(MANIFEST_1), waitingToStabilizeMessage(MANIFEST_2));
 
@@ -273,7 +270,7 @@ final class WaitForManifestStableTaskTest {
                     .putAll(myStage.getContext())
                     .putAll(result.getContext())
                     .build()));
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
     assertThat(getMessages(result))
         .containsExactly(failedMessage(MANIFEST_1), waitingToStabilizeMessage(MANIFEST_2));
   }
@@ -293,7 +290,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result)).containsExactly(waitingToStabilizeMessage(MANIFEST_2));
     assertThat(getErrors(result)).isEmpty();
 
@@ -311,7 +308,7 @@ final class WaitForManifestStableTaskTest {
                     .putAll(result.getContext())
                     .build()));
 
-    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result)).isEmpty();
     assertThat(getErrors(result)).isEmpty();
   }

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskTest.java
@@ -17,7 +17,11 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -34,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import okhttp3.Request;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 
 final class WaitForManifestStableTaskTest {
@@ -58,7 +61,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(true).failed(true).build());
 
     TaskResult result = task.execute(myStage);
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
     assertThat(getMessages(result)).containsExactly(failedMessage(MANIFEST_1));
     assertThat(getErrors(result)).containsExactly(failedMessage(MANIFEST_1));
   }
@@ -75,7 +78,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(true).build());
 
     TaskResult result = task.execute(myStage);
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
     assertThat(getMessages(result)).containsExactly(failedMessage(MANIFEST_1));
     assertThat(getErrors(result)).containsExactly(failedMessage(MANIFEST_1));
   }
@@ -92,7 +95,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result)).containsExactly(waitingToStabilizeMessage(MANIFEST_1));
     assertThat(getErrors(result)).isEmpty();
   }
@@ -109,7 +112,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(true).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
     assertThat(getMessages(result)).isEmpty();
     assertThat(getErrors(result)).isEmpty();
   }
@@ -126,7 +129,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().build());
 
     TaskResult result = task.execute(myStage);
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result)).containsExactly(waitingToStabilizeMessage(MANIFEST_1));
     assertThat(getErrors(result)).isEmpty();
   }
@@ -146,7 +149,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
 
     reset(oortService);
 
@@ -160,7 +163,7 @@ final class WaitForManifestStableTaskTest {
                     .putAll(myStage.getContext())
                     .putAll(result.getContext())
                     .build()));
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
     verify(oortService, times(0)).getManifest(ACCOUNT, NAMESPACE, MANIFEST_1, false);
   }
 
@@ -179,7 +182,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result)).containsExactly(waitingToStabilizeMessage(MANIFEST_2));
     assertThat(getErrors(result)).isEmpty();
 
@@ -195,7 +198,7 @@ final class WaitForManifestStableTaskTest {
                     .putAll(myStage.getContext())
                     .putAll(result.getContext())
                     .build()));
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
     assertThat(getMessages(result)).containsExactly(waitingToStabilizeMessage(MANIFEST_2));
     assertThat(getErrors(result)).isEmpty();
   }
@@ -215,7 +218,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result))
         .containsExactly(failedMessage(MANIFEST_1), waitingToStabilizeMessage(MANIFEST_2));
     assertThat(getErrors(result)).containsExactly(failedMessage(MANIFEST_1));
@@ -233,7 +236,7 @@ final class WaitForManifestStableTaskTest {
                     .putAll(result.getContext())
                     .build()));
 
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
     assertThat(getMessages(result))
         .containsExactly(failedMessage(MANIFEST_1), waitingToStabilizeMessage(MANIFEST_2));
     assertThat(getErrors(result)).containsExactly(failedMessage(MANIFEST_1));
@@ -254,7 +257,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().build());
 
     TaskResult result = task.execute(myStage);
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result))
         .containsExactly(failedMessage(MANIFEST_1), waitingToStabilizeMessage(MANIFEST_2));
 
@@ -270,7 +273,7 @@ final class WaitForManifestStableTaskTest {
                     .putAll(myStage.getContext())
                     .putAll(result.getContext())
                     .build()));
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
     assertThat(getMessages(result))
         .containsExactly(failedMessage(MANIFEST_1), waitingToStabilizeMessage(MANIFEST_2));
   }
@@ -290,7 +293,7 @@ final class WaitForManifestStableTaskTest {
         .thenReturn(manifestBuilder().stable(false).failed(false).build());
 
     TaskResult result = task.execute(myStage);
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result)).containsExactly(waitingToStabilizeMessage(MANIFEST_2));
     assertThat(getErrors(result)).isEmpty();
 
@@ -308,7 +311,7 @@ final class WaitForManifestStableTaskTest {
                     .putAll(result.getContext())
                     .build()));
 
-    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    assertThat((CharSequence) result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
     assertThat(getMessages(result)).isEmpty();
     assertThat(getErrors(result)).isEmpty();
   }

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskTest.java
@@ -17,7 +17,11 @@
 package com.netflix.spinnaker.orca.clouddriver.tasks.manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/WaitForManifestStableTaskTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
@@ -32,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import okhttp3.Request;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 
@@ -148,7 +150,6 @@ final class WaitForManifestStableTaskTest {
 
     reset(oortService);
 
-    verify(oortService, times(0)).getManifest(ACCOUNT, NAMESPACE, MANIFEST_1, false);
     when(oortService.getManifest(ACCOUNT, NAMESPACE, MANIFEST_2, false))
         .thenReturn(manifestBuilder().stable(true).failed(false).build());
 
@@ -160,6 +161,7 @@ final class WaitForManifestStableTaskTest {
                     .putAll(result.getContext())
                     .build()));
     AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.SUCCEEDED);
+    verify(oortService, times(0)).getManifest(ACCOUNT, NAMESPACE, MANIFEST_1, false);
   }
 
   @Test
@@ -271,6 +273,44 @@ final class WaitForManifestStableTaskTest {
     AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.TERMINAL);
     assertThat(getMessages(result))
         .containsExactly(failedMessage(MANIFEST_1), waitingToStabilizeMessage(MANIFEST_2));
+  }
+
+  @Test
+  void waitTaskContextIsRestartedWhenClouddriverReturnsException() {
+    OortService oortService = mock(OortService.class);
+    WaitForManifestStableTask task = new WaitForManifestStableTask(oortService);
+
+    StageExecutionImpl myStage =
+        createStageWithManifests(
+            ImmutableMap.of(NAMESPACE, ImmutableList.of(MANIFEST_1, MANIFEST_2)));
+
+    when(oortService.getManifest(ACCOUNT, NAMESPACE, MANIFEST_1, false))
+        .thenReturn(manifestBuilder().stable(true).failed(false).build());
+    when(oortService.getManifest(ACCOUNT, NAMESPACE, MANIFEST_2, false))
+        .thenReturn(manifestBuilder().stable(false).failed(false).build());
+
+    TaskResult result = task.execute(myStage);
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    assertThat(getMessages(result)).containsExactly(waitingToStabilizeMessage(MANIFEST_2));
+    assertThat(getErrors(result)).isEmpty();
+
+    reset(oortService);
+
+    when(oortService.getManifest(ACCOUNT, NAMESPACE, MANIFEST_2, false))
+        .thenThrow(
+            new SpinnakerServerException(new Request.Builder().url("http://localhost").build()));
+
+    result =
+        task.execute(
+            createStageWithContext(
+                ImmutableMap.<String, Object>builder()
+                    .putAll(myStage.getContext())
+                    .putAll(result.getContext())
+                    .build()));
+
+    AssertionsForClassTypes.assertThat(result.getStatus()).isEqualTo(ExecutionStatus.RUNNING);
+    assertThat(getMessages(result)).isEmpty();
+    assertThat(getErrors(result)).isEmpty();
   }
 
   private static String waitingToStabilizeMessage(String manifest) {


### PR DESCRIPTION
Adding a missing test for WaitForManifestStableTask. This test validates that the task's context is reset if Clouddriver returns a SpinnakerServerException while waiting for the manifests to stabilize. This means that the stable manifests previously validated by Orca are removed from the context, and Orca restarts the validation process for all deployed manifests.
