### PR TITLE
fix(retrofit1): exclude Retrofit2EncodeCorrectionInterceptor from the retrofit1 clients

### DIFF
--- a/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.java
+++ b/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfiguration.java
@@ -206,7 +206,7 @@ public class CloudDriverConfiguration {
           .setEndpoint(newFixedEndpoint(url))
           .setClient(
               new Ok3Client(
-                  clientProvider.getClient(new DefaultServiceEndpoint("clouddriver", url))))
+                  clientProvider.getClient(new DefaultServiceEndpoint("clouddriver", url), true)))
           .setLogLevel(retrofitLogLevel)
           .setLog(new RetrofitSlf4jLog(type))
           .setConverter(new JacksonConverter(objectMapper))

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
@@ -72,7 +72,7 @@ class KatoRestServiceSpec extends Specification {
         OkHttpClient.Builder get(ServiceEndpoint service) {
           return new OkHttpClient().newBuilder()
         }
-      }], new Retrofit2EncodeCorrectionInterceptor()),
+      }]),
       FULL,
       noopInterceptor,
       new CloudDriverConfigurationProperties(clouddriver: new CloudDriverConfigurationProperties.CloudDriver(baseUrl: wireMockServer.url("/"))))

--- a/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationTest.java
+++ b/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/config/CloudDriverConfigurationTest.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.config.ServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientBuilderProvider;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
-import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor;
 import com.netflix.spinnaker.orca.clouddriver.KatoRestService;
 import com.netflix.spinnaker.orca.test.YamlFileApplicationContextInitializer;
@@ -75,8 +74,7 @@ public class CloudDriverConfigurationTest extends YamlFileApplicationContextInit
           }
         };
     OkHttpClientProvider okHttpClientProvider =
-        new OkHttpClientProvider(
-            List.of(okHttpClientBuilderProvider), new Retrofit2EncodeCorrectionInterceptor());
+        new OkHttpClientProvider(List.of(okHttpClientBuilderProvider));
 
     ObjectMapper objectMapper = new ObjectMapper();
     RestAdapter.LogLevel logLevel = RestAdapter.LogLevel.FULL;

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
@@ -68,7 +68,7 @@ class EchoConfiguration {
   EchoService echoService(Endpoint echoEndpoint) {
     new RestAdapter.Builder()
       .setEndpoint(echoEndpoint)
-      .setClient(new Ok3Client(clientProvider.getClient(new DefaultServiceEndpoint("echo", echoEndpoint.url))))
+      .setClient(new Ok3Client(clientProvider.getClient(new DefaultServiceEndpoint("echo", echoEndpoint.url), true)))
       .setLogLevel(retrofitLogLevel)
       .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .setLog(new RetrofitSlf4jLog(EchoService))

--- a/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/IgorConfiguration.groovy
+++ b/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/IgorConfiguration.groovy
@@ -59,7 +59,7 @@ class IgorConfiguration {
   IgorService igorService(Endpoint igorEndpoint, ObjectMapper mapper, RequestInterceptor spinnakerRequestInterceptor) {
     new RestAdapter.Builder()
       .setEndpoint(igorEndpoint)
-      .setClient(new Ok3Client(clientProvider.getClient(new DefaultServiceEndpoint("igor", igorEndpoint.url))))
+      .setClient(new Ok3Client(clientProvider.getClient(new DefaultServiceEndpoint("igor", igorEndpoint.url), true)))
       .setLogLevel(retrofitLogLevel)
       .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .setRequestInterceptor(spinnakerRequestInterceptor)

--- a/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/config/KeelConfiguration.kt
+++ b/orca-keel/src/main/kotlin/com/netflix/spinnaker/orca/config/KeelConfiguration.kt
@@ -59,7 +59,7 @@ class KeelConfiguration {
     RestAdapter.Builder()
       .setRequestInterceptor(spinnakerRequestInterceptor)
       .setEndpoint(keelEndpoint)
-      .setClient(Ok3Client(clientProvider.getClient(DefaultServiceEndpoint("keel", keelEndpoint.url))))
+      .setClient(Ok3Client(clientProvider.getClient(DefaultServiceEndpoint("keel", keelEndpoint.url), true)))
       .setLogLevel(retrofitLogLevel)
       .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .setConverter(JacksonConverter(keelObjectMapper))


### PR DESCRIPTION
This PR, along with https://github.com/spinnaker/kork/pull/1233, fixes any issues arising due to the addition of Retrofit2EncodeCorrectionInterceptor to the OkHttpClient that is used for retrofit1 client.
