### PR TITLE
Fix(orca-echo) manual judgment notifications for stage start

### DIFF
--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
@@ -62,9 +62,8 @@ class EchoNotifyingStageListener implements StageListener {
   @Override
   @CompileDynamic
   void beforeStage(StageExecution stage) {
-    // Manual Judgment fix is already present
+    // Skip notifications for Manual Judgment stages
     if (stage.type == "manualJudgment") {
-      log.debug("Manual Judgment fix is already present")
       return
     }
     

--- a/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
+++ b/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
@@ -62,6 +62,12 @@ class EchoNotifyingStageListener implements StageListener {
   @Override
   @CompileDynamic
   void beforeStage(StageExecution stage) {
+    // Manual Judgment fix is already present
+    if (stage.type == "manualJudgment") {
+      log.debug("Manual Judgment fix is already present")
+      return
+    }
+    
     recordEvent("stage", "starting", stage)
   }
 


### PR DESCRIPTION
**Problem**
Manual Judgment stages currently send stage start notifications even though there is no UI option to configure this behavior. It wasn't the behaviour around 1.32 

This creates several issues:

Users receive unwanted notifications when Manual Judgment stages begin
These notifications cannot be disabled through the UI configuration
This behavior differs from earlier Spinnaker versions, which did not send these notifications
It leads to notification fatigue and confusion for users

**Solution**
This PR adds a simple conditional check in EchoNotifyingStageListener.groovy to bypass sending start notifications specifically for Manual Judgment stages. The implementation:

Adds an early return in the beforeStage() method when the stage type is "manualJudgment"
Preserves all other notification functionality
Makes minimal changes to the codebase